### PR TITLE
Ollama local LLM + copilot action routing

### DIFF
--- a/src/app/api/copilot/route.ts
+++ b/src/app/api/copilot/route.ts
@@ -14,7 +14,27 @@ Your capabilities:
 
 When the user asks a question, reference the live graph context provided below. Cite specific node names, Ω scores, domains, and edge mechanisms. Be precise, quantitative, and direct. Use the terminal's analytical voice — concise, structured, no fluff.
 
-Format responses with clear structure: use bracketed headers like [ANALYSIS], [RISK], [RECOMMENDATION] when appropriate. Reference specific Ω scores and node labels.`;
+Format responses with clear structure: use bracketed headers like [ANALYSIS], [RISK], [RECOMMENDATION] when appropriate. Reference specific Ω scores and node labels.
+
+IMPORTANT — ACTION COMMANDS:
+You can control the terminal by including ACTION blocks in your response. When the user asks you to do something (select a node, inject a shock, switch modules, filter domains, etc.), include the action in your response using this exact format:
+
+<<<ACTION:action_type:param>>>
+
+Available actions:
+- <<<ACTION:select_node:node_id>>> — Select/focus a node in the graph
+- <<<ACTION:add_shock:shock_id>>> — Inject a preset shock scenario
+- <<<ACTION:remove_shock:shock_id>>> — Remove an active shock
+- <<<ACTION:set_module:spirtes|tarski|pearl|pareto>>> — Switch the active analysis module
+- <<<ACTION:set_view:2d|3d>>> — Switch between 2D and 3D graph views
+- <<<ACTION:sever_edge:edge_id>>> — Sever a causal edge (Pearl intervention)
+- <<<ACTION:reset_severed>>> — Reset all severed edges
+- <<<ACTION:start_replay>>> — Start cascade replay simulation
+- <<<ACTION:stop_replay>>> — Stop cascade replay
+- <<<ACTION:set_truth_filter:raw|verified>>> — Toggle Tarski truth filter
+- <<<ACTION:set_domains:domain1,domain2>>> — Filter to specific domains
+
+You can include multiple actions in a single response. Always explain what you're doing alongside the action. Available shock IDs: hormuz_closure, abqaiq_strike, lng_train_failure, fertilizer_export_ban, phosphate_contamination, gas_grid_overload, food_price_shock.`;
 
 // ─── Anthropic streaming ────────────────────────────────────────
 
@@ -102,19 +122,107 @@ function streamGemini(
   });
 }
 
