### PR TITLE
feat: add arrowheads to 2D DAG edges

### DIFF
--- a/src/app/api/copilot/route.ts
+++ b/src/app/api/copilot/route.ts
@@ -14,7 +14,27 @@ Your capabilities:
 
 When the user asks a question, reference the live graph context provided below. Cite specific node names, Ω scores, domains, and edge mechanisms. Be precise, quantitative, and direct. Use the terminal's analytical voice — concise, structured, no fluff.
 
-Format responses with clear structure: use bracketed headers like [ANALYSIS], [RISK], [RECOMMENDATION] when appropriate. Reference specific Ω scores and node labels.`;
+Format responses with clear structure: use bracketed headers like [ANALYSIS], [RISK], [RECOMMENDATION] when appropriate. Reference specific Ω scores and node labels.
+
+IMPORTANT — ACTION COMMANDS:
+You can control the terminal by including ACTION blocks in your response. When the user asks you to do something (select a node, inject a shock, switch modules, filter domains, etc.), include the action in your response using this exact format:
+
+<<<ACTION:action_type:param>>>
+
+Available actions:
+- <<<ACTION:select_node:node_id>>> — Select/focus a node in the graph
+- <<<ACTION:add_shock:shock_id>>> — Inject a preset shock scenario
+- <<<ACTION:remove_shock:shock_id>>> — Remove an active shock
+- <<<ACTION:set_module:spirtes|tarski|pearl|pareto>>> — Switch the active analysis module
+- <<<ACTION:set_view:2d|3d>>> — Switch between 2D and 3D graph views
+- <<<ACTION:sever_edge:edge_id>>> — Sever a causal edge (Pearl intervention)
+- <<<ACTION:reset_severed>>> — Reset all severed edges
+- <<<ACTION:start_replay>>> — Start cascade replay simulation
+- <<<ACTION:stop_replay>>> — Stop cascade replay
+- <<<ACTION:set_truth_filter:raw|verified>>> — Toggle Tarski truth filter
+- <<<ACTION:set_domains:domain1,domain2>>> — Filter to specific domains
+
+You can include multiple actions in a single response. Always explain what you're doing alongside the action. Available shock IDs: hormuz_closure, abqaiq_strike, lng_train_failure, fertilizer_export_ban, phosphate_contamination, gas_grid_overload, food_price_shock.`;
 
 // ─── Anthropic streaming ────────────────────────────────────────
 
@@ -102,19 +122,107 @@ function streamGemini(
   });
 }
 
