### PR TITLE
perf: eliminate wasted render/frame work across DAG, store, and bundle paths

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,20 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // Enable gzip/brotli compression for served assets
+  compress: true,
+
+  // next/image optimization defaults (formats, device sizes)
+  images: {
+    formats: ["image/avif", "image/webp"],
+    deviceSizes: [640, 750, 828, 1080, 1200, 1920],
+    imageSizes: [16, 32, 48, 64, 96, 128, 256],
+  },
+
+  // Inline critical CSS to cut render-blocking stylesheets
+  experimental: {
+    optimizeCss: true,
+  },
 };
 
 export default nextConfig;

--- a/src/app/expired/page.tsx
+++ b/src/app/expired/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import { createClient } from "@/lib/supabase/client";
 
 export default function ExpiredPage() {
@@ -18,10 +19,13 @@ export default function ExpiredPage() {
       <div className="w-full max-w-md space-y-8 text-center">
         {/* Logo */}
         <div className="space-y-2">
-          <img
+          <Image
             src="/logo.png"
             alt="Manifold Logo"
-            className="w-40 h-40 mx-auto object-contain"
+            width={160}
+            height={160}
+            className="mx-auto object-contain"
+            priority
           />
           <h1 className="text-xl font-[family-name:var(--font-michroma)] tracking-[0.3em] text-accent-cyan">
             MANIFOLD

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { createClient } from "@/lib/supabase/client";
 
 export default function ForgotPasswordPage() {
@@ -35,10 +36,13 @@ export default function ForgotPasswordPage() {
     <div className="min-h-screen flex items-center justify-center bg-background px-4">
       <div className="w-full max-w-md space-y-8">
         <div className="text-center space-y-2">
-          <img
+          <Image
             src="/logo.png"
             alt="Manifold Logo"
-            className="w-40 h-40 mx-auto object-contain"
+            width={160}
+            height={160}
+            className="mx-auto object-contain"
+            priority
           />
           <h1 className="text-xl font-[family-name:var(--font-michroma)] tracking-[0.3em] text-accent-cyan">
             MANIFOLD

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 import { createClient } from "@/lib/supabase/client";
 
 export default function LoginPage() {
@@ -38,10 +39,13 @@ export default function LoginPage() {
       <div className="w-full max-w-md space-y-8">
         {/* Logo */}
         <div className="text-center space-y-2">
-          <img
+          <Image
             src="/logo.png"
             alt="Manifold Logo"
-            className="w-40 h-40 mx-auto object-contain"
+            width={160}
+            height={160}
+            className="mx-auto object-contain"
+            priority
           />
           <h1 className="text-xl font-[family-name:var(--font-michroma)] tracking-[0.3em] text-accent-cyan">
             MANIFOLD

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,6 @@ import Link from "next/link";
 import dynamic from "next/dynamic";
 import { useApexStore } from "@/stores/useApexStore";
 import { protectGraphData } from "@/lib/data-protection";
-import { MAIN_GRAPH } from "@/lib/graph-data";
 import HeaderBar from "@/components/HeaderBar";
 import SystemCopilot from "@/components/SystemCopilot";
 import RiskPropagationFlow from "@/components/RiskPropagationFlow";
@@ -46,9 +45,12 @@ const CausalDAGMap = dynamic(() => import("@/components/CausalDAGMap"), {
 export default function Home() {
   const viewMode = useApexStore((s) => s.viewMode);
 
-  // Protect graph data from console extraction
+  // Protect graph data from console extraction — import dynamically so the
+  // 2,920-line graph-data module isn't on the critical-path bundle (item #6).
   useEffect(() => {
-    protectGraphData(MAIN_GRAPH);
+    import("@/lib/graph-data").then(({ MAIN_GRAPH }) => {
+      protectGraphData(MAIN_GRAPH);
+    });
   }, []);
 
   // Block DevTools shortcuts in production

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 import { createClient } from "@/lib/supabase/client";
 
 export default function ResetPasswordPage() {
@@ -61,10 +62,13 @@ export default function ResetPasswordPage() {
     <div className="min-h-screen flex items-center justify-center bg-background px-4">
       <div className="w-full max-w-md space-y-8">
         <div className="text-center space-y-2">
-          <img
+          <Image
             src="/logo.png"
             alt="Manifold Logo"
-            className="w-40 h-40 mx-auto object-contain"
+            width={160}
+            height={160}
+            className="mx-auto object-contain"
+            priority
           />
           <h1 className="text-xl font-[family-name:var(--font-michroma)] tracking-[0.3em] text-accent-cyan">
             MANIFOLD

--- a/src/app/trial-signup/page.tsx
+++ b/src/app/trial-signup/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 import { createClient } from "@/lib/supabase/client";
 
 export default function TrialSignupPage() {
@@ -45,10 +46,13 @@ export default function TrialSignupPage() {
       <div className="w-full max-w-md space-y-8">
         {/* Logo */}
         <div className="text-center space-y-2">
-          <img
+          <Image
             src="/logo.png"
             alt="Manifold Logo"
-            className="w-40 h-40 mx-auto object-contain"
+            width={160}
+            height={160}
+            className="mx-auto object-contain"
+            priority
           />
           <h1 className="text-xl font-[family-name:var(--font-michroma)] tracking-[0.3em] text-accent-cyan">
             MANIFOLD

--- a/src/components/CausalDAG3D.tsx
+++ b/src/components/CausalDAG3D.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useMemo, useRef, useState, forwardRef } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Canvas, useThree, useFrame } from "@react-three/fiber";
 import { OrbitControls } from "@react-three/drei";
 import * as THREE from "three";
@@ -327,6 +327,44 @@ function FrameMonitor() {
   return null;
 }
 
+// Drives invalidate() while replay is active so demand-mode still animates.
+function ReplayInvalidator() {
+  const { invalidate } = useThree();
+  useFrame(() => {
+    const { replayActive, replayPlaying } = useApexStore.getState();
+    if (replayActive && replayPlaying) invalidate();
+  });
+  return null;
+}
+
+// Watches store slices that change during interaction and calls invalidate()
+// so demand-mode Canvas re-renders exactly when needed (item #1).
+function StoreInvalidator() {
+  const { invalidate } = useThree();
+  const selectedNode = useApexStore((s) => s.selectedNode);
+  const selectedNodes = useApexStore((s) => s.selectedNodes);
+  const timelinePosition = useApexStore((s) => s.timelinePosition);
+  const severedEdges = useApexStore((s) => s.severedEdges);
+  const currentEpoch = useApexStore((s) => s.currentEpoch);
+
+  // Invalidate on any store change that affects visible state
+  useEffect(() => { invalidate(); }, [selectedNode, invalidate]);
+  useEffect(() => { invalidate(); }, [selectedNodes, invalidate]);
+  useEffect(() => { invalidate(); }, [timelinePosition, invalidate]);
+  useEffect(() => { invalidate(); }, [severedEdges, invalidate]);
+  useEffect(() => { invalidate(); }, [currentEpoch, invalidate]);
+
+  // Expose a stable callback so node hover can trigger invalidate
+  // without subscribing StoreInvalidator to hover state
+  useEffect(() => {
+    const handler = () => invalidate();
+    window.addEventListener("dag3d-invalidate", handler);
+    return () => window.removeEventListener("dag3d-invalidate", handler);
+  }, [invalidate]);
+
+  return null;
+}
+
 function ReplayTickDriver() {
   useReplayTick();
   return null;
@@ -424,32 +462,31 @@ function ShiftDragSelect({
 
 export default function CausalDAG3D() {
   const graphData = useFilteredGraph();
-  const {
-    setGraphData,
-    truthFilter,
-    interventionMode,
-    interventionTarget,
-    setInterventionTarget,
-    selectedNode,
-    setSelectedNode,
-    selectedNodes: multiSelectedNodes,
-    setSelectedNodes,
-    isolateSelection,
-    scissorsMode,
-    severedEdges,
-    severEdge,
-    ablationMode,
-    ablatedNodeIds,
-    ablatedEdgeIds,
-    toggleAblatedNode,
-    toggleAblatedEdge,
-    replayActive,
-    currentEpoch,
-    baselineEpochs,
-    interventionEpochs,
-    activeTimeline,
-    isLive,
-  } = useApexStore();
+  // Fine-grained selectors — each subscribes only to its own slice (item #4)
+  const setGraphData = useApexStore((s) => s.setGraphData);
+  const truthFilter = useApexStore((s) => s.truthFilter);
+  const interventionMode = useApexStore((s) => s.interventionMode);
+  const interventionTarget = useApexStore((s) => s.interventionTarget);
+  const setInterventionTarget = useApexStore((s) => s.setInterventionTarget);
+  const selectedNode = useApexStore((s) => s.selectedNode);
+  const setSelectedNode = useApexStore((s) => s.setSelectedNode);
+  const multiSelectedNodes = useApexStore((s) => s.selectedNodes);
+  const setSelectedNodes = useApexStore((s) => s.setSelectedNodes);
+  const isolateSelection = useApexStore((s) => s.isolateSelection);
+  const scissorsMode = useApexStore((s) => s.scissorsMode);
+  const severedEdges = useApexStore((s) => s.severedEdges);
+  const severEdge = useApexStore((s) => s.severEdge);
+  const ablationMode = useApexStore((s) => s.ablationMode);
+  const ablatedNodeIds = useApexStore((s) => s.ablatedNodeIds);
+  const ablatedEdgeIds = useApexStore((s) => s.ablatedEdgeIds);
+  const toggleAblatedNode = useApexStore((s) => s.toggleAblatedNode);
+  const toggleAblatedEdge = useApexStore((s) => s.toggleAblatedEdge);
+  const replayActive = useApexStore((s) => s.replayActive);
+  const currentEpoch = useApexStore((s) => s.currentEpoch);
+  const baselineEpochs = useApexStore((s) => s.baselineEpochs);
+  const interventionEpochs = useApexStore((s) => s.interventionEpochs);
+  const activeTimeline = useApexStore((s) => s.activeTimeline);
+  const isLive = useApexStore((s) => s.isLive);
 
   const selectionBoxRef = useRef<{ x1: number; y1: number; x2: number; y2: number } | null>(null);
   const [selectionRect, setSelectionRect] = useState<{ x1: number; y1: number; x2: number; y2: number } | null>(null);
@@ -526,6 +563,15 @@ export default function CausalDAG3D() {
     return map;
   }, [graphData.edges]);
 
+  // Pre-build nodeById map keyed on topologyKey (item #10): O(N) lookup inside posMap
+  // instead of the O(N²) graphData.nodes.find(n => n.id === nodeId) per scrub tick.
+  const nodeById = useMemo(() => {
+    const m = new Map<string, (typeof graphData.nodes)[number]>();
+    for (const n of graphData.nodes) m.set(n.id, n);
+    return m;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [topologyKey]);
+
   // Store baseline omega scores (live/initial values) as a reference point.
   // Movement during scrubbing is driven by the DELTA from baseline, not absolute omega.
   const baselineOmegaRef = useRef<Record<string, number>>({});
@@ -563,7 +609,8 @@ export default function CausalDAG3D() {
       // Historical mode: use the temporal omega value directly
       // High omega (>5) = stressed, pulls inward
       // Low omega (<5) = relaxed, pushes outward
-      const node = graphData.nodes.find((n) => n.id === nodeId);
+      // Use O(1) nodeById lookup (item #10) instead of O(N) find
+      const node = nodeById.get(nodeId);
       if (!node) return 0;
       const omega = node.omegaFragility.composite;
       // Map 0-10 omega to -1 to +1 stress (5 = neutral)
@@ -582,8 +629,11 @@ export default function CausalDAG3D() {
 
     // Compute per-domain centroids for more structured movement
     const domainCentroids: Record<string, [number, number, number, number]> = {};
-    for (const node of graphData.nodes) {
-      const p = basePosMap[node.id];
+    // Use nodeById for O(1) per-node lookup (item #10)
+    for (const id of ids) {
+      const node = nodeById.get(id);
+      if (!node) continue;
+      const p = basePosMap[id];
       if (!p) continue;
       if (!domainCentroids[node.domain]) domainCentroids[node.domain] = [0, 0, 0, 0];
       domainCentroids[node.domain][0] += p[0];
@@ -608,7 +658,7 @@ export default function CausalDAG3D() {
         continue;
       }
 
-      const node = graphData.nodes.find((n) => n.id === id);
+      const node = nodeById.get(id);
       const dc = node ? domainCentroids[node.domain] : null;
 
       if (stress > 0) {
@@ -666,7 +716,7 @@ export default function CausalDAG3D() {
 
     return map;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [basePosMap, currentSnapshot, neighbors, omegaKey, isLive]);
+  }, [basePosMap, currentSnapshot, neighbors, omegaKey, isLive, nodeById]);
 
   const domainMap = useMemo(() => getNodeDomainMap(), []);
 
@@ -881,8 +931,11 @@ export default function CausalDAG3D() {
         />
       )}
       <DAGErrorBoundary>
+      {/* frameloop="demand" stops the render loop when idle — invalidate() is called
+          on every interaction event so nothing visible is lost (item #1). */}
       <Canvas
         key={canvasKey}
+        frameloop="demand"
         camera={{ position: [40, 30, 80], fov: 60 }}
         style={{ background: "#050508", position: "absolute", inset: 0, touchAction: "none" }}
         gl={{ antialias: true, powerPreference: "high-performance", preserveDrawingBuffer: true }}
@@ -898,7 +951,9 @@ export default function CausalDAG3D() {
         }}
         onPointerMissed={() => {
           if (selectedNode) setSelectedNode(null);
+          window.dispatchEvent(new Event("dag3d-invalidate"));
         }}
+        onPointerMove={() => window.dispatchEvent(new Event("dag3d-invalidate"))}
       >
           <ambientLight intensity={0.4} />
           <pointLight position={[80, 80, 80]} intensity={0.8} color="#00e5ff" />
@@ -1016,6 +1071,8 @@ export default function CausalDAG3D() {
           <CameraRig posMap={posMap} topologyKey={topologyKey} shiftDragging={shiftDragging} />
           <FrameMonitor />
           <ReplayTickDriver />
+          <ReplayInvalidator />
+          <StoreInvalidator />
           <ShiftDragSelect
             posMap={posMap}
             graphNodes={graphData.nodes}

--- a/src/components/ModulePanel.tsx
+++ b/src/components/ModulePanel.tsx
@@ -1399,6 +1399,18 @@ function CascadeHeader() {
   const cascade = useMemo(() => engine.discoverStructure(graphData), [engine, graphData]);
   const [expandedMetric, setExpandedMetric] = useState<string | null>(null);
 
+  // Pre-build full-graph adjacency, memoized on graphData.edges identity only
+  // so selection changes don't rebuild it (item #9).
+  const fullNeighborSets = useMemo(() => {
+    const m = new Map<string, Set<string>>();
+    graphData.nodes.forEach((nd) => m.set(nd.id, new Set()));
+    graphData.edges.filter((e) => !e.isSevered).forEach((e) => {
+      m.get(e.source)?.add(e.target);
+      m.get(e.target)?.add(e.source);
+    });
+    return m;
+  }, [graphData.edges, graphData.nodes]);
+
   // Compute comprehensive network metrics
   const netMetrics = useMemo(() => {
     const allNodes = graphData.nodes;
@@ -1511,12 +1523,19 @@ function CascadeHeader() {
       }));
 
     // 5. Clustering coefficient (local, undirected)
-    const neighborSets = new Map<string, Set<string>>();
-    nodes.forEach((nd) => neighborSets.set(nd.id, new Set()));
-    edges.forEach((e) => {
-      neighborSets.get(e.source)?.add(e.target);
-      neighborSets.get(e.target)?.add(e.source);
-    });
+    // Reuse pre-built adjacency (item #9): if no selection, use fullNeighborSets
+    // directly; if scoped, rebuild only for the selected subgraph.
+    const neighborSets: Map<string, Set<string>> = isScoped
+      ? (() => {
+          const m = new Map<string, Set<string>>();
+          nodes.forEach((nd) => m.set(nd.id, new Set()));
+          edges.forEach((e) => {
+            m.get(e.source)?.add(e.target);
+            m.get(e.target)?.add(e.source);
+          });
+          return m;
+        })()
+      : fullNeighborSets;
     let clusterSum = 0;
     let clusterCount = 0;
     nodes.forEach((nd) => {
@@ -1595,7 +1614,7 @@ function CascadeHeader() {
       totalNodeCount: allNodes.length, totalEdgeCount: allEdges.length,
       isScoped,
     };
-  }, [graphData, cascade, selectedNodes]);
+  }, [graphData, cascade, selectedNodes, fullNeighborSets]);
 
   const metricColor = (val: number, threshLow: number, threshHigh: number) =>
     val < threshLow ? "#00e676" : val < threshHigh ? "#ffab00" : "#ff1744";

--- a/src/components/SystemCopilot.tsx
+++ b/src/components/SystemCopilot.tsx
@@ -41,46 +41,47 @@ function getRoleLabel(role: CopilotMessage["role"]): string {
 }
 
 export default function SystemCopilot() {
-  const {
-    copilotMessages,
-    addCopilotMessage,
-    graphData,
-    selectedNode,
-    severedEdges,
-    shocks,
-    interventionMode,
-    interventionTarget,
-    ablationMode,
-    ablatedNodeIds,
-    ablatedEdgeIds,
-    activeModule,
-    llmProvider,
-    claudeApiKey,
-    geminiApiKey,
-    claudeModel,
-    geminiModel,
-    ollamaUrl,
-    ollamaModel,
-    isLlmStreaming,
-    setLlmProvider,
-    setClaudeApiKey,
-    setGeminiApiKey,
-    setClaudeModel,
-    setGeminiModel,
-    setOllamaUrl,
-    setOllamaModel,
-    setIsLlmStreaming,
-    importedDatasets,
-    removeImportedDataset,
-    currentSnapshot,
-    snapshotHistory,
-    isComputeLoading,
-    setSnapshot,
-    setIsComputeLoading,
-    baselineEpochs,
-    currentEpoch,
-    tarskiReport,
-  } = useApexStore();
+  // Fine-grained selectors — subscribe only to fields this component actually
+  // uses, so unrelated store mutations (graph topology, timeline scrub, etc.)
+  // don't trigger re-renders here (item #8).
+  const copilotMessages = useApexStore((s) => s.copilotMessages);
+  const addCopilotMessage = useApexStore((s) => s.addCopilotMessage);
+  const graphData = useApexStore((s) => s.graphData);
+  const selectedNode = useApexStore((s) => s.selectedNode);
+  const severedEdges = useApexStore((s) => s.severedEdges);
+  const shocks = useApexStore((s) => s.shocks);
+  const interventionMode = useApexStore((s) => s.interventionMode);
+  const interventionTarget = useApexStore((s) => s.interventionTarget);
+  const ablationMode = useApexStore((s) => s.ablationMode);
+  const ablatedNodeIds = useApexStore((s) => s.ablatedNodeIds);
+  const ablatedEdgeIds = useApexStore((s) => s.ablatedEdgeIds);
+  const activeModule = useApexStore((s) => s.activeModule);
+  const llmProvider = useApexStore((s) => s.llmProvider);
+  const claudeApiKey = useApexStore((s) => s.claudeApiKey);
+  const geminiApiKey = useApexStore((s) => s.geminiApiKey);
+  const claudeModel = useApexStore((s) => s.claudeModel);
+  const geminiModel = useApexStore((s) => s.geminiModel);
+  const ollamaUrl = useApexStore((s) => s.ollamaUrl);
+  const ollamaModel = useApexStore((s) => s.ollamaModel);
+  const isLlmStreaming = useApexStore((s) => s.isLlmStreaming);
+  const setLlmProvider = useApexStore((s) => s.setLlmProvider);
+  const setClaudeApiKey = useApexStore((s) => s.setClaudeApiKey);
+  const setGeminiApiKey = useApexStore((s) => s.setGeminiApiKey);
+  const setClaudeModel = useApexStore((s) => s.setClaudeModel);
+  const setGeminiModel = useApexStore((s) => s.setGeminiModel);
+  const setOllamaUrl = useApexStore((s) => s.setOllamaUrl);
+  const setOllamaModel = useApexStore((s) => s.setOllamaModel);
+  const setIsLlmStreaming = useApexStore((s) => s.setIsLlmStreaming);
+  const importedDatasets = useApexStore((s) => s.importedDatasets);
+  const removeImportedDataset = useApexStore((s) => s.removeImportedDataset);
+  const currentSnapshot = useApexStore((s) => s.currentSnapshot);
+  const snapshotHistory = useApexStore((s) => s.snapshotHistory);
+  const isComputeLoading = useApexStore((s) => s.isComputeLoading);
+  const setSnapshot = useApexStore((s) => s.setSnapshot);
+  const setIsComputeLoading = useApexStore((s) => s.setIsComputeLoading);
+  const baselineEpochs = useApexStore((s) => s.baselineEpochs);
+  const currentEpoch = useApexStore((s) => s.currentEpoch);
+  const tarskiReport = useApexStore((s) => s.tarskiReport);
 
   // Copilot provider: Gemini or Ollama; Claude is for compute only
   const copilotProvider: LLMProvider = llmProvider === "ollama" ? "ollama" : "gemini";
@@ -102,6 +103,11 @@ export default function SystemCopilot() {
   const datasetPanelRef = useRef<HTMLDivElement>(null);
   const lastSelectedRef = useRef<string | null>(null);
   const streamingMsgRef = useRef<string | null>(null);
+  // Streaming text is held in a ref (not store state) during the stream so each
+  // token doesn't trigger a full store subscriber cascade (item #8).
+  // Local React state is used for incremental UI updates instead.
+  const streamingTextRef = useRef<string>("");
+  const [streamingDisplayText, setStreamingDisplayText] = useState<string>("");
   const badgeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const recognitionRef = useRef<SpeechRecognition | null>(null);
   const lastSpokenMsgRef = useRef<string | null>(null);
@@ -418,30 +424,31 @@ export default function SystemCopilot() {
         const reader = stream.getReader();
         const decoder = new TextDecoder();
         let accumulated = "";
+        streamingTextRef.current = "";
+        setStreamingDisplayText("");
 
         while (true) {
           const { done, value } = await reader.read();
           if (done) break;
           accumulated += decoder.decode(value, { stream: true });
-          // During streaming, only strip action tags for display — do NOT execute.
-          // Executing here would fire every action multiple times as it appears in
-          // successive chunks.
+          // During streaming, keep text in local ref/state — NOT in the store —
+          // so per-token updates don't cascade to every store subscriber (item #8).
           const displayTextStreaming = stripActions(accumulated);
-          useApexStore.setState((s) => ({
-            copilotMessages: s.copilotMessages.map((m) =>
-              m.id === assistantId ? { ...m, content: displayTextStreaming } : m
-            ),
-          }));
+          streamingTextRef.current = displayTextStreaming;
+          setStreamingDisplayText(displayTextStreaming);
         }
 
         // After streaming completes, execute any actions from the full response
         const { displayText, actionResults } = processLlmActions(accumulated);
-        // Update final display text
+        // Flush final text to the store in one write
         useApexStore.setState((s) => ({
           copilotMessages: s.copilotMessages.map((m) =>
             m.id === assistantId ? { ...m, content: displayText } : m
           ),
         }));
+        // Reset local streaming state
+        streamingTextRef.current = "";
+        setStreamingDisplayText("");
         // Log action results as system messages
         if (actionResults.length > 0) {
           const actionSummary = actionResults.map((r) => `  \u2022 ${r}`).join("\n");
@@ -463,6 +470,8 @@ export default function SystemCopilot() {
         }));
       } finally {
         streamingMsgRef.current = null;
+        streamingTextRef.current = "";
+        setStreamingDisplayText("");
         setIsLlmStreaming(false);
       }
     },
@@ -886,14 +895,18 @@ export default function SystemCopilot() {
                   className="whitespace-pre-wrap pl-2 border-l border-border"
                   style={{ color: getRoleColor(msg.role) }}
                 >
-                  {msg.content || (isLlmStreaming && msg.id === streamingMsgRef.current ? "" : msg.content)}
+                  {/* During streaming, show local state text (not store) to avoid
+                      per-token store subscriber cascade (item #8) */}
+                  {msg.id === streamingMsgRef.current && isLlmStreaming
+                    ? streamingDisplayText
+                    : msg.content}
                 </div>
               </motion.div>
             ))}
           </AnimatePresence>
 
-          {/* Thinking indicator */}
-          {isLlmStreaming && copilotMessages[copilotMessages.length - 1]?.content === "" && (
+          {/* Thinking indicator — show while streaming has not yet produced text */}
+          {isLlmStreaming && streamingDisplayText === "" && (
             <div className="text-[10px] font-mono text-accent-cyan animate-pulse pl-2">
               APEX is thinking...
             </div>

--- a/src/components/dag3d/DAGNode3D.tsx
+++ b/src/components/dag3d/DAGNode3D.tsx
@@ -110,7 +110,11 @@ function DAGNode3DInner({
   const dimmed = anyNodeSelected && !isSelected && !isNeighborOfSelected;
   const nodeOpacity = isAblated ? 0.15 : isGreyedOut ? 0.08 : dimmed ? 0.2 : 0.9;
 
-  useFrame((_, delta) => {
+  useFrame(({ clock }, delta) => {
+    // Gate all per-frame work: skip static nodes that don't need animation (item #2)
+    const needsAnimation = isConsequence || shockGlow > 0 || birthProgress.current < 1 || isSelected;
+    if (!needsAnimation) return;
+
     // Birth animation for consequence nodes
     if (birthProgress.current < 1) {
       birthProgress.current = Math.min(1, birthProgress.current + delta * 2);
@@ -124,12 +128,15 @@ function DAGNode3DInner({
       const birth = birthProgress.current;
       const baseScale = (isSelected ? 1.15 : 1) * birth;
       const pulseIntensity = isConsequence ? 0.08 : (0.03 + shockGlow * 0.12);
-      const pulseSpeed = isConsequence ? 0.005 : (0.002 + shockGlow * 0.003);
-      const pulse = Math.sin(Date.now() * pulseSpeed * (1 + composite / 10)) * pulseIntensity;
+      // Use clock.elapsedTime instead of Date.now() (item #2)
+      const t = clock.elapsedTime;
+      const pulseSpeed = isConsequence ? 5 : (2 + shockGlow * 3);
+      const pulse = Math.sin(t * pulseSpeed * (1 + composite / 10)) * pulseIntensity;
       meshRef.current.scale.setScalar(baseScale + pulse);
     }
     if (selectionRingRef.current) {
-      const ringPulse = 0.3 + Math.sin(Date.now() * 0.004) * 0.15;
+      const t = clock.elapsedTime;
+      const ringPulse = 0.3 + Math.sin(t * 4) * 0.15;
       const mat = selectionRingRef.current.material as THREE.MeshBasicMaterial;
       mat.opacity = ringPulse;
     }
@@ -199,10 +206,13 @@ function DAGNode3DInner({
           e.stopPropagation();
           setHovered(true);
           document.body.style.cursor = "pointer";
+          // Trigger a frame in demand mode (item #1)
+          window.dispatchEvent(new Event("dag3d-invalidate"));
         }}
         onPointerOut={() => {
           setHovered(false);
           document.body.style.cursor = "";
+          window.dispatchEvent(new Event("dag3d-invalidate"));
         }}
       >
         <sphereGeometry args={[size, 24, 24]} />

--- a/src/components/dag3d/DAGOverlay.tsx
+++ b/src/components/dag3d/DAGOverlay.tsx
@@ -6,7 +6,22 @@ import { getDomainColor } from "@/lib/graph-data";
 import { useTemporalGraph } from "@/hooks/useTemporalGraph";
 
 export default function DAGOverlay() {
-  const { graphData, activeModule, viewMode, setViewMode, truthFilter, selectedNode, setSelectedNode, selectedNodes, setSelectedNodes, isolateSelection, setIsolateSelection, addCopilotMessage, isLive, timelinePosition } = useApexStore();
+  // Fine-grained selectors so this component only re-renders when its own
+  // slices change, not on any store mutation (item #4).
+  const graphData = useApexStore((s) => s.graphData);
+  const activeModule = useApexStore((s) => s.activeModule);
+  const viewMode = useApexStore((s) => s.viewMode);
+  const setViewMode = useApexStore((s) => s.setViewMode);
+  const truthFilter = useApexStore((s) => s.truthFilter);
+  const selectedNode = useApexStore((s) => s.selectedNode);
+  const setSelectedNode = useApexStore((s) => s.setSelectedNode);
+  const selectedNodes = useApexStore((s) => s.selectedNodes);
+  const setSelectedNodes = useApexStore((s) => s.setSelectedNodes);
+  const isolateSelection = useApexStore((s) => s.isolateSelection);
+  const setIsolateSelection = useApexStore((s) => s.setIsolateSelection);
+  const addCopilotMessage = useApexStore((s) => s.addCopilotMessage);
+  const isLive = useApexStore((s) => s.isLive);
+  const timelinePosition = useApexStore((s) => s.timelinePosition);
   const [activeDomain, setActiveDomain] = useState<string | null>(null);
   const { graph: temporalGraph } = useTemporalGraph();
   const activeGraph = isLive ? graphData : temporalGraph;

--- a/src/lib/real-timeseries.ts
+++ b/src/lib/real-timeseries.ts
@@ -341,6 +341,11 @@ export async function loadRealTemporalData(
     .filter((e) => e.date >= rangeStart && e.date <= rangeEnd)
     .map((e, i) => ({ ...e, id: `real-evt-${i}` }));
 
+  // Release the 2.3MB raw JSON — its only job was to prevent concurrent
+  // double-fetches during this processing pass. Now that we're done it has
+  // no value and can be GC'd (item #14).
+  cachedData = null;
+
   return { nodes: nodeMap, edges: edgeMap, events, rangeStart, rangeEnd };
 }
 

--- a/src/stores/useApexStore.ts
+++ b/src/stores/useApexStore.ts
@@ -41,7 +41,7 @@ export const DATASET_COLORS = [
   "#76ff03", // lime
 ];
 import { mergeGraphs } from "@/lib/import/merge";
-import { MAIN_GRAPH, EMPTY_GRAPH } from "@/lib/graph-data";
+import { EMPTY_GRAPH } from "@/lib/graph-data";
 import { simulateCascade } from "@/lib/cascade-simulator";
 import type { LLMProvider } from "@/lib/llm-providers";
 import type { TimeGranularity, TemporalDataset } from "@/lib/temporal-data";

--- a/src/stores/useApexStore.ts
+++ b/src/stores/useApexStore.ts
@@ -222,6 +222,11 @@ interface ApexState {
   timelineSelection: { start: number; end: number } | null; // user-selected date range window
   timelineFullRange: { start: number; end: number } | null; // saved full range before zoom
   setTimelinePosition: (ts: number) => void;
+  // rAF-batched variant — coalesces rapid scrub calls to ≤ display refresh rate
+  // (~60fps), preventing posMap/omegaKey recalculation on every pointer-move pixel.
+  // TimeDial (or any scrub handler) should prefer this over setTimelinePosition
+  // for continuous drag events (item #5).
+  setTimelinePositionThrottled: (ts: number) => void;
   setTimelineRange: (range: { start: number; end: number }) => void;
   setIsLive: (live: boolean) => void;
   setTimelineGranularity: (g: TimeGranularity) => void;
@@ -701,6 +706,26 @@ export const useApexStore = create<ApexState>((set, get) => ({
 
   setTimelinePosition: (ts) =>
     set({ timelinePosition: ts, isLive: false }),
+
+  // rAF-batched scrub: coalesces rapid pointer-move events into at most one
+  // store write per animation frame (~60fps).  Eliminates O(N) omegaKey/posMap
+  // recalculation on every scrub pixel.  Use this for continuous drag; the
+  // semantics of setTimelinePosition are unchanged (item #5).
+  setTimelinePositionThrottled: (() => {
+    let rafHandle: number | null = null;
+    let pending: number | null = null;
+    return (ts: number) => {
+      pending = ts;
+      if (rafHandle !== null) return; // already scheduled
+      rafHandle = requestAnimationFrame(() => {
+        rafHandle = null;
+        if (pending !== null) {
+          set({ timelinePosition: pending, isLive: false });
+          pending = null;
+        }
+      });
+    };
+  })(),
 
   setTimelineRange: (range) =>
     set({ timelineRange: range }),


### PR DESCRIPTION
## Summary

- **#1 — frameloop=demand + invalidate wiring**: Added `frameloop="demand"` to the R3F Canvas so the GPU frame loop only runs when state changes. Added `ReplayInvalidator` (drives `invalidate()` while replay is playing), `StoreInvalidator` (subscribes to selectedNode, selectedNodes, timelinePosition, severedEdges, currentEpoch), and `dag3d-invalidate` custom-event wiring from pointer events and DAGNode3D hover.

- **#2 — DAGNode3D useFrame optimization**: Replaced `Date.now()` inside `useFrame` with `clock.elapsedTime` from the state argument. Gated all pulse math behind `isConsequence || shockGlow > 0 || isSelected` so completely static nodes do zero per-frame work.

- **#3 — initTemporalData double-fire prevention**: Confirmed the store action already guards with `if (state.temporalData) return` and `loadTimeseriesJSON` deduplicates concurrent fetches via module-level `cachedData`. No double-firing path found.

- **#4 — Fine-grained store selectors in CausalDAG3D + DAGOverlay**: Replaced `useApexStore()` full-destructures with individual `useApexStore((s) => s.field)` calls in both components so unrelated store mutations do not trigger re-renders.

- **#5 — setTimelinePositionThrottled**: Added rAF-batched `setTimelinePositionThrottled` action to the store that coalesces rapid scrub calls into at most one store write per animation frame. The existing `setTimelinePosition` semantics are unchanged. TimeDial (parallel-agent work) can adopt the new action.

- **#6 — Defer graph-data.ts off critical-path bundle**: Removed dead `MAIN_GRAPH` import from `useApexStore.ts`. Converted the `protectGraphData(MAIN_GRAPH)` call in `page.tsx` from a static import to a dynamic `import("@/lib/graph-data")` inside the effect, so the 2,920-line module does not parse synchronously at page load.

- **#8 — SystemCopilot fine-grained selectors + streaming buffering**: Replaced full-store destructure with per-field selectors. During LLM streaming, text accumulates in `streamingTextRef` and `streamingDisplayText` local state instead of `useApexStore.setState` on every token — eliminating the per-chunk subscriber cascade. Final text is flushed to the store in one write after the stream completes.

- **#9 — ModulePanel neighborSets hoisted**: Pre-build `fullNeighborSets` adjacency in a separate `useMemo` keyed on `graphData.edges` identity inside `CascadeHeader`. The expensive `netMetrics` memo reuses it for the unscoped case so selection changes no longer rebuild the adjacency.

- **#10 — O(N^2) nodeById lookup eliminated in CausalDAG3D posMap**: Added `nodeById` Map in its own `useMemo` keyed on `topologyKey`. Replaced all `graphData.nodes.find(n => n.id === nodeId)` calls inside `posMap` (called on every scrub tick) with O(1) `nodeById.get(nodeId)`.

- **#11 — next.config.ts enriched**: Added `compress: true`, `images.formats: [avif, webp]`, `experimental.optimizeCss`. Converted `<img src="/logo.png">` to `<Image priority>` on all 5 above-the-fold auth pages (login, trial-signup, forgot-password, reset-password, expired).

- **#13 — CausalDAGMap CSS**: Already deferred — `CausalDAGMap` is loaded via `next/dynamic` with `ssr: false` from `page.tsx`, so the `maplibre-gl/dist/maplibre-gl.css` import is already in a split chunk and not on the critical-path CSS. No further change needed.

- **#14 — Timeseries JSON GC**: Set `cachedData = null` after `loadRealTemporalData` finishes processing, allowing the 2.3 MB raw JSON blob to be garbage collected.

## Deferred to follow-up

- **#7 — RiskPropagationFlow.tsx Map alloc**: Deferred — a parallel agent owns this file.
- **#12 — TimeDial framer-motion note**: Deferred — a parallel agent owns this file. That agent should consider adopting `setTimelinePositionThrottled` (added in #5) for the continuous drag handler.

## Test plan

- [ ] `npx tsc --noEmit` clean (only pre-existing `fetch-url/route.ts` errors)
- [ ] 3D DAG renders correctly — nodes visible, correct colors, selection ring pulses
- [ ] Timeline scrubbing still animates node positions
- [ ] Hover tooltip appears and disappears
- [ ] Node click/double-click selection and camera fly-to works
- [ ] Shift+drag rectangle selection works
- [ ] Scissors mode severs edges
- [ ] Shock application cascades through graph
- [ ] Replay play/pause/scrub works (frame loop resumes during replay, stops when paused)
- [ ] Copilot streams assistant responses incrementally (text appears token-by-token in UI)
- [ ] Copilot "thinking..." indicator shows while waiting for first token
- [ ] Domain selector opens graph; changing domains reloads DAG
- [ ] Map view renders with geo nodes
- [ ] Login / auth pages show logo with correct sizing

Generated with [Claude Code](https://claude.com/claude-code)
