### PR TITLE
fix(ui): keep module panel content clear of fixed FEEDBACK button

### DIFF
--- a/src/components/ModulePanel.tsx
+++ b/src/components/ModulePanel.tsx
@@ -65,8 +65,9 @@ export default function ModulePanel() {
       {/* Node Inspector (persistent across modules) */}
       <NodeInspector />
 
-      {/* Module Content */}
-      <div className="flex-1 overflow-y-auto">
+      {/* Module Content — pb-16 reserves space for the fixed FEEDBACK button
+          so the bottom of the last panel never sits under it at full scroll. */}
+      <div className="flex-1 overflow-y-auto pb-16">
         {activeModule === "spirtes" && (
           <>
             <CascadeHeader />


### PR DESCRIPTION
## Summary
- **Fixes NEWS INTERPRETER toggle being hidden by the floating FEEDBACK button.** The FEEDBACK widget is `position: fixed; bottom: 16px; right: 16px; z-index: 50`, which carves out ~48px in the bottom-right corner of the viewport. When the module panel scrolled to its end, the last panel's controls (most visibly the `PASTE NEWS` / `HIDE` toggle on the NEWS INTERPRETER in Pareto) could land under the button.
- **Fix:** `pb-16` on the module panel's scrollable content container so the last panel always has ~64px clearance at full scroll.

## Test plan
- [ ] Open Pareto, scroll the right module panel all the way down.
- [ ] Confirm the NEWS INTERPRETER heading + toggle (HIDE / PASTE NEWS) is fully visible and clickable, not under the FEEDBACK button.
- [ ] Confirm CASCADE DEFENSE, SCENARIO INJECTION, and other panels still render the same — only the scroll-end padding changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)