### PR TITLE
fix: dynamic Tarski copilot responses

### DIFF
--- a/src/components/SystemCopilot.tsx
+++ b/src/components/SystemCopilot.tsx
@@ -74,6 +74,7 @@ export default function SystemCopilot() {
     setIsComputeLoading,
     baselineEpochs,
     currentEpoch,
+    tarskiReport,
   } = useApexStore();
 
   // Copilot always uses Gemini; Claude key is for compute only
@@ -290,6 +291,7 @@ export default function SystemCopilot() {
           ablatedNodeIds,
           ablatedEdgeIds,
           snapshotContext,
+          tarskiReport,
         });
 
         const reader = stream.getReader();
@@ -353,7 +355,7 @@ export default function SystemCopilot() {
     if (isLlmActive) {
       handleStreamingQuery(userContent);
     } else {
-      const responses = processAction(action, graphData);
+      const responses = processAction(action, graphData, tarskiReport);
       responses.forEach((msg) => addCopilotMessage(msg));
     }
   };

--- a/src/lib/__tests__/copilot-engine.test.ts
+++ b/src/lib/__tests__/copilot-engine.test.ts
@@ -60,10 +60,27 @@ describe("processAction", () => {
     expect(msgs[0].content).toContain(String(graph.metadata.totalEdges));
   });
 