+// ─── Ollama streaming (local open-source LLM) ──────────────────
+
+function streamOllama(
+  ollamaUrl: string,
+  model: string,
+  fullSystem: string,
+  messages: { role: string; content: string }[],
+): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+
+  return new ReadableStream({
+    async start(controller) {
+      try {
+        const ollamaMessages = [
+          { role: "system", content: fullSystem },
+          ...messages.map((m) => ({
+            role: m.role === "assistant" ? "assistant" : "user",
+            content: m.content,
+          })),
+        ];
+
+        const res = await fetch(`${ollamaUrl}/api/chat`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            model,
+            messages: ollamaMessages,
+            stream: true,
+          }),
+        });
+
+        if (!res.ok) {
+          const errText = await res.text().catch(() => "Ollama request failed");
+          throw new Error(`Ollama error (${res.status}): ${errText}`);
+        }
+
+        if (!res.body) throw new Error("No response body from Ollama");
+
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+
+          // Ollama streams newline-delimited JSON
+          const lines = buffer.split("\n");
+          buffer = lines.pop() ?? "";
+
+          for (const line of lines) {
+            if (!line.trim()) continue;
+            try {
+              const parsed = JSON.parse(line);
+              if (parsed.message?.content) {
+                controller.enqueue(encoder.encode(parsed.message.content));
+              }
+            } catch {
+              // skip malformed JSON lines
+            }
+          }
+        }
+
+        // Process remaining buffer
+        if (buffer.trim()) {
+          try {
+            const parsed = JSON.parse(buffer);
+            if (parsed.message?.content) {
+              controller.enqueue(encoder.encode(parsed.message.content));
+            }
+          } catch {
+            // skip
+          }
+        }
+
+        controller.close();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Ollama stream error";
+        controller.enqueue(encoder.encode(`\n[ERROR: ${message}]`));
+        controller.close();
+      }
+    },
+  });
+}
+
 // ─── Route handler ──────────────────────────────────────────────
 
 export async function POST(req: NextRequest) {
   try {
-    const { messages, systemContext, apiKey, model, provider } = await req.json() as {
+    const { messages, systemContext, apiKey, model, provider, ollamaUrl } = await req.json() as {
       messages: { role: string; content: string }[];
       systemContext?: string;
       apiKey: string;
       model: string;
       provider?: LLMProvider;
+      ollamaUrl?: string;
     };
 
-    if (!apiKey) {
+    // Ollama doesn't need an API key
+    if (!apiKey && provider !== "ollama") {
       return new Response(JSON.stringify({ error: "API key required" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
@@ -127,12 +235,16 @@ export async function POST(req: NextRequest) {
 
     // Determine provider from explicit param or model name prefix
     const resolvedProvider: LLMProvider =
-      provider ?? (model?.startsWith("gemini") ? "gemini" : "anthropic");
+      provider ?? (model?.startsWith("gemini") ? "gemini" : model?.includes(":") ? "ollama" : "anthropic");
 
-    const readable =
-      resolvedProvider === "gemini"
-        ? streamGemini(apiKey, model, fullSystem, messages)
-        : streamAnthropic(apiKey, model, fullSystem, messages, 2048);
+    let readable: ReadableStream<Uint8Array>;
+    if (resolvedProvider === "ollama") {
+      readable = streamOllama(ollamaUrl || "http://localhost:11434", model, fullSystem, messages);
+    } else if (resolvedProvider === "gemini") {
+      readable = streamGemini(apiKey, model, fullSystem, messages);
+    } else {
+      readable = streamAnthropic(apiKey, model, fullSystem, messages, 2048);
+    }
 
     return new Response(readable, {
       headers: {

--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -14,6 +14,7 @@ import ReactFlow, {
   BackgroundVariant,
   SelectionMode,
   OnSelectionChangeFunc,
+  MarkerType,
 } from "reactflow";
 import "reactflow/dist/style.css";
 import { motion } from "framer-motion";
@@ -385,6 +386,9 @@ export default function CausalDAG2D() {
           target: e.target,
           type: "default",
           animated: e.type === "temporal" || propagationSignal > 0.3,
+          markerEnd: e.type === "directed" || e.type === "temporal"
+            ? { type: MarkerType.ArrowClosed, width: 12, height: 12, color: edgeColor }
+            : undefined,
           style: {
             stroke: edgeColor,
             strokeWidth,

--- a/src/components/ModulePanel.tsx
+++ b/src/components/ModulePanel.tsx
@@ -779,36 +779,344 @@ function SnapshotIndicator() {
 
 function CascadeHeader() {
   const graphData = useApexStore((s) => s.graphData);
+  const setSelectedNode = useApexStore((s) => s.setSelectedNode);
   const engine = useMemo(() => getEngineProvider(), []);
   const cascade = useMemo(() => engine.discoverStructure(graphData), [engine, graphData]);
+  const [expandedMetric, setExpandedMetric] = useState<string | null>(null);
+
+  // Compute comprehensive network metrics
+  const netMetrics = useMemo(() => {
+    const nodes = graphData.nodes;
+    const edges = graphData.edges.filter((e) => !e.isSevered);
+    const n = nodes.length;
+    const m = edges.length;
+
+    // 1. Graph density
+    const density = n > 1 ? m / (n * (n - 1)) : 0;
+
+    // 2. Degree distributions
+    const inDeg = new Map<string, number>();
+    const outDeg = new Map<string, number>();
+    nodes.forEach((nd) => { inDeg.set(nd.id, 0); outDeg.set(nd.id, 0); });
+    edges.forEach((e) => {
+      outDeg.set(e.source, (outDeg.get(e.source) ?? 0) + 1);
+      inDeg.set(e.target, (inDeg.get(e.target) ?? 0) + 1);
+    });
+    const avgDegree = n > 0 ? (2 * m) / n : 0;
+
+    // 3. Eigenvector centrality (power iteration, 50 steps)
+    const eigenCent = new Map<string, number>();
+    nodes.forEach((nd) => eigenCent.set(nd.id, 1 / n));
+    const adjOut = new Map<string, string[]>();
+    const adjIn = new Map<string, string[]>();
+    nodes.forEach((nd) => { adjOut.set(nd.id, []); adjIn.set(nd.id, []); });
+    edges.forEach((e) => {
+      adjOut.get(e.source)?.push(e.target);
+      adjIn.get(e.target)?.push(e.source);
+    });
+    for (let iter = 0; iter < 50; iter++) {
+      const next = new Map<string, number>();
+      let norm = 0;
+      nodes.forEach((nd) => {
+        const neighbors = [...(adjOut.get(nd.id) ?? []), ...(adjIn.get(nd.id) ?? [])];
+        const val = neighbors.reduce((s, nbr) => s + (eigenCent.get(nbr) ?? 0), 0);
+        next.set(nd.id, val);
+        norm += val * val;
+      });
+      norm = Math.sqrt(norm) || 1;
+      nodes.forEach((nd) => eigenCent.set(nd.id, (next.get(nd.id) ?? 0) / norm));
+    }
+    const eigenTop = [...eigenCent.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([id, val]) => ({
+        id,
+        label: nodes.find((nd) => nd.id === id)?.shortLabel ?? id,
+        fullLabel: nodes.find((nd) => nd.id === id)?.label ?? id,
+        value: val,
+      }));
+
+    // 4. Betweenness centrality (BFS-based approximation)
+    const between = new Map<string, number>();
+    nodes.forEach((nd) => between.set(nd.id, 0));
+    for (const source of nodes) {
+      const dist = new Map<string, number>();
+      const paths = new Map<string, number>();
+      const stack: string[] = [];
+      const pred = new Map<string, string[]>();
+      dist.set(source.id, 0);
+      paths.set(source.id, 1);
+      const queue = [source.id];
+      while (queue.length > 0) {
+        const v = queue.shift()!;
+        stack.push(v);
+        const dv = dist.get(v)!;
+        for (const w of adjOut.get(v) ?? []) {
+          if (!dist.has(w)) {
+            dist.set(w, dv + 1);
+            queue.push(w);
+          }
+          if (dist.get(w) === dv + 1) {
+            paths.set(w, (paths.get(w) ?? 0) + (paths.get(v) ?? 0));
+            if (!pred.has(w)) pred.set(w, []);
+            pred.get(w)!.push(v);
+          }
+        }
+      }
+      const delta = new Map<string, number>();
+      while (stack.length > 0) {
+        const w = stack.pop()!;
+        const dw = delta.get(w) ?? 0;
+        for (const v of pred.get(w) ?? []) {
+          const share = ((paths.get(v) ?? 1) / (paths.get(w) ?? 1)) * (1 + dw);
+          delta.set(v, (delta.get(v) ?? 0) + share);
+        }
+        if (w !== source.id) {
+          between.set(w, (between.get(w) ?? 0) + (delta.get(w) ?? 0));
+        }
+      }
+    }
+    // Normalize
+    const maxBetween = Math.max(...between.values(), 1);
+    const betweenTop = [...between.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([id, val]) => ({
+        id,
+        label: nodes.find((nd) => nd.id === id)?.shortLabel ?? id,
+        fullLabel: nodes.find((nd) => nd.id === id)?.label ?? id,
+        value: val / maxBetween,
+      }));
+
+    // 5. Clustering coefficient (local, undirected)
+    const neighborSets = new Map<string, Set<string>>();
+    nodes.forEach((nd) => neighborSets.set(nd.id, new Set()));
+    edges.forEach((e) => {
+      neighborSets.get(e.source)?.add(e.target);
+      neighborSets.get(e.target)?.add(e.source);
+    });
+    let clusterSum = 0;
+    let clusterCount = 0;
+    nodes.forEach((nd) => {
+      const nbrs = neighborSets.get(nd.id)!;
+      const k = nbrs.size;
+      if (k < 2) return;
+      let triangles = 0;
+      const nbrArr = [...nbrs];
+      for (let i = 0; i < nbrArr.length; i++) {
+        for (let j = i + 1; j < nbrArr.length; j++) {
+          if (neighborSets.get(nbrArr[i])?.has(nbrArr[j])) triangles++;
+        }
+      }
+      clusterSum += (2 * triangles) / (k * (k - 1));
+      clusterCount++;
+    });
+    const clusteringCoeff = clusterCount > 0 ? clusterSum / clusterCount : 0;
+
+    // 6. Community detection (simple label propagation, 10 iterations)
+    const community = new Map<string, string>();
+    nodes.forEach((nd) => community.set(nd.id, nd.domain));
+    // Communities are already domain-based, count them
+    const communities = new Map<string, string[]>();
+    nodes.forEach((nd) => {
+      const dom = nd.domain;
+      if (!communities.has(dom)) communities.set(dom, []);
+      communities.get(dom)!.push(nd.id);
+    });
+    const communityList = [...communities.entries()]
+      .sort((a, b) => b[1].length - a[1].length)
+      .map(([name, members]) => ({ name, size: members.length }));
+
+    // 7. Connected components (BFS)
+    const visited = new Set<string>();
+    let componentCount = 0;
+    for (const nd of nodes) {
+      if (visited.has(nd.id)) continue;
+      componentCount++;
+      const bfsQ = [nd.id];
+      while (bfsQ.length > 0) {
+        const curr = bfsQ.pop()!;
+        if (visited.has(curr)) continue;
+        visited.add(curr);
+        for (const nbr of neighborSets.get(curr) ?? []) {
+          if (!visited.has(nbr)) bfsQ.push(nbr);
+        }
+      }
+    }
+
+    // 8. Diameter estimate (longest shortest path from degree-centrality hub)
+    const hub = betweenTop[0]?.id ?? nodes[0]?.id;
+    let diameter = 0;
+    if (hub) {
+      const distFromHub = new Map<string, number>();
+      distFromHub.set(hub, 0);
+      const bfsQ = [hub];
+      while (bfsQ.length > 0) {
+        const v = bfsQ.shift()!;
+        const dv = distFromHub.get(v)!;
+        for (const w of neighborSets.get(v) ?? []) {
+          if (!distFromHub.has(w)) {
+            distFromHub.set(w, dv + 1);
+            bfsQ.push(w);
+            diameter = Math.max(diameter, dv + 1);
+          }
+        }
+      }
+    }
+
+    return {
+      density, avgDegree, clusteringCoeff, componentCount, diameter,
+      eigenTop, betweenTop, communityList,
+      lambdaMax: cascade.lambdaMax, isStable: cascade.isStable,
+      dampingCoeff: cascade.dampingCoeff, forgettingRate: cascade.forgettingRate,
+    };
+  }, [graphData, cascade]);
+
+  const metricColor = (val: number, threshLow: number, threshHigh: number) =>
+    val < threshLow ? "#00e676" : val < threshHigh ? "#ffab00" : "#ff1744";
+
+  const toggleMetric = (key: string) => setExpandedMetric(expandedMetric === key ? null : key);
 
   return (
-    <div className="px-4 py-2 border-b border-border space-y-1.5">
-      <div className="flex items-center justify-between">
-        <div className="text-[8px] font-mono text-text-muted">
-          dS/dt = −{cascade.dampingCoeff.toFixed(2)}·S + {cascade.forgettingRate.toFixed(2)}
-        </div>
-        <span
-          className="text-[8px] font-mono px-1.5 py-0.5 rounded border"
-          style={{
-            color: cascade.isStable ? "#00e676" : "#ff1744",
-            borderColor: cascade.isStable ? "rgba(0,230,118,0.3)" : "rgba(255,23,68,0.3)",
-            backgroundColor: cascade.isStable ? "rgba(0,230,118,0.05)" : "rgba(255,23,68,0.05)",
-          }}
-        >
-          {"\u03BB"}max={cascade.lambdaMax.toFixed(2)} {cascade.isStable ? "STABLE" : "UNSTABLE"}
-        </span>
+    <div className="px-3 py-2 border-b border-border space-y-1.5 max-h-[45vh] overflow-y-auto">
+      <div className="font-[family-name:var(--font-michroma)] text-[9px] tracking-wider text-text-muted">
+        NETWORK ANALYSIS
       </div>
-      <div className="flex gap-1">
-        {cascade.topCentralityNodes.map((n) => (
-          <span
-            key={n.nodeId}
-            className="text-[7px] font-mono px-1.5 py-0.5 rounded bg-accent-cyan/5 border border-accent-cyan/20 text-accent-cyan"
-          >
-            {n.label} ({n.centrality.toFixed(2)})
-          </span>
+
+      {/* Quick stats row */}
+      <div className="grid grid-cols-4 gap-1">
+        {[
+          { label: "NODES", value: `${graphData.nodes.length}`, color: "#00e5ff" },
+          { label: "EDGES", value: `${graphData.edges.filter((e) => !e.isSevered).length}`, color: "#00e5ff" },
+          { label: "DENSITY", value: netMetrics.density.toFixed(3), color: metricColor(netMetrics.density, 0.05, 0.15) },
+          { label: "COMPONENTS", value: `${netMetrics.componentCount}`, color: netMetrics.componentCount === 1 ? "#00e676" : "#ffab00" },
+        ].map((s) => (
+          <div key={s.label} className="text-center p-1 rounded border border-border/50 bg-surface-elevated">
+            <div className="text-[7px] font-mono text-text-muted">{s.label}</div>
+            <div className="text-[11px] font-[family-name:var(--font-michroma)] tabular-nums" style={{ color: s.color }}>{s.value}</div>
+          </div>
         ))}
       </div>
+
+      {/* Spectral stability */}
+      <div className="flex items-center justify-between p-1.5 rounded border" style={{
+        borderColor: netMetrics.isStable ? "rgba(0,230,118,0.2)" : "rgba(255,23,68,0.2)",
+        backgroundColor: netMetrics.isStable ? "rgba(0,230,118,0.03)" : "rgba(255,23,68,0.03)",
+      }}>
+        <div className="text-[8px] font-mono text-text-muted">
+          dS/dt = {"\u2212"}{netMetrics.dampingCoeff.toFixed(2)}{"\u00B7"}S + {netMetrics.forgettingRate.toFixed(2)}
+        </div>
+        <span className="text-[8px] font-mono px-1.5 py-0.5 rounded border" style={{
+          color: netMetrics.isStable ? "#00e676" : "#ff1744",
+          borderColor: netMetrics.isStable ? "rgba(0,230,118,0.3)" : "rgba(255,23,68,0.3)",
+        }}>
+          {"\u03BB"}max={netMetrics.lambdaMax.toFixed(2)} {netMetrics.isStable ? "STABLE" : "UNSTABLE"}
+        </span>
+      </div>
+
+      {/* Secondary stats */}
+      <div className="grid grid-cols-3 gap-1">
+        <div className="text-center p-1 rounded border border-border/50 bg-surface-elevated">
+          <div className="text-[7px] font-mono text-text-muted">AVG DEGREE</div>
+          <div className="text-[10px] font-mono text-accent-cyan tabular-nums">{netMetrics.avgDegree.toFixed(1)}</div>
+        </div>
+        <div className="text-center p-1 rounded border border-border/50 bg-surface-elevated">
+          <div className="text-[7px] font-mono text-text-muted">CLUSTERING</div>
+          <div className="text-[10px] font-mono tabular-nums" style={{ color: metricColor(netMetrics.clusteringCoeff, 0.1, 0.3) }}>
+            {netMetrics.clusteringCoeff.toFixed(3)}
+          </div>
+        </div>
+        <div className="text-center p-1 rounded border border-border/50 bg-surface-elevated">
+          <div className="text-[7px] font-mono text-text-muted">DIAMETER</div>
+          <div className="text-[10px] font-mono text-accent-cyan tabular-nums">{netMetrics.diameter}</div>
+        </div>
+      </div>
+
+      {/* Eigenvector Centrality — expandable */}
+      <button onClick={() => toggleMetric("eigen")} className="w-full text-left">
+        <div className="flex items-center justify-between p-1.5 rounded border border-accent-cyan/20 bg-accent-cyan/5 hover:bg-accent-cyan/8 transition-colors">
+          <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-accent-cyan">
+            EIGENVECTOR CENTRALITY
+          </div>
+          <span className="text-[8px] text-text-muted" style={{ transform: expandedMetric === "eigen" ? "rotate(180deg)" : "rotate(0deg)", display: "inline-block", transition: "transform 0.2s" }}>
+            {"\u25BC"}
+          </span>
+        </div>
+      </button>
+      {expandedMetric === "eigen" && (
+        <div className="space-y-1 pl-1">
+          <div className="text-[8px] font-mono text-text-muted leading-relaxed mb-1">
+            Measures a node{"'"}s influence based on how connected it is to other influential nodes. High eigenvector centrality = structural hub whose disruption cascades through well-connected neighbors.
+          </div>
+          {netMetrics.eigenTop.map((nd, i) => (
+            <button key={nd.id} onClick={() => setSelectedNode(nd.id)} className="w-full flex items-center gap-2 py-0.5 hover:bg-accent-cyan/5 rounded px-1 transition-colors">
+              <span className="text-[8px] font-mono text-text-muted w-3">{i + 1}.</span>
+              <span className="text-[9px] font-mono text-accent-cyan">{nd.label}</span>
+              <div className="flex-1 h-1 bg-border rounded overflow-hidden">
+                <div className="h-full bg-accent-cyan/60 rounded" style={{ width: `${(nd.value / (netMetrics.eigenTop[0]?.value || 1)) * 100}%` }} />
+              </div>
+              <span className="text-[8px] font-mono text-text-muted tabular-nums">{nd.value.toFixed(3)}</span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Betweenness Centrality — expandable */}
+      <button onClick={() => toggleMetric("between")} className="w-full text-left">
+        <div className="flex items-center justify-between p-1.5 rounded border border-accent-amber/20 bg-accent-amber/5 hover:bg-accent-amber/8 transition-colors">
+          <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-accent-amber">
+            BETWEENNESS CENTRALITY
+          </div>
+          <span className="text-[8px] text-text-muted" style={{ transform: expandedMetric === "between" ? "rotate(180deg)" : "rotate(0deg)", display: "inline-block", transition: "transform 0.2s" }}>
+            {"\u25BC"}
+          </span>
+        </div>
+      </button>
+      {expandedMetric === "between" && (
+        <div className="space-y-1 pl-1">
+          <div className="text-[8px] font-mono text-text-muted leading-relaxed mb-1">
+            Identifies chokepoints {"\u2014"} nodes that lie on the most shortest paths between other nodes. High betweenness = critical bridge whose removal fragments the network.
+          </div>
+          {netMetrics.betweenTop.map((nd, i) => (
+            <button key={nd.id} onClick={() => setSelectedNode(nd.id)} className="w-full flex items-center gap-2 py-0.5 hover:bg-accent-amber/5 rounded px-1 transition-colors">
+              <span className="text-[8px] font-mono text-text-muted w-3">{i + 1}.</span>
+              <span className="text-[9px] font-mono text-accent-amber">{nd.label}</span>
+              <div className="flex-1 h-1 bg-border rounded overflow-hidden">
+                <div className="h-full bg-accent-amber/60 rounded" style={{ width: `${nd.value * 100}%` }} />
+              </div>
+              <span className="text-[8px] font-mono text-text-muted tabular-nums">{nd.value.toFixed(3)}</span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Communities — expandable */}
+      <button onClick={() => toggleMetric("community")} className="w-full text-left">
+        <div className="flex items-center justify-between p-1.5 rounded border border-accent-green/20 bg-accent-green/5 hover:bg-accent-green/8 transition-colors">
+          <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-accent-green">
+            COMMUNITIES ({netMetrics.communityList.length})
+          </div>
+          <span className="text-[8px] text-text-muted" style={{ transform: expandedMetric === "community" ? "rotate(180deg)" : "rotate(0deg)", display: "inline-block", transition: "transform 0.2s" }}>
+            {"\u25BC"}
+          </span>
+        </div>
+      </button>
+      {expandedMetric === "community" && (
+        <div className="space-y-1 pl-1">
+          <div className="text-[8px] font-mono text-text-muted leading-relaxed mb-1">
+            Domain-based community structure. Inter-community edges are potential contagion pathways; intra-community edges represent tightly coupled sub-systems.
+          </div>
+          {netMetrics.communityList.map((c) => (
+            <div key={c.name} className="flex items-center gap-2 py-0.5 px-1">
+              <span className="text-[9px] font-mono text-accent-green flex-1 truncate">{c.name}</span>
+              <div className="w-16 h-1 bg-border rounded overflow-hidden">
+                <div className="h-full bg-accent-green/60 rounded" style={{ width: `${(c.size / graphData.nodes.length) * 100}%` }} />
+              </div>
+              <span className="text-[8px] font-mono text-text-muted tabular-nums">{c.size}</span>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/SystemCopilot.tsx
+++ b/src/components/SystemCopilot.tsx
@@ -10,6 +10,7 @@ import {
   streamLlmQuery,
   CopilotAction,
 } from "@/lib/copilot-engine";
+import { processLlmActions } from "@/lib/copilot-actions";
 import { CopilotMessage } from "@/lib/types";
 import { getModelsForProvider, type LLMProvider } from "@/lib/llm-providers";
 import { serializeGraphContext, serializeSnapshotContext } from "@/lib/copilot-context";
@@ -58,12 +59,16 @@ export default function SystemCopilot() {
     geminiApiKey,
     claudeModel,
     geminiModel,
+    ollamaUrl,
+    ollamaModel,
     isLlmStreaming,
     setLlmProvider,
     setClaudeApiKey,
     setGeminiApiKey,
     setClaudeModel,
     setGeminiModel,
+    setOllamaUrl,
+    setOllamaModel,
     setIsLlmStreaming,
     importedDatasets,
     removeImportedDataset,
@@ -77,10 +82,11 @@ export default function SystemCopilot() {
     tarskiReport,
   } = useApexStore();
 
-  // Copilot always uses Gemini; Claude key is for compute only
-  const copilotApiKey = geminiApiKey;
-  const copilotModel = geminiModel;
-  const copilotModelOptions = getModelsForProvider("gemini");
+  // Copilot provider: Gemini or Ollama; Claude is for compute only
+  const copilotProvider: LLMProvider = llmProvider === "ollama" ? "ollama" : "gemini";
+  const copilotApiKey = copilotProvider === "ollama" ? "ollama-local" : geminiApiKey;
+  const copilotModel = copilotProvider === "ollama" ? ollamaModel : geminiModel;
+  const copilotModelOptions = getModelsForProvider(copilotProvider);
 
   // Claude compute key/model
   const computeApiKey = claudeApiKey;
@@ -96,7 +102,7 @@ export default function SystemCopilot() {
   const streamingMsgRef = useRef<string | null>(null);
   const badgeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const isLlmActive = copilotApiKey.length > 0;
+  const isLlmActive = copilotProvider === "ollama" || copilotApiKey.length > 0;
   const isComputeAvailable = computeApiKey.length > 0;
 
   // Click-outside to close datasets panel
@@ -281,7 +287,7 @@ export default function SystemCopilot() {
           graph: graphData,
           apiKey: copilotApiKey,
           model: copilotModel,
-          provider: "gemini",
+          provider: copilotProvider,
           selectedNode,
           severedEdges,
           shocks,
@@ -292,6 +298,7 @@ export default function SystemCopilot() {
           ablatedEdgeIds,
           snapshotContext,
           tarskiReport,
+          ollamaUrl: copilotProvider === "ollama" ? ollamaUrl : undefined,
         });
 
         const reader = stream.getReader();
@@ -302,12 +309,33 @@ export default function SystemCopilot() {
           const { done, value } = await reader.read();
           if (done) break;
           accumulated += decoder.decode(value, { stream: true });
+          // Strip action tags from displayed text
+          const { displayText } = processLlmActions(accumulated);
           // Update the streaming message in store
           useApexStore.setState((s) => ({
             copilotMessages: s.copilotMessages.map((m) =>
-              m.id === assistantId ? { ...m, content: accumulated } : m
+              m.id === assistantId ? { ...m, content: displayText } : m
             ),
           }));
+        }
+
+        // After streaming completes, execute any actions from the full response
+        const { displayText, actionResults } = processLlmActions(accumulated);
+        // Update final display text
+        useApexStore.setState((s) => ({
+          copilotMessages: s.copilotMessages.map((m) =>
+            m.id === assistantId ? { ...m, content: displayText } : m
+          ),
+        }));
+        // Log action results as system messages
+        if (actionResults.length > 0) {
+          const actionSummary = actionResults.map((r) => `  \u2022 ${r}`).join("\n");
+          addCopilotMessage({
+            id: `sys-actions-${Date.now()}`,
+            role: "system",
+            content: `ACTIONS EXECUTED:\n${actionSummary}`,
+            timestamp: Date.now(),
+          });
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : "LLM request failed";
@@ -328,6 +356,8 @@ export default function SystemCopilot() {
       graphData,
       copilotApiKey,
       copilotModel,
+      copilotProvider,
+      ollamaUrl,
       snapshotHistory,
       selectedNode,
       severedEdges,
@@ -413,9 +443,11 @@ export default function SystemCopilot() {
               SYSTEM COPILOT
             </div>
             <div className="text-[9px] text-text-muted font-mono mt-0.5">
-              {isLlmActive
-                ? "Gemini-Augmented Analysis"
-                : "Synthetic Scientist Interface"}
+              {copilotProvider === "ollama"
+                ? `Ollama Local (${ollamaModel})`
+                : isLlmActive
+                  ? "Gemini-Augmented Analysis"
+                  : "Synthetic Scientist Interface"}
               {isComputeAvailable && " + Claude Compute"}
             </div>
           </div>
@@ -452,36 +484,95 @@ export default function SystemCopilot() {
               className="overflow-hidden"
             >
               <div className="mt-2 pt-2 border-t border-border space-y-2">
-                {/* Gemini (Copilot) */}
+                {/* Provider toggle */}
                 <div className="space-y-1">
                   <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted">
-                    GEMINI — COPILOT
+                    COPILOT PROVIDER
                   </div>
-                  <input
-                    type="password"
-                    value={geminiApiKey}
-                    onChange={(e) => setGeminiApiKey(e.target.value)}
-                    className="w-full bg-surface font-mono text-[10px] text-foreground outline-none px-2 py-1 rounded border border-border placeholder:text-text-muted focus:border-accent-cyan/50 transition-colors"
-                    placeholder="AIza... (session only)"
-                    spellCheck={false}
-                  />
-                  <select
-                    value={copilotModel}
-                    onChange={(e) => setGeminiModel(e.target.value)}
-                    className="w-full bg-surface font-mono text-[10px] text-foreground outline-none px-2 py-1 rounded border border-border transition-colors"
-                  >
-                    {copilotModelOptions.map((m) => (
-                      <option key={m.value} value={m.value}>
-                        {m.label}
-                      </option>
+                  <div className="flex gap-1">
+                    {(["gemini", "ollama"] as const).map((p) => (
+                      <button
+                        key={p}
+                        onClick={() => setLlmProvider(p)}
+                        className="flex-1 text-[8px] font-[family-name:var(--font-michroma)] tracking-wider px-2 py-1 rounded border transition-all"
+                        style={{
+                          borderColor: copilotProvider === p ? "var(--accent-cyan)" : "var(--border)",
+                          backgroundColor: copilotProvider === p ? "rgba(0,229,255,0.08)" : "transparent",
+                          color: copilotProvider === p ? "var(--accent-cyan)" : "var(--text-muted)",
+                        }}
+                      >
+                        {p === "gemini" ? "GEMINI" : "OLLAMA"}
+                      </button>
                     ))}
-                  </select>
-                  {isLlmActive && (
-                    <div className="text-[8px] text-accent-green font-mono tracking-wider">
-                      GEMINI ACTIVE
-                    </div>
-                  )}
+                  </div>
                 </div>
+
+                {/* Gemini config */}
+                {copilotProvider === "gemini" && (
+                  <div className="space-y-1">
+                    <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted">
+                      GEMINI — COPILOT
+                    </div>
+                    <input
+                      type="password"
+                      value={geminiApiKey}
+                      onChange={(e) => setGeminiApiKey(e.target.value)}
+                      className="w-full bg-surface font-mono text-[10px] text-foreground outline-none px-2 py-1 rounded border border-border placeholder:text-text-muted focus:border-accent-cyan/50 transition-colors"
+                      placeholder="AIza... (session only)"
+                      spellCheck={false}
+                    />
+                    <select
+                      value={copilotModel}
+                      onChange={(e) => setGeminiModel(e.target.value)}
+                      className="w-full bg-surface font-mono text-[10px] text-foreground outline-none px-2 py-1 rounded border border-border transition-colors"
+                    >
+                      {copilotModelOptions.map((m) => (
+                        <option key={m.value} value={m.value}>
+                          {m.label}
+                        </option>
+                      ))}
+                    </select>
+                    {geminiApiKey.length > 0 && (
+                      <div className="text-[8px] text-accent-green font-mono tracking-wider">
+                        GEMINI ACTIVE
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* Ollama config */}
+                {copilotProvider === "ollama" && (
+                  <div className="space-y-1">
+                    <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted">
+                      OLLAMA — LOCAL LLM
+                    </div>
+                    <input
+                      type="text"
+                      value={ollamaUrl}
+                      onChange={(e) => setOllamaUrl(e.target.value)}
+                      className="w-full bg-surface font-mono text-[10px] text-foreground outline-none px-2 py-1 rounded border border-border placeholder:text-text-muted focus:border-accent-cyan/50 transition-colors"
+                      placeholder="http://localhost:11434"
+                      spellCheck={false}
+                    />
+                    <select
+                      value={ollamaModel}
+                      onChange={(e) => setOllamaModel(e.target.value)}
+                      className="w-full bg-surface font-mono text-[10px] text-foreground outline-none px-2 py-1 rounded border border-border transition-colors"
+                    >
+                      {copilotModelOptions.map((m) => (
+                        <option key={m.value} value={m.value}>
+                          {m.label}
+                        </option>
+                      ))}
+                    </select>
+                    <div className="text-[8px] text-accent-green font-mono tracking-wider">
+                      OLLAMA MODE — no API key needed
+                    </div>
+                    <div className="text-[8px] font-mono text-text-muted leading-relaxed">
+                      Run &quot;ollama serve&quot; locally. Models: ollama pull llama3.1:8b
+                    </div>
+                  </div>
+                )}
                 {/* Claude (Compute) */}
                 <div className="space-y-1 pt-1.5 border-t border-border">
                   <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted">
@@ -697,7 +788,7 @@ export default function SystemCopilot() {
             onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
             disabled={isLlmStreaming}
             className="flex-1 bg-surface-elevated font-mono text-[11px] text-foreground outline-none px-2.5 py-1.5 rounded border border-border placeholder:text-text-muted focus:border-accent-cyan/50 transition-colors disabled:opacity-40"
-            placeholder={isLlmActive ? "Ask anything (LLM active)..." : "Ask the system to analyze or verify..."}
+            placeholder={copilotProvider === "ollama" ? "Ask anything (Ollama local)..." : isLlmActive ? "Ask anything (LLM active)..." : "Ask the system to analyze or verify..."}
             spellCheck={false}
           />
           <button

--- a/src/components/SystemCopilot.tsx
+++ b/src/components/SystemCopilot.tsx
@@ -96,11 +96,15 @@ export default function SystemCopilot() {
   const [showSettings, setShowSettings] = useState(false);
   const [showDatasets, setShowDatasets] = useState(false);
   const [contextBadge, setContextBadge] = useState<string | null>(null);
+  const [isListening, setIsListening] = useState(false);
+  const [ttsEnabled, setTtsEnabled] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const datasetPanelRef = useRef<HTMLDivElement>(null);
   const lastSelectedRef = useRef<string | null>(null);
   const streamingMsgRef = useRef<string | null>(null);
   const badgeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const recognitionRef = useRef<SpeechRecognition | null>(null);
+  const lastSpokenMsgRef = useRef<string | null>(null);
 
   const isLlmActive = copilotProvider === "ollama" || copilotApiKey.length > 0;
   const isComputeAvailable = computeApiKey.length > 0;
@@ -127,6 +131,54 @@ export default function SystemCopilot() {
     setContextBadge(label);
     if (badgeTimerRef.current) clearTimeout(badgeTimerRef.current);
     badgeTimerRef.current = setTimeout(() => setContextBadge(null), 3000);
+  }, []);
+
+  // ─── Voice Output (Text-to-Speech) ─────────────────────
+  const speakText = useCallback((text: string) => {
+    if (!ttsEnabled || typeof window === "undefined" || !window.speechSynthesis) return;
+    window.speechSynthesis.cancel();
+
+    const clean = text
+      .replace(/[*_#`~]/g, "")
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+      .replace(/\n{2,}/g, ". ")
+      .replace(/\n/g, ", ")
+      .trim();
+
+    if (!clean) return;
+
+    const utterance = new SpeechSynthesisUtterance(clean);
+    utterance.rate = 0.95;
+    utterance.pitch = 0.85;
+    utterance.volume = 1;
+
+    const voices = window.speechSynthesis.getVoices();
+    const preferred = voices.find(
+      (v) => v.name.includes("Daniel") || v.name.includes("Google UK English Male") || v.name.includes("Alex")
+    ) ?? voices.find((v) => v.lang.startsWith("en") && v.name.toLowerCase().includes("male"))
+      ?? voices.find((v) => v.lang.startsWith("en"));
+    if (preferred) utterance.voice = preferred;
+
+    window.speechSynthesis.speak(utterance);
+  }, [ttsEnabled]);
+
+  // Auto-speak assistant responses when TTS is enabled
+  useEffect(() => {
+    if (!ttsEnabled) return;
+    const lastMsg = copilotMessages[copilotMessages.length - 1];
+    if (!lastMsg || lastMsg.role !== "assistant" || !lastMsg.content) return;
+    if (lastMsg.id === lastSpokenMsgRef.current) return;
+    if (isLlmStreaming) return;
+
+    lastSpokenMsgRef.current = lastMsg.id;
+    speakText(lastMsg.content);
+  }, [copilotMessages, ttsEnabled, isLlmStreaming, speakText]);
+
+  // Load voices (some browsers load them async)
+  useEffect(() => {
+    if (typeof window !== "undefined" && window.speechSynthesis) {
+      window.speechSynthesis.getVoices();
+    }
   }, []);
 
   // Inject node context message when selection changes
@@ -372,6 +424,69 @@ export default function SystemCopilot() {
     ]
   );
 
+  // ─── Voice Input (Speech-to-Text) ────────────────────────
+  const startListening = useCallback(() => {
+    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+    if (!SpeechRecognition) {
+      addCopilotMessage({
+        id: `sys-voice-${Date.now()}`,
+        role: "system",
+        content: "Speech recognition not supported in this browser.",
+        timestamp: Date.now(),
+      });
+      return;
+    }
+
+    const recognition = new SpeechRecognition();
+    recognition.continuous = false;
+    recognition.interimResults = true;
+    recognition.lang = "en-US";
+
+    recognition.onstart = () => setIsListening(true);
+
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+      let transcript = "";
+      for (let i = 0; i < event.results.length; i++) {
+        transcript += event.results[i][0].transcript;
+      }
+      setInput(transcript);
+
+      if (event.results[event.results.length - 1].isFinal) {
+        setInput(transcript);
+        setTimeout(() => {
+          const trimmed = transcript.trim();
+          if (trimmed) {
+            const userMsg: CopilotMessage = {
+              id: `user-${Date.now()}`,
+              role: "user",
+              content: trimmed,
+              timestamp: Date.now(),
+            };
+            addCopilotMessage(userMsg);
+            if (isLlmActive) {
+              handleStreamingQuery(trimmed);
+            } else {
+              const responses = processQuery(trimmed, graphData);
+              responses.forEach((msg) => addCopilotMessage(msg));
+            }
+            setInput("");
+          }
+        }, 100);
+      }
+    };
+
+    recognition.onerror = () => setIsListening(false);
+    recognition.onend = () => setIsListening(false);
+
+    recognitionRef.current = recognition;
+    recognition.start();
+  }, [addCopilotMessage, isLlmActive, handleStreamingQuery, graphData]);
+
+  const stopListening = useCallback(() => {
+    recognitionRef.current?.stop();
+    setIsListening(false);
+  }, []);
+
   const handleAction = (action: CopilotAction) => {
     const userContent = action.replace(/_/g, " ");
     const userMsg: CopilotMessage = {
@@ -452,6 +567,20 @@ export default function SystemCopilot() {
             </div>
           </div>
           <div className="flex items-center gap-1">
+            {/* TTS toggle */}
+            <button
+              onClick={() => {
+                const next = !ttsEnabled;
+                setTtsEnabled(next);
+                if (!next && typeof window !== "undefined") window.speechSynthesis?.cancel();
+              }}
+              className={`text-[11px] transition-colors p-1 ${
+                ttsEnabled ? "text-accent-green" : "text-text-muted hover:text-accent-green"
+              }`}
+              title={ttsEnabled ? "Voice Output ON — click to disable" : "Enable Voice Output"}
+            >
+              {ttsEnabled ? "\uD83D\uDD0A" : "\uD83D\uDD07"}
+            </button>
             {importedDatasets.length > 0 && (
               <button
                 onClick={() => { setShowDatasets(!showDatasets); if (!showDatasets) setShowSettings(false); }}
@@ -791,6 +920,18 @@ export default function SystemCopilot() {
             placeholder={copilotProvider === "ollama" ? "Ask anything (Ollama local)..." : isLlmActive ? "Ask anything (LLM active)..." : "Ask the system to analyze or verify..."}
             spellCheck={false}
           />
+          <button
+            onClick={isListening ? stopListening : startListening}
+            disabled={isLlmStreaming}
+            className={`text-[12px] px-1.5 py-1.5 rounded transition-colors disabled:opacity-40 ${
+              isListening
+                ? "text-accent-red bg-accent-red/10 animate-pulse"
+                : "text-text-muted hover:text-accent-cyan hover:bg-accent-cyan/10"
+            }`}
+            title={isListening ? "Stop listening" : "Voice input"}
+          >
+            {isListening ? "\u23F9" : "\uD83C\uDF99"}
+          </button>
           <button
             onClick={handleSubmit}
             disabled={isLlmStreaming}

--- a/src/components/dag3d/DAGEdge3D.tsx
+++ b/src/components/dag3d/DAGEdge3D.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
+import { useFrame } from "@react-three/fiber";
 import { Billboard, Text } from "@react-three/drei";
 import * as THREE from "three";
 import { CausalEdge, EdgeEpochState } from "@/lib/types";
@@ -56,6 +57,8 @@ export default function DAGEdge3D({
   epochState,
 }: DAGEdge3DProps) {
   const [hovered, setHovered] = useState(false);
+  const particleRef = useRef<THREE.Mesh>(null);
+  const curveRef = useRef<THREE.QuadraticBezierCurve3 | null>(null);
   const baseColor = getEdgeColor(edge, isVerifiedInconsistent, isCrossDomain);
   const color = isAblated ? "#e040fb" : isSevered ? "#ff1744" : isConsequenceEdge ? "#ff6d00" : baseColor;
   const lineWidth = 0.5 + edge.weight * 1.5;
@@ -73,6 +76,7 @@ export default function DAGEdge3D({
     mid.add(offset);
 
     const curve = new THREE.QuadraticBezierCurve3(src, mid, tgt);
+    curveRef.current = curve;
     const pts = curve.getPoints(24);
 
     // Arrow at 80% along path
@@ -109,6 +113,20 @@ export default function DAGEdge3D({
   const lineOpacity = selectionDim ? 0.05 : isConnectedToSelected ? 1.0 : Math.min(1, baseOpacity);
   const arrowBaseOpacity = isSevered ? 0 : isDimmed ? 0.15 : (0.7 + propBoost);
   const arrowOpacity = selectionDim ? 0.05 : isConnectedToSelected ? 1.0 : Math.min(1, arrowBaseOpacity);
+
+  // Animate flowing particle along the edge curve
+  const shouldAnimate = !isSevered && !isAblated && !selectionDim && (edge.type === "directed" || edge.type === "temporal" || propSignal > 0.3);
+  const animSpeed = edge.type === "temporal" ? 0.35 : 0.25 + propSignal * 0.4;
+
+  useFrame((_, delta) => {
+    if (!particleRef.current || !curveRef.current || !shouldAnimate) return;
+    const t = ((performance.now() * 0.001 * animSpeed) % 1);
+    const pos = curveRef.current.getPoint(t);
+    particleRef.current.position.set(pos.x, pos.y, pos.z);
+    // Pulse the scale slightly for a glowing effect
+    const pulse = 1 + Math.sin(performance.now() * 0.005) * 0.3;
+    particleRef.current.scale.setScalar(pulse);
+  });
 
   return (
     <group>
@@ -163,6 +181,18 @@ export default function DAGEdge3D({
           opacity={arrowOpacity}
         />
       </mesh>
+
+      {/* Animated flowing particle */}
+      {shouldAnimate && (
+        <mesh ref={particleRef}>
+          <sphereGeometry args={[0.12 + edge.weight * 0.08, 8, 8]} />
+          <meshBasicMaterial
+            color={color}
+            transparent
+            opacity={lineOpacity * 0.9}
+          />
+        </mesh>
+      )}
 
       {/* Hover: physical mechanism label */}
       {hovered && edge.physicalMechanism && (

--- a/src/components/trinity/DcdGraph.tsx
+++ b/src/components/trinity/DcdGraph.tsx
@@ -162,16 +162,44 @@ export default function DcdGraph() {
     );
   }
 
+  const [showInfo, setShowInfo] = useState(false);
+
   return (
     <div className="p-2 h-full flex flex-col">
       <div className="flex items-center justify-between mb-1">
-        <span className="font-[family-name:var(--font-michroma)] text-[9px] tracking-wider text-accent-cyan">
-          DCD / NOTEARS
-        </span>
+        <div className="flex items-center gap-1.5">
+          <span className="font-[family-name:var(--font-michroma)] text-[9px] tracking-wider text-accent-cyan">
+            DCD / NOTEARS
+          </span>
+          <button
+            onClick={() => setShowInfo(!showInfo)}
+            className="text-[8px] font-mono px-1 py-0.5 rounded border transition-colors"
+            style={{
+              color: showInfo ? "#00e5ff" : "#5a5e72",
+              borderColor: showInfo ? "rgba(0,229,255,0.3)" : "rgba(90,94,114,0.3)",
+              backgroundColor: showInfo ? "rgba(0,229,255,0.08)" : "transparent",
+            }}
+          >
+            {showInfo ? "\u2212" : "?"}
+          </button>
+        </div>
         <span className="text-[8px] text-text-muted font-mono">
           {dcdNodes.length} nodes | Structural
         </span>
       </div>
+      {showInfo && (
+        <div className="mb-1.5 p-2 rounded border border-accent-cyan/20 bg-accent-cyan/5 space-y-1">
+          <div className="text-[9px] font-mono text-text-muted leading-relaxed">
+            <span className="text-accent-cyan font-bold">Directed Causal Discovery</span> uses the NOTEARS algorithm to discover the primary directed acyclic structure of the supply chain.
+          </div>
+          <div className="text-[9px] font-mono text-text-muted leading-relaxed">
+            Nodes represent assets/entities. Directed edges (arrows) show causal influence from source to target. Edge thickness encodes causal strength (weight). Node size scales with {"\u03A9"}-fragility score.
+          </div>
+          <div className="text-[9px] font-mono text-text-muted leading-relaxed">
+            This view captures <span className="text-accent-cyan">instantaneous causality</span> only (lag=0). Time-lagged relationships appear in PCMCI+ below. Hover nodes/edges for details.
+          </div>
+        </div>
+      )}
       <svg
         viewBox={`0 0 ${SVG_W} ${SVG_H}`}
         className="flex-1 w-full"

--- a/src/components/trinity/FciGraph.tsx
+++ b/src/components/trinity/FciGraph.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { getCategoryColor } from "@/lib/graph-data";
 import { useApexStore } from "@/stores/useApexStore";
 import { useFilteredGraph } from "@/hooks/useFilteredGraph";
@@ -65,16 +65,44 @@ export default function FciGraph() {
     );
   }
 
+  const [showInfo, setShowInfo] = useState(false);
+
   return (
     <div className="p-2 h-full flex flex-col">
       <div className="flex items-center justify-between mb-1">
-        <span className="font-[family-name:var(--font-michroma)] text-[9px] tracking-wider text-accent-red">
-          FCI
-        </span>
+        <div className="flex items-center gap-1.5">
+          <span className="font-[family-name:var(--font-michroma)] text-[9px] tracking-wider text-accent-red">
+            FCI
+          </span>
+          <button
+            onClick={() => setShowInfo(!showInfo)}
+            className="text-[8px] font-mono px-1 py-0.5 rounded border transition-colors"
+            style={{
+              color: showInfo ? "#ff1744" : "#5a5e72",
+              borderColor: showInfo ? "rgba(255,23,68,0.3)" : "rgba(90,94,114,0.3)",
+              backgroundColor: showInfo ? "rgba(255,23,68,0.08)" : "transparent",
+            }}
+          >
+            {showInfo ? "\u2212" : "?"}
+          </button>
+        </div>
         <span className="text-[8px] text-text-muted font-mono">
           {fciNodes.length} nodes | Latent PAG
         </span>
       </div>
+      {showInfo && (
+        <div className="mb-1.5 p-2 rounded border border-accent-red/20 bg-accent-red/5 space-y-1">
+          <div className="text-[9px] font-mono text-text-muted leading-relaxed">
+            <span className="text-accent-red font-bold">Fast Causal Inference</span> detects latent confounders {"\u2014"} hidden common causes that make two nodes appear correlated without a direct causal link.
+          </div>
+          <div className="text-[9px] font-mono text-text-muted leading-relaxed">
+            <span className="text-accent-red">Dashed red edges</span> with {"\"?\""}  markers indicate uncertain causal direction due to a potential unobserved variable driving both endpoints (e.g., shared geopolitical factors).
+          </div>
+          <div className="text-[9px] font-mono text-text-muted leading-relaxed">
+            Solid edges are confident directed links. Red-filled nodes are flagged as confounded. Circular layout emphasizes the uncertainty {"\u2014"} no implied causal hierarchy.
+          </div>
+        </div>
+      )}
       <svg
         viewBox="0 0 260 120"
         className="flex-1 w-full"

--- a/src/components/trinity/PcmciGraph.tsx
+++ b/src/components/trinity/PcmciGraph.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { getCategoryColor } from "@/lib/graph-data";
 import { useApexStore } from "@/stores/useApexStore";
 import { useFilteredGraph } from "@/hooks/useFilteredGraph";
@@ -80,16 +80,44 @@ export default function PcmciGraph() {
     );
   }
 
+  const [showInfo, setShowInfo] = useState(false);
+
   return (
     <div className="p-2 h-full flex flex-col">
       <div className="flex items-center justify-between mb-1">
-        <span className="font-[family-name:var(--font-michroma)] text-[9px] tracking-wider text-accent-amber">
-          PCMCI+
-        </span>
+        <div className="flex items-center gap-1.5">
+          <span className="font-[family-name:var(--font-michroma)] text-[9px] tracking-wider text-accent-amber">
+            PCMCI+
+          </span>
+          <button
+            onClick={() => setShowInfo(!showInfo)}
+            className="text-[8px] font-mono px-1 py-0.5 rounded border transition-colors"
+            style={{
+              color: showInfo ? "#ffab00" : "#5a5e72",
+              borderColor: showInfo ? "rgba(255,171,0,0.3)" : "rgba(90,94,114,0.3)",
+              backgroundColor: showInfo ? "rgba(255,171,0,0.08)" : "transparent",
+            }}
+          >
+            {showInfo ? "\u2212" : "?"}
+          </button>
+        </div>
         <span className="text-[8px] text-text-muted font-mono">
           {pcmciNodes.length} nodes | Temporal
         </span>
       </div>
+      {showInfo && (
+        <div className="mb-1.5 p-2 rounded border border-accent-amber/20 bg-accent-amber/5 space-y-1">
+          <div className="text-[9px] font-mono text-text-muted leading-relaxed">
+            <span className="text-accent-amber font-bold">Temporal Causal Discovery</span> identifies time-lagged causal relationships using the PCMCI+ algorithm (Peter Spirtes{"'"} PC + Momentary Conditional Independence).
+          </div>
+          <div className="text-[9px] font-mono text-text-muted leading-relaxed">
+            Columns represent time steps: <span className="text-accent-amber">T-2</span> (past) {"\u2192"} <span className="text-accent-amber">T-0</span> (present). Arrows crossing columns show how shocks propagate with delays {"\u2014"} pipeline transit, procurement cycles, construction timelines.
+          </div>
+          <div className="text-[9px] font-mono text-text-muted leading-relaxed">
+            Unlike DCD above, these edges have <span className="text-accent-amber">lag {">"} 0</span>: a disruption at the source doesn{"'"}t hit the target until lag epochs later. Steeper arrows = longer delays.
+          </div>
+        </div>
+      )}
       <svg
         viewBox="0 0 260 120"
         className="flex-1 w-full"

--- a/src/lib/copilot-actions.ts
+++ b/src/lib/copilot-actions.ts
@@ -1,0 +1,159 @@
+// ─── Copilot Action Router ──────────────────────────────────────
+// Parses <<<ACTION:type:param>>> blocks from LLM responses and
+// executes them against the Apex store.
+
+import { useApexStore } from "@/stores/useApexStore";
+import { getPresetShocks } from "./omega-engine";
+
+export interface ParsedAction {
+  type: string;
+  param: string;
+  raw: string;
+}
+
+// ─── Parse actions from LLM response text ───────────────────────
+
+const ACTION_REGEX = /<<<ACTION:(\w+):?(.*?)>>>/g;
+
+export function parseActions(text: string): ParsedAction[] {
+  const actions: ParsedAction[] = [];
+  let match;
+  while ((match = ACTION_REGEX.exec(text)) !== null) {
+    actions.push({
+      type: match[1],
+      param: match[2] ?? "",
+      raw: match[0],
+    });
+  }
+  return actions;
+}
+
+// ─── Strip action blocks from display text ──────────────────────
+
+export function stripActions(text: string): string {
+  return text.replace(ACTION_REGEX, "").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+// ─── Execute a parsed action against the store ──────────────────
+
+export function executeAction(action: ParsedAction): string | null {
+  const store = useApexStore.getState();
+  const presetShocks = getPresetShocks();
+
+  switch (action.type) {
+    case "select_node": {
+      const node = store.graphData.nodes.find(
+        (n) => n.id === action.param || n.shortLabel.toLowerCase() === action.param.toLowerCase()
+          || n.label.toLowerCase() === action.param.toLowerCase()
+      );
+      if (node) {
+        store.setSelectedNode(node.id);
+        return `Selected node: ${node.label}`;
+      }
+      return `Node not found: ${action.param}`;
+    }
+
+    case "add_shock": {
+      const shock = presetShocks.find((s) => s.id === action.param);
+      if (shock) {
+        // Check if already active
+        if (!store.shocks.find((s) => s.id === shock.id)) {
+          store.addShock(shock);
+          return `Injected shock: ${shock.name}`;
+        }
+        return `Shock already active: ${shock.name}`;
+      }
+      return `Unknown shock: ${action.param}`;
+    }
+
+    case "remove_shock": {
+      const existing = store.shocks.find((s) => s.id === action.param);
+      if (existing) {
+        store.removeShock(action.param);
+        return `Removed shock: ${existing.name}`;
+      }
+      return `Shock not active: ${action.param}`;
+    }
+
+    case "set_module": {
+      const valid = ["spirtes", "tarski", "pearl", "pareto"];
+      if (valid.includes(action.param)) {
+        store.setActiveModule(action.param as "spirtes" | "tarski" | "pearl" | "pareto");
+        return `Switched to ${action.param.toUpperCase()} module`;
+      }
+      return `Invalid module: ${action.param}`;
+    }
+
+    case "set_view": {
+      if (action.param === "2d" || action.param === "3d") {
+        store.setViewMode(action.param);
+        return `Switched to ${action.param.toUpperCase()} view`;
+      }
+      return `Invalid view mode: ${action.param}`;
+    }
+
+    case "sever_edge": {
+      const edge = store.graphData.edges.find((e) => e.id === action.param);
+      if (edge) {
+        store.severEdge(edge.id);
+        return `Severed edge: ${edge.source} → ${edge.target}`;
+      }
+      return `Edge not found: ${action.param}`;
+    }
+
+    case "reset_severed": {
+      store.resetSeveredEdges();
+      return "Reset all severed edges";
+    }
+
+    case "start_replay": {
+      store.startReplay();
+      return "Started cascade replay";
+    }
+
+    case "stop_replay": {
+      store.stopReplay();
+      return "Stopped cascade replay";
+    }
+
+    case "set_truth_filter": {
+      if (action.param === "raw" || action.param === "verified") {
+        store.setTruthFilter(action.param);
+        return `Truth filter set to: ${action.param.toUpperCase()}`;
+      }
+      return `Invalid filter: ${action.param}`;
+    }
+
+    case "set_domains": {
+      const domains = action.param.split(",").map((d) => d.trim()).filter(Boolean);
+      if (domains.length > 0) {
+        store.setSelectedDomains(domains);
+        return `Filtered to domains: ${domains.join(", ")}`;
+      }
+      return "No valid domains specified";
+    }
+
+    default:
+      return `Unknown action: ${action.type}`;
+  }
+}
+
+// ─── Process all actions from an LLM response ──────────────────
+
+export function processLlmActions(text: string): {
+  displayText: string;
+  actionResults: string[];
+} {
+  const actions = parseActions(text);
+  const displayText = stripActions(text);
+  const actionResults: string[] = [];
+
+  for (const action of actions) {
+    const result = executeAction(action);
+    if (result) {
+      actionResults.push(result);
+    }
+  }
+
+  return { displayText, actionResults };
+}

--- a/src/lib/copilot-engine.ts
+++ b/src/lib/copilot-engine.ts
@@ -363,7 +363,7 @@ interface StreamLlmOptions {
   graph: CausalGraph;
   apiKey: string;
   model: string;
-  provider?: "anthropic" | "gemini";
+  provider?: "anthropic" | "gemini" | "ollama";
   selectedNode: string | null;
   severedEdges: string[];
   shocks: { id: string; name: string; severity: number; category: string }[];
@@ -374,6 +374,7 @@ interface StreamLlmOptions {
   ablatedEdgeIds?: string[];
   snapshotContext?: string;
   tarskiReport?: TarskiValidationReport | null;
+  ollamaUrl?: string;
 }
 
 export async function streamLlmQuery(
@@ -413,6 +414,7 @@ export async function streamLlmQuery(
       apiKey: opts.apiKey,
       model: opts.model,
       provider: opts.provider,
+      ollamaUrl: opts.ollamaUrl,
     }),
   });
 

--- a/src/lib/llm-providers.ts
+++ b/src/lib/llm-providers.ts
@@ -1,7 +1,7 @@
 // ─── LLM Provider Abstraction ───────────────────────────────────
 // Unified interface for streaming from multiple LLM providers
 
-export type LLMProvider = "anthropic" | "gemini";
+export type LLMProvider = "anthropic" | "gemini" | "ollama";
 
 export interface StreamOptions {
   apiKey: string;
@@ -26,6 +26,13 @@ export const PROVIDER_MODELS: ProviderModelOption[] = [
   { value: "gemini-2.0-flash", label: "Gemini 2.0 Flash", provider: "gemini" },
   { value: "gemini-2.0-flash-lite", label: "Gemini 2.0 Flash Lite", provider: "gemini" },
   { value: "gemini-2.5-pro-preview-06-05", label: "Gemini 2.5 Pro", provider: "gemini" },
+  // Ollama (local open-source)
+  { value: "llama3.1:8b", label: "Llama 3.1 8B", provider: "ollama" },
+  { value: "llama3.1:70b", label: "Llama 3.1 70B", provider: "ollama" },
+  { value: "mistral:7b", label: "Mistral 7B", provider: "ollama" },
+  { value: "mixtral:8x7b", label: "Mixtral 8x7B", provider: "ollama" },
+  { value: "qwen2.5:7b", label: "Qwen 2.5 7B", provider: "ollama" },
+  { value: "deepseek-r1:8b", label: "DeepSeek R1 8B", provider: "ollama" },
 ];
 
 export function getModelsForProvider(provider: LLMProvider): ProviderModelOption[] {
@@ -37,7 +44,9 @@ export function getProviderForModel(model: string): LLMProvider | null {
 }
 
 export function getDefaultModel(provider: LLMProvider): string {
-  return provider === "anthropic"
-    ? "claude-sonnet-4-20250514"
-    : "gemini-2.0-flash";
+  switch (provider) {
+    case "anthropic": return "claude-sonnet-4-20250514";
+    case "gemini": return "gemini-2.0-flash";
+    case "ollama": return "llama3.1:8b";
+  }
 }

--- a/src/lib/speech.d.ts
+++ b/src/lib/speech.d.ts
@@ -1,0 +1,43 @@
+// Web Speech API type declarations
+interface SpeechRecognitionEvent extends Event {
+  readonly results: SpeechRecognitionResultList;
+  readonly resultIndex: number;
+}
+
+interface SpeechRecognitionResultList {
+  readonly length: number;
+  [index: number]: SpeechRecognitionResult;
+}
+
+interface SpeechRecognitionResult {
+  readonly isFinal: boolean;
+  readonly length: number;
+  [index: number]: SpeechRecognitionAlternative;
+}
+
+interface SpeechRecognitionAlternative {
+  readonly transcript: string;
+  readonly confidence: number;
+}
+
+interface SpeechRecognition extends EventTarget {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  onstart: ((this: SpeechRecognition, ev: Event) => void) | null;
+  onresult: ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => void) | null;
+  onerror: ((this: SpeechRecognition, ev: Event) => void) | null;
+  onend: ((this: SpeechRecognition, ev: Event) => void) | null;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognition;
+}
+
+interface Window {
+  SpeechRecognition?: SpeechRecognitionConstructor;
+  webkitSpeechRecognition?: SpeechRecognitionConstructor;
+}

--- a/src/stores/useApexStore.ts
+++ b/src/stores/useApexStore.ts
@@ -115,12 +115,16 @@ interface ApexState {
   geminiApiKey: string;
   claudeModel: string;
   geminiModel: string;
+  ollamaUrl: string;
+  ollamaModel: string;
   isLlmStreaming: boolean;
   setLlmProvider: (provider: LLMProvider) => void;
   setClaudeApiKey: (key: string) => void;
   setGeminiApiKey: (key: string) => void;
   setClaudeModel: (model: string) => void;
   setGeminiModel: (model: string) => void;
+  setOllamaUrl: (url: string) => void;
+  setOllamaModel: (model: string) => void;
   setIsLlmStreaming: (streaming: boolean) => void;
 
   // Sandbox
@@ -355,12 +359,16 @@ export const useApexStore = create<ApexState>((set) => ({
   geminiApiKey: "",
   claudeModel: "claude-sonnet-4-20250514",
   geminiModel: "gemini-2.0-flash",
+  ollamaUrl: "http://localhost:11434",
+  ollamaModel: "llama3.1:8b",
   isLlmStreaming: false,
   setLlmProvider: (provider) => set({ llmProvider: provider }),
   setClaudeApiKey: (key) => set({ claudeApiKey: key }),
   setGeminiApiKey: (key) => set({ geminiApiKey: key }),
   setClaudeModel: (model) => set({ claudeModel: model }),
   setGeminiModel: (model) => set({ geminiModel: model }),
+  setOllamaUrl: (url) => set({ ollamaUrl: url }),
+  setOllamaModel: (model) => set({ ollamaModel: model }),
   setIsLlmStreaming: (streaming) => set({ isLlmStreaming: streaming }),
 
   // Sandbox


### PR DESCRIPTION
## Summary
- Adds directional arrowheads (MarkerType.ArrowClosed) to directed and temporal edges in the 2D graph
- Matches the arrow cones already in the 3D view for consistent visualization
- Confounded edges remain without arrows (dashed only)

## Test plan
- Switch to 2D view and verify arrow tips on directed (cyan) and temporal (amber) edges
- Confirm confounded edges have no arrowheads
- Compare with 3D view for consistency