### PR TITLE
fix: restore time series rendering for selected nodes in bottom panel

### DIFF
--- a/src/components/RiskPropagationFlow.tsx
+++ b/src/components/RiskPropagationFlow.tsx
@@ -95,6 +95,7 @@ export default function RiskPropagationFlow() {
   const graphData = useFilteredGraph();
   const shocks = useApexStore((s) => s.shocks);
   const selectedNode = useApexStore((s) => s.selectedNode);
+  const selectedNodes = useApexStore((s) => s.selectedNodes);
   const setSelectedNode = useApexStore((s) => s.setSelectedNode);
   const isLive = useApexStore((s) => s.isLive);
   const temporalData = useApexStore((s) => s.temporalData);
@@ -113,19 +114,50 @@ export default function RiskPropagationFlow() {
   // Use temporal graph when scrubbing, otherwise use live graph
   const activeGraph = isLive ? graphData : temporalGraph;
 
+  // Combine single-select and multi-select into a unified set of selected IDs
+  const allSelectedIds = useMemo(() => {
+    const ids = new Set(selectedNodes);
+    if (selectedNode) ids.add(selectedNode);
+    return ids;
+  }, [selectedNode, selectedNodes]);
+
   // Get the nodes to display time series for
-  // If a node is selected, show that node prominently
-  // Otherwise show top risk nodes
+  // Selected nodes (single + multi) shown first, then fill remaining slots with top risk nodes
   const displayNodes = useMemo(() => {
     const riskCards = buildRiskCards(activeGraph, shocks);
-    if (selectedNode) {
-      // Put selected node first, then top risk nodes (excluding selected)
-      const selected = riskCards.find((c) => c.nodeId === selectedNode);
-      const others = riskCards.filter((c) => c.nodeId !== selectedNode).slice(0, 4);
-      return selected ? [selected, ...others] : riskCards.slice(0, 5);
+    const riskMap = new Map(riskCards.map((c) => [c.nodeId, c]));
+
+    if (allSelectedIds.size > 0) {
+      // Build cards for all selected nodes, even if they're not top-risk
+      const selectedCards: typeof riskCards = [];
+      for (const id of allSelectedIds) {
+        const existing = riskMap.get(id);
+        if (existing) {
+          selectedCards.push(existing);
+        } else {
+          // Node not in top risk — build a card from graph data
+          const node = activeGraph.nodes.find((n) => n.id === id);
+          if (node) {
+            const totalSeverity = shocks.reduce((sum, s) => sum + s.severity, 0);
+            const shockMult = Math.min(1, totalSeverity);
+            selectedCards.push({
+              nodeId: node.id,
+              label: node.label,
+              category: node.category,
+              omegaScore: parseFloat((node.omegaFragility.composite * (1 + shockMult * 0.05)).toFixed(1)),
+              domain: node.domain,
+              globalConcentration: node.globalConcentration,
+            });
+          }
+        }
+      }
+      // Fill remaining slots with top risk nodes not already selected
+      const remaining = riskCards.filter((c) => !allSelectedIds.has(c.nodeId));
+      const maxSlots = Math.max(5, allSelectedIds.size);
+      return [...selectedCards, ...remaining].slice(0, maxSlots);
     }
     return riskCards.slice(0, 5);
-  }, [activeGraph, shocks, selectedNode]);
+  }, [activeGraph, shocks, allSelectedIds]);
 
   // Get temporal history for each display node
   const nodeHistories = useMemo(() => {
@@ -173,7 +205,11 @@ export default function RiskPropagationFlow() {
         className="flex items-center justify-between w-full px-4 py-1 hover:bg-surface transition-colors"
       >
         <span className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted">
-          {selectedNode ? "ΩF TIME SERIES — SELECTED NODE" : "ΩF TIME SERIES — TOP RISK NODES"}
+          {allSelectedIds.size > 1
+            ? `ΩF TIME SERIES — ${allSelectedIds.size} SELECTED NODES`
+            : allSelectedIds.size === 1
+              ? "ΩF TIME SERIES — SELECTED NODE"
+              : "ΩF TIME SERIES — TOP RISK NODES"}
         </span>
         <span className="text-[9px] font-mono text-text-muted">
           {collapsed ? "\u25B6" : "\u25BC"}
@@ -194,7 +230,7 @@ export default function RiskPropagationFlow() {
               {displayNodes.map((card, i) => {
                 const history = nodeHistories.get(card.nodeId) ?? [];
                 const domainColor = getDomainColor(card.domain);
-                const isActive = selectedNode === card.nodeId;
+                const isActive = allSelectedIds.has(card.nodeId);
                 const currentOmega = card.omegaScore;
                 const hoveredOmega =
                   hoveredDay !== null && history[hoveredDay]

--- a/src/components/RiskPropagationFlow.tsx
+++ b/src/components/RiskPropagationFlow.tsx
@@ -199,20 +199,22 @@ export default function RiskPropagationFlow() {
 
   return (
     <div className="border-t border-border bg-surface-elevated" data-tour="risk-flow">
-      {/* Toggle bar */}
+      {/* Toggle bar — aligned with TimeDial layout */}
       <button
         onClick={() => setCollapsed((c) => !c)}
-        className="flex items-center justify-between w-full px-4 py-1 hover:bg-surface transition-colors"
+        className="flex items-center gap-3 w-full px-4 py-1 hover:bg-surface transition-colors"
       >
+        <div className="min-w-[72px] flex-shrink-0 flex items-center justify-center">
+          <span className="text-[9px] font-mono text-text-muted">
+            {collapsed ? "\u25B6" : "\u25BC"}
+          </span>
+        </div>
         <span className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted">
           {allSelectedIds.size > 1
             ? `ΩF TIME SERIES — ${allSelectedIds.size} SELECTED NODES`
             : allSelectedIds.size === 1
               ? "ΩF TIME SERIES — SELECTED NODE"
               : "ΩF TIME SERIES — TOP RISK NODES"}
-        </span>
-        <span className="text-[9px] font-mono text-text-muted">
-          {collapsed ? "\u25B6" : "\u25BC"}
         </span>
       </button>
 
@@ -226,7 +228,18 @@ export default function RiskPropagationFlow() {
             transition={{ duration: 0.15 }}
             className="overflow-hidden"
           >
-            <div ref={containerRef} className="flex items-stretch gap-2 px-4 pb-2 overflow-x-auto">
+            <div className="flex items-stretch gap-3 px-4 pb-2">
+              {/* Left label — matches TimeDial label column for alignment */}
+              <div className="min-w-[72px] flex-shrink-0 flex flex-col items-center justify-center gap-0.5">
+                <span className="text-[8px] font-[family-name:var(--font-michroma)] tracking-[0.15em] text-text-muted uppercase">
+                  ΩF Series
+                </span>
+                <span className="text-[9px] font-mono text-foreground">
+                  {displayNodes.length}
+                </span>
+              </div>
+              {/* Cards — aligns with TimeDial track */}
+              <div ref={containerRef} className="flex-1 flex items-stretch gap-2 overflow-x-auto min-w-0">
               {displayNodes.map((card, i) => {
                 const history = nodeHistories.get(card.nodeId) ?? [];
                 const domainColor = getDomainColor(card.domain);
@@ -337,6 +350,7 @@ export default function RiskPropagationFlow() {
                   </motion.div>
                 );
               })}
+              </div>
             </div>
           </motion.div>
         )}


### PR DESCRIPTION
## Summary
- **Multi-select was ignored**: Bottom panel only read `selectedNode` (single click), not `selectedNodes` (shift+drag / shift+click). Now merges both into a unified selection set — all selected nodes get time series cards.
- **Selected nodes silently dropped**: `buildRiskCards` returns only top 6 by omega score. If a user selected a low-omega node, it wasn't found and the panel fell back to default. Now builds cards for any selected node directly from graph data.
- Header dynamically shows "N SELECTED NODES" for multi-select
- All selected node cards highlighted with active cyan styling

## Context
The time series data and rendering pipeline (`temporalData` → `nodeHistories` → `OmegaSparkline`) was intact. The issue was in the display node selection logic — it couldn't find selected nodes that weren't top-risk, and completely ignored multi-select state.

Omega recalculation per time step already works via `useTemporalGraph` hook, which transforms node omega scores based on timeline position. Distance measures update through the same temporal graph pipeline.

## Files changed
- `src/components/RiskPropagationFlow.tsx` — selection logic + header text + active styling

## Test plan
- [ ] Click a single node → its time series appears first in bottom panel
- [ ] Click a low-omega node (not top risk) → still appears with time series
- [ ] Shift+drag to box-select multiple nodes → all appear as overlaid cards
- [ ] Shift+click individual nodes → each appears/disappears from panel
- [ ] Header shows "N SELECTED NODES" for multi-select, "SELECTED NODE" for single
- [ ] Deselect all → panel reverts to "TOP RISK NODES" view
- [ ] Scrub timeline → sparklines update highlight position per time step
- [ ] No regressions on hover tooltip or date range labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)