### PR TITLE
feat: lasso selection, tooltip sizing, hierarchical DCD layout

### DIFF
--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -12,6 +12,8 @@ import ReactFlow, {
   Handle,
   Position,
   BackgroundVariant,
+  SelectionMode,
+  OnSelectionChangeFunc,
 } from "reactflow";
 import "reactflow/dist/style.css";
 import { motion } from "framer-motion";
@@ -23,25 +25,32 @@ import { useReplayTickDOM } from "@/lib/useReplayTick";
 import type { CausalEdge, EpochSnapshot } from "@/lib/types";
 import { AnimatePresence } from "framer-motion";
 
-function CausalNode2D({ data }: NodeProps) {
+function CausalNode2D({ data, selected }: NodeProps) {
   const { label, category, omegaComposite, isRestricted, domain, datasetColor, shockIntensity } = data;
   const color = datasetColor ?? getCategoryColor(category);
   const isFractured = omegaComposite > 9;
   const isStressed = omegaComposite > 7;
   const shockGlow = shockIntensity ?? 0;
 
+  const selectionGlow = selected
+    ? "0 0 12px #00e5ff80, 0 0 24px #00e5ff40"
+    : "";
+
   return (
     <motion.div
       className="relative px-5 py-3 rounded border font-mono text-[11px] tracking-wider text-center min-w-[120px]"
       style={{
-        borderColor: isRestricted ? "#ff1744" : color,
+        borderColor: selected ? "#00e5ff" : isRestricted ? "#ff1744" : color,
         backgroundColor: `color-mix(in srgb, ${color} ${Math.round(5 + (omegaComposite / 10) * 15)}%, #0a0b10)`,
         color,
-        boxShadow: shockGlow > 0
-          ? `0 0 ${Math.round(shockGlow * 30)}px ${color}80, 0 0 ${Math.round(shockGlow * 15)}px ${color}40, inset 0 0 ${Math.round(shockGlow * 10)}px ${color}30`
-          : omegaComposite > 0
-            ? `0 0 ${Math.round((omegaComposite / 10) * 20)}px ${color}40, inset 0 0 ${Math.round((omegaComposite / 10) * 10)}px ${color}20`
-            : "none",
+        boxShadow: [
+          selectionGlow,
+          shockGlow > 0
+            ? `0 0 ${Math.round(shockGlow * 30)}px ${color}80, 0 0 ${Math.round(shockGlow * 15)}px ${color}40, inset 0 0 ${Math.round(shockGlow * 10)}px ${color}30`
+            : omegaComposite > 0
+              ? `0 0 ${Math.round((omegaComposite / 10) * 20)}px ${color}40, inset 0 0 ${Math.round((omegaComposite / 10) * 10)}px ${color}20`
+              : "",
+        ].filter(Boolean).join(", ") || "none",
       }}
       animate={
         shockGlow > 0.3
@@ -409,6 +418,15 @@ export default function CausalDAG2D() {
   );
 
   const setSelectedNode = useApexStore((s) => s.setSelectedNode);
+  const selectedNodesCount = useApexStore((s) => s.selectedNodes.length);
+  const setSelectedNodes = useApexStore((s) => s.setSelectedNodes);
+
+  const onSelectionChange: OnSelectionChangeFunc = useCallback(
+    ({ nodes: selNodes }) => {
+      setSelectedNodes(selNodes.map((n) => n.id));
+    },
+    [setSelectedNodes]
+  );
 
   const onNodeClick: NodeMouseHandler = useCallback(
     (_event, rfNode) => {
@@ -442,6 +460,10 @@ export default function CausalDAG2D() {
         onNodeClick={onNodeClick}
         onEdgeClick={onEdgeClick}
         onPaneClick={onPaneClick}
+        onSelectionChange={onSelectionChange}
+        selectionMode={SelectionMode.Partial}
+        selectionOnDrag
+        panOnDrag={[1]}
         fitView
         fitViewOptions={{ padding: 0.3 }}
         proOptions={{ hideAttribution: true }}
@@ -453,6 +475,13 @@ export default function CausalDAG2D() {
         <Background variant={BackgroundVariant.Dots} gap={20} size={1} color="#1a1c2e" />
         <Controls showInteractive={false} position="bottom-right" />
       </ReactFlow>
+      {selectedNodesCount > 0 && (
+        <div className="absolute top-3 right-3 z-50 px-3 py-1.5 rounded border border-accent-cyan/40 bg-background/90 backdrop-blur-sm">
+          <span className="text-[10px] font-mono text-accent-cyan">
+            {selectedNodesCount} node{selectedNodesCount !== 1 ? "s" : ""} selected
+          </span>
+        </div>
+      )}
       <AnimatePresence>
         {selectedEdge && (
           <EdgeInspector

--- a/src/components/CausalDAG3D.tsx
+++ b/src/components/CausalDAG3D.tsx
@@ -168,6 +168,86 @@ function ReplayTickDriver() {
   return null;
 }
 
+// Shift+drag rectangle selection — runs inside the R3F Canvas
+function ShiftDragSelect({
+  posMap,
+  graphNodes,
+  onSelect,
+  selectionBoxRef,
+}: {
+  posMap: Record<string, [number, number, number]>;
+  graphNodes: { id: string }[];
+  onSelect: (ids: string[]) => void;
+  selectionBoxRef: React.MutableRefObject<{ x1: number; y1: number; x2: number; y2: number } | null>;
+}) {
+  const { camera, gl, size: canvasSize } = useThree();
+  const dragging = useRef(false);
+  const startRef = useRef({ x: 0, y: 0 });
+
+  useEffect(() => {
+    const canvas = gl.domElement;
+
+    const onDown = (e: PointerEvent) => {
+      if (!e.shiftKey) return;
+      dragging.current = true;
+      const rect = canvas.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      startRef.current = { x, y };
+      selectionBoxRef.current = { x1: x, y1: y, x2: x, y2: y };
+    };
+
+    const onMove = (e: PointerEvent) => {
+      if (!dragging.current) return;
+      const rect = canvas.getBoundingClientRect();
+      const x2 = e.clientX - rect.left;
+      const y2 = e.clientY - rect.top;
+      selectionBoxRef.current = { ...startRef.current, x1: startRef.current.x, y1: startRef.current.y, x2, y2 };
+    };
+
+    const onUp = () => {
+      if (!dragging.current) return;
+      dragging.current = false;
+      const b = selectionBoxRef.current;
+      if (!b) return;
+
+      const minX = Math.min(b.x1, b.x2);
+      const maxX = Math.max(b.x1, b.x2);
+      const minY = Math.min(b.y1, b.y2);
+      const maxY = Math.max(b.y1, b.y2);
+
+      selectionBoxRef.current = null;
+
+      if (maxX - minX < 5 && maxY - minY < 5) return;
+
+      const ids: string[] = [];
+      const vec = new THREE.Vector3();
+      for (const node of graphNodes) {
+        const pos = posMap[node.id];
+        if (!pos) continue;
+        vec.set(pos[0], pos[1], pos[2]).project(camera);
+        const sx = ((vec.x + 1) / 2) * canvasSize.width;
+        const sy = ((-vec.y + 1) / 2) * canvasSize.height;
+        if (sx >= minX && sx <= maxX && sy >= minY && sy <= maxY) {
+          ids.push(node.id);
+        }
+      }
+      onSelect(ids);
+    };
+
+    canvas.addEventListener("pointerdown", onDown);
+    canvas.addEventListener("pointermove", onMove);
+    canvas.addEventListener("pointerup", onUp);
+    return () => {
+      canvas.removeEventListener("pointerdown", onDown);
+      canvas.removeEventListener("pointermove", onMove);
+      canvas.removeEventListener("pointerup", onUp);
+    };
+  }, [gl, graphNodes, posMap, camera, canvasSize, onSelect, selectionBoxRef]);
+
+  return null;
+}
+
 export default function CausalDAG3D() {
   const graphData = useFilteredGraph();
   const {
@@ -178,6 +258,8 @@ export default function CausalDAG3D() {
     setInterventionTarget,
     selectedNode,
     setSelectedNode,
+    selectedNodes: multiSelectedNodes,
+    setSelectedNodes,
     scissorsMode,
     severedEdges,
     severEdge,
@@ -192,6 +274,15 @@ export default function CausalDAG3D() {
     interventionEpochs,
     activeTimeline,
   } = useApexStore();
+
+  const selectionBoxRef = useRef<{ x1: number; y1: number; x2: number; y2: number } | null>(null);
+
+  const handleShiftSelect = useCallback(
+    (ids: string[]) => {
+      setSelectedNodes(ids);
+    },
+    [setSelectedNodes]
+  );
 
   // Derive current snapshot from active timeline
   const replayEpochs = activeTimeline === "baseline" ? baselineEpochs : interventionEpochs;
@@ -462,6 +553,25 @@ export default function CausalDAG3D() {
   return (
     <div style={{ position: "absolute", inset: 0 }}>
       <DAGOverlay />
+      {multiSelectedNodes.length > 0 && (
+        <div
+          style={{
+            position: "absolute",
+            top: 12,
+            right: 12,
+            zIndex: 50,
+            padding: "6px 12px",
+            borderRadius: 4,
+            border: "1px solid rgba(0, 229, 255, 0.4)",
+            background: "rgba(10, 11, 16, 0.9)",
+            backdropFilter: "blur(4px)",
+          }}
+        >
+          <span style={{ fontSize: 10, fontFamily: "monospace", color: "#00e5ff" }}>
+            {multiSelectedNodes.length} node{multiSelectedNodes.length !== 1 ? "s" : ""} selected
+          </span>
+        </div>
+      )}
       <DAGErrorBoundary>
       <Canvas
         key={canvasKey}
@@ -494,7 +604,8 @@ export default function CausalDAG3D() {
 
             const isTarget = interventionTarget === node.id;
             const isRestricted = truthFilter === "verified" && node.isRestricted;
-            const isSelected = selectedNode === node.id;
+            const isMultiSelected = multiSelectedNodes.includes(node.id);
+            const isSelected = selectedNode === node.id || isMultiSelected;
             const isNeighborOfSelected = selectedNeighborNodes.has(node.id);
             const anyNodeSelected = selectedNode !== null;
 
@@ -581,6 +692,12 @@ export default function CausalDAG3D() {
 
           <CameraRig posMap={posMap} />
           <ReplayTickDriver />
+          <ShiftDragSelect
+            posMap={posMap}
+            graphNodes={graphData.nodes}
+            onSelect={handleShiftSelect}
+            selectionBoxRef={selectionBoxRef}
+          />
       </Canvas>
       </DAGErrorBoundary>
     </div>

--- a/src/components/dag3d/DAGNode3D.tsx
+++ b/src/components/dag3d/DAGNode3D.tsx
@@ -190,7 +190,6 @@ export default function DAGNode3D({
           position={[0, size * 1.6 + 1.5, 0]}
           center
           style={{ pointerEvents: "none" }}
-          distanceFactor={35}
         >
           <div
             style={{
@@ -230,7 +229,6 @@ export default function DAGNode3D({
           position={[0, size + (isSelected ? 4.5 : 3), 0]}
           center
           style={{ pointerEvents: "none" }}
-          distanceFactor={40}
         >
           <div
             style={{

--- a/src/components/trinity/DcdGraph.tsx
+++ b/src/components/trinity/DcdGraph.tsx
@@ -1,32 +1,118 @@
 "use client";
 
-import { useMemo } from "react";
-import { getCategoryColor } from "@/lib/graph-data";
+import { useMemo, useState } from "react";
+import { getCategoryColor, getDomainColor } from "@/lib/graph-data";
 import { useApexStore } from "@/stores/useApexStore";
 import { useFilteredGraph } from "@/hooks/useFilteredGraph";
 import { CausalNode, CausalEdge } from "@/lib/types";
 
-function layoutNodes(nodes: CausalNode[]) {
-  const w = 260;
-  const h = 140;
-  const cx = w / 2;
-  const cy = h / 2;
-  const r = Math.min(w, h) * 0.35;
+const SVG_W = 280;
+const SVG_H = 160;
+const PAD_X = 30;
+const PAD_Y = 20;
 
-  return nodes.map((n, i) => {
-    const angle = (2 * Math.PI * i) / nodes.length - Math.PI / 2;
-    return {
-      ...n,
-      x: cx + r * Math.cos(angle),
-      y: cy + r * Math.sin(angle),
-    };
-  });
+/**
+ * Sugiyama-style layered layout: assign layers via longest-path from sources,
+ * then spread nodes vertically within each layer with edge-crossing minimization.
+ */
+function layoutHierarchical(
+  nodes: CausalNode[],
+  edges: CausalEdge[]
+): (CausalNode & { x: number; y: number })[] {
+  if (nodes.length === 0) return [];
+
+  const nodeIds = new Set(nodes.map((n) => n.id));
+  const incoming = new Map<string, string[]>();
+  const outgoing = new Map<string, string[]>();
+  for (const n of nodes) {
+    incoming.set(n.id, []);
+    outgoing.set(n.id, []);
+  }
+  for (const e of edges) {
+    if (nodeIds.has(e.source) && nodeIds.has(e.target)) {
+      outgoing.get(e.source)?.push(e.target);
+      incoming.get(e.target)?.push(e.source);
+    }
+  }
+
+  // Layer assignment via longest path from sources
+  const layer = new Map<string, number>();
+  const sources = nodes.filter((n) => (incoming.get(n.id)?.length ?? 0) === 0);
+
+  // If no true sources (cycle), pick all nodes as potential starts
+  const starts = sources.length > 0 ? sources : nodes;
+
+  // BFS longest path
+  const queue: { id: string; depth: number }[] = starts.map((n) => ({ id: n.id, depth: 0 }));
+  while (queue.length > 0) {
+    const { id, depth } = queue.shift()!;
+    if ((layer.get(id) ?? -1) >= depth) continue;
+    layer.set(id, depth);
+    for (const tgt of outgoing.get(id) ?? []) {
+      queue.push({ id: tgt, depth: depth + 1 });
+    }
+  }
+
+  // Ensure all nodes have a layer (handle disconnected nodes)
+  for (const n of nodes) {
+    if (!layer.has(n.id)) layer.set(n.id, 0);
+  }
+
+  // Group by layer
+  const maxLayer = Math.max(...layer.values(), 0);
+  const layers: string[][] = Array.from({ length: maxLayer + 1 }, () => []);
+  for (const n of nodes) {
+    layers[layer.get(n.id)!].push(n.id);
+  }
+
+  // Simple barycenter ordering to reduce edge crossings
+  for (let pass = 0; pass < 4; pass++) {
+    for (let l = 1; l <= maxLayer; l++) {
+      const bary = new Map<string, number>();
+      for (const id of layers[l]) {
+        const preds = incoming.get(id)?.filter((p) => layer.get(p) === l - 1) ?? [];
+        if (preds.length > 0) {
+          const avgPos = preds.reduce((sum, p) => sum + layers[l - 1].indexOf(p), 0) / preds.length;
+          bary.set(id, avgPos);
+        } else {
+          bary.set(id, layers[l].indexOf(id));
+        }
+      }
+      layers[l].sort((a, b) => (bary.get(a) ?? 0) - (bary.get(b) ?? 0));
+    }
+  }
+
+  // Position: layers flow left→right
+  const colCount = maxLayer + 1;
+  const colWidth = colCount > 1 ? (SVG_W - PAD_X * 2) / (colCount - 1) : 0;
+
+  const nodeMap = new Map(nodes.map((n) => [n.id, n]));
+  const result: (CausalNode & { x: number; y: number })[] = [];
+
+  for (let l = 0; l <= maxLayer; l++) {
+    const col = layers[l];
+    const rowCount = col.length;
+    const rowHeight = rowCount > 1 ? (SVG_H - PAD_Y * 2) / (rowCount - 1) : 0;
+
+    for (let r = 0; r < col.length; r++) {
+      const n = nodeMap.get(col[r])!;
+      result.push({
+        ...n,
+        x: colCount > 1 ? PAD_X + l * colWidth : SVG_W / 2,
+        y: rowCount > 1 ? PAD_Y + r * rowHeight : SVG_H / 2,
+      });
+    }
+  }
+
+  return result;
 }
 
 export default function DcdGraph() {
   const graphData = useFilteredGraph();
   const selectedNode = useApexStore((s) => s.selectedNode);
   const setSelectedNode = useApexStore((s) => s.setSelectedNode);
+  const [hoveredNode, setHoveredNode] = useState<string | null>(null);
+  const [hoveredEdge, setHoveredEdge] = useState<string | null>(null);
 
   const dcdNodes = useMemo(() => {
     return graphData.nodes.filter(
@@ -42,12 +128,28 @@ export default function DcdGraph() {
     );
   }, [graphData.edges, dcdNodes]);
 
-  const positioned = useMemo(() => layoutNodes(dcdNodes), [dcdNodes]);
+  const positioned = useMemo(
+    () => layoutHierarchical(dcdNodes, dcdEdges),
+    [dcdNodes, dcdEdges]
+  );
+
   const posMap = useMemo(() => {
     const m: Record<string, { x: number; y: number }> = {};
-    positioned.forEach((n) => { m[n.id] = { x: n.x, y: n.y }; });
+    positioned.forEach((n) => {
+      m[n.id] = { x: n.x, y: n.y };
+    });
     return m;
   }, [positioned]);
+
+  const hoveredNodeData = useMemo(() => {
+    if (!hoveredNode) return null;
+    return positioned.find((n) => n.id === hoveredNode) ?? null;
+  }, [hoveredNode, positioned]);
+
+  const hoveredEdgeData = useMemo(() => {
+    if (!hoveredEdge) return null;
+    return dcdEdges.find((e) => e.id === hoveredEdge) ?? null;
+  }, [hoveredEdge, dcdEdges]);
 
   if (dcdNodes.length === 0) {
     return (
@@ -71,7 +173,7 @@ export default function DcdGraph() {
         </span>
       </div>
       <svg
-        viewBox="0 0 260 140"
+        viewBox={`0 0 ${SVG_W} ${SVG_H}`}
         className="flex-1 w-full"
         style={{ minHeight: 0 }}
       >
@@ -80,18 +182,45 @@ export default function DcdGraph() {
           const src = posMap[edge.source];
           const tgt = posMap[edge.target];
           if (!src || !tgt) return null;
+          const isHovered = hoveredEdge === edge.id;
           return (
-            <line
-              key={edge.id}
-              x1={src.x}
-              y1={src.y}
-              x2={tgt.x}
-              y2={tgt.y}
-              stroke="#00e5ff"
-              strokeWidth={0.5 + edge.weight}
-              strokeOpacity={0.5}
-              markerEnd="url(#arrow-dcd)"
-            />
+            <g key={edge.id}>
+              <line
+                x1={src.x}
+                y1={src.y}
+                x2={tgt.x}
+                y2={tgt.y}
+                stroke={isHovered ? "#00e5ff" : "#00e5ff"}
+                strokeWidth={isHovered ? 1.5 + edge.weight : 0.5 + edge.weight}
+                strokeOpacity={isHovered ? 0.9 : 0.5}
+                markerEnd="url(#arrow-dcd)"
+              />
+              {/* Wider invisible hit area for hover */}
+              <line
+                x1={src.x}
+                y1={src.y}
+                x2={tgt.x}
+                y2={tgt.y}
+                stroke="transparent"
+                strokeWidth={8}
+                style={{ cursor: "pointer" }}
+                onMouseEnter={() => setHoveredEdge(edge.id)}
+                onMouseLeave={() => setHoveredEdge(null)}
+              />
+              {/* Edge weight label on hover */}
+              {isHovered && (
+                <text
+                  x={(src.x + tgt.x) / 2}
+                  y={(src.y + tgt.y) / 2 - 4}
+                  textAnchor="middle"
+                  fontSize={6}
+                  fill="#00e5ff"
+                  fontFamily="monospace"
+                >
+                  w={edge.weight.toFixed(2)}
+                </text>
+              )}
+            </g>
           );
         })}
 
@@ -100,20 +229,23 @@ export default function DcdGraph() {
           const color = getCategoryColor(node.category);
           const r = 4 + (node.omegaFragility.composite / 10) * 6;
           const isActive = selectedNode === node.id;
+          const isHovered = hoveredNode === node.id;
           return (
             <g
               key={node.id}
               style={{ cursor: "pointer" }}
               onClick={() => setSelectedNode(isActive ? null : node.id)}
+              onMouseEnter={() => setHoveredNode(node.id)}
+              onMouseLeave={() => setHoveredNode(null)}
             >
               <circle
                 cx={node.x}
                 cy={node.y}
                 r={r}
                 fill={isActive ? "#00e5ff" : color}
-                fillOpacity={isActive ? 0.35 : 0.2}
-                stroke={isActive ? "#00e5ff" : color}
-                strokeWidth={isActive ? 2 : 1}
+                fillOpacity={isActive ? 0.35 : isHovered ? 0.3 : 0.2}
+                stroke={isActive ? "#00e5ff" : isHovered ? "#00e5ff" : color}
+                strokeWidth={isActive ? 2 : isHovered ? 1.5 : 1}
               />
               <text
                 x={node.x}
@@ -130,6 +262,80 @@ export default function DcdGraph() {
             </g>
           );
         })}
+
+        {/* Hover tooltip for nodes */}
+        {hoveredNodeData && (
+          <foreignObject
+            x={Math.min(hoveredNodeData.x + 10, SVG_W - 100)}
+            y={Math.max(hoveredNodeData.y - 40, 2)}
+            width={95}
+            height={50}
+          >
+            <div
+              style={{
+                background: "rgba(10, 11, 16, 0.95)",
+                border: "1px solid rgba(0, 229, 255, 0.3)",
+                borderRadius: 3,
+                padding: "3px 5px",
+                fontFamily: "monospace",
+                fontSize: 6,
+                color: "#c8cad0",
+              }}
+            >
+              <div style={{ fontWeight: "bold", fontSize: 7, color: "#fff", marginBottom: 2 }}>
+                {hoveredNodeData.label}
+              </div>
+              <div>
+                <span style={{ color: "#5a5e72" }}>{"\u03A9"} </span>
+                <span style={{ color: "#00e5ff" }}>
+                  {hoveredNodeData.omegaFragility.composite.toFixed(1)}
+                </span>
+              </div>
+              <div style={{ color: getDomainColor(hoveredNodeData.domain), fontSize: 5, marginTop: 1 }}>
+                {hoveredNodeData.domain.toUpperCase()}
+              </div>
+            </div>
+          </foreignObject>
+        )}
+
+        {/* Hover tooltip for edges */}
+        {hoveredEdgeData && (() => {
+          const src = posMap[hoveredEdgeData.source];
+          const tgt = posMap[hoveredEdgeData.target];
+          if (!src || !tgt) return null;
+          const mx = (src.x + tgt.x) / 2;
+          const my = (src.y + tgt.y) / 2;
+          return (
+            <foreignObject
+              x={Math.min(mx + 5, SVG_W - 100)}
+              y={Math.max(my - 30, 2)}
+              width={95}
+              height={40}
+            >
+              <div
+                style={{
+                  background: "rgba(10, 11, 16, 0.95)",
+                  border: "1px solid rgba(0, 229, 255, 0.3)",
+                  borderRadius: 3,
+                  padding: "3px 5px",
+                  fontFamily: "monospace",
+                  fontSize: 6,
+                  color: "#c8cad0",
+                }}
+              >
+                <div style={{ fontSize: 5, color: "#5a5e72" }}>
+                  {hoveredEdgeData.physicalMechanism || "—"}
+                </div>
+                <div style={{ marginTop: 1 }}>
+                  <span style={{ color: "#5a5e72" }}>w=</span>
+                  <span style={{ color: "#00e5ff" }}>{hoveredEdgeData.weight.toFixed(2)}</span>
+                  <span style={{ color: "#5a5e72", marginLeft: 4 }}>conf=</span>
+                  <span style={{ color: "#00e5ff" }}>{(hoveredEdgeData.confidence * 100).toFixed(0)}%</span>
+                </div>
+              </div>
+            </foreignObject>
+          );
+        })()}
 
         {/* Arrow marker */}
         <defs>

--- a/src/stores/useApexStore.ts
+++ b/src/stores/useApexStore.ts
@@ -74,6 +74,10 @@ interface ApexState {
   selectedNode: string | null;
   setSelectedNode: (nodeId: string | null) => void;
 
+  // Multi-selection (lasso/area select)
+  selectedNodes: string[];
+  setSelectedNodes: (nodeIds: string[]) => void;
+
   // Intervention mode
   interventionMode: boolean;
   interventionTarget: string | null;
@@ -236,6 +240,10 @@ export const useApexStore = create<ApexState>((set) => ({
   // Selected node
   selectedNode: null,
   setSelectedNode: (nodeId) => set({ selectedNode: nodeId }),
+
+  // Multi-selection
+  selectedNodes: [],
+  setSelectedNodes: (nodeIds) => set({ selectedNodes: nodeIds }),
 
   // Intervention
   interventionMode: false,


### PR DESCRIPTION
## Summary
- **2D Lasso Selection**: ReactFlow drag-select with `SelectionMode.Partial`, cyan border glow on selected nodes, "N nodes selected" badge. Selection stored in `useApexStore.selectedNodes`.
- **3D Shift+Drag Selection**: Shift+drag rectangle selection via pointer events + screen-space projection. Selected nodes get cyan highlight ring, synced to same store state.
- **Tooltip Distance Fix**: Removed `distanceFactor` from both `<Html>` elements in `DAGNode3D.tsx` so labels and hover cards render at consistent screen-space size regardless of camera depth.
- **DCD Hierarchical Layout**: Replaced circular layout with Sugiyama-style layered DAG — sources on left, sinks on right, barycenter ordering for edge-crossing minimization. Expanded SVG viewBox to 280×160.
- **DCD Interactivity** (Change 4): Hover tooltips on nodes showing Ω composite + domain, hover tooltips on edges showing physicalMechanism + weight + confidence, edge weight labels on hover.

## Test plan
- [ ] Verify 2D drag-select highlights nodes with cyan glow and shows badge
- [ ] Verify 3D Shift+drag selects nodes and shows badge
- [ ] Verify 3D tooltips are consistent size at all zoom levels
- [ ] Verify DCD graph shows left→right causal flow instead of circle
- [ ] Verify DCD node/edge hover tooltips appear correctly
- [ ] Run `npx tsc --noEmit` — passes clean
- [ ] Verify Vercel preview deploy builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)