### PR TITLE
Rename Interdiction to CASCADE DEFENSE + AI ablation interpretation

### DIFF
--- a/src/components/AblationPanel.tsx
+++ b/src/components/AblationPanel.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useApexStore } from "@/stores/useApexStore";
-import { computeAblationComparison } from "@/lib/ablation-engine";
+import { computeAblationComparison, AblationComparison } from "@/lib/ablation-engine";
+import { streamLlmQuery } from "@/lib/copilot-engine";
 
 export default function AblationPanel() {
   const {
@@ -15,12 +16,86 @@ export default function AblationPanel() {
     graphData,
   } = useApexStore();
 
+  const [interpretation, setInterpretation] = useState<string | null>(null);
+  const [interpreting, setInterpreting] = useState(false);
+
   const comparison = useMemo(() => {
     if (ablatedNodeIds.length === 0 && ablatedEdgeIds.length === 0) return null;
     return computeAblationComparison(graphData, ablatedNodeIds, ablatedEdgeIds);
   }, [graphData, ablatedNodeIds, ablatedEdgeIds]);
 
   const hasSelections = ablatedNodeIds.length > 0 || ablatedEdgeIds.length > 0;
+
+  // Get names of ablated nodes for context
+  const ablatedNodeNames = useMemo(() => {
+    return ablatedNodeIds.map((id) => {
+      const node = graphData.nodes.find((n) => n.id === id);
+      return node ? (node.shortLabel || node.label) : id;
+    });
+  }, [ablatedNodeIds, graphData.nodes]);
+
+  const ablatedEdgeLabels = useMemo(() => {
+    return ablatedEdgeIds.map((id) => {
+      const edge = graphData.edges.find((e) => e.id === id);
+      if (!edge) return id;
+      const src = graphData.nodes.find((n) => n.id === edge.source);
+      const tgt = graphData.nodes.find((n) => n.id === edge.target);
+      return `${src?.shortLabel ?? edge.source} → ${tgt?.shortLabel ?? edge.target}`;
+    });
+  }, [ablatedEdgeIds, graphData]);
+
+  const requestInterpretation = useCallback(async (comp: AblationComparison) => {
+    setInterpreting(true);
+    setInterpretation(null);
+
+    // Build a focused prompt for the LLM
+    const prompt = buildAblationPrompt(comp, ablatedNodeNames, ablatedEdgeLabels);
+
+    try {
+      // Get LLM settings from store (mirror SystemCopilot's provider logic)
+      const state = useApexStore.getState();
+      const provider = state.llmProvider === "ollama" ? "ollama" : "gemini";
+      const model = provider === "ollama" ? state.ollamaModel : state.geminiModel;
+      const apiKey = provider === "ollama" ? "ollama-local" : state.geminiApiKey;
+      const ollamaUrl = state.ollamaUrl || "http://localhost:11434";
+
+      const stream = await streamLlmQuery({
+        copilotMessages: [
+          { id: "abl-1", role: "user", content: prompt, timestamp: Date.now() },
+        ],
+        graph: graphData,
+        apiKey,
+        model,
+        provider,
+        selectedNode: null,
+        severedEdges: [],
+        shocks: [],
+        interventionMode: false,
+        interventionTarget: null,
+        ollamaUrl,
+      });
+
+      const reader = stream.getReader();
+      const decoder = new TextDecoder();
+      let fullText = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        fullText += decoder.decode(value, { stream: true });
+        setInterpretation(fullText);
+      }
+    } catch (err) {
+      setInterpretation(`⚠ Could not generate interpretation: ${err instanceof Error ? err.message : "Unknown error"}. Make sure Ollama is running.`);
+    } finally {
+      setInterpreting(false);
+    }
+  }, [ablatedNodeNames, ablatedEdgeLabels, graphData]);
+
+  const handleReset = useCallback(() => {
+    resetAblation();
+    setInterpretation(null);
+  }, [resetAblation]);
 
   return (
     <div className="mt-3 pt-3 border-t border-border space-y-2">
@@ -78,6 +153,39 @@ export default function AblationPanel() {
             </div>
           )}
 
+          {/* LLM Interpretation */}
+          {comparison && (
+            <button
+              onClick={() => requestInterpretation(comparison)}
+              disabled={interpreting}
+              className="w-full text-[8px] font-[family-name:var(--font-michroma)] tracking-wider px-2 py-1.5 rounded border transition-colors disabled:opacity-50"
+              style={{
+                borderColor: interpreting ? "rgba(224,64,251,0.6)" : "rgba(0,229,255,0.4)",
+                color: interpreting ? "#e040fb" : "var(--accent-cyan)",
+                backgroundColor: interpreting ? "rgba(224,64,251,0.08)" : "rgba(0,229,255,0.05)",
+              }}
+            >
+              {interpreting ? "INTERPRETING..." : interpretation ? "RE-INTERPRET" : "INTERPRET WITH AI"}
+            </button>
+          )}
+
+          {interpretation && (
+            <div
+              className="p-2.5 rounded border text-[8px] font-mono leading-relaxed overflow-y-auto"
+              style={{
+                borderColor: "rgba(0,229,255,0.2)",
+                backgroundColor: "rgba(0,229,255,0.03)",
+                color: "var(--foreground)",
+                maxHeight: "200px",
+              }}
+            >
+              <div className="font-[family-name:var(--font-michroma)] text-[7px] tracking-wider text-accent-cyan mb-1.5">
+                AI INTERPRETATION
+              </div>
+              <div className="whitespace-pre-wrap">{interpretation}</div>
+            </div>
+          )}
+
           <div className="flex gap-2">
             <button
               onClick={startAblationReplay}
@@ -91,7 +199,7 @@ export default function AblationPanel() {
               APPLY TO REPLAY
             </button>
             <button
-              onClick={resetAblation}
+              onClick={handleReset}
               className="text-[8px] font-mono px-2 py-1.5 rounded border border-border text-text-muted hover:text-accent-red transition-colors"
             >
               RESET
@@ -101,6 +209,41 @@ export default function AblationPanel() {
       )}
     </div>
   );
