### PR TITLE
feat(news): URL-fetch button — paste a link instead of article text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
         "@google/generative-ai": "^0.24.1",
+        "@mozilla/readability": "^0.6.0",
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",
         "@react-three/postprocessing": "^3.0.4",
@@ -34,6 +35,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@types/jsdom": "^28.0.1",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -1441,6 +1443,15 @@
       },
       "peerDependencies": {
         "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/@mozilla/readability": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.6.0.tgz",
+      "integrity": "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@napi-rs/canvas": {
@@ -3289,6 +3300,52 @@
         "@types/geojson": "*"
       }
     },
+    "node_modules/@types/jsdom": {
+      "version": "28.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-28.0.1.tgz",
+      "integrity": "sha512-GJq2QE4TAZ5ajSoCasn5DOFm8u1mI3tIFvM5tIq3W5U/RTB6gsHwc6Yhpl91X9VSDOUVblgXmG+2+sSvFQrdlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0",
+        "undici-types": "^7.21.0"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/undici-types": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.25.0.tgz",
+      "integrity": "sha512-AXNgS1Byr27fTI+2bsPEkV9CxkT8H6xNyRI68b3TatlZo3RkzlqQBLL+w7SmGPVpokjHbcuNVQUWE7FRTg+LRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3398,6 +3455,13 @@
         "fflate": "~0.8.2",
         "meshoptimizer": "~1.0.1"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/webxr": {
       "version": "0.5.24",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
     "@google/generative-ai": "^0.24.1",
+    "@mozilla/readability": "^0.6.0",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.5.0",
     "@react-three/postprocessing": "^3.0.4",
@@ -39,6 +40,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/jsdom": "^28.0.1",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/app/api/news/fetch-url/route.ts
+++ b/src/app/api/news/fetch-url/route.ts
@@ -1,0 +1,139 @@
+import { Readability } from "@mozilla/readability";
+import { JSDOM } from "jsdom";
+import { NextRequest } from "next/server";
+
+const USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36";
+
+const FETCH_TIMEOUT_MS = 12_000;
+const MAX_BYTES = 2_000_000;
+
+export async function POST(req: NextRequest) {
+  try {
+    const { url } = (await req.json()) as { url?: string };
+
+    if (!url || typeof url !== "string") {
+      return jsonError("URL required", 400);
+    }
+
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      return jsonError("Invalid URL", 400);
+    }
+
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return jsonError("Only http(s) URLs are supported", 400);
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    let res: Response;
+    try {
+      res = await fetch(parsed.toString(), {
+        signal: controller.signal,
+        redirect: "follow",
+        headers: {
+          "User-Agent": USER_AGENT,
+          Accept:
+            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+          "Accept-Language": "en-US,en;q=0.9",
+        },
+      });
+    } catch (err) {
+      clearTimeout(timeout);
+      const isAbort = err instanceof Error && err.name === "AbortError";
+      return jsonError(
+        isAbort
+          ? "Fetch timed out (12s). The site may be slow or blocking requests."
+          : `Fetch failed: ${err instanceof Error ? err.message : "unknown"}`,
+        502
+      );
+    }
+    clearTimeout(timeout);
+
+    if (!res.ok) {
+      return jsonError(
+        `Upstream returned ${res.status}. The site may require login, a paywall, or is blocking scrapers. Try pasting the article text manually.`,
+        502
+      );
+    }
+
+    const contentType = res.headers.get("content-type") || "";
+    if (!contentType.includes("text/html") && !contentType.includes("xml")) {
+      return jsonError(
+        `Unsupported content-type (${contentType || "unknown"}). URL must point to an HTML article.`,
+        415
+      );
+    }
+
+    const reader = res.body?.getReader();
+    if (!reader) {
+      return jsonError("Empty response body", 502);
+    }
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > MAX_BYTES) {
+        await reader.cancel();
+        return jsonError("Page too large (>2MB). Refusing to parse.", 413);
+      }
+      chunks.push(value);
+    }
+    const buf = new Uint8Array(total);
+    let offset = 0;
+    for (const c of chunks) {
+      buf.set(c, offset);
+      offset += c.byteLength;
+    }
+    const html = new TextDecoder("utf-8").decode(buf);
+
+    const dom = new JSDOM(html, { url: parsed.toString() });
+    const article = new Readability(dom.window.document).parse();
+
+    if (!article || !article.textContent) {
+      return jsonError(
+        "Couldn't extract article text. The page may be an index, login wall, or JS-rendered app. Paste the article manually.",
+        422
+      );
+    }
+
+    const text = article.textContent.trim().replace(/\n{3,}/g, "\n\n");
+
+    if (text.length < 100) {
+      return jsonError(
+        `Extracted text is very short (${text.length} chars). The page may not be a full article. Paste manually if needed.`,
+        422
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        title: article.title ?? "",
+        byline: article.byline ?? "",
+        siteName: article.siteName ?? parsed.hostname,
+        excerpt: article.excerpt ?? "",
+        text,
+        url: parsed.toString(),
+      }),
+      { headers: { "Content-Type": "application/json" } }
+    );
+  } catch (err) {
+    return jsonError(
+      err instanceof Error ? err.message : "Unknown error",
+      500
+    );
+  }
+}
+
+function jsonError(message: string, status: number) {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/src/components/NewsInterpreterPanel.tsx
+++ b/src/components/NewsInterpreterPanel.tsx
@@ -34,6 +34,9 @@ export default function NewsInterpreterPanel() {
   const geminiModel = useApexStore((s) => s.geminiModel);
 
   const [articleText, setArticleText] = useState("");
+  const [articleUrl, setArticleUrl] = useState("");
+  const [fetchInfo, setFetchInfo] = useState<string | null>(null);
+  const [fetching, setFetching] = useState(false);
   const [expanded, setExpanded] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -55,6 +58,32 @@ export default function NewsInterpreterPanel() {
   // Always use Gemini (same as SystemCopilot). Server falls back to
   // process.env.GEMINI_API_KEY when the client key is empty.
   const canRun = graphData.nodes.length > 0 && articleText.trim().length >= 20;
+  const canFetch = articleUrl.trim().length > 0 && !fetching;
+
+  const runFetchUrl = useCallback(async () => {
+    setFetching(true);
+    setError(null);
+    setFetchInfo(null);
+    try {
+      const res = await fetch("/api/news/fetch-url", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: articleUrl.trim() }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setError(json.error || `HTTP ${res.status}`);
+        return;
+      }
+      setArticleText(json.text);
+      const title = json.title || json.siteName || "article";
+      setFetchInfo(`Fetched: ${title} (${json.text.length} chars)`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Fetch failed");
+    } finally {
+      setFetching(false);
+    }
+  }, [articleUrl]);
 
   const runInterpret = useCallback(async () => {
     setLoading(true);
@@ -170,15 +199,49 @@ export default function NewsInterpreterPanel() {
         </button>
       </div>
       <div className="text-[8px] font-mono text-text-muted">
-        Paste a news article — Claude maps implied disruptions onto graph nodes/edges as shock, sever, or ablate interventions.
+        Paste a URL or article text. Gemini maps implied disruptions onto graph nodes/edges as shock, sever, or ablate interventions.
       </div>
 
       {expanded && (
         <>
+          <div className="flex gap-1">
+            <input
+              type="url"
+              value={articleUrl}
+              onChange={(e) => setArticleUrl(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && canFetch) {
+                  e.preventDefault();
+                  runFetchUrl();
+                }
+              }}
+              placeholder="https://... (article URL)"
+              className="flex-1 min-w-0 px-2 py-1 bg-surface-elevated border border-border rounded text-[9px] font-mono text-foreground placeholder:text-text-muted/40 focus:outline-none focus:border-accent-cyan/60 transition-colors"
+            />
+            <button
+              onClick={runFetchUrl}
+              disabled={!canFetch}
+              className="px-2 py-1 rounded border text-[8px] font-[family-name:var(--font-michroma)] tracking-wider transition-all disabled:opacity-30 shrink-0"
+              style={{
+                borderColor: "rgba(0, 229, 255, 0.4)",
+                color: "var(--accent-cyan)",
+                background: fetching ? "rgba(0, 229, 255, 0.15)" : "rgba(0, 229, 255, 0.05)",
+              }}
+            >
+              {fetching ? "FETCHING..." : "FETCH"}
+            </button>
+          </div>
+
+          {fetchInfo && (
+            <div className="text-[8px] font-mono text-accent-green/80 italic">
+              {fetchInfo}
+            </div>
+          )}
+
           <textarea
             value={articleText}
             onChange={(e) => setArticleText(e.target.value)}
-            placeholder="Paste article text here (at least 20 characters)..."
+            placeholder="...or paste article text here (at least 20 characters)"
             rows={6}
             className="w-full px-2 py-1.5 bg-surface-elevated border border-border rounded text-[9px] font-mono text-foreground placeholder:text-text-muted/40 focus:outline-none focus:border-accent-cyan/60 transition-colors resize-y"
           />


### PR DESCRIPTION
## Summary
- New `/api/news/fetch-url` endpoint using `@mozilla/readability` + `jsdom` to extract article body server-side.
- News Interpreter panel gets a URL input row + **FETCH** button above the textarea. Fetched text drops into the textarea; the existing INTERPRET flow runs unchanged.
- Replaces the copy-paste-from-browser step for the common case (public news article). Paywalls, JS-only apps, and 403-ers still fall back to manual paste — the endpoint returns a clear actionable error in those cases.

## Endpoint guards
- 12s AbortController timeout
- 2MB byte cap
- Spoofed Chrome User-Agent (many sites 403 headless requests)
- `http(s)` only; content-type must be `text/html` or `xml`
- Tiered error responses: paywall/403 → "may require login", empty extract → "paste manually", short extract → length warning

## Test plan
- [x] `POST /api/news/fetch-url` with Wikipedia URL → 200, Readability returns ~60k chars clean text
- [x] UI wired: URL input + FETCH button render, Enter submits, fetching state disables button
- [x] Extracted text populates textarea, INTERPRET then runs against it unchanged
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)