### PR TITLE
feat: persona gating in DomainSelector + pin top-bar module labels

### DIFF
--- a/src/components/DomainSelector.tsx
+++ b/src/components/DomainSelector.tsx
@@ -48,6 +48,21 @@ interface DomainGroup {
   domains: DomainCard[];
 }
 
+type Persona = "scientist" | "analyst" | "cross";
+
+const PERSONAS: { id: Persona; label: string; desc: string }[] = [
+  { id: "analyst", label: "ANALYST", desc: "Geopolitical · Financial · Macro" },
+  { id: "scientist", label: "SCIENTIST", desc: "Life Sciences" },
+  { id: "cross", label: "CROSS-DOMAIN", desc: "All domains · cross-dataset multi-select" },
+];
+
+// Which dataset families each persona may see
+const PERSONA_DATASETS: Record<Persona, Set<DomainCard["dataset"]>> = {
+  analyst: new Set(["main", "athena"]),
+  scientist: new Set(["t1d"]),
+  cross: new Set(["main", "athena", "t1d"]),
+};
+
 const DOMAIN_GROUPS: DomainGroup[] = [
   {
     label: "MENA ENERGY & COMMODITIES",
@@ -323,6 +338,8 @@ export default function DomainSelector() {
     setVisibleDiscoverySources,
     setSelectedDataSources,
     setGraphData,
+    activePersona,
+    setActivePersona,
   } = useApexStore();
 
   const [localSelected, setLocalSelected] = useState<string[]>([]);
@@ -331,15 +348,52 @@ export default function DomainSelector() {
   const [localSources, setLocalSources] = useState<Set<string>>(new Set());
   const [showDataLayers, setShowDataLayers] = useState(false);
 
+  // Cards visible for the active persona
+  const allowedDatasets = PERSONA_DATASETS[activePersona];
+  const visibleGroups = DOMAIN_GROUPS.map((g) => ({
+    ...g,
+    domains: g.domains.filter((d) => allowedDatasets.has(d.dataset)),
+  })).filter((g) => g.domains.length > 0);
+
+  const switchPersona = useCallback(
+    (persona: Persona) => {
+      setActivePersona(persona);
+      const allowed = PERSONA_DATASETS[persona];
+      // Drop any currently-selected cards that don't belong to the new persona's datasets
+      setLocalSelected((prev) =>
+        prev.filter((id) => {
+          const card = DOMAIN_CARDS.find((d) => d.id === id);
+          return card && allowed.has(card.dataset);
+        })
+      );
+      // Cross-domain is the only persona that allows cross-dataset multi-select;
+      // others still allow multi-select within their own family.
+      // We don't force single-select on switch — just drop out-of-persona cards.
+    },
+    [setActivePersona]
+  );
+
   const toggleDomain = useCallback(
     (id: string) => {
       setLocalSelected((prev) => {
         if (prev.includes(id)) return prev.filter((d) => d !== id);
         if (!localMulti) return [id];
+        // In Analyst/Scientist personas, multi-select is allowed within the same
+        // dataset family only. In Cross-Domain, any combination is allowed.
+        if (activePersona !== "cross") {
+          const card = DOMAIN_CARDS.find((d) => d.id === id);
+          const filtered = card
+            ? prev.filter((prevId) => {
+                const prevCard = DOMAIN_CARDS.find((d) => d.id === prevId);
+                return prevCard && prevCard.dataset === card.dataset;
+              })
+            : prev;
+          return [...filtered, id];
+        }
         return [...prev, id];
       });
     },
-    [localMulti]
+    [localMulti, activePersona]
   );
 
   const switchMode = useCallback(
@@ -427,6 +481,35 @@ export default function DomainSelector() {
               </div>
             </div>
 
+            {/* Persona Selector */}
+            <div className="px-6 pt-4 pb-2 border-b border-border/50">
+              <div className="text-[7px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted/60 mb-2">
+                PERSONA
+              </div>
+              <div className="flex gap-2 flex-wrap">
+                {PERSONAS.map((p) => {
+                  const isActive = activePersona === p.id;
+                  return (
+                    <button
+                      key={p.id}
+                      onClick={() => switchPersona(p.id)}
+                      className="flex flex-col px-3 py-1.5 rounded border transition-all text-left"
+                      style={{
+                        borderColor: isActive ? "var(--accent-cyan)" : "var(--border)",
+                        backgroundColor: isActive ? "rgba(0,229,255,0.08)" : "transparent",
+                        color: isActive ? "var(--accent-cyan)" : "var(--text-muted)",
+                      }}
+                    >
+                      <span className="text-[9px] font-[family-name:var(--font-michroma)] tracking-wider">
+                        {p.label}
+                      </span>
+                      <span className="text-[7px] font-mono opacity-60 mt-0.5">{p.desc}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
             {/* Mode Toggle */}
             <div className="px-6 pt-4 flex gap-2">
               <button
@@ -460,7 +543,7 @@ export default function DomainSelector() {
 
             {/* Grouped Domain Cards */}
             <div className="px-6 py-4 max-h-[420px] overflow-y-auto space-y-4">
-              {DOMAIN_GROUPS.map((group) => (
+              {visibleGroups.map((group) => (
                 <div key={group.label}>
                   <div
                     className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider mb-1.5"

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -9,17 +9,20 @@ import CDOmegaMonitor from "./CDOmegaMonitor";
 import ImportButton from "./import/ImportButton";
 import { ModuleId } from "@/lib/types";
 import { DOMAIN_CARDS } from "./DomainSelector";
-import { resolveDomainProfile } from "@/lib/domain-profiles";
+import { GEOPOLITICAL_PROFILE } from "@/lib/domain-profiles";
+
+// Top-bar tabs are pinned to the four canonical labels regardless of active
+// domain profile. Profile-scoped vocabulary lives in the right panel / pillar
+// bars / methodology popup only.
+const MODULE_TABS = GEOPOLITICAL_PROFILE.modules.map((m) => ({
+  id: m.id as ModuleId,
+  label: m.name,
+  icon: m.icon,
+  color: m.color,
+}));
 
 export default function HeaderBar() {
   const { activeModule, setActiveModule, shocks, replayActive, currentEpoch, baselineEpochs, interventionEpochs, activeTimeline, setTourActive, selectedDomains, setDomainSelectorOpen } = useApexStore();
-  const profile = resolveDomainProfile(selectedDomains);
-  const MODULE_TABS = profile.modules.map((m) => ({
-    id: m.id as ModuleId,
-    label: m.name,
-    icon: m.icon,
-    color: m.color,
-  }));
   const baseState = useMemo(() => computeOmegaState(shocks), [shocks]);
 
   // During replay, override omega state with current epoch's values

--- a/src/stores/useApexStore.ts
+++ b/src/stores/useApexStore.ts
@@ -162,6 +162,10 @@ interface ApexState {
   setIsMultiDomainMode: (multi: boolean) => void;
   setDomainSelectorOpen: (open: boolean) => void;
 
+  // Persona
+  activePersona: "scientist" | "analyst" | "cross";
+  setActivePersona: (persona: "scientist" | "analyst" | "cross") => void;
+
   // Data source selection (which datasets to load)
   selectedDataSources: string[];
   setSelectedDataSources: (sources: string[]) => void;
@@ -491,6 +495,10 @@ export const useApexStore = create<ApexState>((set, get) => ({
   setSelectedDomains: (domains) => set({ selectedDomains: domains }),
   setIsMultiDomainMode: (multi) => set({ isMultiDomainMode: multi }),
   setDomainSelectorOpen: (open) => set({ domainSelectorOpen: open }),
+
+  // Persona
+  activePersona: "analyst",
+  setActivePersona: (persona) => set({ activePersona: persona }),
 
   // Data sources
   selectedDataSources: ["middle-east-playbooks"],


### PR DESCRIPTION
## Summary

- **Persona selector** — adds three pills (ANALYST / SCIENTIST / CROSS-DOMAIN) at the top of the Domain Workspace modal, between the header and the mode-toggle row. Stored as `activePersona: "scientist" | "analyst" | "cross"` in `useApexStore`; default is `"analyst"` (matches previous behaviour). No persistence — resets on page load.
  - **Analyst** — shows only geopolitical / financial / macro / defense cards (`dataset: main | athena`).
  - **Scientist** — shows only Life Sciences cards (`dataset: t1d`).
  - **Cross-Domain** — shows all cards; the only persona where multi-select across different dataset families is permitted.
  - Switching persona silently drops any currently-selected cards that don't belong to the new persona's dataset family.
  - Within Analyst and Scientist, multi-select is still allowed, but only among cards sharing the same dataset family (enforced in `toggleDomain`).

- **Top-bar module labels pinned to canonical names** — `HeaderBar.tsx` previously resolved `MODULE_TABS` from `resolveDomainProfile(selectedDomains).modules`, so switching to the T1D profile renamed the tabs to MECHANISM / AXIOMS / INTERVENTION / CRITICALITY. The tabs now read from `GEOPOLITICAL_PROFILE.modules` directly (a module-level constant, not per-render). Profile-scoped vocabulary (T1D module names, pillar labels, composite methodology) continues to flow through `ManifoldSidebar`, pillar bars, and the methodology popup unchanged.

## Design decisions noted

- **Persona state lives in the store, not local component state** — this lets other parts of the app (e.g. a future top-bar indicator) read the active persona without prop-drilling.
- **Sidebar keeps profile-scoped labels** — `ManifoldSidebar` still reads `resolveDomainProfile().modules` so the expanded sidebar shows T1D-specific subtitles/descriptions when the T1D profile is active. Only the top-bar tabs are pinned.
- **`Persona` type is local to `DomainSelector.tsx`** — the canonical string union `"scientist" | "analyst" | "cross"` is defined in `useApexStore.ts`; the `Persona` alias in `DomainSelector.tsx` is a convenience mirror. Both are in sync.

## Test plan

- [ ] Open Domain Workspace modal — persona pills appear below the header, ANALYST is highlighted by default.
- [ ] Switch to SCIENTIST — only the LIFE SCIENCES group (T1D β-Cell Restoration) is visible.
- [ ] Switch to ANALYST — LIFE SCIENCES group disappears; geopolitical/financial/macro/defense cards are shown.
- [ ] Switch to CROSS-DOMAIN — all groups visible.
- [ ] Select an Energy Systems card (Analyst), then switch to Scientist — selection is silently cleared.
- [ ] In ANALYST + MULTI-DOMAIN mode, select Energy Systems then select T1D β-Cell — only the newly-clicked card should remain selected (enforces within-family multi-select).
- [ ] In CROSS-DOMAIN + MULTI-DOMAIN mode, select Energy Systems then T1D β-Cell — both should be selected.
- [ ] Launch a workspace with T1D selected — top-bar tabs should still read SPIRTES / TARSKI / PEARL / PARETO (not MECHANISM / AXIOMS / INTERVENTION / CRITICALITY).
- [ ] ManifoldSidebar (if visible) should still show T1D-specific subtitles when T1D profile is active.
- [ ] `npx tsc --noEmit` — only the two pre-existing errors in `src/app/api/news/fetch-url/route.ts` (missing `@mozilla/readability` and `jsdom` type declarations); no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)