+}
+
+// ─── LLM Prompt Builder ──────────────────────────────────────────
+
+function buildAblationPrompt(
+  comparison: AblationComparison,
+  ablatedNodeNames: string[],
+  ablatedEdgeLabels: string[]
+): string {
+  return `You are a causal network analyst. Interpret the following ablation results in 3-4 concise sentences. Explain what removing these elements means for system resilience, cascade risk, and stability. Be specific about the practical implications — avoid restating the raw numbers.
+
+ABLATED NODES: ${ablatedNodeNames.join(", ") || "none"}
+ABLATED EDGES: ${ablatedEdgeLabels.join("; ") || "none"}
+
+BEFORE:
+- Nodes: ${comparison.before.nodeCount}, Edges: ${comparison.before.edgeCount}
+- Density: ${comparison.before.density.toFixed(3)}
+- Lambda_max (spectral radius): ${comparison.before.lambdaMax.toFixed(2)} (${comparison.before.isStable ? "STABLE" : "UNSTABLE"})
+- Mean Omega fragility: ${comparison.before.meanOmega.toFixed(2)}, Max Omega: ${comparison.before.maxOmega.toFixed(2)}
+- Structural integrity: 100%
+
+AFTER:
+- Nodes: ${comparison.after.nodeCount}, Edges: ${comparison.after.edgeCount}
+- Density: ${comparison.after.density.toFixed(3)}
+- Lambda_max (spectral radius): ${comparison.after.lambdaMax.toFixed(2)} (${comparison.after.isStable ? "STABLE" : "UNSTABLE"})
+- Mean Omega fragility: ${comparison.after.meanOmega.toFixed(2)}, Max Omega: ${comparison.after.maxOmega.toFixed(2)}
+- Structural integrity: ${(100 + comparison.deltas.structuralIntegrityPct).toFixed(1)}%
+
+KEY DELTAS:
+- Lambda_max change: ${comparison.deltas.lambdaMax > 0 ? "+" : ""}${comparison.deltas.lambdaMax.toFixed(2)} (${comparison.deltas.lambdaMax < 0 ? "reduced cascade amplification" : "increased cascade amplification"})
+- Stability: ${comparison.deltas.stability}
+- Mean Omega change: ${comparison.deltas.meanOmega > 0 ? "+" : ""}${comparison.deltas.meanOmega.toFixed(2)}
+- Integrity change: ${comparison.deltas.structuralIntegrityPct > 0 ? "+" : ""}${comparison.deltas.structuralIntegrityPct.toFixed(1)}%
+
+Respond concisely. No bullet points. Plain paragraph format.`;
 }
 
 function MetricRow({

--- a/src/components/InterdictionPanel.tsx
+++ b/src/components/InterdictionPanel.tsx
@@ -42,10 +42,10 @@ export default function InterdictionPanel() {
   return (
     <div className="space-y-2 pt-3 border-t border-border">
       <div className="font-[family-name:var(--font-michroma)] text-[10px] tracking-wider text-accent-amber">
-        NETWORK INTERDICTION
+        CASCADE DEFENSE
       </div>
       <div className="text-[8px] font-mono text-text-muted">
-        Minimax optimization — find optimal interventions to minimize worst-case cascade damage
+        Minimax optimization — find optimal defensive cuts to minimize worst-case cascade damage
       </div>
 
       {/* Controls */}
@@ -96,7 +96,7 @@ export default function InterdictionPanel() {
           background: computing ? "rgba(255, 171, 0, 0.15)" : "rgba(255, 171, 0, 0.05)",
         }}
       >
-        {computing ? "COMPUTING MINIMAX..." : "SOLVE INTERDICTION"}
+        {computing ? "COMPUTING MINIMAX..." : "SOLVE CASCADE DEFENSE"}
       </button>
 
       {!canRun && (
@@ -137,7 +137,7 @@ export default function InterdictionPanel() {
           {result.interventions.length > 0 ? (
             <div className="space-y-1">
               <div className="text-[8px] font-mono text-text-muted">
-                OPTIMAL INTERVENTIONS ({result.interventions.length})
+                OPTIMAL DEFENSIVE CUTS ({result.interventions.length})
               </div>
               {result.interventions.map((c, i) => (
                 <div


### PR DESCRIPTION
## Summary
- Renames **NETWORK INTERDICTION** to **CASCADE DEFENSE** in Pareto module to clearly differentiate from Pearl's causal Intervention (do-calculus)
- Adds **INTERPRET WITH AI** button to Ablation panel — streams a plain-English LLM explanation of before/after structural metrics
- Uses the same Ollama/Gemini provider configured in the copilot settings

## Test plan
- [ ] Verify Pareto module shows CASCADE DEFENSE (not NETWORK INTERDICTION)
- [ ] Enable ablation, mark nodes, click INTERPRET WITH AI
- [ ] Confirm LLM streams a readable interpretation below the metrics table
- [ ] Verify RESET clears both metrics and interpretation