+  it("DISCOVER_STRUCTURE includes dynamic cascade chains", () => {
+    const msgs = processAction("DISCOVER_STRUCTURE", richGraph());
+    // Should reference actual node labels, not hardcoded ones
+    expect(msgs[0].content).toContain("TSM");
+  });
+
   it("EXPLAIN_REJECTION returns Tarski module output", () => {
     const msgs = processAction("EXPLAIN_REJECTION", richGraph());
     expect(msgs[0].module).toBe("tarski");
     expect(msgs[0].content).toContain("TARSKI");
+  });
+
+  it("EXPLAIN_REJECTION uses dynamic Tarski data", () => {
+    const msgs = processAction("EXPLAIN_REJECTION", richGraph());
+    const content = msgs[0].content;
+    // Should contain detected counts from validation, not hardcoded text
+    expect(content).toContain("inconsistent edge(s)");
+    expect(content).toContain("node(s)");
+    // Should NOT contain old hardcoded references
+    expect(content).not.toContain("N. Virginia Hub");
+    expect(content).not.toContain("Fed Swap Lines");
   });
 
   it("VERIFY_LOGIC returns Pearl module output", () => {
@@ -71,6 +88,13 @@ describe("processAction", () => {
     expect(msgs[0].module).toBe("pearl");
     expect(msgs[0].content).toContain("PEARL");
     expect(msgs[0].content).toContain("do-calculus");
+  });
+
+  it("VERIFY_LOGIC includes dynamic intervention targets", () => {
+    const msgs = processAction("VERIFY_LOGIC", richGraph());
+    const content = msgs[0].content;
+    // Should reference actual graph nodes
+    expect(content).toContain("TSM");
   });
 
   it("all messages have valid IDs and timestamps", () => {
@@ -139,6 +163,15 @@ describe("processQuery", () => {
     const msgs = processQuery("risk propagation paths", richGraph());
     expect(msgs[0].content).toContain("Risk propagation");
     expect(msgs[0].module).toBe("spirtes");
+  });
+
+  it("risk query includes dynamic cascade chains from graph", () => {
+    const msgs = processQuery("risk propagation", richGraph());
+    const content = msgs[0].content;
+    // Should reference actual graph nodes, not hardcoded chains
+    expect(content).toContain("TSM");
+    expect(content).not.toContain("ZEISS Optics");
+    expect(content).not.toContain("Baotou Rare Earth");
   });
 
   it("routes COUNTERFACTUAL keyword to Pearl engine", () => {

--- a/src/lib/copilot-context.ts
+++ b/src/lib/copilot-context.ts
@@ -1,6 +1,7 @@
 import { CausalGraph, CausalNode, CausalEdge } from "./types";
 import type { SystemStateSnapshot } from "./snapshots/types";
 import { diffSnapshots } from "./snapshots/diff";
+import { TarskiValidationReport, AXIOM_LIBRARY } from "./tarski-data";
 
 interface ContextOptions {
   selectedNode: string | null;
@@ -11,6 +12,7 @@ interface ContextOptions {
   ablationMode?: boolean;
   ablatedNodeIds?: string[];
   ablatedEdgeIds?: string[];
+  tarskiReport?: TarskiValidationReport | null;
 }
 
 const MAX_ADJACENCY_NODES = 30;
@@ -171,6 +173,37 @@ export function serializeGraphContext(
       (e) => !opts.ablatedEdgeIds?.includes(e.id) && !opts.ablatedNodeIds?.includes(e.source) && !opts.ablatedNodeIds?.includes(e.target)
     );
     lines.push(`Post-ablation: ${remainingNodes.length} nodes, ${remainingEdges.length} edges`);
+  }
+
+  // Tarski validation report
+  if (opts.tarskiReport && opts.tarskiReport.proofTraces.length > 0) {
+    lines.push("");
+    lines.push("=== TARSKI VALIDATION ===");
+    lines.push(
+      `Inconsistent edges: ${opts.tarskiReport.inconsistentEdgeIds.size} | ` +
+        `Restricted nodes: ${opts.tarskiReport.restrictedNodeIds.size} | ` +
+        `Proof traces: ${opts.tarskiReport.proofTraces.length}`
+    );
+    for (const trace of opts.tarskiReport.proofTraces.slice(0, 15)) {
+      const edge = graph.edges.find((e) => e.id === trace.edgeId);
+      if (edge) {
+        const src = graph.nodes.find((n) => n.id === edge.source);
+        const tgt = graph.nodes.find((n) => n.id === edge.target);
+        const axiomNames = trace.violatedAxioms
+          .map((id) => {
+            const ax = AXIOM_LIBRARY.find((a) => a.id === id);
+            return ax ? `${ax.name} (${id}, L${ax.level})` : id;
+          })
+          .join(", ");
+        lines.push(
+          `${src?.shortLabel ?? edge.source} → ${tgt?.shortLabel ?? edge.target} ` +
+            `[${trace.verdict}] axioms: ${axiomNames}`
+        );
+      }
+    }
+    if (opts.tarskiReport.proofTraces.length > 15) {
+      lines.push(`(${opts.tarskiReport.proofTraces.length - 15} more traces omitted)`);
+    }
   }
 
   return lines.join("\n");

--- a/src/lib/copilot-engine.ts
+++ b/src/lib/copilot-engine.ts
@@ -1,5 +1,6 @@
 import { CopilotMessage, ModuleId, CausalGraph } from "./types";
 import { serializeGraphContext } from "./copilot-context";
+import { runTarskiValidation, TarskiValidationReport, AXIOM_LIBRARY } from "./tarski-data";
 
 let msgCounter = 0;
 
@@ -17,6 +18,61 @@ function makeMsg(
   };
 }
 
+// ─── Helpers ──────────────────────────────────────────────────────
+
+function getAxiomName(axiomId: string): string {
+  return AXIOM_LIBRARY.find((a) => a.id === axiomId)?.name ?? axiomId;
+}
+
+function getAxiomLevel(axiomId: string): number {
+  return AXIOM_LIBRARY.find((a) => a.id === axiomId)?.level ?? -1;
+}
+
+const LEVEL_LABELS: Record<number, string> = {
+  0: "Physical Laws",
+  1: "Regulatory / Geopolitical",
+  2: "Heuristic",
+};
+
+/** Build a cascade chain string from a starting node, walking outbound edges. */
+function traceCascadePath(graph: CausalGraph, startId: string, maxDepth = 5): string[] {
+  const path: string[] = [];
+  const visited = new Set<string>();
+  let current = startId;
+
+  for (let i = 0; i < maxDepth; i++) {
+    const node = graph.nodes.find((n) => n.id === current);
+    if (!node || visited.has(current)) break;
+    visited.add(current);
+    path.push(node.shortLabel || node.label);
+
+    // Follow the highest-weight outbound edge
+    const outEdges = graph.edges
+      .filter((e) => e.source === current && !e.isSevered)
+      .sort((a, b) => b.weight - a.weight);
+    if (outEdges.length === 0) break;
+    current = outEdges[0].target;
+  }
+
+  return path;
+}
+
+/** Get top cascade chains from the graph's highest-omega root nodes. */
+function getTopCascadeChains(graph: CausalGraph, count = 3): string[] {
+  const topNodes = [...graph.nodes]
+    .sort((a, b) => b.omegaFragility.composite - a.omegaFragility.composite)
+    .slice(0, count);
+
+  return topNodes
+    .map((n) => {
+      const path = traceCascadePath(graph, n.id);
+      return path.length >= 2 ? path.join(" \u2192 ") : null;
+    })
+    .filter((p): p is string => p !== null);
+}
+
+// ─── Actions ──────────────────────────────────────────────────────
+
 export type CopilotAction =
   | "DISCOVER_STRUCTURE"
   | "EXPLAIN_REJECTION"
@@ -24,7 +80,8 @@ export type CopilotAction =
 
 export function processAction(
   action: CopilotAction,
-  graph: CausalGraph
+  graph: CausalGraph,
+  tarskiReport?: TarskiValidationReport | null
 ): CopilotMessage[] {
   const domains = [...new Set(graph.nodes.map((n) => n.domain))];
   const topNode = [...graph.nodes].sort(
@@ -32,7 +89,12 @@ export function processAction(
   )[0];
 
   switch (action) {
-    case "DISCOVER_STRUCTURE":
+    case "DISCOVER_STRUCTURE": {
+      const chains = getTopCascadeChains(graph);
+      const chainsText = chains.length > 0
+        ? `Cross-domain cascades detected: ${chains.join(", ")}.\n\n`
+        : "";
+
       return [
         makeMsg(
           "assistant",
@@ -46,42 +108,117 @@ export function processAction(
             `  \u2022 DCD/NOTEARS \u2014 nonlinear structural\n` +
             `  \u2022 PCMCI+ \u2014 temporal lag analysis\n` +
             `  \u2022 FCI \u2014 latent confounding detection\n\n` +
-            `Cross-domain cascades detected: EUV \u2192 AI Compute, Rare Earth \u2192 HVDC \u2192 Grid \u2192 Data Centers, Undersea Cables \u2192 Dollar Funding.\n\n` +
+            chainsText +
             `Structure locked. Awaiting Tarski verification pass.`,
           "spirtes"
         ),
       ];
+    }
 
-    case "EXPLAIN_REJECTION":
+    case "EXPLAIN_REJECTION": {
+      // Run Tarski validation dynamically if not provided
+      const report = tarskiReport ?? runTarskiValidation(graph);
+
+      // Group proof traces by axiom level
+      const byLevel = new Map<number, { edgeId: string; axioms: string[]; verdict: string }[]>();
+      for (const trace of report.proofTraces) {
+        for (const axiomId of trace.violatedAxioms) {
+          const level = getAxiomLevel(axiomId);
+          if (!byLevel.has(level)) byLevel.set(level, []);
+          byLevel.get(level)!.push({
+            edgeId: trace.edgeId,
+            axioms: trace.violatedAxioms,
+            verdict: trace.verdict,
+          });
+        }
+      }
+
+      // Build detail lines
+      let detailText = "";
+      for (const [level, traces] of [...byLevel.entries()].sort((a, b) => a[0] - b[0])) {
+        const levelLabel = LEVEL_LABELS[level] ?? `Level ${level}`;
+        // Deduplicate by edgeId within this level
+        const seen = new Set<string>();
+        const uniqueTraces = traces.filter((t) => {
+          if (seen.has(t.edgeId)) return false;
+          seen.add(t.edgeId);
+          return true;
+        });
+
+        detailText += `${levelLabel}:\n`;
+        for (const trace of uniqueTraces.slice(0, 5)) {
+          const edge = graph.edges.find((e) => e.id === trace.edgeId);
+          if (edge) {
+            const src = graph.nodes.find((n) => n.id === edge.source);
+            const tgt = graph.nodes.find((n) => n.id === edge.target);
+            const axiomNames = trace.axioms.map((a) => `${getAxiomName(a)} (${a})`).join(", ");
+            detailText += `  \u2022 ${src?.shortLabel ?? edge.source} \u2194 ${tgt?.shortLabel ?? edge.target} \u2014 ${axiomNames}\n`;
+          }
+        }
+        if (uniqueTraces.length > 5) {
+          detailText += `  ... and ${uniqueTraces.length - 5} more\n`;
+        }
+        detailText += "\n";
+      }
+
+      // Restricted nodes summary
+      let restrictedText = "";
+      if (report.restrictedNodeIds.size > 0) {
+        const restrictedNodes = graph.nodes.filter((n) => report.restrictedNodeIds.has(n.id));
+        const top5 = restrictedNodes
+          .sort((a, b) => b.omegaFragility.composite - a.omegaFragility.composite)
+          .slice(0, 5);
+        restrictedText = `Restricted nodes: ${top5.map((n) => `${n.shortLabel} (\u03A9 ${n.omegaFragility.composite.toFixed(1)})`).join(", ")}`;
+        if (restrictedNodes.length > 5) {
+          restrictedText += ` ... and ${restrictedNodes.length - 5} more`;
+        }
+        restrictedText += "\n\n";
+      }
+
       return [
         makeMsg(
           "assistant",
           `[TARSKI] Truth filter scan complete.\n\n` +
-            `Detected: ${graph.metadata.inconsistentEdges} inconsistent edge(s)\n` +
-            `Restricted: ${graph.metadata.restrictedNodes} node(s)\n\n` +
-            `Inconsistency detail:\n` +
-            `  \u2022 N. Virginia Hub \u2194 Grid Stability \u2014 bidirectional load/supply loop violates DAG acyclicity\n` +
-            `  \u2022 Fed Swap Lines \u2194 FX Swap Basis \u2014 confounded relationship, latent policy variable suspected\n\n` +
+            `Detected: ${report.inconsistentEdgeIds.size} inconsistent edge(s)\n` +
+            `Restricted: ${report.restrictedNodeIds.size} node(s)\n\n` +
+            detailText +
+            restrictedText +
             `Physical constraint violations checked across ${domains.length} domains.\n` +
             `Recommendation: Apply FCI pass to identify hidden common causes. Toggle VERIFIED mode to see restricted edges.`,
           "tarski"
         ),
       ];
+    }
 
-    case "VERIFY_LOGIC":
+    case "VERIFY_LOGIC": {
+      // Build dynamic intervention examples from top-omega nodes
+      const topNodes = [...graph.nodes]
+        .sort((a, b) => b.omegaFragility.composite - a.omegaFragility.composite)
+        .slice(0, 3);
+
+      const interventionLines = topNodes.map((node) => {
+        const path = traceCascadePath(graph, node.id);
+        const omegas = path.map((label) => {
+          const n = graph.nodes.find((nd) => nd.shortLabel === label || nd.label === label);
+          return n ? n.omegaFragility.composite.toFixed(1) : "?";
+        });
+        const cascadeStr = path.join(" \u2192 ");
+        const omegaStr = omegas.join(" \u2192 ");
+        return `  \u2022 do(${node.shortLabel} = 0) \u2192 Expected cascade: ${cascadeStr} (\u03A9 propagation ${omegaStr})`;
+      });
+
       return [
         makeMsg(
           "assistant",
           `[PEARL] Causal logic verification via do-calculus...\n\n` +
             `Testing interventional consistency across ${domains.length} domains:\n` +
-            `  \u2022 do(TSMC CoWoS = 0) \u2192 Expected cascade: AI Compute \u2192 Data Center \u2192 Credit markets (\u03A9 propagation 9.9 \u2192 9.5 \u2192 9.2)\n` +
-            `  \u2022 do(Baotou Refining = embargo) \u2192 NdFeB \u2192 HVDC \u2192 Grid cascade (\u03A9 9.7 \u2192 9.4 \u2192 9.5 \u2192 8.8)\n` +
-            `  \u2022 P(Credit Stress | do(Landing Stations cut)) diverges from observational by \u0394=0.42\n\n` +
-            `Conclusion: Cross-domain causal effects are non-spurious. The DAG structure supports valid interventional reasoning.\n\n` +
+            interventionLines.join("\n") +
+            `\n\nConclusion: Cross-domain causal effects are non-spurious. The DAG structure supports valid interventional reasoning.\n\n` +
             `Pearl Engine status: READY for counterfactual queries.`,
           "pearl"
         ),
       ];
+    }
   }
 }
 
@@ -156,6 +293,11 @@ export function processQuery(
     .slice(0, 5);
 
   if (q.includes("RISK") || q.includes("PROPAGAT")) {
+    const chains = getTopCascadeChains(graph);
+    const chainsText = chains.length > 0
+      ? chains.map((c) => `  ${c}`).join("\n")
+      : "  No multi-hop cascade chains detected.";
+
     return [
       makeMsg(
         "assistant",
@@ -168,10 +310,8 @@ export function processQuery(
             )
             .join("\n") +
           `\n\nKey cross-domain cascade chains:\n` +
-          `  ZEISS Optics \u2192 ASML EUV \u2192 TSMC Fab \u2192 CoWoS \u2192 AI Compute \u2192 Data Centers \u2192 Credit\n` +
-          `  Baotou Rare Earth \u2192 NdFeB \u2192 HVDC \u2192 Grid \u2192 Data Centers\n` +
-          `  Landing Stations \u2192 FX Swap Basis \u2192 UST Repo \u2192 Fed Swap Lines\n\n` +
-          `Total risk exposure: OMEGA-CRITICAL across 8 domains.`,
+          chainsText +
+          `\n\nTotal risk exposure: ${topNodes[0]?.omegaFragility.composite > 9 ? "OMEGA-CRITICAL" : "ELEVATED"} across ${[...new Set(graph.nodes.map((n) => n.domain))].length} domains.`,
         "spirtes"
       ),
     ];
@@ -233,6 +373,7 @@ interface StreamLlmOptions {
   ablatedNodeIds?: string[];
   ablatedEdgeIds?: string[];
   snapshotContext?: string;
+  tarskiReport?: TarskiValidationReport | null;
 }
 
 export async function streamLlmQuery(
@@ -247,6 +388,7 @@ export async function streamLlmQuery(
     ablationMode: opts.ablationMode,
     ablatedNodeIds: opts.ablatedNodeIds,
     ablatedEdgeIds: opts.ablatedEdgeIds,
+    tarskiReport: opts.tarskiReport,
   });
 
   // Append snapshot context if available


### PR DESCRIPTION
## Summary
- Replaced all hardcoded copilot text (old US infra references like "N. Virginia Hub", "ZEISS Optics → ASML EUV") with dynamic output from the actual Tarski validation engine and live graph data
- EXPLAIN_REJECTION now runs `runTarskiValidation()` against the real graph, grouping violations by axiom level (Physical / Regulatory / Heuristic) with actual edge labels
- DISCOVER_STRUCTURE and VERIFY_LOGIC trace real cascade paths from the highest-Ω nodes in the current dataset
- LLM streaming context now includes a `TARSKI VALIDATION` section with proof traces so Gemini answers accurately too

## Test plan
- [x] All 23 copilot-engine tests pass (including new assertions that old hardcoded strings are gone)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Manually verify: load Middle East dataset → click EXPLAIN REJECTION → should show Saudi Aramco / QatarEnergy / QAFCO violations, not old US infra
- [ ] Manually verify: DISCOVER STRUCTURE and VERIFY LOGIC reference actual graph nodes
- [ ] Verify Gemini streaming path also returns accurate Tarski data when API key is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)