+// ─── Ollama streaming (local open-source LLM) ──────────────────
+
+function streamOllama(
+  ollamaUrl: string,
+  model: string,
+  fullSystem: string,
+  messages: { role: string; content: string }[],
+): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+
+  return new ReadableStream({
+    async start(controller) {
+      try {
+        const ollamaMessages = [
+          { role: "system", content: fullSystem },
+          ...messages.map((m) => ({
+            role: m.role === "assistant" ? "assistant" : "user",
+            content: m.content,
+          })),
+        ];
+
+        const res = await fetch(`${ollamaUrl}/api/chat`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            model,
+            messages: ollamaMessages,
+            stream: true,
+          }),
+        });
+
+        if (!res.ok) {
+          const errText = await res.text().catch(() => "Ollama request failed");
+          throw new Error(`Ollama error (${res.status}): ${errText}`);
+        }
+
+        if (!res.body) throw new Error("No response body from Ollama");
+
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+
+          // Ollama streams newline-delimited JSON
+          const lines = buffer.split("\n");
+          buffer = lines.pop() ?? "";
+
+          for (const line of lines) {
+            if (!line.trim()) continue;
+            try {
+              const parsed = JSON.parse(line);
+              if (parsed.message?.content) {
+                controller.enqueue(encoder.encode(parsed.message.content));
+              }
+            } catch {
+              // skip malformed JSON lines
+            }
+          }
+        }
+
+        // Process remaining buffer
+        if (buffer.trim()) {
+          try {
+            const parsed = JSON.parse(buffer);
+            if (parsed.message?.content) {
+              controller.enqueue(encoder.encode(parsed.message.content));
+            }
+          } catch {
+            // skip
+          }
+        }
+
+        controller.close();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Ollama stream error";
+        controller.enqueue(encoder.encode(`\n[ERROR: ${message}]`));
+        controller.close();
+      }
+    },
+  });
+}
+
 // ─── Route handler ──────────────────────────────────────────────
 
 export async function POST(req: NextRequest) {
   try {
-    const { messages, systemContext, apiKey, model, provider } = await req.json() as {
+    const { messages, systemContext, apiKey, model, provider, ollamaUrl } = await req.json() as {
       messages: { role: string; content: string }[];
       systemContext?: string;
       apiKey: string;
       model: string;
       provider?: LLMProvider;
+      ollamaUrl?: string;
     };
 
-    if (!apiKey) {
+    // Ollama doesn't need an API key
+    if (!apiKey && provider !== "ollama") {
       return new Response(JSON.stringify({ error: "API key required" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
@@ -127,12 +235,16 @@ export async function POST(req: NextRequest) {
 
     // Determine provider from explicit param or model name prefix
     const resolvedProvider: LLMProvider =
-      provider ?? (model?.startsWith("gemini") ? "gemini" : "anthropic");
+      provider ?? (model?.startsWith("gemini") ? "gemini" : model?.includes(":") ? "ollama" : "anthropic");
 
-    const readable =
-      resolvedProvider === "gemini"
-        ? streamGemini(apiKey, model, fullSystem, messages)
-        : streamAnthropic(apiKey, model, fullSystem, messages, 2048);
+    let readable: ReadableStream<Uint8Array>;
+    if (resolvedProvider === "ollama") {
+      readable = streamOllama(ollamaUrl || "http://localhost:11434", model, fullSystem, messages);
+    } else if (resolvedProvider === "gemini") {
+      readable = streamGemini(apiKey, model, fullSystem, messages);
+    } else {
+      readable = streamAnthropic(apiKey, model, fullSystem, messages, 2048);
+    }
 
     return new Response(readable, {
       headers: {

--- a/src/components/SystemCopilot.tsx
+++ b/src/components/SystemCopilot.tsx
@@ -10,6 +10,7 @@ import {
   streamLlmQuery,
   CopilotAction,
 } from "@/lib/copilot-engine";
+import { processLlmActions } from "@/lib/copilot-actions";
 import { CopilotMessage } from "@/lib/types";
 import { getModelsForProvider, type LLMProvider } from "@/lib/llm-providers";
 import { serializeGraphContext, serializeSnapshotContext } from "@/lib/copilot-context";
@@ -58,12 +59,16 @@ export default function SystemCopilot() {
     geminiApiKey,
     claudeModel,
     geminiModel,
+    ollamaUrl,
+    ollamaModel,
     isLlmStreaming,
     setLlmProvider,
     setClaudeApiKey,
     setGeminiApiKey,
     setClaudeModel,
     setGeminiModel,
+    setOllamaUrl,
+    setOllamaModel,
     setIsLlmStreaming,
     importedDatasets,
     removeImportedDataset,
@@ -77,10 +82,11 @@ export default function SystemCopilot() {
     tarskiReport,
   } = useApexStore();
 
-  // Copilot always uses Gemini; Claude key is for compute only
-  const copilotApiKey = geminiApiKey;
-  const copilotModel = geminiModel;
-  const copilotModelOptions = getModelsForProvider("gemini");
+  // Copilot provider: Gemini or Ollama; Claude is for compute only
+  const copilotProvider: LLMProvider = llmProvider === "ollama" ? "ollama" : "gemini";
+  const copilotApiKey = copilotProvider === "ollama" ? "ollama-local" : geminiApiKey;
+  const copilotModel = copilotProvider === "ollama" ? ollamaModel : geminiModel;
+  const copilotModelOptions = getModelsForProvider(copilotProvider);
 
   // Claude compute key/model
   const computeApiKey = claudeApiKey;
@@ -96,7 +102,7 @@ export default function SystemCopilot() {
   const streamingMsgRef = useRef<string | null>(null);
   const badgeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const isLlmActive = copilotApiKey.length > 0;
+  const isLlmActive = copilotProvider === "ollama" || copilotApiKey.length > 0;
   const isComputeAvailable = computeApiKey.length > 0;
 
   // Click-outside to close datasets panel
@@ -281,7 +287,7 @@ export default function SystemCopilot() {
           graph: graphData,
           apiKey: copilotApiKey,
           model: copilotModel,
-          provider: "gemini",
+          provider: copilotProvider,
           selectedNode,
           severedEdges,
           shocks,
@@ -292,6 +298,7 @@ export default function SystemCopilot() {
           ablatedEdgeIds,
           snapshotContext,
           tarskiReport,
+          ollamaUrl: copilotProvider === "ollama" ? ollamaUrl : undefined,
         });
 
         const reader = stream.getReader();
@@ -302,12 +309,33 @@ export default function SystemCopilot() {
           const { done, value } = await reader.read();
           if (done) break;
           accumulated += decoder.decode(value, { stream: true });
+          // Strip action tags from displayed text
+          const { displayText } = processLlmActions(accumulated);
           // Update the streaming message in store
           useApexStore.setState((s) => ({
             copilotMessages: s.copilotMessages.map((m) =>
-              m.id === assistantId ? { ...m, content: accumulated } : m
+              m.id === assistantId ? { ...m, content: displayText } : m
             ),
           }));
+        }
+
+        // After streaming completes, execute any actions from the full response
+        const { displayText, actionResults } = processLlmActions(accumulated);
+        // Update final display text
+        useApexStore.setState((s) => ({
+          copilotMessages: s.copilotMessages.map((m) =>
+            m.id === assistantId ? { ...m, content: displayText } : m
+          ),
+        }));
+        // Log action results as system messages
+        if (actionResults.length > 0) {
+          const actionSummary = actionResults.map((r) => `  \u2022 ${r}`).join("\n");
+          addCopilotMessage({
+            id: `sys-actions-${Date.now()}`,
+            role: "system",
+            content: `ACTIONS EXECUTED:\n${actionSummary}`,
+            timestamp: Date.now(),
+          });
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : "LLM request failed";
@@ -328,6 +356,8 @@ export default function SystemCopilot() {
       graphData,
       copilotApiKey,
       copilotModel,
+      copilotProvider,
+      ollamaUrl,
       snapshotHistory,
       selectedNode,
       severedEdges,
@@ -413,9 +443,11 @@ export default function SystemCopilot() {
               SYSTEM COPILOT
             </div>
             <div className="text-[9px] text-text-muted font-mono mt-0.5">
-              {isLlmActive
-                ? "Gemini-Augmented Analysis"
-                : "Synthetic Scientist Interface"}
+              {copilotProvider === "ollama"
+                ? `Ollama Local (${ollamaModel})`
+                : isLlmActive
+                  ? "Gemini-Augmented Analysis"
+                  : "Synthetic Scientist Interface"}
               {isComputeAvailable && " + Claude Compute"}
             </div>
           </div>
@@ -452,36 +484,95 @@ export default function SystemCopilot() {
               className="overflow-hidden"
             >
               <div className="mt-2 pt-2 border-t border-border space-y-2">
-                {/* Gemini (Copilot) */}
+                {/* Provider toggle */}
                 <div className="space-y-1">
                   <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted">
-                    GEMINI — COPILOT
+                    COPILOT PROVIDER
                   </div>
-                  <input
-                    type="password"
-                    value={geminiApiKey}
-                    onChange={(e) => setGeminiApiKey(e.target.value)}
-                    className="w-full bg-surface font-mono text-[10px] text-foreground outline-none px-2 py-1 rounded border border-border placeholder:text-text-muted focus:border-accent-cyan/50 transition-colors"
-                    placeholder="AIza... (session only)"
-                    spellCheck={false}
-                  />
-                  <select
-                    value={copilotModel}
-                    onChange={(e) => setGeminiModel(e.target.value)}
-                    className="w-full bg-surface font-mono text-[10px] text-foreground outline-none px-2 py-1 rounded border border-border transition-colors"
-                  >
-                    {copilotModelOptions.map((m) => (
-                      <option key={m.value} value={m.value}>
-                        {m.label}
-                      </option>
+                  <div className="flex gap-1">
+                    {(["gemini", "ollama"] as const).map((p) => (
+                      <button
+                        key={p}
+                        onClick={() => setLlmProvider(p)}
+                        className="flex-1 text-[8px] font-[family-name:var(--font-michroma)] tracking-wider px-2 py-1 rounded border transition-all"
+                        style={{
+                          borderColor: copilotProvider === p ? "var(--accent-cyan)" : "var(--border)",
+                          backgroundColor: copilotProvider === p ? "rgba(0,229,255,0.08)" : "transparent",
+                          color: copilotProvider === p ? "var(--accent-cyan)" : "var(--text-muted)",
+                        }}
+                      >
+                        {p === "gemini" ? "GEMINI" : "OLLAMA"}
+                      </button>
                     ))}
-                  </select>
-                  {isLlmActive && (
-                    <div className="text-[8px] text-accent-green font-mono tracking-wider">
-                      GEMINI ACTIVE
-                    </div>
-                  )}
+                  </div>
                 </div>
+
+                {/* Gemini config */}
+                {copilotProvider === "gemini" && (
+                  <div className="space-y-1">
+                    <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted">
+                      GEMINI — COPILOT
+                    </div>
+                    <input
+                      type="password"
+                      value={geminiApiKey}
+                      onChange={(e) => setGeminiApiKey(e.target.value)}
+                      className="w-full bg-surface font-mono text-[10px] text-foreground outline-none px-2 py-1 rounded border border-border placeholder:text-text-muted focus:border-accent-cyan/50 transition-colors"
+                      placeholder="AIza... (session only)"
+                      spellCheck={false}
+                    />
+                    <select
+                      value={copilotModel}
+                      onChange={(e) => setGeminiModel(e.target.value)}
+                      className="w-full bg-surface font-mono text-[10px] text-foreground outline-none px-2 py-1 rounded border border-border transition-colors"
+                    >
+                      {copilotModelOptions.map((m) => (
+                        <option key={m.value} value={m.value}>
+                          {m.label}
+                        </option>
+                      ))}
+                    </select>
+                    {geminiApiKey.length > 0 && (
+                      <div className="text-[8px] text-accent-green font-mono tracking-wider">
+                        GEMINI ACTIVE
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* Ollama config */}
+                {copilotProvider === "ollama" && (
+                  <div className="space-y-1">
+                    <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted">
+                      OLLAMA — LOCAL LLM
+                    </div>
+                    <input
+                      type="text"
+                      value={ollamaUrl}
+                      onChange={(e) => setOllamaUrl(e.target.value)}
+                      className="w-full bg-surface font-mono text-[10px] text-foreground outline-none px-2 py-1 rounded border border-border placeholder:text-text-muted focus:border-accent-cyan/50 transition-colors"
+                      placeholder="http://localhost:11434"
+                      spellCheck={false}
+                    />
+                    <select
+                      value={ollamaModel}
+                      onChange={(e) => setOllamaModel(e.target.value)}
+                      className="w-full bg-surface font-mono text-[10px] text-foreground outline-none px-2 py-1 rounded border border-border transition-colors"
+                    >
+                      {copilotModelOptions.map((m) => (
+                        <option key={m.value} value={m.value}>
+                          {m.label}
+                        </option>
+                      ))}
+                    </select>
+                    <div className="text-[8px] text-accent-green font-mono tracking-wider">
+                      OLLAMA MODE — no API key needed
+                    </div>
+                    <div className="text-[8px] font-mono text-text-muted leading-relaxed">
+                      Run &quot;ollama serve&quot; locally. Models: ollama pull llama3.1:8b
+                    </div>
+                  </div>
+                )}
                 {/* Claude (Compute) */}
                 <div className="space-y-1 pt-1.5 border-t border-border">
                   <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted">
@@ -697,7 +788,7 @@ export default function SystemCopilot() {
             onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
             disabled={isLlmStreaming}
             className="flex-1 bg-surface-elevated font-mono text-[11px] text-foreground outline-none px-2.5 py-1.5 rounded border border-border placeholder:text-text-muted focus:border-accent-cyan/50 transition-colors disabled:opacity-40"
-            placeholder={isLlmActive ? "Ask anything (LLM active)..." : "Ask the system to analyze or verify..."}
+            placeholder={copilotProvider === "ollama" ? "Ask anything (Ollama local)..." : isLlmActive ? "Ask anything (LLM active)..." : "Ask the system to analyze or verify..."}
             spellCheck={false}
           />
           <button

--- a/src/lib/copilot-actions.ts
+++ b/src/lib/copilot-actions.ts
@@ -1,0 +1,159 @@
+// ─── Copilot Action Router ──────────────────────────────────────
+// Parses <<<ACTION:type:param>>> blocks from LLM responses and
+// executes them against the Apex store.
+
+import { useApexStore } from "@/stores/useApexStore";
+import { getPresetShocks } from "./omega-engine";
+
+export interface ParsedAction {
+  type: string;
+  param: string;
+  raw: string;
+}
+
+// ─── Parse actions from LLM response text ───────────────────────
+
+const ACTION_REGEX = /<<<ACTION:(\w+):?(.*?)>>>/g;
+
+export function parseActions(text: string): ParsedAction[] {
+  const actions: ParsedAction[] = [];
+  let match;
+  while ((match = ACTION_REGEX.exec(text)) !== null) {
+    actions.push({
+      type: match[1],
+      param: match[2] ?? "",
+      raw: match[0],
+    });
+  }
+  return actions;
+}
+
+// ─── Strip action blocks from display text ──────────────────────
+
+export function stripActions(text: string): string {
+  return text.replace(ACTION_REGEX, "").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+// ─── Execute a parsed action against the store ──────────────────
+
+export function executeAction(action: ParsedAction): string | null {
+  const store = useApexStore.getState();
+  const presetShocks = getPresetShocks();
+
+  switch (action.type) {
+    case "select_node": {
+      const node = store.graphData.nodes.find(
+        (n) => n.id === action.param || n.shortLabel.toLowerCase() === action.param.toLowerCase()
+          || n.label.toLowerCase() === action.param.toLowerCase()
+      );
+      if (node) {
+        store.setSelectedNode(node.id);
+        return `Selected node: ${node.label}`;
+      }
+      return `Node not found: ${action.param}`;
+    }
+
+    case "add_shock": {
+      const shock = presetShocks.find((s) => s.id === action.param);
+      if (shock) {
+        // Check if already active
+        if (!store.shocks.find((s) => s.id === shock.id)) {
+          store.addShock(shock);
+          return `Injected shock: ${shock.name}`;
+        }
+        return `Shock already active: ${shock.name}`;
+      }
+      return `Unknown shock: ${action.param}`;
+    }
+
+    case "remove_shock": {
+      const existing = store.shocks.find((s) => s.id === action.param);
+      if (existing) {
+        store.removeShock(action.param);
+        return `Removed shock: ${existing.name}`;
+      }
+      return `Shock not active: ${action.param}`;
+    }
+
+    case "set_module": {
+      const valid = ["spirtes", "tarski", "pearl", "pareto"];
+      if (valid.includes(action.param)) {
+        store.setActiveModule(action.param as "spirtes" | "tarski" | "pearl" | "pareto");
+        return `Switched to ${action.param.toUpperCase()} module`;
+      }
+      return `Invalid module: ${action.param}`;
+    }
+
+    case "set_view": {
+      if (action.param === "2d" || action.param === "3d") {
+        store.setViewMode(action.param);
+        return `Switched to ${action.param.toUpperCase()} view`;
+      }
+      return `Invalid view mode: ${action.param}`;
+    }
+
+    case "sever_edge": {
+      const edge = store.graphData.edges.find((e) => e.id === action.param);
+      if (edge) {
+        store.severEdge(edge.id);
+        return `Severed edge: ${edge.source} → ${edge.target}`;
+      }
+      return `Edge not found: ${action.param}`;
+    }
+
+    case "reset_severed": {
+      store.resetSeveredEdges();
+      return "Reset all severed edges";
+    }
+
+    case "start_replay": {
+      store.startReplay();
+      return "Started cascade replay";
+    }
+
+    case "stop_replay": {
+      store.stopReplay();
+      return "Stopped cascade replay";
+    }
+
+    case "set_truth_filter": {
+      if (action.param === "raw" || action.param === "verified") {
+        store.setTruthFilter(action.param);
+        return `Truth filter set to: ${action.param.toUpperCase()}`;
+      }
+      return `Invalid filter: ${action.param}`;
+    }
+
+    case "set_domains": {
+      const domains = action.param.split(",").map((d) => d.trim()).filter(Boolean);
+      if (domains.length > 0) {
+        store.setSelectedDomains(domains);
+        return `Filtered to domains: ${domains.join(", ")}`;
+      }
+      return "No valid domains specified";
+    }
+
+    default:
+      return `Unknown action: ${action.type}`;
+  }
+}
+
+// ─── Process all actions from an LLM response ──────────────────
+
+export function processLlmActions(text: string): {
+  displayText: string;
+  actionResults: string[];
+} {
+  const actions = parseActions(text);
+  const displayText = stripActions(text);
+  const actionResults: string[] = [];
+
+  for (const action of actions) {
+    const result = executeAction(action);
+    if (result) {
+      actionResults.push(result);
+    }
+  }
+
+  return { displayText, actionResults };
+}

--- a/src/lib/copilot-engine.ts
+++ b/src/lib/copilot-engine.ts
@@ -363,7 +363,7 @@ interface StreamLlmOptions {
   graph: CausalGraph;
   apiKey: string;
   model: string;
-  provider?: "anthropic" | "gemini";
+  provider?: "anthropic" | "gemini" | "ollama";
   selectedNode: string | null;
   severedEdges: string[];
   shocks: { id: string; name: string; severity: number; category: string }[];
@@ -374,6 +374,7 @@ interface StreamLlmOptions {
   ablatedEdgeIds?: string[];
   snapshotContext?: string;
   tarskiReport?: TarskiValidationReport | null;
+  ollamaUrl?: string;
 }
 
 export async function streamLlmQuery(
@@ -413,6 +414,7 @@ export async function streamLlmQuery(
       apiKey: opts.apiKey,
       model: opts.model,
       provider: opts.provider,
+      ollamaUrl: opts.ollamaUrl,
     }),
   });
 

--- a/src/lib/llm-providers.ts
+++ b/src/lib/llm-providers.ts
@@ -1,7 +1,7 @@
 // ─── LLM Provider Abstraction ───────────────────────────────────
 // Unified interface for streaming from multiple LLM providers
 
-export type LLMProvider = "anthropic" | "gemini";
+export type LLMProvider = "anthropic" | "gemini" | "ollama";
 
 export interface StreamOptions {
   apiKey: string;
@@ -26,6 +26,13 @@ export const PROVIDER_MODELS: ProviderModelOption[] = [
   { value: "gemini-2.0-flash", label: "Gemini 2.0 Flash", provider: "gemini" },
   { value: "gemini-2.0-flash-lite", label: "Gemini 2.0 Flash Lite", provider: "gemini" },
   { value: "gemini-2.5-pro-preview-06-05", label: "Gemini 2.5 Pro", provider: "gemini" },
+  // Ollama (local open-source)
+  { value: "llama3.1:8b", label: "Llama 3.1 8B", provider: "ollama" },
+  { value: "llama3.1:70b", label: "Llama 3.1 70B", provider: "ollama" },
+  { value: "mistral:7b", label: "Mistral 7B", provider: "ollama" },
+  { value: "mixtral:8x7b", label: "Mixtral 8x7B", provider: "ollama" },
+  { value: "qwen2.5:7b", label: "Qwen 2.5 7B", provider: "ollama" },
+  { value: "deepseek-r1:8b", label: "DeepSeek R1 8B", provider: "ollama" },
 ];
 
 export function getModelsForProvider(provider: LLMProvider): ProviderModelOption[] {
@@ -37,7 +44,9 @@ export function getProviderForModel(model: string): LLMProvider | null {
 }
 
 export function getDefaultModel(provider: LLMProvider): string {
-  return provider === "anthropic"
-    ? "claude-sonnet-4-20250514"
-    : "gemini-2.0-flash";
+  switch (provider) {
+    case "anthropic": return "claude-sonnet-4-20250514";
+    case "gemini": return "gemini-2.0-flash";
+    case "ollama": return "llama3.1:8b";
+  }
 }

--- a/src/stores/useApexStore.ts
+++ b/src/stores/useApexStore.ts
@@ -115,12 +115,16 @@ interface ApexState {
   geminiApiKey: string;
   claudeModel: string;
   geminiModel: string;
+  ollamaUrl: string;
+  ollamaModel: string;
   isLlmStreaming: boolean;
   setLlmProvider: (provider: LLMProvider) => void;
   setClaudeApiKey: (key: string) => void;
   setGeminiApiKey: (key: string) => void;
   setClaudeModel: (model: string) => void;
   setGeminiModel: (model: string) => void;
+  setOllamaUrl: (url: string) => void;
+  setOllamaModel: (model: string) => void;
   setIsLlmStreaming: (streaming: boolean) => void;
 
   // Sandbox
@@ -355,12 +359,16 @@ export const useApexStore = create<ApexState>((set) => ({
   geminiApiKey: "",
   claudeModel: "claude-sonnet-4-20250514",
   geminiModel: "gemini-2.0-flash",
+  ollamaUrl: "http://localhost:11434",
+  ollamaModel: "llama3.1:8b",
   isLlmStreaming: false,
   setLlmProvider: (provider) => set({ llmProvider: provider }),
   setClaudeApiKey: (key) => set({ claudeApiKey: key }),
   setGeminiApiKey: (key) => set({ geminiApiKey: key }),
   setClaudeModel: (model) => set({ claudeModel: model }),
   setGeminiModel: (model) => set({ geminiModel: model }),
+  setOllamaUrl: (url) => set({ ollamaUrl: url }),
+  setOllamaModel: (model) => set({ ollamaModel: model }),
   setIsLlmStreaming: (streaming) => set({ isLlmStreaming: streaming }),
 
   // Sandbox


### PR DESCRIPTION
## Summary
- **Ollama integration**: Added as a third LLM provider alongside Gemini and Claude. Streams via local `/api/chat` endpoint — no API key required, fully on-device
- **Action routing**: LLM responses can now control the terminal via `<<<ACTION:type:param>>>` blocks. Actions are parsed, executed against the store, and stripped from display text
- **Available actions**: select_node, add/remove_shock, set_module, set_view, sever_edge, reset_severed, start/stop_replay, set_truth_filter, set_domains
- **UI**: Provider toggle (Gemini/Ollama) in settings, Ollama URL + model selector, pre-configured models (Llama 3.1, Mistral, Mixtral, Qwen 2.5, DeepSeek R1)

## Test plan
- [ ] Toggle to Ollama provider in settings — verify no API key field shown
- [ ] With `ollama serve` running, send a query — verify streaming response
- [ ] Verify action blocks (e.g., "select the highest risk node") trigger store actions
- [ ] Verify action results appear as SYS messages after execution
- [ ] Toggle back to Gemini — verify Gemini still works with API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)