### PR TITLE
refactor(pareto): declutter panel — collapse cards, drop redundant Ω-summary

### DIFF
--- a/src/components/ModulePanel.tsx
+++ b/src/components/ModulePanel.tsx
@@ -978,15 +978,6 @@ function ParetoPanel({
 
   const paretoSectionExpanded = expandedChart === "pareto";
 
-  // Sync criticality card expansion with panel-level expand/collapse
-  useEffect(() => {
-    if (paretoSectionExpanded) {
-      setExpandedCrit({ csd: true, ph: true, lppls: true });
-    } else {
-      setExpandedCrit({});
-    }
-  }, [paretoSectionExpanded]);
-
   return (
     <>
       {/* Three Criticality Modules */}
@@ -1062,16 +1053,6 @@ function ParetoPanel({
           formula={`ω = ${lpplsData.omega.toFixed(2)} | m = ${lpplsData.m.toFixed(3)} | tc = ${lpplsData.tc.toFixed(3)} | ${replayEpochs.length >= 10 ? `R² = ${(lpplsData.residualFit * 100).toFixed(1)}%` : "R² = pending simulation"}`}
           assessment={`Mean Ω-fragility: ${(graphData.nodes.reduce((s, n) => s + n.omegaFragility.composite, 0) / Math.max(1, graphData.nodes.length)).toFixed(2)}/10. Acceleration factor: ${((graphData.nodes.reduce((s, n) => s + n.omegaFragility.composite, 0) / Math.max(1, graphData.nodes.length) / 10) * (1 + shocks.reduce((s, sh) => s + sh.severity, 0))).toFixed(3)}. ${shocks.length > 0 ? `${shocks.length} active shock(s) increasing ω by ${(shocks.reduce((s, sh) => s + sh.severity, 0) * 2.1).toFixed(1)} rad.` : "No active shocks — baseline oscillation frequency."}`}
         />
-      </div>
-
-      {/* Ω-Fragility Assessment */}
-      <div className="font-[family-name:var(--font-michroma)] text-[11px] tracking-wider text-text-muted mt-3">
-        {"\u03A9"}-FRAGILITY ASSESSMENT
-      </div>
-      <div className="text-[10px] font-mono text-text-muted space-y-1">
-        <div>Buffer: <span style={{ color: omegaState.status === "NOMINAL" ? "var(--accent-green)" : "var(--accent-red)" }}>{omegaState.buffer.toFixed(1)}%</span></div>
-        <div>Status: <span style={{ color: omegaState.status === "NOMINAL" ? "var(--accent-green)" : "var(--accent-red)" }}>{omegaState.status}</span></div>
-        <div>Active Scenarios: {shocks.length}</div>
       </div>
 
       {/* Ω-Fragility Ranking */}


### PR DESCRIPTION
## Summary
- **Criticality cards (CSD, PH, LPPLS) default to collapsed.** Previously a `useEffect` auto-expanded all three whenever the Pareto section opened, so the panel landed as a wall of charts + methodology + formulas on load. Killed the effect; each card's existing click-to-expand still works. Collapsed state already shows name + `T-N` countdown + `% conf` + colored progress bar — the at-a-glance "model + relevance" view the user asked for.
- **Removed Ω-FRAGILITY ASSESSMENT block.** `Buffer / Status / Active Scenarios` was duplicating (a) the top-right `CDΩ NOMINAL` badge, (b) the SCENARIO INJECTION list directly below, and (c) the criticality progress bars themselves. Three redundant lines gone.
- `TOP Ω-CRITICAL NODES` ranking stays — that's the genuine navigation handle into per-node NodeInspector drill-down.

## Test plan
- [x] Open Pareto module → three criticality cards render collapsed (name + countdown + conf badge + progress bar + one-line description each).
- [x] Click a card → it expands in place (TEMPORAL SIGNAL + METHODOLOGY + formula + CURRENT ASSESSMENT); clicking again collapses it.
- [x] Clicking one card does not toggle the others (previously the useEffect tied them together at the panel level).
- [x] TOP Ω-CRITICAL NODES list still renders and clicks still open NodeInspector.
- [x] Ω-FRAGILITY ASSESSMENT block no longer appears between the criticality cards and the node ranking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
