### PR TITLE
Dynamic temporal edges — links change as timeline scrubs

### DIFF
--- a/src/hooks/useFilteredGraph.ts
+++ b/src/hooks/useFilteredGraph.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { useApexStore } from "@/stores/useApexStore";
+import { useTemporalGraph } from "./useTemporalGraph";
 import type { CausalGraph } from "@/lib/types";
 
 /**
@@ -13,11 +14,16 @@ const DOMAIN_MAP: Record<string, string[]> = {
 
 /**
  * Returns graph data filtered to only the domains selected in the
- * DomainSelector. If no domains are selected, returns the full graph.
+ * DomainSelector. Uses temporal graph data when timeline is scrubbed
+ * (non-live), so edges/nodes reflect their historical state.
  */
 export function useFilteredGraph(): CausalGraph {
-  const graphData = useApexStore((s) => s.graphData);
+  const baseGraphData = useApexStore((s) => s.graphData);
   const selectedDomains = useApexStore((s) => s.selectedDomains);
+  const { graph: temporalGraph, isTemporalActive } = useTemporalGraph();
+
+  // Use temporal graph when available and scrubbed; fall back to base
+  const graphData = isTemporalActive ? temporalGraph : baseGraphData;
 
   return useMemo(() => {
     // No filter active — show everything

--- a/src/hooks/useTemporalGraph.ts
+++ b/src/hooks/useTemporalGraph.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { useApexStore } from "@/stores/useApexStore";
-import { getNodeStateAt, getVisibleNodesAt, getEventsInRange } from "@/lib/temporal-data";
-import type { CausalGraph, CausalNode, CausalEdge, OmegaFragilityProfile } from "@/lib/types";
+import { getNodeStateAt, getEdgeStateAt, getVisibleNodesAt, getEventsInRange } from "@/lib/temporal-data";
+import type { CausalGraph, CausalNode, CausalEdge } from "@/lib/types";
 import type { TemporalEvent } from "@/lib/temporal-data";
 
 export interface TemporalGraphSnapshot {
@@ -16,7 +16,7 @@ export interface TemporalGraphSnapshot {
 /**
  * Hook that returns a transformed graph based on the current timeline position.
  * When isLive is true, returns the original graph unmodified.
- * When scrubbed to a past position, adjusts omega scores and filters nodes.
+ * When scrubbed to a past position, adjusts omega scores, edge weights, and filters nodes.
  */
 export function useTemporalGraph(): TemporalGraphSnapshot {
   const graphData = useApexStore((s) => s.graphData);
@@ -57,10 +57,29 @@ export function useTemporalGraph(): TemporalGraphSnapshot {
 
     const visibleNodeIds = new Set(transformedNodes.map((n) => n.id));
 
-    // Filter edges to only include those between visible nodes
-    const transformedEdges: CausalEdge[] = graphData.edges.filter(
-      (e) => visibleNodeIds.has(e.source) && visibleNodeIds.has(e.target),
-    );
+    // Transform edges — apply temporal weight/confidence/stress changes
+    const transformedEdges: CausalEdge[] = graphData.edges
+      .filter((e) => visibleNodeIds.has(e.source) && visibleNodeIds.has(e.target))
+      .map((edge) => {
+        const edgeData = temporalData.edges.get(edge.id);
+        if (!edgeData) return edge;
+
+        const state = getEdgeStateAt(edgeData, ts);
+        if (!state) return edge;
+
+        // Apply temporal state to edge properties
+        return {
+          ...edge,
+          weight: state.weight,
+          confidence: state.confidence,
+          // When strained, reclassify as "temporal" type to show animated dashes
+          type: state.isStrained && edge.type === "directed"
+            ? ("temporal" as const)
+            : edge.type,
+          // Mark edges under high stress as inconsistent (visual: red dashed)
+          isInconsistent: state.stressSignal > 0.8 ? true : edge.isInconsistent,
+        };
+      });
 
     const graph: CausalGraph = {
       nodes: transformedNodes,

--- a/src/lib/temporal-data.ts
+++ b/src/lib/temporal-data.ts
@@ -1,4 +1,4 @@
-import type { CausalNode, OmegaFragilityProfile } from "./types";
+import type { CausalNode, CausalEdge, OmegaFragilityProfile } from "./types";
 
 // ─── Temporal Types ──────────────────────────────────────────────
 export type TimeGranularity = "hour" | "day" | "week" | "month";
@@ -26,8 +26,23 @@ export interface TemporalNodeData {
   history: NodeTemporalState[];
 }
 
+/** Edge state at a point in time — derived from connected node stress levels */
+export interface EdgeTemporalState {
+  timestamp: number;
+  weight: number;        // dynamic weight (0-1) modulated by node stress
+  confidence: number;    // dynamic confidence (0-1)
+  stressSignal: number;  // 0-1 stress propagation intensity through this edge
+  isStrained: boolean;   // true when connected nodes are under high stress
+}
+
+export interface TemporalEdgeData {
+  edgeId: string;
+  history: EdgeTemporalState[];
+}
+
 export interface TemporalDataset {
   nodes: Map<string, TemporalNodeData>;
+  edges: Map<string, TemporalEdgeData>;
   events: TemporalEvent[];
   rangeStart: Date;
   rangeEnd: Date;
@@ -97,6 +112,7 @@ const EVENT_TEMPLATES: Omit<TemporalEvent, "id" | "date">[] = [
 // ─── Generator ──────────────────────────────────────────────────
 export function generateTemporalData(
   nodes: CausalNode[],
+  edges: CausalEdge[],
   daysBack: number = 60,
 ): TemporalDataset {
   const rand = seededRandom(42);
@@ -185,7 +201,54 @@ export function generateTemporalData(
     }
   }
 
-  return { nodes: nodeMap, events, rangeStart, rangeEnd };
+  // ── Generate temporal edge states ──
+  // Edge weight/confidence/stress are derived from connected node omega over time
+  const edgeMap = new Map<string, TemporalEdgeData>();
+
+  for (const edge of edges) {
+    const sourceNode = nodeMap.get(edge.source);
+    const targetNode = nodeMap.get(edge.target);
+    if (!sourceNode || !targetNode) continue;
+
+    const edgeHistory: EdgeTemporalState[] = [];
+    const baseWeight = edge.weight;
+    const baseConfidence = edge.confidence;
+
+    // Walk through timestamps — use source node's history as time axis
+    for (const srcSnap of sourceNode.history) {
+      const ts = srcSnap.timestamp;
+      const tgtSnap = getNodeStateAt(targetNode, ts);
+      if (!tgtSnap) continue;
+
+      // Stress signal: average of how far both nodes deviate from their baselines
+      const srcStress = Math.max(0, (srcSnap.omegaComposite - 5) / 5); // 0-1 when omega > 5
+      const tgtStress = Math.max(0, (tgtSnap.omegaComposite - 5) / 5);
+      const avgStress = (srcStress + tgtStress) / 2;
+
+      // When nodes are stressed, edge weight increases (more load on the link)
+      // but confidence drops (higher uncertainty under stress)
+      const stressMultiplier = 1 + avgStress * 0.4; // up to 1.4x weight
+      const confidenceDrop = 1 - avgStress * 0.3;   // down to 0.7x confidence
+
+      const dynamicWeight = Math.min(1, baseWeight * stressMultiplier);
+      const dynamicConfidence = Math.max(0.2, baseConfidence * confidenceDrop);
+
+      // Stress signal for rendering (opacity/glow effects)
+      const stressSignal = Math.min(1, avgStress * 1.2);
+
+      edgeHistory.push({
+        timestamp: ts,
+        weight: Math.round(dynamicWeight * 1000) / 1000,
+        confidence: Math.round(dynamicConfidence * 1000) / 1000,
+        stressSignal: Math.round(stressSignal * 1000) / 1000,
+        isStrained: avgStress > 0.5,
+      });
+    }
+
+    edgeMap.set(edge.id, { edgeId: edge.id, history: edgeHistory });
+  }
+
+  return { nodes: nodeMap, edges: edgeMap, events, rangeStart, rangeEnd };
 }
 
 // ─── Query Helpers ──────────────────────────────────────────────
@@ -224,6 +287,27 @@ export function getVisibleNodesAt(
     }
   }
   return visible;
+}
+
+/** Get the edge state at a specific point in time */
+export function getEdgeStateAt(
+  temporal: TemporalEdgeData,
+  timestamp: number,
+): EdgeTemporalState | null {
+  if (temporal.history.length === 0) return null;
+
+  // Binary search for nearest snapshot <= timestamp
+  let lo = 0;
+  let hi = temporal.history.length - 1;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if (temporal.history[mid].timestamp <= timestamp) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return temporal.history[lo].timestamp <= timestamp ? temporal.history[lo] : null;
 }
 
 /** Get events in a date range */

--- a/src/stores/useApexStore.ts
+++ b/src/stores/useApexStore.ts
@@ -622,7 +622,7 @@ export const useApexStore = create<ApexState>((set) => ({
   initTemporalData: () =>
     set((s) => {
       if (s.temporalData) return s;
-      const data = generateTemporalData(s.graphData.nodes, 60);
+      const data = generateTemporalData(s.graphData.nodes, s.graphData.edges, 60);
       return {
         temporalData: data,
         timelineRange: {


### PR DESCRIPTION
## Summary
- **Root cause fix**: `useFilteredGraph` was reading static store data, completely bypassing temporal transforms — edges never changed when scrubbing the timeline
- **Temporal edge states**: Each edge now has a full temporal history (weight, confidence, stressSignal) derived from connected node omega stress levels
- **Visual changes on scrub**: As you move the timeline slider, edges dynamically change width (stress increases weight), become animated/dashed when strained, and turn red when stress exceeds threshold

## Test plan
- [ ] Scrub timeline slider — edges should visibly change thickness and animation style
- [ ] Move to event markers — edges near affected nodes should show increased stress (wider, animated)
- [ ] Verify 2D and 3D views both reflect temporal edge changes
- [ ] Toggle RAW/VERIFIED filter — Tarski flags should still work alongside temporal transforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)