### PR TITLE
feat(shocks): widen ShockCategory for financial/cyber/regulatory/environmental/health

### DIFF
--- a/src/app/api/news/route.ts
+++ b/src/app/api/news/route.ts
@@ -8,7 +8,7 @@ const SYSTEM_PROMPT = `You are APEX's causal news interpreter. Given a news arti
 The graph is a DAG of real-world systems (energy, manufacturing, finance, geopolitics, etc.). Each node is an entity or capability. Each edge is a causal dependency (source → target). An intervention is a perturbation the article describes or implies.
 
 Three intervention techniques are available:
-- "shock": inject an exogenous disruption on a node (use when article describes an ongoing/imminent disruption — strike, sanction, outage, disaster). Requires severity 0-1 and category from {compute, energy, cooling, supply, geopolitical}.
+- "shock": inject an exogenous disruption on a node (use when article describes an ongoing/imminent disruption — strike, sanction, outage, disaster, cyberattack, bank run, pandemic, recall, etc.). Requires severity 0-1 and category from {compute, energy, cooling, supply, geopolitical, financial, cyber, regulatory, environmental, health}. Pick the category that best fits the article's causal mechanism — e.g. banking/credit crises → financial, ransomware/data breach → cyber, antitrust ruling or SEC action → regulatory, hurricane/earthquake/climate event → environmental, pandemic/public-health emergency → health.
 - "sever": break a causal edge (use when article describes a dependency being cut — pipeline closure, export ban, route blocked).
 - "ablate": remove a node entirely (use when article describes a total capacity loss — factory destruction, company shutdown).
 

--- a/src/components/CausalDAG.tsx
+++ b/src/components/CausalDAG.tsx
@@ -47,6 +47,11 @@ function getNodeColor(category: string): string {
     case "energy": return "#00e676";
     case "cooling": return "#448aff";
     case "geopolitical": return "#ff1744";
+    case "financial": return "#ffc400";
+    case "cyber": return "#ff4081";
+    case "regulatory": return "#90a4ae";
+    case "environmental": return "#26a69a";
+    case "health": return "#ab47bc";
     default: return "#5a5e72";
   }
 }

--- a/src/components/ShockPanel.tsx
+++ b/src/components/ShockPanel.tsx
@@ -124,6 +124,11 @@ function getCategoryColor(cat: string): string {
     case "cooling": return "#448aff";
     case "supply": return "var(--accent-amber)";
     case "geopolitical": return "var(--accent-red)";
+    case "financial": return "#ffc400";
+    case "cyber": return "#ff4081";
+    case "regulatory": return "#90a4ae";
+    case "environmental": return "#26a69a";
+    case "health": return "#ab47bc";
     default: return "var(--text-muted)";
   }
 }
@@ -135,6 +140,11 @@ function getCategoryIcon(cat: string): string {
     case "cooling": return "◈";
     case "supply": return "◆";
     case "geopolitical": return "⚠";
+    case "financial": return "$";
+    case "cyber": return "⟁";
+    case "regulatory": return "§";
+    case "environmental": return "❂";
+    case "health": return "✚";
     default: return "●";
   }
 }

--- a/src/lib/cascade-simulator.ts
+++ b/src/lib/cascade-simulator.ts
@@ -38,6 +38,11 @@ const SHOCK_TO_NODE_CATEGORIES: Record<ShockCategory, NodeCategory[]> = {
   cooling: ["infrastructure"],
   supply: ["manufacturing", "communications", "agriculture"],
   geopolitical: ["geopolitical", "finance"],
+  financial: ["finance", "economic"],
+  cyber: ["infrastructure", "communications"],
+  regulatory: ["finance", "economic", "geopolitical"],
+  environmental: ["energy", "infrastructure", "agriculture"],
+  health: ["economic", "agriculture"],
 };
 
 export function mapShocksToNodes(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,15 @@
 // ─── Causal Shocks ───────────────────────────────────────────────
-export type ShockCategory = "compute" | "energy" | "cooling" | "supply" | "geopolitical";
+export type ShockCategory =
+  | "compute"
+  | "energy"
+  | "cooling"
+  | "supply"
+  | "geopolitical"
+  | "financial"
+  | "cyber"
+  | "regulatory"
+  | "environmental"
+  | "health";
 
 export interface CausalShock {
   id: string;


### PR DESCRIPTION
## Summary
Widens `ShockCategory` so the News Interpreter can honestly label interventions outside the original 5-category set. The shock primitive itself is already domain-agnostic — this just makes the category badge semantically accurate for financial contagion, cyberattacks, regulatory actions, natural disasters, and public-health events.

## Changes
- **`src/lib/types.ts`** — `ShockCategory` now: `compute | energy | cooling | supply | geopolitical | financial | cyber | regulatory | environmental | health`.
- **`src/lib/cascade-simulator.ts`** — extends `SHOCK_TO_NODE_CATEGORIES` record so each new shock class maps to plausible node categories (e.g. `financial → [finance, economic]`, `cyber → [infrastructure, communications]`).
- **`src/components/ShockPanel.tsx`** + **`src/components/CausalDAG.tsx`** — adds explicit color + icon cases for each new category (gold `$` for financial, hot-pink `⟁` for cyber, blue-gray `§` for regulatory, teal `❂` for environmental, purple `✚` for health).
- **`src/app/api/news/route.ts`** — system prompt lists the expanded category set with concrete guidance so Gemini routes to the right one (banking crisis → financial, ransomware → cyber, SEC action → regulatory, hurricane → environmental, pandemic → health).

## Test plan
- [x] `vitest run` — 219/219 passing.
- [x] `tsc --noEmit` — no errors.
- [ ] On manifold: paste a financial-contagion article in PARETO → INTERPRET → confirm shocks are labeled `FINANCIAL` with the gold `$` badge, not shoehorned into `GEOPOLITICAL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
