### PR TITLE
fix(news): reuse Copilot's Gemini auth (server env fallback)

### DIFF
--- a/src/app/api/news/route.ts
+++ b/src/app/api/news/route.ts
@@ -48,15 +48,24 @@ export async function POST(req: NextRequest) {
       provider?: LLMProvider;
     };
 
-    if (!apiKey) {
-      return new Response(JSON.stringify({ error: "API key required" }), {
+    if (!articleText || articleText.trim().length < 20) {
+      return new Response(JSON.stringify({ error: "Article text too short" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
       });
     }
 
-    if (!articleText || articleText.trim().length < 20) {
-      return new Response(JSON.stringify({ error: "Article text too short" }), {
+    const resolvedProvider: LLMProvider =
+      provider ?? (model?.startsWith("gemini") ? "gemini" : "anthropic");
+
+    const resolvedApiKey =
+      apiKey
+      || (resolvedProvider === "gemini" ? process.env.GEMINI_API_KEY : undefined)
+      || (resolvedProvider === "anthropic" ? process.env.ANTHROPIC_API_KEY : undefined)
+      || "";
+
+    if (!resolvedApiKey) {
+      return new Response(JSON.stringify({ error: "API key required" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
       });
@@ -84,13 +93,10 @@ ${articleText}
 
 Extract the graph-mappable interventions.`;
 
-    const resolvedProvider: LLMProvider =
-      provider ?? (model?.startsWith("gemini") ? "gemini" : "anthropic");
-
     let responseText: string;
 
     if (resolvedProvider === "gemini") {
-      const genAI = new GoogleGenerativeAI(apiKey);
+      const genAI = new GoogleGenerativeAI(resolvedApiKey);
       const genModel = genAI.getGenerativeModel({
         model: model || "gemini-2.5-flash",
         systemInstruction: SYSTEM_PROMPT,
@@ -100,7 +106,7 @@ Extract the graph-mappable interventions.`;
       });
       responseText = result.response.text();
     } else {
-      const client = new Anthropic({ apiKey });
+      const client = new Anthropic({ apiKey: resolvedApiKey });
       const response = await client.messages.create({
         model: model || "claude-sonnet-4-20250514",
         max_tokens: 4096,

--- a/src/components/NewsInterpreterPanel.tsx
+++ b/src/components/NewsInterpreterPanel.tsx
@@ -30,10 +30,7 @@ export default function NewsInterpreterPanel() {
   const toggleAblatedNode = useApexStore((s) => s.toggleAblatedNode);
   const addShock = useApexStore((s) => s.addShock);
 
-  const llmProvider = useApexStore((s) => s.llmProvider);
-  const claudeApiKey = useApexStore((s) => s.claudeApiKey);
   const geminiApiKey = useApexStore((s) => s.geminiApiKey);
-  const claudeModel = useApexStore((s) => s.claudeModel);
   const geminiModel = useApexStore((s) => s.geminiModel);
 
   const [articleText, setArticleText] = useState("");
@@ -55,15 +52,9 @@ export default function NewsInterpreterPanel() {
     return m;
   }, [graphData.edges]);
 
-  const { apiKey, model, provider } = useMemo(() => {
-    if (llmProvider === "gemini") {
-      return { apiKey: geminiApiKey, model: geminiModel, provider: "gemini" as const };
-    }
-    return { apiKey: claudeApiKey, model: claudeModel, provider: "anthropic" as const };
-  }, [llmProvider, claudeApiKey, geminiApiKey, claudeModel, geminiModel]);
-
-  const canRun =
-    graphData.nodes.length > 0 && articleText.trim().length >= 20 && apiKey.length > 0;
+  // Always use Gemini (same as SystemCopilot). Server falls back to
+  // process.env.GEMINI_API_KEY when the client key is empty.
+  const canRun = graphData.nodes.length > 0 && articleText.trim().length >= 20;
 
   const runInterpret = useCallback(async () => {
     setLoading(true);
@@ -88,9 +79,9 @@ export default function NewsInterpreterPanel() {
             target: e.target,
             physicalMechanism: e.physicalMechanism,
           })),
-          apiKey,
-          model,
-          provider,
+          apiKey: geminiApiKey,
+          model: geminiModel,
+          provider: "gemini",
         }),
       });
       const json = await res.json();
@@ -104,7 +95,7 @@ export default function NewsInterpreterPanel() {
     } finally {
       setLoading(false);
     }
-  }, [articleText, graphData, apiKey, model, provider]);
+  }, [articleText, graphData, geminiApiKey, geminiModel]);
 
   const applyIntervention = useCallback(
     (iv: NewsIntervention, idx: number) => {
@@ -205,11 +196,6 @@ export default function NewsInterpreterPanel() {
             {loading ? "INTERPRETING..." : "INTERPRET ARTICLE"}
           </button>
 
-          {!apiKey && (
-            <div className="text-[8px] font-mono text-text-muted italic">
-              Set an API key in the Copilot settings to enable interpretation.
-            </div>
-          )}
           {graphData.nodes.length === 0 && (
             <div className="text-[8px] font-mono text-text-muted italic">
               Load a domain graph first — the interpreter needs nodes to map onto.


### PR DESCRIPTION
## Summary
- **Fixes "Set an API key in the Copilot settings" hint blocking the News Interpreter** even when the SystemCopilot is already authenticated (Gemini via `GEMINI_API_KEY`).
- `/api/news` now falls back to `process.env.GEMINI_API_KEY` / `ANTHROPIC_API_KEY` when the client key is empty, mirroring `/api/copilot`.
- `NewsInterpreterPanel` hardcodes `provider=gemini` and reads `geminiApiKey` from the store. One less surface, one auth path to configure.

## Why
The original panel had its own provider picker and required a client-side key — which diverged from how the Copilot already works. Users who'd configured Gemini via server env var saw a spurious "key required" error in the News panel.

## Test plan
- [x] Verified locally: with `.env.local` `GEMINI_API_KEY` set and empty client key, `/api/news` returns 200 and Gemini maps interventions to real graph node IDs (`qf_strait_of_hormuz`, `sa_ras_tanura_terminal`, `qe_ras_laffan_port`).
- [ ] On Vercel: confirm `GEMINI_API_KEY` is set on manifold env, then paste article in Pareto → INTERPRET ARTICLE → applied interventions land in the graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
