### PR TITLE
Time window selection in historical view + AI-contextualized analysis

### DIFF
--- a/src/components/AblationPanel.tsx
+++ b/src/components/AblationPanel.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { useApexStore } from "@/stores/useApexStore";
 import { computeAblationComparison, AblationComparison } from "@/lib/ablation-engine";
-import { streamLlmQuery } from "@/lib/copilot-engine";
 
 export default function AblationPanel() {
   const {
@@ -14,10 +13,8 @@ export default function AblationPanel() {
     resetAblation,
     startAblationReplay,
     graphData,
+    addCopilotMessage,
   } = useApexStore();
-
-  const [interpretation, setInterpretation] = useState<string | null>(null);
-  const [interpreting, setInterpreting] = useState(false);
 
   const comparison = useMemo(() => {
     if (ablatedNodeIds.length === 0 && ablatedEdgeIds.length === 0) return null;
@@ -26,7 +23,7 @@ export default function AblationPanel() {
 
   const hasSelections = ablatedNodeIds.length > 0 || ablatedEdgeIds.length > 0;
 
-  // Get names of ablated nodes for context
+  // Get names of ablated nodes/edges for context
   const ablatedNodeNames = useMemo(() => {
     return ablatedNodeIds.map((id) => {
       const node = graphData.nodes.find((n) => n.id === id);
@@ -40,62 +37,24 @@ export default function AblationPanel() {
       if (!edge) return id;
       const src = graphData.nodes.find((n) => n.id === edge.source);
       const tgt = graphData.nodes.find((n) => n.id === edge.target);
-      return `${src?.shortLabel ?? edge.source} → ${tgt?.shortLabel ?? edge.target}`;
+      return `${src?.shortLabel ?? edge.source} \u2192 ${tgt?.shortLabel ?? edge.target}`;
     });
   }, [ablatedEdgeIds, graphData]);
 
-  const requestInterpretation = useCallback(async (comp: AblationComparison) => {
-    setInterpreting(true);
-    setInterpretation(null);
-
-    // Build a focused prompt for the LLM
+  const requestInterpretation = useCallback((comp: AblationComparison) => {
     const prompt = buildAblationPrompt(comp, ablatedNodeNames, ablatedEdgeLabels);
 
-    try {
-      // Get LLM settings from store (mirror SystemCopilot's provider logic)
-      const state = useApexStore.getState();
-      const provider = state.llmProvider === "ollama" ? "ollama" : "gemini";
-      const model = provider === "ollama" ? state.ollamaModel : state.geminiModel;
-      const apiKey = provider === "ollama" ? "ollama-local" : state.geminiApiKey;
-      const ollamaUrl = state.ollamaUrl || "http://localhost:11434";
+    // Add a user message to the copilot chat
+    addCopilotMessage({
+      id: `abl-req-${Date.now()}`,
+      role: "user",
+      content: `INTERPRET ABLATION (${ablatedNodeIds.length} nodes, ${ablatedEdgeIds.length} edges removed)`,
+      timestamp: Date.now(),
+    });
 
-      const stream = await streamLlmQuery({
-        copilotMessages: [
-          { id: "abl-1", role: "user", content: prompt, timestamp: Date.now() },
-        ],
-        graph: graphData,
-        apiKey,
-        model,
-        provider,
-        selectedNode: null,
-        severedEdges: [],
-        shocks: [],
-        interventionMode: false,
-        interventionTarget: null,
-        ollamaUrl,
-      });
-
-      const reader = stream.getReader();
-      const decoder = new TextDecoder();
-      let fullText = "";
-
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        fullText += decoder.decode(value, { stream: true });
-        setInterpretation(fullText);
-      }
-    } catch (err) {
-      setInterpretation(`⚠ Could not generate interpretation: ${err instanceof Error ? err.message : "Unknown error"}. Make sure Ollama is running.`);
-    } finally {
-      setInterpreting(false);
-    }
-  }, [ablatedNodeNames, ablatedEdgeLabels, graphData]);
-
-  const handleReset = useCallback(() => {
-    resetAblation();
-    setInterpretation(null);
-  }, [resetAblation]);
+    // Dispatch to SystemCopilot for LLM streaming (same pattern as ANALYZE)
+    window.dispatchEvent(new CustomEvent("apex-ablation-interpret", { detail: { prompt } }));
+  }, [ablatedNodeNames, ablatedEdgeLabels, ablatedNodeIds.length, ablatedEdgeIds.length, addCopilotMessage]);
 
   return (
     <div className="mt-3 pt-3 border-t border-border space-y-2">
@@ -153,37 +112,19 @@ export default function AblationPanel() {
             </div>
           )}
 
-          {/* LLM Interpretation */}
+          {/* Interpret button — sends to copilot chat */}
           {comparison && (
             <button
               onClick={() => requestInterpretation(comparison)}
-              disabled={interpreting}
-              className="w-full text-[8px] font-[family-name:var(--font-michroma)] tracking-wider px-2 py-1.5 rounded border transition-colors disabled:opacity-50"
+              className="w-full text-[8px] font-[family-name:var(--font-michroma)] tracking-wider px-2 py-1.5 rounded border transition-colors"
               style={{
-                borderColor: interpreting ? "rgba(224,64,251,0.6)" : "rgba(0,229,255,0.4)",
-                color: interpreting ? "#e040fb" : "var(--accent-cyan)",
-                backgroundColor: interpreting ? "rgba(224,64,251,0.08)" : "rgba(0,229,255,0.05)",
+                borderColor: "rgba(0,229,255,0.4)",
+                color: "var(--accent-cyan)",
+                backgroundColor: "rgba(0,229,255,0.05)",
               }}
             >
-              {interpreting ? "INTERPRETING..." : interpretation ? "RE-INTERPRET" : "INTERPRET WITH AI"}
+              INTERPRET WITH AI
             </button>
-          )}
-
-          {interpretation && (
-            <div
-              className="p-2.5 rounded border text-[8px] font-mono leading-relaxed overflow-y-auto"
-              style={{
-                borderColor: "rgba(0,229,255,0.2)",
-                backgroundColor: "rgba(0,229,255,0.03)",
-                color: "var(--foreground)",
-                maxHeight: "200px",
-              }}
-            >
-              <div className="font-[family-name:var(--font-michroma)] text-[7px] tracking-wider text-accent-cyan mb-1.5">
-                AI INTERPRETATION
-              </div>
-              <div className="whitespace-pre-wrap">{interpretation}</div>
-            </div>
           )}
 
           <div className="flex gap-2">
@@ -199,7 +140,7 @@ export default function AblationPanel() {
               APPLY TO REPLAY
             </button>
             <button
-              onClick={handleReset}
+              onClick={resetAblation}
               className="text-[8px] font-mono px-2 py-1.5 rounded border border-border text-text-muted hover:text-accent-red transition-colors"
             >
               RESET
@@ -218,7 +159,7 @@ function buildAblationPrompt(
   ablatedNodeNames: string[],
   ablatedEdgeLabels: string[]
 ): string {
-  return `You are a causal network analyst. Interpret the following ablation results in 3-4 concise sentences. Explain what removing these elements means for system resilience, cascade risk, and stability. Be specific about the practical implications — avoid restating the raw numbers.
+  return `You are a causal network analyst. Interpret the following ablation results in 3-4 concise sentences. Explain what removing these elements means for system resilience, cascade risk, and stability. Be specific about the practical implications \u2014 avoid restating the raw numbers.
 
 ABLATED NODES: ${ablatedNodeNames.join(", ") || "none"}
 ABLATED EDGES: ${ablatedEdgeLabels.join("; ") || "none"}

--- a/src/components/SystemCopilot.tsx
+++ b/src/components/SystemCopilot.tsx
@@ -13,7 +13,7 @@ import {
 import { processLlmActions } from "@/lib/copilot-actions";
 import { CopilotMessage } from "@/lib/types";
 import { getModelsForProvider, type LLMProvider } from "@/lib/llm-providers";
-import { serializeGraphContext, serializeSnapshotContext } from "@/lib/copilot-context";
+import { serializeGraphContext, serializeSnapshotContext, serializeTimeWindowContext } from "@/lib/copilot-context";
 import { buildSnapshot } from "@/lib/snapshots/serializer";
 
 const ACTIONS: { label: string; action: CopilotAction; color: string }[] = [
@@ -330,9 +330,16 @@ export default function SystemCopilot() {
         ];
 
         // Enrich system context with snapshot data if available
-        const snapshotContext = snapshotHistory.length > 0
+        let snapshotContext = snapshotHistory.length > 0
           ? serializeSnapshotContext(snapshotHistory)
           : "";
+
+        // Add temporal window context if a time range is selected
+        const timelineSel = useApexStore.getState().timelineSelection;
+        const tempData = useApexStore.getState().temporalData;
+        if (timelineSel && tempData) {
+          snapshotContext += serializeTimeWindowContext(timelineSel, tempData, graphData);
+        }
 
         const stream = await streamLlmQuery({
           copilotMessages: allMessages,

--- a/src/components/SystemCopilot.tsx
+++ b/src/components/SystemCopilot.tsx
@@ -443,6 +443,25 @@ export default function SystemCopilot() {
     return () => window.removeEventListener("apex-analyze-selection", handler);
   }, [isLlmActive, handleStreamingQuery, addCopilotMessage]);
 
+  // Listen for ablation interpretation events from AblationPanel
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail;
+      if (detail?.prompt && isLlmActive) {
+        handleStreamingQuery(detail.prompt);
+      } else if (detail?.prompt) {
+        addCopilotMessage({
+          id: `sys-abl-${Date.now()}`,
+          role: "assistant",
+          content: "LLM not configured. Please set up Gemini or Ollama in settings to interpret ablation results.",
+          timestamp: Date.now(),
+        });
+      }
+    };
+    window.addEventListener("apex-ablation-interpret", handler);
+    return () => window.removeEventListener("apex-ablation-interpret", handler);
+  }, [isLlmActive, handleStreamingQuery, addCopilotMessage]);
+
   // ─── Voice Input (Speech-to-Text) ────────────────────────
   const startListening = useCallback(() => {
     const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;

--- a/src/components/TimeDial.tsx
+++ b/src/components/TimeDial.tsx
@@ -57,6 +57,13 @@ function formatFullDate(ts: number): string {
   });
 }
 
+function formatShortDate(ts: number): string {
+  return new Date(ts).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
 /** Generate evenly-spaced tick marks for the timeline */
 function generateTicks(
   start: number,
@@ -102,12 +109,14 @@ export default function TimeDial() {
   const {
     timelinePosition,
     timelineRange,
+    timelineSelection,
     isLive,
     timelineGranularity,
     temporalData,
     setTimelinePosition,
     setIsLive,
     setTimelineGranularity,
+    setTimelineSelection,
     initTemporalData,
     goLive,
     // Replay state
@@ -132,6 +141,8 @@ export default function TimeDial() {
 
   const trackRef = useRef<HTMLDivElement>(null);
   const [isDragging, setIsDragging] = useState(false);
+  const [isRangeSelecting, setIsRangeSelecting] = useState(false);
+  const [rangeAnchor, setRangeAnchor] = useState<number | null>(null);
   const [hoveredEvent, setHoveredEvent] = useState<TemporalEvent | null>(null);
 
   // Initialize temporal data on mount
@@ -155,6 +166,15 @@ export default function TimeDial() {
     ? maxEpoch > 0 ? currentEpoch / maxEpoch : 0
     : range > 0 ? (timelinePosition - start) / range : 1;
 
+  // Selection as fractions 0-1
+  const selectionFracs = useMemo(() => {
+    if (!timelineSelection || range <= 0) return null;
+    return {
+      start: Math.max(0, (timelineSelection.start - start) / range),
+      end: Math.min(1, (timelineSelection.end - start) / range),
+    };
+  }, [timelineSelection, start, range]);
+
   // Tick marks (only for historical mode)
   const ticks = useMemo(
     () => generateTicks(start, end, timelineGranularity),
@@ -165,6 +185,23 @@ export default function TimeDial() {
   const events = useMemo(
     () => (temporalData ? getEventsInRange(temporalData, start, end) : []),
     [temporalData, start, end],
+  );
+
+  // Events within selection (for context)
+  const selectionEventCount = useMemo(() => {
+    if (!timelineSelection || !temporalData) return 0;
+    return getEventsInRange(temporalData, timelineSelection.start, timelineSelection.end).length;
+  }, [timelineSelection, temporalData]);
+
+  // Convert pixel position to timestamp
+  const pixelToTimestamp = useCallback(
+    (clientX: number): number => {
+      if (!trackRef.current) return start;
+      const rect = trackRef.current.getBoundingClientRect();
+      const fraction = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+      return start + fraction * range;
+    },
+    [start, range],
   );
 
   // Convert pixel position to timestamp (historical) or epoch (replay)
@@ -191,23 +228,45 @@ export default function TimeDial() {
   const handlePointerDown = useCallback(
     (e: React.PointerEvent) => {
       e.preventDefault();
-      setIsDragging(true);
-      handleTrackScrub(e.clientX);
       (e.target as HTMLElement).setPointerCapture(e.pointerId);
+
+      // Alt+drag = range selection (historical mode only)
+      if (e.altKey && !replayActive) {
+        setIsRangeSelecting(true);
+        const ts = pixelToTimestamp(e.clientX);
+        setRangeAnchor(ts);
+        setTimelineSelection({ start: ts, end: ts });
+        return;
+      }
+
+      // Normal drag = scrub
+      setIsDragging(true);
+      setTimelineSelection(null); // Clear selection on normal click
+      handleTrackScrub(e.clientX);
     },
-    [handleTrackScrub],
+    [handleTrackScrub, replayActive, pixelToTimestamp, setTimelineSelection],
   );
 
   const handlePointerMove = useCallback(
     (e: React.PointerEvent) => {
+      if (isRangeSelecting && rangeAnchor !== null) {
+        const ts = pixelToTimestamp(e.clientX);
+        setTimelineSelection({
+          start: Math.min(rangeAnchor, ts),
+          end: Math.max(rangeAnchor, ts),
+        });
+        return;
+      }
       if (!isDragging) return;
       handleTrackScrub(e.clientX);
     },
-    [isDragging, handleTrackScrub],
+    [isDragging, isRangeSelecting, rangeAnchor, handleTrackScrub, pixelToTimestamp, setTimelineSelection],
   );
 
   const handlePointerUp = useCallback(() => {
     setIsDragging(false);
+    setIsRangeSelecting(false);
+    setRangeAnchor(null);
   }, []);
 
   // Criticality display for cascade mode
@@ -287,6 +346,13 @@ export default function TimeDial() {
 
       // Historical-mode shortcuts (Shift+Arrow)
       if (!replayActive) {
+        // Escape clears time window selection
+        if (e.key === "Escape" && timelineSelection) {
+          e.preventDefault();
+          setTimelineSelection(null);
+          return;
+        }
+
         const DAY = 86400000;
         let step = 0;
 
@@ -324,9 +390,9 @@ export default function TimeDial() {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [
     replayActive, replayPlaying, replaySpeed, timelineGranularity,
-    timelinePosition, start, end, setTimelinePosition, goLive,
+    timelinePosition, timelineSelection, start, end, setTimelinePosition, goLive,
     setReplayPlaying, stepEpoch, setReplaySpeed, branchFromCurrentEpoch,
-    stopReplay,
+    stopReplay, setTimelineSelection,
   ]);
 
   if (!temporalData) return null;
@@ -347,6 +413,17 @@ export default function TimeDial() {
             >
               Cascade
             </motion.span>
+          ) : timelineSelection ? (
+            <motion.span
+              key="window"
+              initial={{ opacity: 0, y: -4 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 4 }}
+              className="text-[8px] font-[family-name:var(--font-michroma)] tracking-[0.15em] uppercase"
+              style={{ color: "var(--accent-cyan)" }}
+            >
+              Window
+            </motion.span>
           ) : (
             <motion.span
               key="timedial"
@@ -362,9 +439,11 @@ export default function TimeDial() {
         <span className="text-[9px] font-mono text-foreground">
           {replayActive
             ? `E${currentEpoch}/${maxEpoch}`
-            : isLive
-              ? "LIVE"
-              : formatDate(timelinePosition, timelineGranularity)}
+            : timelineSelection
+              ? `${Math.round((timelineSelection.end - timelineSelection.start) / 86400000)}d`
+              : isLive
+                ? "LIVE"
+                : formatDate(timelinePosition, timelineGranularity)}
         </span>
       </div>
 
@@ -393,7 +472,7 @@ export default function TimeDial() {
               style={{ color: "var(--accent-amber)" }}
               title="Play/Pause (Space)"
             >
-              {replayPlaying ? "▐▐" : "▶"}
+              {replayPlaying ? "\u2590\u2590" : "\u25B6"}
             </button>
             {/* Step forward */}
             <button
@@ -462,7 +541,7 @@ export default function TimeDial() {
 
       {/* Timeline track */}
       <div className="flex-1 flex flex-col gap-1">
-        {/* Date at cursor / epoch count */}
+        {/* Date at cursor / epoch count / selection range */}
         <div className="flex justify-between items-center h-3">
           {replayActive ? (
             <>
@@ -478,6 +557,18 @@ export default function TimeDial() {
                 style={{ color: critColor }}
               >
                 {critLabel}
+              </span>
+            </>
+          ) : timelineSelection ? (
+            <>
+              <span className="text-[8px] font-mono" style={{ color: "var(--accent-cyan)" }}>
+                {formatShortDate(timelineSelection.start)}
+              </span>
+              <span className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider" style={{ color: "var(--accent-cyan)" }}>
+                {selectionEventCount > 0 ? `${selectionEventCount} event${selectionEventCount > 1 ? "s" : ""} in window` : "Alt+drag to adjust"}
+              </span>
+              <span className="text-[8px] font-mono" style={{ color: "var(--accent-cyan)" }}>
+                {formatShortDate(timelineSelection.end)}
               </span>
             </>
           ) : (
@@ -522,6 +613,21 @@ export default function TimeDial() {
                   : "linear-gradient(90deg, rgba(0,229,255,0.03), rgba(0,229,255,0.12))",
             }}
           />
+
+          {/* Time window selection overlay */}
+          {!replayActive && selectionFracs && (
+            <div
+              className="absolute top-0 h-full z-10 pointer-events-none rounded"
+              style={{
+                left: `${selectionFracs.start * 100}%`,
+                width: `${(selectionFracs.end - selectionFracs.start) * 100}%`,
+                background: "rgba(0,229,255,0.15)",
+                borderLeft: "2px solid rgba(0,229,255,0.6)",
+                borderRight: "2px solid rgba(0,229,255,0.6)",
+                boxShadow: "inset 0 0 8px rgba(0,229,255,0.1)",
+              }}
+            />
+          )}
 
           {/* Cascade epoch markers — show epoch positions as small amber ticks */}
           {replayActive && maxEpoch > 0 && (
@@ -638,6 +744,26 @@ export default function TimeDial() {
         {/* Bottom tick labels spacer */}
         <div className="h-2" />
       </div>
+
+      {/* Time window clear button — shown when selection is active */}
+      <AnimatePresence>
+        {!replayActive && timelineSelection && (
+          <motion.button
+            initial={{ opacity: 0, scale: 0.9 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.9 }}
+            onClick={() => setTimelineSelection(null)}
+            className="px-1.5 py-0.5 rounded text-[7px] font-[family-name:var(--font-michroma)] tracking-wider transition-colors hover:bg-red-500/10 whitespace-nowrap"
+            style={{
+              color: "var(--accent-red)",
+              border: "1px solid rgba(255, 23, 68, 0.3)",
+            }}
+            title="Clear time window (Escape)"
+          >
+            CLEAR
+          </motion.button>
+        )}
+      </AnimatePresence>
 
       {/* Cascade mode: omega buffer + timeline tabs + branch + stop */}
       <AnimatePresence>
@@ -763,7 +889,7 @@ export default function TimeDial() {
               background: "rgba(255, 171, 0, 0.08)",
             }}
           >
-            <span className="text-[10px]">▶</span>
+            <span className="text-[10px]">{"\u25B6"}</span>
             <span className="text-[8px] font-[family-name:var(--font-michroma)] tracking-[0.1em]">
               CASCADE
             </span>

--- a/src/lib/copilot-context.ts
+++ b/src/lib/copilot-context.ts
@@ -2,6 +2,8 @@ import { CausalGraph, CausalNode, CausalEdge } from "./types";
 import type { SystemStateSnapshot } from "./snapshots/types";
 import { diffSnapshots } from "./snapshots/diff";
 import { TarskiValidationReport, AXIOM_LIBRARY } from "./tarski-data";
+import type { TemporalDataset } from "./temporal-data";
+import { getEventsInRange, getNodeStateAt } from "./temporal-data";
 
 interface ContextOptions {
   selectedNode: string | null;
@@ -292,6 +294,77 @@ export function serializeSnapshotContext(
     }
     lines.push("");
   }
+
+  return lines.join("\n");
+}
+
+// ─── Time Window Context ──────────────────────────────────────
+
+export function serializeTimeWindowContext(
+  selection: { start: number; end: number },
+  temporalData: TemporalDataset,
+  graph: CausalGraph,
+): string {
+  const lines: string[] = [];
+  const startDate = new Date(selection.start);
+  const endDate = new Date(selection.end);
+  const durationDays = Math.round((selection.end - selection.start) / 86400000);
+
+  lines.push("\n=== SELECTED TIME WINDOW ===");
+  lines.push(`From: ${startDate.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric", year: "numeric" })}`);
+  lines.push(`To: ${endDate.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric", year: "numeric" })}`);
+  lines.push(`Duration: ${durationDays} day${durationDays !== 1 ? "s" : ""}`);
+  lines.push("");
+
+  // Events in the window
+  const windowEvents = getEventsInRange(temporalData, selection.start, selection.end);
+  if (windowEvents.length > 0) {
+    lines.push("Events in window:");
+    for (const evt of windowEvents) {
+      lines.push(`  \u2022 ${evt.date.toLocaleDateString("en-US", { month: "short", day: "numeric" })} \u2014 ${evt.label} (severity: ${(evt.severity * 100).toFixed(0)}%)`);
+      lines.push(`    ${evt.description}`);
+      lines.push(`    Affected: ${evt.affectedNodeIds.join(", ")}`);
+    }
+    lines.push("");
+  } else {
+    lines.push("No recorded events in this window.\n");
+  }
+
+  // Node omega trends in the window (top movers)
+  const nodeDeltas: { nodeId: string; label: string; startOmega: number; endOmega: number; delta: number }[] = [];
+
+  for (const node of graph.nodes) {
+    const nodeData = temporalData.nodes.get(node.id);
+    if (!nodeData) continue;
+
+    const startState = getNodeStateAt(nodeData, selection.start);
+    const endState = getNodeStateAt(nodeData, selection.end);
+    if (!startState || !endState) continue;
+
+    const delta = endState.omegaComposite - startState.omegaComposite;
+    nodeDeltas.push({
+      nodeId: node.id,
+      label: node.shortLabel || node.label,
+      startOmega: startState.omegaComposite,
+      endOmega: endState.omegaComposite,
+      delta,
+    });
+  }
+
+  // Sort by absolute delta, show top movers
+  nodeDeltas.sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta));
+  const topMovers = nodeDeltas.slice(0, 8);
+
+  if (topMovers.length > 0) {
+    lines.push("Top \u03A9-fragility movers in window:");
+    for (const m of topMovers) {
+      const arrow = m.delta > 0 ? "\u2191" : m.delta < 0 ? "\u2193" : "\u2192";
+      lines.push(`  ${arrow} ${m.label}: \u03A9 ${m.startOmega.toFixed(1)} \u2192 ${m.endOmega.toFixed(1)} (${m.delta > 0 ? "+" : ""}${m.delta.toFixed(2)})`);
+    }
+    lines.push("");
+  }
+
+  lines.push("IMPORTANT: The user has selected this time window. Contextualize your analysis to this specific period. Reference events and trends within this window.");
 
   return lines.join("\n");
 }

--- a/src/stores/useApexStore.ts
+++ b/src/stores/useApexStore.ts
@@ -196,10 +196,12 @@ interface ApexState {
   isLive: boolean; // whether following real-time
   timelineGranularity: TimeGranularity;
   temporalData: TemporalDataset | null;
+  timelineSelection: { start: number; end: number } | null; // user-selected date range window
   setTimelinePosition: (ts: number) => void;
   setTimelineRange: (range: { start: number; end: number }) => void;
   setIsLive: (live: boolean) => void;
   setTimelineGranularity: (g: TimeGranularity) => void;
+  setTimelineSelection: (sel: { start: number; end: number } | null) => void;
   initTemporalData: () => void;
   goLive: () => void;
 }
@@ -626,6 +628,7 @@ export const useApexStore = create<ApexState>((set) => ({
   },
   isLive: true,
   timelineGranularity: "day",
+  timelineSelection: null,
   temporalData: null,
 
   setTimelinePosition: (ts) =>
@@ -642,6 +645,9 @@ export const useApexStore = create<ApexState>((set) => ({
 
   setTimelineGranularity: (g) =>
     set({ timelineGranularity: g }),
+
+  setTimelineSelection: (sel) =>
+    set({ timelineSelection: sel }),
 
   initTemporalData: () =>
     set((s) => {


### PR DESCRIPTION
## Summary
- **Alt+drag** on the TimeDial to select a date range (from \u2192 to)
- Renders a **cyan highlighted band** on the timeline track
- Shows **WINDOW** mode with duration, start/end dates, and event count
- Routes ablation interpretation to **copilot chat** (from PR #32)
- When **ANALYZE** is triggered with a time window active, the LLM receives:
  - Events that occurred in the window
  - Top omega-fragility movers (which nodes changed most)
  - Instruction to contextualize analysis to that period

## Test plan
- [ ] Alt+drag on timeline to select a date range
- [ ] Verify cyan band appears with correct dates
- [ ] Click (without Alt) to clear the selection
- [ ] Press Escape to clear the selection  
- [ ] With a window selected, trigger ANALYZE and verify LLM references the time period
- [ ] Verify the WINDOW label shows duration in days