### PR TITLE
feat(pareto): news interpreter panel — article → graph interventions

### DIFF
--- a/src/app/api/news/route.ts
+++ b/src/app/api/news/route.ts
@@ -1,0 +1,142 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { GoogleGenerativeAI } from "@google/generative-ai";
+import { NextRequest } from "next/server";
+import type { LLMProvider } from "@/lib/llm-providers";
+
+const SYSTEM_PROMPT = `You are APEX's causal news interpreter. Given a news article and a causal graph (nodes + edges), extract the interventions the article implies and map them onto the graph.
+
+The graph is a DAG of real-world systems (energy, manufacturing, finance, geopolitics, etc.). Each node is an entity or capability. Each edge is a causal dependency (source → target). An intervention is a perturbation the article describes or implies.
+
+Three intervention techniques are available:
+- "shock": inject an exogenous disruption on a node (use when article describes an ongoing/imminent disruption — strike, sanction, outage, disaster). Requires severity 0-1 and category from {compute, energy, cooling, supply, geopolitical}.
+- "sever": break a causal edge (use when article describes a dependency being cut — pipeline closure, export ban, route blocked).
+- "ablate": remove a node entirely (use when article describes a total capacity loss — factory destruction, company shutdown).
+
+Map each implied intervention to the MOST SPECIFIC matching node or edge ID in the graph. Do not invent IDs. If no node/edge reasonably matches, skip that intervention rather than forcing it.
+
+Return ONLY valid JSON (no markdown fences):
+{
+  "summary": "<one-sentence summary of the article>",
+  "interventions": [
+    {
+      "technique": "shock" | "sever" | "ablate",
+      "targetNodeId": "<id or null>",
+      "targetEdgeId": "<id or null>",
+      "severity": <0-1 or null>,
+      "category": "<shock category or null>",
+      "rationale": "<why this intervention maps here>",
+      "sourceQuote": "<the sentence or phrase from the article that supports this>"
+    }
+  ]
+}
+
+Rules:
+- shock → targetNodeId set, targetEdgeId null, severity + category set
+- sever → targetEdgeId set, targetNodeId null, severity null
+- ablate → targetNodeId set, targetEdgeId null, severity null
+- Severity maps as: minor=0.2, notable=0.4, serious=0.6, severe=0.8, catastrophic=1.0
+- Return an empty interventions array if the article has no clear graph-mappable causal implications.`;
+
+export async function POST(req: NextRequest) {
+  try {
+    const { articleText, nodes, edges, apiKey, model, provider } = (await req.json()) as {
+      articleText: string;
+      nodes: { id: string; label: string; category: string; domain: string }[];
+      edges: { id: string; source: string; target: string; physicalMechanism?: string }[];
+      apiKey: string;
+      model?: string;
+      provider?: LLMProvider;
+    };
+
+    if (!apiKey) {
+      return new Response(JSON.stringify({ error: "API key required" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (!articleText || articleText.trim().length < 20) {
+      return new Response(JSON.stringify({ error: "Article text too short" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const nodeCatalog = nodes
+      .map((n) => `- ${n.id}: "${n.label}" (${n.category} / ${n.domain})`)
+      .join("\n");
+
+    const edgeCatalog = edges
+      .map((e) => {
+        const mech = e.physicalMechanism ? ` [${e.physicalMechanism}]` : "";
+        return `- ${e.id}: ${e.source} → ${e.target}${mech}`;
+      })
+      .join("\n");
+
+    const userMessage = `GRAPH NODES (${nodes.length}):
+${nodeCatalog}
+
+GRAPH EDGES (${edges.length}):
+${edgeCatalog}
+
+ARTICLE:
+${articleText}
+
+Extract the graph-mappable interventions.`;
+
+    const resolvedProvider: LLMProvider =
+      provider ?? (model?.startsWith("gemini") ? "gemini" : "anthropic");
+
+    let responseText: string;
+
+    if (resolvedProvider === "gemini") {
+      const genAI = new GoogleGenerativeAI(apiKey);
+      const genModel = genAI.getGenerativeModel({
+        model: model || "gemini-2.5-flash",
+        systemInstruction: SYSTEM_PROMPT,
+      });
+      const result = await genModel.generateContent({
+        contents: [{ role: "user", parts: [{ text: userMessage }] }],
+      });
+      responseText = result.response.text();
+    } else {
+      const client = new Anthropic({ apiKey });
+      const response = await client.messages.create({
+        model: model || "claude-sonnet-4-20250514",
+        max_tokens: 4096,
+        system: SYSTEM_PROMPT,
+        messages: [{ role: "user", content: userMessage }],
+      });
+      const textBlock = response.content.find((b) => b.type === "text");
+      if (!textBlock || textBlock.type !== "text") {
+        return new Response(
+          JSON.stringify({ error: "No text response from LLM" }),
+          { status: 502, headers: { "Content-Type": "application/json" } }
+        );
+      }
+      responseText = textBlock.text;
+    }
+
+    const cleaned = responseText.replace(/^```(?:json)?\s*/m, "").replace(/\s*```\s*$/m, "");
+
+    let result;
+    try {
+      result = JSON.parse(cleaned);
+    } catch {
+      return new Response(
+        JSON.stringify({ error: "LLM returned invalid JSON", raw: responseText.slice(0, 500) }),
+        { status: 502, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    return new Response(JSON.stringify(result), {
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return new Response(JSON.stringify({ error: message }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}

--- a/src/components/ModulePanel.tsx
+++ b/src/components/ModulePanel.tsx
@@ -11,6 +11,7 @@ import InterventionControls from "./InterventionControls";
 import MonteCarloForecast from "./MonteCarloForecast";
 import AblationPanel from "./AblationPanel";
 import InterdictionPanel from "./InterdictionPanel";
+import NewsInterpreterPanel from "./NewsInterpreterPanel";
 import NodeInspector from "./NodeInspector";
 
 export default function ModulePanel() {
@@ -101,6 +102,7 @@ export default function ModulePanel() {
             <SnapshotIndicator />
             <ParetoPanel expandedChart={expandedChart} setExpandedChart={setExpandedChart} />
             <InterdictionPanel />
+            <NewsInterpreterPanel />
           </div>
         )}
       </div>

--- a/src/components/NewsInterpreterPanel.tsx
+++ b/src/components/NewsInterpreterPanel.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { useApexStore } from "@/stores/useApexStore";
+import type { CausalShock, ShockCategory } from "@/lib/types";
+
+type Technique = "shock" | "sever" | "ablate";
+
+interface NewsIntervention {
+  technique: Technique;
+  targetNodeId: string | null;
+  targetEdgeId: string | null;
+  severity: number | null;
+  category: ShockCategory | null;
+  rationale: string;
+  sourceQuote: string;
+}
+
+interface NewsResponse {
+  summary: string;
+  interventions: NewsIntervention[];
+}
+
+export default function NewsInterpreterPanel() {
+  const graphData = useApexStore((s) => s.graphData);
+  const severedEdges = useApexStore((s) => s.severedEdges);
+  const ablatedNodeIds = useApexStore((s) => s.ablatedNodeIds);
+  const shocks = useApexStore((s) => s.shocks);
+  const severEdge = useApexStore((s) => s.severEdge);
+  const toggleAblatedNode = useApexStore((s) => s.toggleAblatedNode);
+  const addShock = useApexStore((s) => s.addShock);
+
+  const llmProvider = useApexStore((s) => s.llmProvider);
+  const claudeApiKey = useApexStore((s) => s.claudeApiKey);
+  const geminiApiKey = useApexStore((s) => s.geminiApiKey);
+  const claudeModel = useApexStore((s) => s.claudeModel);
+  const geminiModel = useApexStore((s) => s.geminiModel);
+
+  const [articleText, setArticleText] = useState("");
+  const [expanded, setExpanded] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<NewsResponse | null>(null);
+  const [appliedIdx, setAppliedIdx] = useState<Set<number>>(new Set());
+
+  const nodeLookup = useMemo(() => {
+    const m = new Map<string, string>();
+    graphData.nodes.forEach((n) => m.set(n.id, n.label));
+    return m;
+  }, [graphData.nodes]);
+
+  const edgeLookup = useMemo(() => {
+    const m = new Map<string, { source: string; target: string }>();
+    graphData.edges.forEach((e) => m.set(e.id, { source: e.source, target: e.target }));
+    return m;
+  }, [graphData.edges]);
+
+  const { apiKey, model, provider } = useMemo(() => {
+    if (llmProvider === "gemini") {
+      return { apiKey: geminiApiKey, model: geminiModel, provider: "gemini" as const };
+    }
+    return { apiKey: claudeApiKey, model: claudeModel, provider: "anthropic" as const };
+  }, [llmProvider, claudeApiKey, geminiApiKey, claudeModel, geminiModel]);
+
+  const canRun =
+    graphData.nodes.length > 0 && articleText.trim().length >= 20 && apiKey.length > 0;
+
+  const runInterpret = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    setAppliedIdx(new Set());
+    try {
+      const res = await fetch("/api/news", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          articleText,
+          nodes: graphData.nodes.map((n) => ({
+            id: n.id,
+            label: n.label,
+            category: n.category,
+            domain: n.domain ?? "",
+          })),
+          edges: graphData.edges.map((e) => ({
+            id: e.id,
+            source: e.source,
+            target: e.target,
+            physicalMechanism: e.physicalMechanism,
+          })),
+          apiKey,
+          model,
+          provider,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setError(json.error || `HTTP ${res.status}`);
+        return;
+      }
+      setResult(json as NewsResponse);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Request failed");
+    } finally {
+      setLoading(false);
+    }
+  }, [articleText, graphData, apiKey, model, provider]);
+
+  const applyIntervention = useCallback(
+    (iv: NewsIntervention, idx: number) => {
+      if (iv.technique === "sever" && iv.targetEdgeId) {
+        severEdge(iv.targetEdgeId);
+      } else if (iv.technique === "ablate" && iv.targetNodeId) {
+        if (!ablatedNodeIds.includes(iv.targetNodeId)) {
+          toggleAblatedNode(iv.targetNodeId);
+        }
+      } else if (iv.technique === "shock" && iv.targetNodeId) {
+        const label = nodeLookup.get(iv.targetNodeId) ?? iv.targetNodeId;
+        const shock: CausalShock = {
+          id: `news-${iv.targetNodeId}-${Date.now()}`,
+          name: `News: ${label.slice(0, 40)}`,
+          severity: iv.severity ?? 0.5,
+          category: iv.category ?? "geopolitical",
+          description: iv.rationale,
+        };
+        addShock(shock);
+      }
+      setAppliedIdx((prev) => new Set([...prev, idx]));
+    },
+    [severEdge, toggleAblatedNode, addShock, nodeLookup, ablatedNodeIds]
+  );
+
+  const isAlreadyApplied = (iv: NewsIntervention): boolean => {
+    if (iv.technique === "sever" && iv.targetEdgeId) {
+      return severedEdges.includes(iv.targetEdgeId);
+    }
+    if (iv.technique === "ablate" && iv.targetNodeId) {
+      return ablatedNodeIds.includes(iv.targetNodeId);
+    }
+    if (iv.technique === "shock" && iv.targetNodeId) {
+      return shocks.some((s) => s.id.startsWith(`news-${iv.targetNodeId}-`));
+    }
+    return false;
+  };
+
+  const describeTarget = (iv: NewsIntervention): string => {
+    if (iv.technique === "sever" && iv.targetEdgeId) {
+      const e = edgeLookup.get(iv.targetEdgeId);
+      if (!e) return iv.targetEdgeId;
+      const src = nodeLookup.get(e.source) ?? e.source;
+      const tgt = nodeLookup.get(e.target) ?? e.target;
+      return `${src} → ${tgt}`;
+    }
+    if (iv.targetNodeId) {
+      return nodeLookup.get(iv.targetNodeId) ?? iv.targetNodeId;
+    }
+    return "(unmapped)";
+  };
+
+  const techniqueColor = (t: Technique): string => {
+    switch (t) {
+      case "shock": return "var(--accent-red)";
+      case "sever": return "var(--accent-cyan)";
+      case "ablate": return "var(--accent-amber)";
+    }
+  };
+
+  return (
+    <div className="space-y-2 pt-3 border-t border-border">
+      <div className="flex items-center justify-between">
+        <div className="font-[family-name:var(--font-michroma)] text-[10px] tracking-wider text-accent-cyan">
+          NEWS INTERPRETER
+        </div>
+        <button
+          onClick={() => setExpanded((v) => !v)}
+          className="text-[8px] font-mono text-text-muted hover:text-foreground transition-colors"
+        >
+          {expanded ? "HIDE" : "PASTE NEWS"}
+        </button>
+      </div>
+      <div className="text-[8px] font-mono text-text-muted">
+        Paste a news article — Claude maps implied disruptions onto graph nodes/edges as shock, sever, or ablate interventions.
+      </div>
+
+      {expanded && (
+        <>
+          <textarea
+            value={articleText}
+            onChange={(e) => setArticleText(e.target.value)}
+            placeholder="Paste article text here (at least 20 characters)..."
+            rows={6}
+            className="w-full px-2 py-1.5 bg-surface-elevated border border-border rounded text-[9px] font-mono text-foreground placeholder:text-text-muted/40 focus:outline-none focus:border-accent-cyan/60 transition-colors resize-y"
+          />
+
+          <button
+            onClick={runInterpret}
+            disabled={!canRun || loading}
+            className="w-full px-3 py-2 rounded border text-[9px] font-[family-name:var(--font-michroma)] tracking-wider transition-all disabled:opacity-30"
+            style={{
+              borderColor: "rgba(0, 229, 255, 0.4)",
+              color: "var(--accent-cyan)",
+              background: loading ? "rgba(0, 229, 255, 0.15)" : "rgba(0, 229, 255, 0.05)",
+            }}
+          >
+            {loading ? "INTERPRETING..." : "INTERPRET ARTICLE"}
+          </button>
+
+          {!apiKey && (
+            <div className="text-[8px] font-mono text-text-muted italic">
+              Set an API key in the Copilot settings to enable interpretation.
+            </div>
+          )}
+          {graphData.nodes.length === 0 && (
+            <div className="text-[8px] font-mono text-text-muted italic">
+              Load a domain graph first — the interpreter needs nodes to map onto.
+            </div>
+          )}
+        </>
+      )}
+
+      {error && (
+        <div className="text-[9px] font-mono text-accent-red bg-accent-red/10 border border-accent-red/20 rounded px-2 py-1.5">
+          {error}
+        </div>
+      )}
+
+      {result && (
+        <div className="space-y-2">
+          {result.summary && (
+            <div className="text-[8px] font-mono text-text-muted italic border-l-2 border-accent-cyan/30 pl-2 leading-relaxed">
+              {result.summary}
+            </div>
+          )}
+
+          {result.interventions.length === 0 ? (
+            <div className="text-[8px] font-mono text-text-muted italic">
+              No graph-mappable interventions extracted.
+            </div>
+          ) : (
+            <div className="space-y-1">
+              <div className="text-[8px] font-mono text-text-muted">
+                EXTRACTED INTERVENTIONS ({result.interventions.length})
+              </div>
+              {result.interventions.map((iv, i) => {
+                const alreadyApplied = appliedIdx.has(i) || isAlreadyApplied(iv);
+                const actionLabel = iv.technique.toUpperCase();
+                const appliedLabel =
+                  iv.technique === "shock" ? "INJECTED" :
+                  iv.technique === "sever" ? "SEVERED" : "ABLATED";
+                const color = techniqueColor(iv.technique);
+                return (
+                  <div
+                    key={i}
+                    className="p-1.5 border rounded space-y-1"
+                    style={{
+                      borderColor: "rgba(0, 229, 255, 0.2)",
+                      backgroundColor: "rgba(0, 229, 255, 0.03)",
+                    }}
+                  >
+                    <div className="flex items-center gap-2">
+                      <span className="text-text-muted text-[8px] font-mono w-4">{i + 1}.</span>
+                      <span
+                        className="text-[7px] font-mono px-1 rounded"
+                        style={{
+                          color,
+                          backgroundColor: `${color === "var(--accent-red)" ? "rgba(255,23,68,0.1)" : color === "var(--accent-cyan)" ? "rgba(0,229,255,0.1)" : "rgba(255,171,0,0.1)"}`,
+                        }}
+                      >
+                        {actionLabel}
+                        {iv.technique === "shock" && iv.severity !== null && ` ${(iv.severity * 100).toFixed(0)}%`}
+                      </span>
+                      <span className="text-foreground text-[8px] font-mono flex-1 truncate">
+                        {describeTarget(iv)}
+                      </span>
+                      <button
+                        onClick={() => applyIntervention(iv, i)}
+                        disabled={alreadyApplied}
+                        className={`px-2 py-0.5 rounded text-[7px] font-[family-name:var(--font-michroma)] tracking-wider transition-colors shrink-0 ${
+                          alreadyApplied
+                            ? "text-accent-green border border-accent-green/30 bg-accent-green/5"
+                            : "text-accent-cyan border border-accent-cyan/30 hover:bg-accent-cyan/10"
+                        }`}
+                      >
+                        {alreadyApplied ? appliedLabel : "APPLY"}
+                      </button>
+                    </div>
+                    <div className="text-[8px] font-mono text-text-muted leading-relaxed pl-6">
+                      {iv.rationale}
+                    </div>
+                    {iv.sourceQuote && (
+                      <div className="text-[8px] font-mono text-foreground/60 italic leading-relaxed pl-6 border-l border-border ml-6">
+                        &ldquo;{iv.sourceQuote}&rdquo;
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/TimeDial.tsx
+++ b/src/components/TimeDial.tsx
@@ -684,6 +684,7 @@ export default function TimeDial() {
         {/* Track */}
         <div
           ref={trackRef}
+          data-timedial-track="true"
           className="relative h-6 cursor-crosshair rounded"
           style={{ backgroundColor: "rgba(26,28,46,0.8)" }}
           onPointerDown={handlePointerDown}

--- a/src/components/TimeSeriesOverlay.tsx
+++ b/src/components/TimeSeriesOverlay.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useMemo, useState, useCallback, useRef } from "react";
+import { useMemo, useState, useCallback, useRef, useLayoutEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useApexStore } from "@/stores/useApexStore";
 import { getDomainColor } from "@/lib/graph-data";
 import type { NodeTemporalState } from "@/lib/temporal-data";
 
 const CHART_HEIGHT = 120;
+// left/right are overridden at runtime to match the TimeDial track's actual
+// horizontal span so the chart's plot region and the scrubber line up.
 const PAD = { top: 12, bottom: 20, left: 32, right: 12 };
 
 function getLineColor(value: number): string {
@@ -23,14 +25,58 @@ export default function TimeSeriesOverlay() {
   const temporalData = useApexStore((s) => s.temporalData);
   const graphData = useApexStore((s) => s.graphData);
   const timelineRange = useApexStore((s) => s.timelineRange);
-  const timelineFullRange = useApexStore((s) => s.timelineFullRange);
   const timelinePosition = useApexStore((s) => s.timelinePosition);
   const isLive = useApexStore((s) => s.isLive);
-  const isZoomed = timelineFullRange !== null;
 
   const [hoverX, setHoverX] = useState<number | null>(null);
   const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  // The SVG uses preserveAspectRatio="none", so viewBox width is set to the
+  // rendered pixel width for a 1:1 mapping. Left/right inset inside the SVG
+  // is measured against the TimeDial track below so the chart's plot region
+  // aligns with the scrubber. Falls back to PAD defaults pre-measurement.
+  const [geom, setGeom] = useState<{ width: number; left: number; right: number }>({
+    width: 800,
+    left: PAD.left,
+    right: PAD.right,
+  });
+
+  useLayoutEffect(() => {
+    if (pinnedNodes.length === 0) return;
+    const update = () => {
+      if (!svgRef.current) return;
+      const track = document.querySelector<HTMLElement>("[data-timedial-track]");
+      const svgRect = svgRef.current.getBoundingClientRect();
+      if (svgRect.width === 0) return;
+      const width = svgRect.width;
+      const left = track
+        ? Math.max(0, track.getBoundingClientRect().left - svgRect.left)
+        : PAD.left;
+      const right = track
+        ? Math.max(0, svgRect.right - track.getBoundingClientRect().right)
+        : PAD.right;
+      setGeom((prev) =>
+        Math.abs(prev.width - width) < 0.5 &&
+        Math.abs(prev.left - left) < 0.5 &&
+        Math.abs(prev.right - right) < 0.5
+          ? prev
+          : { width, left, right },
+      );
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    if (svgRef.current) ro.observe(svgRef.current);
+    const track = document.querySelector<HTMLElement>("[data-timedial-track]");
+    if (track) ro.observe(track);
+    window.addEventListener("resize", update);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener("resize", update);
+    };
+  }, [pinnedNodes.length]);
+
+  const plotInset = geom;
+  const chartW = geom.width;
 
   // Gather histories for pinned nodes
   const curves = useMemo(() => {
@@ -110,53 +156,40 @@ export default function TimeSeriesOverlay() {
     return { yMin: yMinRaw, yMax: yMaxRaw, gridLines: lines };
   }, [curves]);
 
-  // Compute x-axis range: when zoomed, match the TimeDial's zoomed range;
-  // otherwise fit to the actual pinned curves' data range
-  const { xStart, xEnd } = useMemo(() => {
-    if (isZoomed) {
-      // Linked to TimeDial zoom — use the same window
-      return { xStart: timelineRange.start, xEnd: timelineRange.end };
-    }
-    if (curves.length === 0) return { xStart: timelineRange.start, xEnd: timelineRange.end };
-    let lo = Infinity;
-    let hi = -Infinity;
-    for (const curve of curves) {
-      for (const h of curve.history) {
-        if (h.timestamp < lo) lo = h.timestamp;
-        if (h.timestamp > hi) hi = h.timestamp;
-      }
-    }
-    // Add a small 2% padding on each side so curves don't touch edges
-    const span = hi - lo || 1;
-    const pad = span * 0.02;
-    return { xStart: lo - pad, xEnd: hi + pad };
-  }, [curves, timelineRange, isZoomed]);
+  // Always mirror the TimeDial's visible window so a timestamp renders at
+  // the same fractional x on both. Previously this fell back to the curves'
+  // own min/max when not zoomed, which made the vertical cursor drift off
+  // the TimeDial scrub below.
+  const { xStart, xEnd } = useMemo(
+    () => ({ xStart: timelineRange.start, xEnd: timelineRange.end }),
+    [timelineRange],
+  );
 
   // Convert data coordinates to SVG coordinates
   const toSvg = useCallback(
     (timestamp: number, omega: number, width: number) => {
       const xRange = xEnd - xStart || 1;
       const x =
-        PAD.left +
+        plotInset.left +
         ((timestamp - xStart) / xRange) *
-          (width - PAD.left - PAD.right);
+          (width - plotInset.left - plotInset.right);
       const y =
         PAD.top +
         (1 - (omega - yMin) / (yMax - yMin || 1)) *
           (CHART_HEIGHT - PAD.top - PAD.bottom);
       return { x, y };
     },
-    [xStart, xEnd, yMin, yMax],
+    [xStart, xEnd, yMin, yMax, plotInset],
   );
 
   // Get hovered values
   const hoverValues = useMemo(() => {
-    if (hoverX === null || !containerRef.current) return null;
-    const width = containerRef.current.getBoundingClientRect().width - 72; // minus label column
+    if (hoverX === null) return null;
     const xRange = xEnd - xStart || 1;
     const ts =
       xStart +
-      ((hoverX - PAD.left) / (width - PAD.left - PAD.right)) * xRange;
+      ((hoverX - plotInset.left) / (chartW - plotInset.left - plotInset.right)) *
+        xRange;
     const values: { nodeId: string; label: string; color: string; omega: number }[] = [];
     for (const curve of curves) {
       // Find closest timestamp in history
@@ -176,20 +209,20 @@ export default function TimeSeriesOverlay() {
       });
     }
     return { ts, values };
-  }, [hoverX, curves, xStart, xEnd]);
+  }, [hoverX, curves, xStart, xEnd, plotInset, chartW]);
 
   const handleMouseMove = useCallback(
     (e: React.MouseEvent<SVGSVGElement>) => {
       if (!svgRef.current) return;
       const rect = svgRef.current.getBoundingClientRect();
       const x = e.clientX - rect.left;
-      if (x >= PAD.left && x <= rect.width - PAD.right) {
+      if (x >= plotInset.left && x <= rect.width - plotInset.right) {
         setHoverX(x);
       } else {
         setHoverX(null);
       }
     },
-    [],
+    [plotInset],
   );
 
   if (pinnedNodes.length === 0) return null;
@@ -245,7 +278,7 @@ export default function TimeSeriesOverlay() {
                 onMouseMove={handleMouseMove}
                 onMouseLeave={() => setHoverX(null)}
                 preserveAspectRatio="none"
-                viewBox={`0 0 ${containerRef.current?.getBoundingClientRect().width ? containerRef.current.getBoundingClientRect().width - 72 : 800} ${CHART_HEIGHT}`}
+                viewBox={`0 0 ${chartW} ${CHART_HEIGHT}`}
               >
                 {/* Grid lines */}
                 {gridLines.map((v) => {
@@ -254,7 +287,7 @@ export default function TimeSeriesOverlay() {
                   return (
                     <line
                       key={v}
-                      x1={PAD.left}
+                      x1={plotInset.left}
                       y1={y}
                       x2="100%"
                       y2={y}
@@ -267,9 +300,7 @@ export default function TimeSeriesOverlay() {
 
                 {/* Curves */}
                 {curves.map((curve) => {
-                  const w = containerRef.current
-                    ? containerRef.current.getBoundingClientRect().width - 72
-                    : 800;
+                  const w = chartW;
                   const points = curve.history
                     .map((h) => {
                       const { x, y } = toSvg(h.timestamp, h.omegaComposite, w);
@@ -312,11 +343,8 @@ export default function TimeSeriesOverlay() {
                     on the chart. In live mode, follows the right edge (current
                     time) as timelineRange.end advances. */}
                 {(() => {
-                  const w = containerRef.current
-                    ? containerRef.current.getBoundingClientRect().width - 72
-                    : 800;
                   const pos = isLive ? xEnd : timelinePosition;
-                  const { x } = toSvg(pos, 0, w);
+                  const { x } = toSvg(pos, 0, chartW);
                   return (
                     <g>
                       <line
@@ -354,10 +382,7 @@ export default function TimeSeriesOverlay() {
                       strokeDasharray="3 3"
                     />
                     {hoverValues?.values.map((v) => {
-                      const w = containerRef.current
-                        ? containerRef.current.getBoundingClientRect().width - 72
-                        : 800;
-                      const { y } = toSvg(hoverValues.ts, v.omega, w);
+                      const { y } = toSvg(hoverValues.ts, v.omega, chartW);
                       return (
                         <g key={v.nodeId}>
                           <circle cx={hoverX} cy={y} r={4} fill={v.color} opacity={0.25} />
@@ -369,8 +394,12 @@ export default function TimeSeriesOverlay() {
                 )}
               </svg>
 
-              {/* X-axis date labels */}
-              <div className="flex justify-between mt-0.5 px-1">
+              {/* X-axis date labels — aligned to the plot region so the
+                  start/mid/end markers sit directly above the TimeDial. */}
+              <div
+                className="flex justify-between mt-0.5"
+                style={{ paddingLeft: plotInset.left, paddingRight: plotInset.right }}
+              >
                 <span className="text-[7px] font-mono text-text-muted/50">
                   {new Date(xStart).toLocaleDateString("en-US", { month: "short", year: "numeric" })}
                 </span>
@@ -382,18 +411,17 @@ export default function TimeSeriesOverlay() {
                 </span>
               </div>
 
-              {/* Hover tooltip — flips to left side when near right edge */}
+              {/* Hover tooltip — anchors next to the crosshair inside the
+                  chart wrapper (which is position: relative). Flips to the
+                  left of the cursor when near the right edge. */}
               {hoverValues && hoverX !== null && (() => {
-                const chartW = containerRef.current
-                  ? containerRef.current.getBoundingClientRect().width - 72
-                  : 800;
                 const flipLeft = hoverX > chartW * 0.7;
                 return (
                 <div
                   className="absolute z-20 pointer-events-none"
                   style={{
-                    left: flipLeft ? undefined : `${hoverX + 84}px`,
-                    right: flipLeft ? `${chartW - hoverX + 4}px` : undefined,
+                    left: flipLeft ? undefined : `${hoverX + 12}px`,
+                    right: flipLeft ? `${chartW - hoverX + 12}px` : undefined,
                     top: "-4px",
                   }}
                 >


### PR DESCRIPTION
## Summary
- **News Interpreter panel** — new sibling of `InterdictionPanel` in the Pareto module. Paste a news article, Claude (or Gemini) maps it onto the active graph as a structured list of interventions (shock / sever / ablate) against real node and edge IDs. Each proposal renders with an APPLY button that calls the same store actions the rest of the intervention UI uses (`addShock`, `severEdge`, `toggleAblatedNode`).
- **New endpoint `POST /api/news`** — mirrors the `/api/enrich` pattern. Returns `{ summary, interventions: [{ technique, targetNodeId?, targetEdgeId?, severity?, category?, rationale, sourceQuote }] }`. Gemini and Anthropic both wired; no streaming (single JSON response).
- First slice of George Korpas's proposal (2) — agentic interpreter over the existing causal graph. Paste-only for MVP, URL-fetch deferred until the extraction proves out.

## Why this slice
George flagged the news interpreter as the easier of his two architecture ideas. The interdiction pipeline already has a "propose → apply" UI pattern (`CopilotInterdictionResults`), so docking the new flow next to it meant ~3 files touched and zero changes to graph primitives, store schema, or existing actions.

## Test plan
- [ ] Load the MENA ENERGY SYSTEMS domain, launch the workspace, switch to the PARETO module.
- [ ] Scroll the right panel past CASCADE DEFENSE — confirm a NEWS INTERPRETER section with a `PASTE NEWS` toggle.
- [ ] Click `PASTE NEWS`; paste a real article mentioning a concrete disruption (e.g. a Strait of Hormuz incident or a Red Sea cable break). INTERPRET ARTICLE should stay disabled until ≥20 chars + API key set.
- [ ] Click INTERPRET ARTICLE — confirm the panel renders a one-sentence summary and 1–N proposed interventions with SHOCK / SEVER / ABLATE labels, rationale, and source-quote blockquote.
- [ ] Click APPLY on a sever proposal — confirm the target edge flips to the severed (dashed/red) style on the DAG.
- [ ] Click APPLY on a shock proposal — confirm a new shock appears in the scenario list and the Ω buffer updates.
- [ ] Click APPLY on an ablate proposal — confirm the target node flips into the ablated state.
- [ ] Clear the graph (no domain selected) — confirm the panel shows "Load a domain graph first…" instead of firing a request.
- [ ] Clear the API key — confirm "Set an API key…" guidance and INTERPRET ARTICLE stays disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)