### PR TITLE
feat: TimeDial with unified cascade replay controls

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import StructuralMetrics from "@/components/StructuralMetrics";
 import CausalDAG2D from "@/components/CausalDAG2D";
 import ImportModal from "@/components/import/ImportModal";
 import SpotlightTour from "@/components/SpotlightTour";
+import TimeDial from "@/components/TimeDial";
 
 // Dynamic import for 3D canvas (no SSR)
 const CausalDAG3D = dynamic(() => import("@/components/CausalDAG3D"), {
@@ -74,6 +75,9 @@ export default function Home() {
 
           {/* Risk Propagation Flow */}
           <RiskPropagationFlow />
+
+          {/* Time Dial — persistent timeline scrubber */}
+          <TimeDial />
 
           {/* Structural Metrics Footer */}
           <StructuralMetrics />

--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -16,12 +16,15 @@ import { motion } from "framer-motion";
 import { useApexStore } from "@/stores/useApexStore";
 import { getCategoryColor } from "@/lib/graph-data";
 import DAGOverlay from "./dag3d/DAGOverlay";
+import { useReplayTickDOM } from "@/lib/useReplayTick";
+import type { EpochSnapshot } from "@/lib/types";
 
 function CausalNode2D({ data }: NodeProps) {
-  const { label, category, omegaComposite, isRestricted, domain, datasetColor } = data;
+  const { label, category, omegaComposite, isRestricted, domain, datasetColor, shockIntensity } = data;
   const color = datasetColor ?? getCategoryColor(category);
   const isFractured = omegaComposite > 9;
   const isStressed = omegaComposite > 7;
+  const shockGlow = shockIntensity ?? 0;
 
   return (
     <motion.div
@@ -30,23 +33,32 @@ function CausalNode2D({ data }: NodeProps) {
         borderColor: isRestricted ? "#ff1744" : color,
         backgroundColor: `color-mix(in srgb, ${color} ${Math.round(5 + (omegaComposite / 10) * 15)}%, #0a0b10)`,
         color,
-        boxShadow: omegaComposite > 0
-          ? `0 0 ${Math.round((omegaComposite / 10) * 20)}px ${color}40, inset 0 0 ${Math.round((omegaComposite / 10) * 10)}px ${color}20`
-          : "none",
+        boxShadow: shockGlow > 0
+          ? `0 0 ${Math.round(shockGlow * 30)}px ${color}80, 0 0 ${Math.round(shockGlow * 15)}px ${color}40, inset 0 0 ${Math.round(shockGlow * 10)}px ${color}30`
+          : omegaComposite > 0
+            ? `0 0 ${Math.round((omegaComposite / 10) * 20)}px ${color}40, inset 0 0 ${Math.round((omegaComposite / 10) * 10)}px ${color}20`
+            : "none",
       }}
       animate={
-        isFractured
-          ? { borderColor: [color, "#ff1744", color], scale: [1, 1.02, 1] }
-          : isStressed
-            ? { opacity: [1, 0.7, 1] }
-            : {}
+        shockGlow > 0.3
+          ? {
+              scale: [1, 1 + shockGlow * 0.06, 1],
+              borderColor: [color, "#ffab00", color],
+            }
+          : isFractured
+            ? { borderColor: [color, "#ff1744", color], scale: [1, 1.02, 1] }
+            : isStressed
+              ? { opacity: [1, 0.7, 1] }
+              : {}
       }
       transition={
-        isFractured
-          ? { duration: 0.8, repeat: Infinity }
-          : isStressed
-            ? { duration: 1.5, repeat: Infinity }
-            : {}
+        shockGlow > 0.3
+          ? { duration: 0.6, repeat: Infinity, ease: "easeInOut" }
+          : isFractured
+            ? { duration: 0.8, repeat: Infinity }
+            : isStressed
+              ? { duration: 1.5, repeat: Infinity }
+              : {}
       }
     >
       <Handle type="target" position={Position.Top} style={{ background: "transparent", border: "none", width: 0, height: 0 }} />
@@ -75,34 +87,111 @@ function CausalNode2D({ data }: NodeProps) {
 const nodeTypes = { causal: CausalNode2D };
 
 export default function CausalDAG2D() {
-  const { graphData, truthFilter } = useApexStore();
+  const {
+    graphData,
+    truthFilter,
+    replayActive,
+    currentEpoch,
+    baselineEpochs,
+    interventionEpochs,
+    activeTimeline,
+  } = useApexStore();
 
-  const nodes: Node[] = useMemo(
-    () =>
-      graphData.nodes.map((n, i) => ({
+  // Drive replay ticking in DOM (outside R3F Canvas)
+  useReplayTickDOM();
+
+  // Derive current snapshot
+  const replayEpochs = activeTimeline === "baseline" ? baselineEpochs : interventionEpochs;
+  const currentSnapshot: EpochSnapshot | null =
+    replayActive && replayEpochs.length > 0
+      ? replayEpochs[currentEpoch] ?? null
+      : null;
+
+  const CONTRACTION = 0.18;
+
+  const nodes: Node[] = useMemo(() => {
+    // Compute base positions
+    const basePositions = graphData.nodes.map((n, i) => ({
+      id: n.id,
+      x: (i % 5) * 200 + 50 + (Math.sin(i * 1.7) * 40),
+      y: Math.floor(i / 5) * 160 + 30 + (Math.cos(i * 2.3) * 30),
+    }));
+
+    // Build adjacency map for contraction
+    const neighbors = new Map<string, string[]>();
+    if (currentSnapshot) {
+      for (const edge of graphData.edges) {
+        if (!neighbors.has(edge.source)) neighbors.set(edge.source, []);
+        if (!neighbors.has(edge.target)) neighbors.set(edge.target, []);
+        neighbors.get(edge.source)!.push(edge.target);
+        neighbors.get(edge.target)!.push(edge.source);
+      }
+    }
+
+    // Build position lookup for contraction
+    const posLookup = new Map<string, { x: number; y: number }>();
+    for (const bp of basePositions) {
+      posLookup.set(bp.id, { x: bp.x, y: bp.y });
+    }
+
+    return graphData.nodes.map((n, i) => {
+      const base = basePositions[i];
+      let posX = base.x;
+      let posY = base.y;
+
+      // Apply contraction during replay
+      if (currentSnapshot) {
+        const state = currentSnapshot.nodeStates[n.id];
+        if (state && state.shockIntensity > 0.01) {
+          const nbs = neighbors.get(n.id) ?? [];
+          let cx = 0, cy = 0, totalWeight = 0;
+          for (const nbId of nbs) {
+            const nbState = currentSnapshot.nodeStates[nbId];
+            const nbPos = posLookup.get(nbId);
+            if (!nbPos) continue;
+            const w = nbState ? 0.3 + nbState.shockIntensity * 0.7 : 0.1;
+            cx += nbPos.x * w;
+            cy += nbPos.y * w;
+            totalWeight += w;
+          }
+
+          if (totalWeight > 0) {
+            cx /= totalWeight;
+            cy /= totalWeight;
+            const pull = state.shockIntensity * CONTRACTION;
+            posX = base.x + (cx - base.x) * pull;
+            posY = base.y + (cy - base.y) * pull;
+          }
+        }
+      }
+
+      const epochOmega = currentSnapshot?.nodeStates[n.id]?.omegaComposite ?? n.omegaFragility.composite;
+      const epochShock = currentSnapshot?.nodeStates[n.id]?.shockIntensity ?? 0;
+
+      return {
         id: n.id,
         type: "causal",
-        position: {
-          x: (i % 5) * 200 + 50 + (Math.sin(i * 1.7) * 40),
-          y: Math.floor(i / 5) * 160 + 30 + (Math.cos(i * 2.3) * 30),
-        },
+        position: { x: posX, y: posY },
         data: {
           label: n.label,
           category: n.category,
-          omegaComposite: n.omegaFragility.composite,
+          omegaComposite: epochOmega,
           domain: n.domain,
           isRestricted: truthFilter === "verified" && n.isRestricted,
           datasetColor: n.datasetColor,
+          shockIntensity: epochShock,
         },
-      })),
-    [graphData, truthFilter]
-  );
+      };
+    });
+  }, [graphData, truthFilter, currentSnapshot]);
 
   const edges: Edge[] = useMemo(
     () =>
       graphData.edges.map((e) => {
         const isInconsistent = truthFilter === "verified" && e.isInconsistent;
-        const edgeColor = isInconsistent
+        const propagationSignal = currentSnapshot?.edgeStates[e.id]?.propagationSignal ?? 0;
+
+        const baseColor = isInconsistent
           ? "#ff1744"
           : e.type === "temporal"
             ? "#ffab00"
@@ -110,17 +199,32 @@ export default function CausalDAG2D() {
               ? "#ff6d00"
               : "#00e5ff";
 
+        // Boost opacity and use amber tint when signal is active
+        const edgeColor = propagationSignal > 0
+          ? "#ffab00"
+          : baseColor;
+
+        const baseOpacity = isInconsistent ? 0.6 : 0.7;
+        const opacity = propagationSignal > 0
+          ? Math.min(1, baseOpacity + propagationSignal * 0.3)
+          : baseOpacity;
+
+        const baseWidth = 0.5 + e.weight * 1.5;
+        const strokeWidth = propagationSignal > 0
+          ? baseWidth + propagationSignal * 2
+          : baseWidth;
+
         return {
           id: e.id,
           source: e.source,
           target: e.target,
           type: "default",
-          animated: e.type === "temporal",
+          animated: e.type === "temporal" || propagationSignal > 0.3,
           style: {
             stroke: edgeColor,
-            strokeWidth: 0.5 + e.weight * 1.5,
+            strokeWidth,
             strokeDasharray: e.type === "confounded" || isInconsistent ? "5,5" : undefined,
-            opacity: isInconsistent ? 0.6 : 0.7,
+            opacity,
           },
           labelStyle: {
             fill: "#5a5e72",
@@ -133,7 +237,7 @@ export default function CausalDAG2D() {
           },
         };
       }),
-    [graphData, truthFilter]
+    [graphData, truthFilter, currentSnapshot]
   );
 
   const onInit = useCallback(() => {}, []);

--- a/src/components/CausalDAG3D.tsx
+++ b/src/components/CausalDAG3D.tsx
@@ -11,7 +11,7 @@ import { getNodeDomainMap } from "@/lib/graph-data";
 import DAGNode3D from "./dag3d/DAGNode3D";
 import DAGEdge3D from "./dag3d/DAGEdge3D";
 import DAGOverlay from "./dag3d/DAGOverlay";
-import ReplayControls from "./ReplayControls";
+// ReplayControls is now integrated into TimeDial
 import { useReplayTick } from "@/lib/useReplayTick";
 import { EpochSnapshot } from "@/lib/types";
 
@@ -461,7 +461,6 @@ export default function CausalDAG3D() {
   return (
     <div style={{ position: "absolute", inset: 0 }}>
       <DAGOverlay />
-      <ReplayControls />
       <DAGErrorBoundary>
       <Canvas
         key={canvasKey}

--- a/src/components/NodeInspector.tsx
+++ b/src/components/NodeInspector.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useApexStore } from "@/stores/useApexStore";
 import { getCategoryColor, getDomainColor, getCategoryLabel } from "@/lib/graph-data";
+import { useTemporalGraph } from "@/hooks/useTemporalGraph";
 
 function getBarColor(value: number): string {
   if (value > 9) return "#ff1744";
@@ -16,11 +17,14 @@ export default function NodeInspector() {
   const selectedNode = useApexStore((s) => s.selectedNode);
   const setSelectedNode = useApexStore((s) => s.setSelectedNode);
   const graphData = useApexStore((s) => s.graphData);
+  const isLive = useApexStore((s) => s.isLive);
+  const { graph: temporalGraph } = useTemporalGraph();
+  const activeGraph = isLive ? graphData : temporalGraph;
 
   const node = useMemo(() => {
     if (!selectedNode) return null;
-    return graphData.nodes.find((n) => n.id === selectedNode) ?? null;
-  }, [selectedNode, graphData.nodes]);
+    return activeGraph.nodes.find((n) => n.id === selectedNode) ?? null;
+  }, [selectedNode, activeGraph.nodes]);
 
   const connectedEdges = useMemo(() => {
     if (!selectedNode) return [];

--- a/src/components/RiskPropagationFlow.tsx
+++ b/src/components/RiskPropagationFlow.tsx
@@ -4,13 +4,19 @@ import { useMemo } from "react";
 import { motion } from "framer-motion";
 import { useApexStore } from "@/stores/useApexStore";
 import { getCategoryColor, getCategoryLabel, getDomainColor, buildRiskCards } from "@/lib/graph-data";
+import { useTemporalGraph } from "@/hooks/useTemporalGraph";
 
 export default function RiskPropagationFlow() {
   const graphData = useApexStore((s) => s.graphData);
   const shocks = useApexStore((s) => s.shocks);
   const selectedNode = useApexStore((s) => s.selectedNode);
   const setSelectedNode = useApexStore((s) => s.setSelectedNode);
-  const riskCards = useMemo(() => buildRiskCards(graphData, shocks), [graphData, shocks]);
+  const isLive = useApexStore((s) => s.isLive);
+  const { graph: temporalGraph } = useTemporalGraph();
+
+  // Use temporal graph when scrubbing, otherwise use live graph
+  const activeGraph = isLive ? graphData : temporalGraph;
+  const riskCards = useMemo(() => buildRiskCards(activeGraph, shocks), [activeGraph, shocks]);
 
   return (
     <div className="flex items-stretch gap-2 px-4 py-2 overflow-x-auto border-t border-border bg-surface-elevated" data-tour="risk-flow">

--- a/src/components/TimeDial.tsx
+++ b/src/components/TimeDial.tsx
@@ -1,0 +1,866 @@
+"use client";
+
+import { useEffect, useCallback, useRef, useMemo, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { useApexStore } from "@/stores/useApexStore";
+import type { TimeGranularity, TemporalEvent } from "@/lib/temporal-data";
+import { getEventsInRange } from "@/lib/temporal-data";
+
+const GRANULARITY_OPTIONS: { value: TimeGranularity; label: string }[] = [
+  { value: "hour", label: "1H" },
+  { value: "day", label: "1D" },
+  { value: "week", label: "1W" },
+  { value: "month", label: "1M" },
+];
+
+const SPEED_OPTIONS = [0.5, 1, 2, 4];
+
+function formatDate(ts: number, granularity: TimeGranularity): string {
+  const d = new Date(ts);
+  switch (granularity) {
+    case "hour":
+      return d.toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+    case "day":
+      return d.toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+      });
+    case "week":
+      return `W${getWeekNumber(d)} ${d.toLocaleDateString("en-US", { month: "short" })}`;
+    case "month":
+      return d.toLocaleDateString("en-US", {
+        month: "short",
+        year: "2-digit",
+      });
+  }
+}
+
+function getWeekNumber(d: Date): number {
+  const start = new Date(d.getFullYear(), 0, 1);
+  const diff = d.getTime() - start.getTime();
+  return Math.ceil((diff / 86400000 + start.getDay() + 1) / 7);
+}
+
+function formatFullDate(ts: number): string {
+  return new Date(ts).toLocaleDateString("en-US", {
+    weekday: "short",
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/** Generate evenly-spaced tick marks for the timeline */
+function generateTicks(
+  start: number,
+  end: number,
+  granularity: TimeGranularity,
+): { ts: number; label: string }[] {
+  const ticks: { ts: number; label: string }[] = [];
+  const range = end - start;
+  const DAY = 86400000;
+
+  let step: number;
+  switch (granularity) {
+    case "hour":
+      step = DAY / 4; // every 6 hours
+      break;
+    case "day":
+      step = DAY * 7; // weekly ticks
+      break;
+    case "week":
+      step = DAY * 14; // bi-weekly
+      break;
+    case "month":
+      step = DAY * 30;
+      break;
+  }
+
+  // Aim for 6-12 ticks
+  const maxTicks = 12;
+  if (range / step > maxTicks) {
+    step = range / maxTicks;
+  }
+
+  let cursor = start;
+  while (cursor <= end) {
+    ticks.push({ ts: cursor, label: formatDate(cursor, granularity) });
+    cursor += step;
+  }
+
+  return ticks;
+}
+
+export default function TimeDial() {
+  const {
+    timelinePosition,
+    timelineRange,
+    isLive,
+    timelineGranularity,
+    temporalData,
+    setTimelinePosition,
+    setIsLive,
+    setTimelineGranularity,
+    initTemporalData,
+    goLive,
+    // Replay state
+    replayActive,
+    replayPlaying,
+    replaySpeed,
+    currentEpoch,
+    baselineEpochs,
+    interventionEpochs,
+    activeTimeline,
+    replayBranchEpoch,
+    shocks,
+    startReplay,
+    stopReplay,
+    setReplayPlaying,
+    setReplaySpeed,
+    setCurrentEpoch,
+    stepEpoch,
+    setActiveTimeline,
+    branchFromCurrentEpoch,
+  } = useApexStore();
+
+  const trackRef = useRef<HTMLDivElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [hoveredEvent, setHoveredEvent] = useState<TemporalEvent | null>(null);
+
+  // Initialize temporal data on mount
+  useEffect(() => {
+    initTemporalData();
+  }, [initTemporalData]);
+
+  const { start, end } = timelineRange;
+  const range = end - start;
+
+  // Replay derived state
+  const replayEpochs = activeTimeline === "baseline" ? baselineEpochs : interventionEpochs;
+  const maxEpoch = Math.max(0, replayEpochs.length - 1);
+  const currentSnapshot = replayActive && replayEpochs.length > 0
+    ? replayEpochs[currentEpoch] ?? null
+    : null;
+  const hasBranch = interventionEpochs.length > 0;
+
+  // Position as fraction 0-1
+  const positionFraction = replayActive
+    ? maxEpoch > 0 ? currentEpoch / maxEpoch : 0
+    : range > 0 ? (timelinePosition - start) / range : 1;
+
+  // Tick marks (only for historical mode)
+  const ticks = useMemo(
+    () => generateTicks(start, end, timelineGranularity),
+    [start, end, timelineGranularity],
+  );
+
+  // Events on the timeline (only for historical mode)
+  const events = useMemo(
+    () => (temporalData ? getEventsInRange(temporalData, start, end) : []),
+    [temporalData, start, end],
+  );
+
+  // Convert pixel position to timestamp (historical) or epoch (replay)
+  const handleTrackScrub = useCallback(
+    (clientX: number) => {
+      if (!trackRef.current) return;
+      const rect = trackRef.current.getBoundingClientRect();
+      const fraction = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+
+      if (replayActive) {
+        // Map fraction to epoch
+        const epoch = Math.round(fraction * maxEpoch);
+        setCurrentEpoch(epoch);
+        setReplayPlaying(false);
+      } else {
+        const ts = start + fraction * range;
+        setTimelinePosition(ts);
+      }
+    },
+    [start, range, replayActive, maxEpoch, setTimelinePosition, setCurrentEpoch, setReplayPlaying],
+  );
+
+  // Handle click/drag on the track
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      e.preventDefault();
+      setIsDragging(true);
+      handleTrackScrub(e.clientX);
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    },
+    [handleTrackScrub],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!isDragging) return;
+      handleTrackScrub(e.clientX);
+    },
+    [isDragging, handleTrackScrub],
+  );
+
+  const handlePointerUp = useCallback(() => {
+    setIsDragging(false);
+  }, []);
+
+  // Criticality display for cascade mode
+  let critLabel = "STABLE";
+  let critColor = "var(--accent-green)";
+  if (currentSnapshot) {
+    if (currentSnapshot.isCritical) {
+      critLabel = "CRITICAL";
+      critColor = "var(--accent-red)";
+    } else if (currentSnapshot.criticalityEstimate !== null) {
+      critLabel = `~${currentSnapshot.criticalityEstimate} EPOCHS`;
+      critColor = "var(--accent-amber)";
+    } else if (currentSnapshot.isStable) {
+      critLabel = "STABLE";
+      critColor = "var(--accent-green)";
+    }
+  }
+
+  const bufferValue = currentSnapshot?.omegaBuffer ?? 100;
+  const bufferSegments = 20;
+  const filledSegments = Math.round((bufferValue / 100) * bufferSegments);
+
+  // Keyboard navigation — merges historical and replay shortcuts
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement
+      )
+        return;
+
+      // Replay-mode shortcuts
+      if (replayActive) {
+        switch (e.key) {
+          case " ":
+            e.preventDefault();
+            setReplayPlaying(!replayPlaying);
+            return;
+          case "ArrowLeft":
+            if (!e.shiftKey) {
+              e.preventDefault();
+              stepEpoch(-1);
+              return;
+            }
+            break;
+          case "ArrowRight":
+            if (!e.shiftKey) {
+              e.preventDefault();
+              stepEpoch(1);
+              return;
+            }
+            break;
+          case "[": {
+            e.preventDefault();
+            const idx = SPEED_OPTIONS.indexOf(replaySpeed);
+            if (idx > 0) setReplaySpeed(SPEED_OPTIONS[idx - 1]);
+            return;
+          }
+          case "]": {
+            e.preventDefault();
+            const idx = SPEED_OPTIONS.indexOf(replaySpeed);
+            if (idx < SPEED_OPTIONS.length - 1)
+              setReplaySpeed(SPEED_OPTIONS[idx + 1]);
+            return;
+          }
+          case "b":
+          case "B":
+            e.preventDefault();
+            if (!replayPlaying) branchFromCurrentEpoch();
+            return;
+          case "Escape":
+            e.preventDefault();
+            stopReplay();
+            return;
+        }
+      }
+
+      // Historical-mode shortcuts (Shift+Arrow)
+      if (!replayActive) {
+        const DAY = 86400000;
+        let step = 0;
+
+        switch (timelineGranularity) {
+          case "hour":
+            step = DAY / 24;
+            break;
+          case "day":
+            step = DAY;
+            break;
+          case "week":
+            step = DAY * 7;
+            break;
+          case "month":
+            step = DAY * 30;
+            break;
+        }
+
+        if (e.key === "ArrowLeft" && e.shiftKey) {
+          e.preventDefault();
+          setTimelinePosition(Math.max(start, timelinePosition - step));
+        } else if (e.key === "ArrowRight" && e.shiftKey) {
+          e.preventDefault();
+          const newTs = Math.min(end, timelinePosition + step);
+          if (newTs >= end - step / 2) {
+            goLive();
+          } else {
+            setTimelinePosition(newTs);
+          }
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [
+    replayActive, replayPlaying, replaySpeed, timelineGranularity,
+    timelinePosition, start, end, setTimelinePosition, goLive,
+    setReplayPlaying, stepEpoch, setReplaySpeed, branchFromCurrentEpoch,
+    stopReplay,
+  ]);
+
+  if (!temporalData) return null;
+
+  return (
+    <div className="relative flex items-center gap-3 px-4 py-2 border-t border-border bg-surface-elevated/90 backdrop-blur-sm select-none">
+      {/* Label — switches between Time Dial and CASCADE MODE */}
+      <div className="flex flex-col items-center gap-0.5 min-w-[72px]">
+        <AnimatePresence mode="wait">
+          {replayActive ? (
+            <motion.span
+              key="cascade"
+              initial={{ opacity: 0, y: -4 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 4 }}
+              className="text-[8px] font-[family-name:var(--font-michroma)] tracking-[0.15em] uppercase"
+              style={{ color: "var(--accent-amber)" }}
+            >
+              Cascade
+            </motion.span>
+          ) : (
+            <motion.span
+              key="timedial"
+              initial={{ opacity: 0, y: -4 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 4 }}
+              className="text-[8px] font-[family-name:var(--font-michroma)] tracking-[0.2em] text-text-muted uppercase"
+            >
+              Time Dial
+            </motion.span>
+          )}
+        </AnimatePresence>
+        <span className="text-[9px] font-mono text-foreground">
+          {replayActive
+            ? `E${currentEpoch}/${maxEpoch}`
+            : isLive
+              ? "LIVE"
+              : formatDate(timelinePosition, timelineGranularity)}
+        </span>
+      </div>
+
+      {/* Cascade transport controls — only shown during replay */}
+      <AnimatePresence>
+        {replayActive && (
+          <motion.div
+            initial={{ opacity: 0, width: 0 }}
+            animate={{ opacity: 1, width: "auto" }}
+            exit={{ opacity: 0, width: 0 }}
+            className="flex items-center gap-1 overflow-hidden"
+          >
+            {/* Step back */}
+            <button
+              onClick={() => stepEpoch(-1)}
+              className="w-6 h-6 flex items-center justify-center rounded text-[9px] transition-colors hover:bg-white/10"
+              style={{ color: "var(--accent-amber)" }}
+              title="Step back (Left arrow)"
+            >
+              &#9664;&#9664;
+            </button>
+            {/* Play/Pause */}
+            <button
+              onClick={() => setReplayPlaying(!replayPlaying)}
+              className="w-7 h-7 flex items-center justify-center rounded text-[11px] transition-colors hover:bg-white/10"
+              style={{ color: "var(--accent-amber)" }}
+              title="Play/Pause (Space)"
+            >
+              {replayPlaying ? "▐▐" : "▶"}
+            </button>
+            {/* Step forward */}
+            <button
+              onClick={() => stepEpoch(1)}
+              className="w-6 h-6 flex items-center justify-center rounded text-[9px] transition-colors hover:bg-white/10"
+              style={{ color: "var(--accent-amber)" }}
+              title="Step forward (Right arrow)"
+            >
+              &#9654;&#9654;
+            </button>
+
+            {/* Speed selector */}
+            <div className="flex items-center gap-0.5 ml-1">
+              {SPEED_OPTIONS.map((s) => (
+                <button
+                  key={s}
+                  onClick={() => setReplaySpeed(s)}
+                  className="px-1 py-0.5 rounded text-[7px] font-mono transition-colors"
+                  style={{
+                    color:
+                      replaySpeed === s ? "var(--accent-amber)" : "var(--text-muted)",
+                    background:
+                      replaySpeed === s ? "rgba(255, 171, 0, 0.12)" : "transparent",
+                  }}
+                >
+                  {s}x
+                </button>
+              ))}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Granularity selector — hidden during cascade */}
+      <AnimatePresence>
+        {!replayActive && (
+          <motion.div
+            initial={{ opacity: 0, width: 0 }}
+            animate={{ opacity: 1, width: "auto" }}
+            exit={{ opacity: 0, width: 0 }}
+            className="flex gap-0.5 rounded border border-border overflow-hidden"
+          >
+            {GRANULARITY_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                onClick={() => setTimelineGranularity(opt.value)}
+                className="px-1.5 py-0.5 text-[8px] font-[family-name:var(--font-michroma)] tracking-wider transition-colors"
+                style={{
+                  backgroundColor:
+                    timelineGranularity === opt.value
+                      ? "rgba(0,229,255,0.15)"
+                      : "transparent",
+                  color:
+                    timelineGranularity === opt.value
+                      ? "var(--accent-cyan)"
+                      : "var(--text-muted)",
+                  borderRight: "1px solid var(--border)",
+                }}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Timeline track */}
+      <div className="flex-1 flex flex-col gap-1">
+        {/* Date at cursor / epoch count */}
+        <div className="flex justify-between items-center h-3">
+          {replayActive ? (
+            <>
+              <span
+                className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider"
+                style={{ color: "var(--accent-amber)" }}
+              >
+                EPOCH {currentEpoch}/{maxEpoch}
+              </span>
+              {/* Criticality */}
+              <span
+                className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider"
+                style={{ color: critColor }}
+              >
+                {critLabel}
+              </span>
+            </>
+          ) : (
+            <>
+              <span className="text-[8px] font-mono text-text-muted">
+                {formatDate(start, timelineGranularity)}
+              </span>
+              {!isLive && (
+                <motion.span
+                  initial={{ opacity: 0, y: -4 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  className="text-[9px] font-mono text-accent-cyan"
+                >
+                  {formatFullDate(timelinePosition)}
+                </motion.span>
+              )}
+              <span className="text-[8px] font-mono text-text-muted">
+                {formatDate(end, timelineGranularity)}
+              </span>
+            </>
+          )}
+        </div>
+
+        {/* Track */}
+        <div
+          ref={trackRef}
+          className="relative h-6 cursor-crosshair rounded"
+          style={{ backgroundColor: "rgba(26,28,46,0.8)" }}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+        >
+          {/* Filled portion */}
+          <div
+            className="absolute top-0 left-0 h-full rounded-l transition-[width] duration-75"
+            style={{
+              width: `${positionFraction * 100}%`,
+              background: replayActive
+                ? "linear-gradient(90deg, rgba(255,171,0,0.05), rgba(255,171,0,0.2))"
+                : isLive
+                  ? "linear-gradient(90deg, rgba(0,229,255,0.05), rgba(0,229,255,0.15))"
+                  : "linear-gradient(90deg, rgba(0,229,255,0.03), rgba(0,229,255,0.12))",
+            }}
+          />
+
+          {/* Cascade epoch markers — show epoch positions as small amber ticks */}
+          {replayActive && maxEpoch > 0 && (
+            <>
+              {/* Show ~20 evenly spaced epoch ticks max */}
+              {Array.from({ length: Math.min(maxEpoch + 1, 30) }).map((_, i) => {
+                const epochIdx = maxEpoch <= 29 ? i : Math.round((i / 29) * maxEpoch);
+                const frac = epochIdx / maxEpoch;
+                return (
+                  <div
+                    key={epochIdx}
+                    className="absolute top-0 h-full pointer-events-none"
+                    style={{ left: `${frac * 100}%` }}
+                  >
+                    <div
+                      className="w-px h-1.5"
+                      style={{ backgroundColor: "rgba(255,171,0,0.3)" }}
+                    />
+                  </div>
+                );
+              })}
+            </>
+          )}
+
+          {/* Historical tick marks — only when not in cascade */}
+          {!replayActive &&
+            ticks.map((tick, i) => {
+              const frac = range > 0 ? (tick.ts - start) / range : 0;
+              return (
+                <div
+                  key={i}
+                  className="absolute top-0 h-full flex flex-col items-center justify-end pointer-events-none"
+                  style={{ left: `${frac * 100}%` }}
+                >
+                  <div
+                    className="w-px h-2"
+                    style={{ backgroundColor: "var(--border-bright)" }}
+                  />
+                  <span
+                    className="text-[7px] font-mono absolute -bottom-3 whitespace-nowrap"
+                    style={{
+                      color: "var(--text-muted)",
+                      transform: "translateX(-50%)",
+                    }}
+                  >
+                    {tick.label}
+                  </span>
+                </div>
+              );
+            })}
+
+          {/* Event markers — only when not in cascade */}
+          {!replayActive &&
+            events.map((evt) => {
+              const frac =
+                range > 0 ? (evt.date.getTime() - start) / range : 0;
+              return (
+                <div
+                  key={evt.id}
+                  className="absolute top-0.5 w-1.5 h-1.5 rounded-full cursor-pointer z-10"
+                  style={{
+                    left: `${frac * 100}%`,
+                    transform: "translateX(-50%)",
+                    backgroundColor:
+                      evt.severity > 0.7
+                        ? "var(--accent-red)"
+                        : evt.severity > 0.4
+                          ? "var(--accent-amber)"
+                          : "var(--accent-cyan)",
+                    boxShadow:
+                      evt.severity > 0.7
+                        ? "0 0 4px var(--accent-red)"
+                        : "none",
+                  }}
+                  onMouseEnter={() => setHoveredEvent(evt)}
+                  onMouseLeave={() => setHoveredEvent(null)}
+                />
+              );
+            })}
+
+          {/* Playhead */}
+          <div
+            className="absolute top-0 h-full w-0.5 z-20 pointer-events-none"
+            style={{
+              left: `${positionFraction * 100}%`,
+              transform: "translateX(-50%)",
+              backgroundColor: replayActive
+                ? "var(--accent-amber)"
+                : isLive
+                  ? "var(--accent-green)"
+                  : "var(--accent-cyan)",
+              boxShadow: replayActive
+                ? "0 0 6px var(--accent-amber)"
+                : isLive
+                  ? "0 0 6px var(--accent-green)"
+                  : "0 0 4px var(--accent-cyan)",
+            }}
+          >
+            {/* Playhead diamond */}
+            <div
+              className="absolute -top-1 left-1/2 w-2 h-2 rotate-45"
+              style={{
+                transform: "translateX(-50%) rotate(45deg)",
+                backgroundColor: replayActive
+                  ? "var(--accent-amber)"
+                  : isLive
+                    ? "var(--accent-green)"
+                    : "var(--accent-cyan)",
+              }}
+            />
+          </div>
+        </div>
+
+        {/* Bottom tick labels spacer */}
+        <div className="h-2" />
+      </div>
+
+      {/* Cascade mode: omega buffer + timeline tabs + branch + stop */}
+      <AnimatePresence>
+        {replayActive && (
+          <motion.div
+            initial={{ opacity: 0, width: 0 }}
+            animate={{ opacity: 1, width: "auto" }}
+            exit={{ opacity: 0, width: 0 }}
+            className="flex items-center gap-2 overflow-hidden"
+          >
+            {/* Mini omega-buffer bar */}
+            <div className="flex flex-col items-center gap-0.5">
+              <span className="text-[7px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted">
+                {"\u03A9"}-BUF
+              </span>
+              <div className="flex gap-[1px]">
+                {Array.from({ length: bufferSegments }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="w-[3px] h-[6px] rounded-[1px]"
+                    style={{
+                      background:
+                        i < filledSegments
+                          ? bufferValue < 15
+                            ? "var(--accent-red)"
+                            : bufferValue < 35
+                              ? "var(--accent-amber)"
+                              : "var(--accent-cyan)"
+                          : "rgba(90, 94, 114, 0.2)",
+                    }}
+                  />
+                ))}
+              </div>
+            </div>
+
+            <div className="h-5 w-px" style={{ background: "rgba(90, 94, 114, 0.3)" }} />
+
+            {/* Timeline tabs */}
+            <div className="flex items-center gap-0.5">
+              <button
+                onClick={() => setActiveTimeline("baseline")}
+                className="px-1.5 py-0.5 rounded text-[7px] font-[family-name:var(--font-michroma)] tracking-wider transition-colors"
+                style={{
+                  color:
+                    activeTimeline === "baseline"
+                      ? "var(--accent-cyan)"
+                      : "var(--text-muted)",
+                  background:
+                    activeTimeline === "baseline"
+                      ? "rgba(0, 229, 255, 0.1)"
+                      : "transparent",
+                }}
+              >
+                BASE
+              </button>
+              {hasBranch && (
+                <button
+                  onClick={() => setActiveTimeline("intervention")}
+                  className="px-1.5 py-0.5 rounded text-[7px] font-[family-name:var(--font-michroma)] tracking-wider transition-colors"
+                  style={{
+                    color:
+                      activeTimeline === "intervention"
+                        ? "var(--accent-amber)"
+                        : "var(--text-muted)",
+                    background:
+                      activeTimeline === "intervention"
+                        ? "rgba(255, 171, 0, 0.1)"
+                        : "transparent",
+                  }}
+                >
+                  INTV
+                  {replayBranchEpoch !== null && (
+                    <span className="ml-0.5 opacity-60">@{replayBranchEpoch}</span>
+                  )}
+                </button>
+              )}
+            </div>
+
+            {/* Branch button */}
+            <button
+              onClick={branchFromCurrentEpoch}
+              disabled={replayPlaying}
+              className="px-1.5 py-0.5 rounded text-[7px] font-[family-name:var(--font-michroma)] tracking-wider transition-colors disabled:opacity-30"
+              style={{
+                color: "var(--accent-amber)",
+                border: "1px solid rgba(255, 171, 0, 0.3)",
+              }}
+              title="Branch from current epoch (B)"
+            >
+              BRANCH
+            </button>
+
+            <div className="h-5 w-px" style={{ background: "rgba(90, 94, 114, 0.3)" }} />
+
+            {/* Stop button */}
+            <button
+              onClick={stopReplay}
+              className="px-1.5 py-0.5 rounded text-[7px] font-[family-name:var(--font-michroma)] tracking-wider transition-colors hover:bg-red-500/10"
+              style={{
+                color: "var(--accent-red)",
+                border: "1px solid rgba(255, 23, 68, 0.3)",
+              }}
+              title="Stop cascade (Escape)"
+            >
+              STOP
+            </button>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Start cascade button — shown when shocks active but replay not started */}
+      <AnimatePresence>
+        {!replayActive && shocks.length > 0 && (
+          <motion.button
+            initial={{ opacity: 0, scale: 0.9 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.9 }}
+            onClick={startReplay}
+            className="flex items-center gap-1.5 px-2.5 py-1 rounded border transition-all duration-200 hover:scale-105 whitespace-nowrap"
+            style={{
+              borderColor: "rgba(255, 171, 0, 0.5)",
+              color: "var(--accent-amber)",
+              background: "rgba(255, 171, 0, 0.08)",
+            }}
+          >
+            <span className="text-[10px]">▶</span>
+            <span className="text-[8px] font-[family-name:var(--font-michroma)] tracking-[0.1em]">
+              CASCADE
+            </span>
+          </motion.button>
+        )}
+      </AnimatePresence>
+
+      {/* Live button — hidden during cascade */}
+      <AnimatePresence>
+        {!replayActive && (
+          <motion.button
+            initial={{ opacity: 0, width: 0 }}
+            animate={{ opacity: 1, width: "auto" }}
+            exit={{ opacity: 0, width: 0 }}
+            onClick={goLive}
+            className="flex items-center gap-1.5 px-2 py-1 rounded border transition-all duration-200 overflow-hidden"
+            style={{
+              borderColor: isLive
+                ? "var(--accent-green)"
+                : "var(--border)",
+              backgroundColor: isLive
+                ? "rgba(0,230,118,0.1)"
+                : "transparent",
+            }}
+          >
+            <span
+              className="relative flex h-2 w-2"
+              style={{ opacity: isLive ? 1 : 0.4 }}
+            >
+              {isLive && (
+                <span
+                  className="animate-ping absolute inline-flex h-full w-full rounded-full opacity-75"
+                  style={{ backgroundColor: "var(--accent-green)" }}
+                />
+              )}
+              <span
+                className="relative inline-flex rounded-full h-2 w-2"
+                style={{
+                  backgroundColor: isLive
+                    ? "var(--accent-green)"
+                    : "var(--text-muted)",
+                }}
+              />
+            </span>
+            <span
+              className="text-[9px] font-[family-name:var(--font-michroma)] tracking-wider"
+              style={{
+                color: isLive ? "var(--accent-green)" : "var(--text-muted)",
+              }}
+            >
+              LIVE
+            </span>
+          </motion.button>
+        )}
+      </AnimatePresence>
+
+      {/* Event tooltip */}
+      <AnimatePresence>
+        {hoveredEvent && !replayActive && (
+          <motion.div
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 8 }}
+            transition={{ duration: 0.15 }}
+            className="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 px-3 py-2 rounded border z-50 max-w-xs"
+            style={{
+              backgroundColor: "var(--surface-elevated)",
+              borderColor: "var(--border-bright)",
+              boxShadow: "0 4px 12px rgba(0,0,0,0.5)",
+            }}
+          >
+            <div className="text-[9px] font-[family-name:var(--font-michroma)] text-accent-amber tracking-wider">
+              {hoveredEvent.label}
+            </div>
+            <div className="text-[8px] font-mono text-text-muted mt-1">
+              {formatFullDate(hoveredEvent.date.getTime())}
+            </div>
+            <div className="text-[9px] font-mono text-foreground mt-1">
+              {hoveredEvent.description}
+            </div>
+            <div className="flex gap-1 mt-1 flex-wrap">
+              {hoveredEvent.affectedNodeIds.map((id) => (
+                <span
+                  key={id}
+                  className="text-[7px] font-mono px-1 py-0.5 rounded"
+                  style={{
+                    backgroundColor: "rgba(0,229,255,0.1)",
+                    color: "var(--accent-cyan)",
+                  }}
+                >
+                  {id}
+                </span>
+              ))}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/components/dag3d/DAGOverlay.tsx
+++ b/src/components/dag3d/DAGOverlay.tsx
@@ -3,31 +3,34 @@
 import { useMemo } from "react";
 import { useApexStore } from "@/stores/useApexStore";
 import { getDomainColor } from "@/lib/graph-data";
+import { useTemporalGraph } from "@/hooks/useTemporalGraph";
 
 export default function DAGOverlay() {
-  const { graphData, activeModule, viewMode, setViewMode, truthFilter, selectedNode, setSelectedNode } = useApexStore();
-  const meta = graphData.metadata;
+  const { graphData, activeModule, viewMode, setViewMode, truthFilter, selectedNode, setSelectedNode, isLive, timelinePosition } = useApexStore();
+  const { graph: temporalGraph } = useTemporalGraph();
+  const activeGraph = isLive ? graphData : temporalGraph;
+  const meta = activeGraph.metadata;
 
   const selectedNodeData = useMemo(() => {
     if (!selectedNode) return null;
-    return graphData.nodes.find((n) => n.id === selectedNode) ?? null;
-  }, [selectedNode, graphData.nodes]);
+    return activeGraph.nodes.find((n) => n.id === selectedNode) ?? null;
+  }, [selectedNode, activeGraph.nodes]);
 
   // Domain legend: count nodes per domain
   const domainCounts = useMemo(() => {
     const map: Record<string, number> = {};
-    graphData.nodes.forEach((n) => {
+    activeGraph.nodes.forEach((n) => {
       map[n.domain] = (map[n.domain] || 0) + 1;
     });
     return Object.entries(map).sort((a, b) => b[1] - a[1]);
-  }, [graphData.nodes]);
+  }, [activeGraph.nodes]);
 
   // Top-Ω nodes
   const topOmega = useMemo(() => {
-    return [...graphData.nodes]
+    return [...activeGraph.nodes]
       .sort((a, b) => b.omegaFragility.composite - a.omegaFragility.composite)
       .slice(0, 5);
-  }, [graphData.nodes]);
+  }, [activeGraph.nodes]);
 
   return (
     <div className="absolute inset-0 pointer-events-none z-10">
@@ -71,6 +74,22 @@ export default function DAGOverlay() {
           {viewMode === "3d" ? "\u2192 2D" : "\u2192 3D"}
         </button>
       </div>
+
+      {/* Temporal scrub indicator */}
+      {!isLive && (
+        <div className="absolute top-12 left-1/2 -translate-x-1/2">
+          <div
+            className="text-[9px] font-[family-name:var(--font-michroma)] tracking-wider px-3 py-1 rounded border"
+            style={{
+              borderColor: "var(--accent-amber)",
+              backgroundColor: "rgba(255,171,0,0.08)",
+              color: "var(--accent-amber)",
+            }}
+          >
+            HISTORICAL VIEW — {new Date(timelinePosition).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}
+          </div>
+        </div>
+      )}
 
       {/* Truth filter badge */}
       {truthFilter === "verified" && (

--- a/src/hooks/useTemporalGraph.ts
+++ b/src/hooks/useTemporalGraph.ts
@@ -1,0 +1,90 @@
+import { useMemo } from "react";
+import { useApexStore } from "@/stores/useApexStore";
+import { getNodeStateAt, getVisibleNodesAt, getEventsInRange } from "@/lib/temporal-data";
+import type { CausalGraph, CausalNode, CausalEdge, OmegaFragilityProfile } from "@/lib/types";
+import type { TemporalEvent } from "@/lib/temporal-data";
+
+export interface TemporalGraphSnapshot {
+  /** The graph filtered/transformed to the selected time */
+  graph: CausalGraph;
+  /** Events near the current position (within 3 days) */
+  nearbyEvents: TemporalEvent[];
+  /** Whether temporal data is available */
+  isTemporalActive: boolean;
+}
+
+/**
+ * Hook that returns a transformed graph based on the current timeline position.
+ * When isLive is true, returns the original graph unmodified.
+ * When scrubbed to a past position, adjusts omega scores and filters nodes.
+ */
+export function useTemporalGraph(): TemporalGraphSnapshot {
+  const graphData = useApexStore((s) => s.graphData);
+  const temporalData = useApexStore((s) => s.temporalData);
+  const timelinePosition = useApexStore((s) => s.timelinePosition);
+  const isLive = useApexStore((s) => s.isLive);
+
+  return useMemo(() => {
+    // No temporal data or live mode — return original graph
+    if (!temporalData || isLive) {
+      return {
+        graph: graphData,
+        nearbyEvents: [],
+        isTemporalActive: !!temporalData,
+      };
+    }
+
+    const ts = timelinePosition;
+
+    // Determine which nodes are visible at this time
+    const visibleIds = new Set(getVisibleNodesAt(temporalData, ts));
+
+    // Transform nodes with historical omega values
+    const transformedNodes: CausalNode[] = graphData.nodes
+      .filter((n) => visibleIds.has(n.id))
+      .map((node) => {
+        const nodeData = temporalData.nodes.get(node.id);
+        if (!nodeData) return node;
+
+        const state = getNodeStateAt(nodeData, ts);
+        if (!state) return node;
+
+        return {
+          ...node,
+          omegaFragility: state.omegaProfile,
+        };
+      });
+
+    const visibleNodeIds = new Set(transformedNodes.map((n) => n.id));
+
+    // Filter edges to only include those between visible nodes
+    const transformedEdges: CausalEdge[] = graphData.edges.filter(
+      (e) => visibleNodeIds.has(e.source) && visibleNodeIds.has(e.target),
+    );
+
+    const graph: CausalGraph = {
+      nodes: transformedNodes,
+      edges: transformedEdges,
+      metadata: {
+        ...graphData.metadata,
+        totalNodes: transformedNodes.length,
+        totalEdges: transformedEdges.length,
+        density:
+          transformedNodes.length > 1
+            ? transformedEdges.length /
+              (transformedNodes.length * (transformedNodes.length - 1))
+            : 0,
+      },
+    };
+
+    // Get events near current position (±3 days)
+    const threeDays = 3 * 24 * 60 * 60 * 1000;
+    const nearbyEvents = getEventsInRange(
+      temporalData,
+      ts - threeDays,
+      ts + threeDays,
+    );
+
+    return { graph, nearbyEvents, isTemporalActive: true };
+  }, [graphData, temporalData, timelinePosition, isLive]);
+}

--- a/src/lib/temporal-data.ts
+++ b/src/lib/temporal-data.ts
@@ -1,0 +1,236 @@
+import type { CausalNode, OmegaFragilityProfile } from "./types";
+
+// ─── Temporal Types ──────────────────────────────────────────────
+export type TimeGranularity = "hour" | "day" | "week" | "month";
+
+export interface TemporalEvent {
+  id: string;
+  date: Date;
+  label: string;
+  description: string;
+  affectedNodeIds: string[];
+  severity: number; // 0-1, magnitude of impact
+}
+
+export interface NodeTemporalState {
+  timestamp: number; // ms since epoch
+  omegaComposite: number;
+  omegaProfile: OmegaFragilityProfile;
+}
+
+export interface TemporalNodeData {
+  nodeId: string;
+  /** When this node first appeared in the causal network */
+  appearedAt: Date;
+  /** Time series of omega score snapshots */
+  history: NodeTemporalState[];
+}
+
+export interface TemporalDataset {
+  nodes: Map<string, TemporalNodeData>;
+  events: TemporalEvent[];
+  rangeStart: Date;
+  rangeEnd: Date;
+}
+
+// ─── Seeded random for determinism ──────────────────────────────
+function seededRandom(seed: number): () => number {
+  let s = seed;
+  return () => {
+    s = (s * 16807 + 0) % 2147483647;
+    return (s - 1) / 2147483646;
+  };
+}
+
+// ─── Synthetic Events ───────────────────────────────────────────
+const EVENT_TEMPLATES: Omit<TemporalEvent, "id" | "date">[] = [
+  {
+    label: "ASML EUV Delay",
+    description: "Supply chain disruption delayed EUV shipments by 6 weeks",
+    affectedNodeIds: ["asml_euv", "zeiss_optics", "tsmc_fab"],
+    severity: 0.7,
+  },
+  {
+    label: "Taiwan Strait Tensions",
+    description: "Elevated military activity near TSMC facilities",
+    affectedNodeIds: ["tsmc_fab", "taiwan_energy", "geopolitical_risk"],
+    severity: 0.85,
+  },
+  {
+    label: "Neon Gas Shortage",
+    description: "Ukrainian neon supply disrupted, affecting lithography",
+    affectedNodeIds: ["asml_euv", "chip_design", "global_foundries"],
+    severity: 0.6,
+  },
+  {
+    label: "EU Export Controls",
+    description: "New restrictions on advanced semiconductor exports",
+    affectedNodeIds: ["asml_euv", "zeiss_optics", "trade_policy"],
+    severity: 0.5,
+  },
+  {
+    label: "Cooling Infra Failure",
+    description: "Major datacenter cooling system outage in Singapore",
+    affectedNodeIds: ["dc_cooling", "cloud_compute", "ai_training"],
+    severity: 0.65,
+  },
+  {
+    label: "Rare Earth Embargo",
+    description: "China restricts gallium and germanium exports",
+    affectedNodeIds: ["rare_earth", "chip_substrate", "defense_chips"],
+    severity: 0.75,
+  },
+  {
+    label: "Energy Grid Instability",
+    description: "Texas power grid fluctuations affect fab operations",
+    affectedNodeIds: ["us_energy", "samsung_fab", "power_grid"],
+    severity: 0.55,
+  },
+  {
+    label: "AI Compute Demand Spike",
+    description: "GPT-5 training clusters drive unprecedented HBM demand",
+    affectedNodeIds: ["hbm_memory", "sk_hynix", "ai_training"],
+    severity: 0.4,
+  },
+];
+
+// ─── Generator ──────────────────────────────────────────────────
+export function generateTemporalData(
+  nodes: CausalNode[],
+  daysBack: number = 60,
+): TemporalDataset {
+  const rand = seededRandom(42);
+  const now = new Date();
+  const rangeEnd = new Date(now);
+  const rangeStart = new Date(now);
+  rangeStart.setDate(rangeStart.getDate() - daysBack);
+
+  const nodeMap = new Map<string, TemporalNodeData>();
+
+  // Generate daily snapshots for each node
+  for (const node of nodes) {
+    // Most nodes appeared at the start; a few appeared later
+    const daysBeforeAppearance =
+      rand() < 0.15 ? Math.floor(rand() * (daysBack * 0.6)) : 0;
+    const appearedAt = new Date(rangeStart);
+    appearedAt.setDate(appearedAt.getDate() + daysBeforeAppearance);
+
+    const history: NodeTemporalState[] = [];
+    let omega = node.omegaFragility.composite;
+    const baseProfile = { ...node.omegaFragility };
+
+    // Walk day by day from appearance to now
+    const cursor = new Date(appearedAt);
+    while (cursor <= rangeEnd) {
+      // Random walk on omega — mean-reverting to base
+      const drift = (node.omegaFragility.composite - omega) * 0.05;
+      const noise = (rand() - 0.5) * 0.3;
+      omega = Math.max(0, Math.min(10, omega + drift + noise));
+
+      const profileScale = omega / Math.max(0.1, node.omegaFragility.composite);
+      history.push({
+        timestamp: cursor.getTime(),
+        omegaComposite: Math.round(omega * 100) / 100,
+        omegaProfile: {
+          composite: Math.round(omega * 100) / 100,
+          substitutionFriction:
+            Math.round(baseProfile.substitutionFriction * profileScale * 100) / 100,
+          downstreamLoad:
+            Math.round(baseProfile.downstreamLoad * profileScale * 100) / 100,
+          cascadingVoltage:
+            Math.round(baseProfile.cascadingVoltage * profileScale * 100) / 100,
+          existentialTailWeight:
+            Math.round(baseProfile.existentialTailWeight * profileScale * 100) / 100,
+        },
+      });
+
+      cursor.setDate(cursor.getDate() + 1);
+    }
+
+    nodeMap.set(node.id, { nodeId: node.id, appearedAt, history });
+  }
+
+  // Place events across the timeline
+  const events: TemporalEvent[] = [];
+  const eventCount = Math.min(EVENT_TEMPLATES.length, Math.floor(daysBack / 8));
+  const usedTemplates = EVENT_TEMPLATES.slice(0, eventCount);
+
+  for (let i = 0; i < usedTemplates.length; i++) {
+    const t = usedTemplates[i];
+    const dayOffset = Math.floor(((i + 1) / (eventCount + 1)) * daysBack);
+    const eventDate = new Date(rangeStart);
+    eventDate.setDate(eventDate.getDate() + dayOffset);
+
+    events.push({ ...t, id: `evt-${i}`, date: eventDate });
+
+    // Apply event impact to affected nodes
+    for (const nodeId of t.affectedNodeIds) {
+      const nodeData = nodeMap.get(nodeId);
+      if (!nodeData) continue;
+
+      // Bump omega scores around the event date
+      for (const snap of nodeData.history) {
+        const snapDate = new Date(snap.timestamp);
+        const daysDiff = Math.abs(
+          (snapDate.getTime() - eventDate.getTime()) / 86400000,
+        );
+        if (daysDiff < 7) {
+          const impact = t.severity * (1 - daysDiff / 7) * 1.5;
+          snap.omegaComposite = Math.min(10, snap.omegaComposite + impact);
+          snap.omegaProfile.composite = snap.omegaComposite;
+        }
+      }
+    }
+  }
+
+  return { nodes: nodeMap, events, rangeStart, rangeEnd };
+}
+
+// ─── Query Helpers ──────────────────────────────────────────────
+
+/** Get the node state at a specific point in time (nearest preceding snapshot) */
+export function getNodeStateAt(
+  temporal: TemporalNodeData,
+  timestamp: number,
+): NodeTemporalState | null {
+  if (temporal.history.length === 0) return null;
+  if (timestamp < temporal.appearedAt.getTime()) return null;
+
+  // Binary search for nearest snapshot <= timestamp
+  let lo = 0;
+  let hi = temporal.history.length - 1;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if (temporal.history[mid].timestamp <= timestamp) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return temporal.history[lo];
+}
+
+/** Get all nodes that existed at a given timestamp */
+export function getVisibleNodesAt(
+  dataset: TemporalDataset,
+  timestamp: number,
+): string[] {
+  const visible: string[] = [];
+  for (const [nodeId, data] of dataset.nodes) {
+    if (data.appearedAt.getTime() <= timestamp) {
+      visible.push(nodeId);
+    }
+  }
+  return visible;
+}
+
+/** Get events in a date range */
+export function getEventsInRange(
+  dataset: TemporalDataset,
+  start: number,
+  end: number,
+): TemporalEvent[] {
+  return dataset.events.filter(
+    (e) => e.date.getTime() >= start && e.date.getTime() <= end,
+  );
+}

--- a/src/lib/useReplayTick.ts
+++ b/src/lib/useReplayTick.ts
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useRef, useEffect } from "react";
 import { useFrame } from "@react-three/fiber";
 import { useApexStore } from "@/stores/useApexStore";
 
@@ -35,4 +35,58 @@ export function useReplayTick() {
       }
     }
   });
+}
+
+/**
+ * DOM-based replay tick driver using requestAnimationFrame.
+ * Works outside of R3F Canvas — use in 2D views.
+ */
+export function useReplayTickDOM() {
+  const lastTimeRef = useRef(0);
+  const accumulator = useRef(0);
+
+  useEffect(() => {
+    let raf: number;
+
+    const tick = (time: number) => {
+      const state = useApexStore.getState();
+      if (!state.replayActive || !state.replayPlaying) {
+        accumulator.current = 0;
+        lastTimeRef.current = time;
+        raf = requestAnimationFrame(tick);
+        return;
+      }
+
+      const delta = lastTimeRef.current ? (time - lastTimeRef.current) / 1000 : 0;
+      lastTimeRef.current = time;
+
+      const epochs =
+        state.activeTimeline === "baseline"
+          ? state.baselineEpochs
+          : state.interventionEpochs;
+      const maxEpoch = epochs.length - 1;
+      if (maxEpoch <= 0) {
+        raf = requestAnimationFrame(tick);
+        return;
+      }
+
+      accumulator.current += delta * 1000;
+      const interval = BASE_INTERVAL_MS / state.replaySpeed;
+
+      if (accumulator.current >= interval) {
+        accumulator.current -= interval;
+        const nextEpoch = state.currentEpoch + 1;
+        if (nextEpoch > maxEpoch) {
+          useApexStore.setState({ replayPlaying: false });
+        } else {
+          useApexStore.setState({ currentEpoch: nextEpoch });
+        }
+      }
+
+      raf = requestAnimationFrame(tick);
+    };
+
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, []);
 }

--- a/src/stores/useApexStore.ts
+++ b/src/stores/useApexStore.ts
@@ -37,6 +37,8 @@ import { mergeGraphs } from "@/lib/import/merge";
 import { MAIN_GRAPH, EMPTY_GRAPH } from "@/lib/graph-data";
 import { simulateCascade } from "@/lib/cascade-simulator";
 import type { LLMProvider } from "@/lib/llm-providers";
+import type { TimeGranularity, TemporalDataset } from "@/lib/temporal-data";
+import { generateTemporalData } from "@/lib/temporal-data";
 
 interface ApexState {
   // Module navigation
@@ -160,6 +162,19 @@ interface ApexState {
   stepEpoch: (delta: number) => void;
   setActiveTimeline: (id: TimelineId) => void;
   branchFromCurrentEpoch: () => void;
+
+  // Timeline / Time Dial
+  timelinePosition: number; // ms timestamp of currently selected point
+  timelineRange: { start: number; end: number }; // viewable range as ms timestamps
+  isLive: boolean; // whether following real-time
+  timelineGranularity: TimeGranularity;
+  temporalData: TemporalDataset | null;
+  setTimelinePosition: (ts: number) => void;
+  setTimelineRange: (range: { start: number; end: number }) => void;
+  setIsLive: (live: boolean) => void;
+  setTimelineGranularity: (g: TimeGranularity) => void;
+  initTemporalData: () => void;
+  goLive: () => void;
 }
 
 export const useApexStore = create<ApexState>((set) => ({
@@ -542,4 +557,49 @@ export const useApexStore = create<ApexState>((set) => ({
         replayPlaying: true,
       };
     }),
+
+  // Timeline / Time Dial
+  timelinePosition: Date.now(),
+  timelineRange: {
+    start: Date.now() - 60 * 24 * 60 * 60 * 1000, // 60 days ago
+    end: Date.now(),
+  },
+  isLive: true,
+  timelineGranularity: "day",
+  temporalData: null,
+
+  setTimelinePosition: (ts) =>
+    set({ timelinePosition: ts, isLive: false }),
+
+  setTimelineRange: (range) =>
+    set({ timelineRange: range }),
+
+  setIsLive: (live) =>
+    set((s) => ({
+      isLive: live,
+      ...(live ? { timelinePosition: s.timelineRange.end } : {}),
+    })),
+
+  setTimelineGranularity: (g) =>
+    set({ timelineGranularity: g }),
+
+  initTemporalData: () =>
+    set((s) => {
+      if (s.temporalData) return s;
+      const data = generateTemporalData(s.graphData.nodes, 60);
+      return {
+        temporalData: data,
+        timelineRange: {
+          start: data.rangeStart.getTime(),
+          end: data.rangeEnd.getTime(),
+        },
+        timelinePosition: data.rangeEnd.getTime(),
+      };
+    }),
+
+  goLive: () =>
+    set((s) => ({
+      isLive: true,
+      timelinePosition: s.timelineRange.end,
+    })),
 }));


### PR DESCRIPTION
## Summary
- **New TimeDial component** — persistent timeline bar at the bottom of the workspace that operates in two modes: historical time scrubbing (with temporal data, event markers, granularity selector) and cascade simulation playback
- **Unified replay controls** — cascade replays now drive the TimeDial playhead instead of rendering as a separate floating panel (ReplayControls removed from CausalDAG3D)
- **2D graph epoch awareness** — CausalDAG2D now responds to cascade replay with node contraction toward activated neighbors, shock glow effects, and edge propagation signal visualization
- **DOM-based replay tick** — new `useReplayTickDOM` hook enables cascade playback in 2D view (outside R3F Canvas)

## New files
- `src/components/TimeDial.tsx` — dual-mode timeline (historical scrub + cascade replay)
- `src/lib/temporal-data.ts` — synthetic historical omega score evolution with events
- `src/hooks/useTemporalGraph.ts` — time-filtered graph snapshot hook

## Test plan
- [ ] Verify TimeDial renders at bottom of workspace with historical timeline, event dots, and LIVE button
- [ ] Inject a shock via Pareto panel → verify ▶ CASCADE button appears in TimeDial
- [ ] Start cascade → verify TimeDial switches to amber cascade mode with transport controls, epoch counter, Ω-buffer bar
- [ ] Scrub the cascade timeline → verify epoch changes and graph updates
- [ ] Switch to 2D view during cascade → verify nodes show shock glow and contraction
- [ ] Stop cascade (STOP or Escape) → verify TimeDial returns to historical mode
- [ ] Test keyboard shortcuts: Space (play/pause), Left/Right (step), [ ] (speed), B (branch), Escape (stop)
- [ ] Verify Vercel preview deployment builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)