### PR TITLE
feat(persona): subdivide ANALYST + fix active pill highlight

### DIFF
--- a/src/components/DomainSelector.tsx
+++ b/src/components/DomainSelector.tsx
@@ -48,19 +48,41 @@ interface DomainGroup {
   domains: DomainCard[];
 }
 
-type Persona = "scientist" | "analyst" | "cross";
+type Persona =
+  | "scientist"
+  | "financial"
+  | "macro"
+  | "geopolitical"
+  | "cross";
 
 const PERSONAS: { id: Persona; label: string; desc: string }[] = [
-  { id: "analyst", label: "ANALYST", desc: "Geopolitical · Financial · Macro" },
+  { id: "financial", label: "FINANCIAL", desc: "Markets · Credit · Sovereign" },
+  { id: "macro", label: "MACRO", desc: "Growth · Inflation · Policy" },
+  { id: "geopolitical", label: "GEOPOLITICAL", desc: "Energy · Infra · Defense" },
   { id: "scientist", label: "SCIENTIST", desc: "Life Sciences" },
-  { id: "cross", label: "CROSS-DOMAIN", desc: "All domains · cross-dataset multi-select" },
+  { id: "cross", label: "CROSS-DOMAIN", desc: "All domains · multi-select" },
 ];
 
-// Which dataset families each persona may see
-const PERSONA_DATASETS: Record<Persona, Set<DomainCard["dataset"]>> = {
-  analyst: new Set(["main", "athena"]),
-  scientist: new Set(["t1d"]),
-  cross: new Set(["main", "athena", "t1d"]),
+// Each persona shows a subset of domain groups (by group label).
+// CROSS shows everything and is the only persona allowed to multi-select
+// across different datasets.
+const PERSONA_GROUPS: Record<Persona, Set<string>> = {
+  financial: new Set(["FINANCIAL & SOVEREIGN", "MENA ENERGY & COMMODITIES"]),
+  macro: new Set(["MACRO IMPACT", "FINANCIAL & SOVEREIGN"]),
+  geopolitical: new Set([
+    "MENA ENERGY & COMMODITIES",
+    "INFRASTRUCTURE & DEFENSE",
+    "FINANCIAL & SOVEREIGN",
+  ]),
+  scientist: new Set(["LIFE SCIENCES", "FRONTIER"]),
+  cross: new Set([
+    "MENA ENERGY & COMMODITIES",
+    "FINANCIAL & SOVEREIGN",
+    "INFRASTRUCTURE & DEFENSE",
+    "MACRO IMPACT",
+    "LIFE SCIENCES",
+    "FRONTIER",
+  ]),
 };
 
 const DOMAIN_GROUPS: DomainGroup[] = [
@@ -328,19 +350,23 @@ function getCascadeExamples(domainIds: string[]): string[] {
 }
 
 export default function DomainSelector() {
-  const {
-    domainSelectorOpen,
-    setDomainSelectorOpen,
-    isMultiDomainMode,
-    setIsMultiDomainMode,
-    setSelectedDomains,
-    setVisibleCategories,
-    setVisibleDiscoverySources,
-    setSelectedDataSources,
-    setGraphData,
-    activePersona,
-    setActivePersona,
-  } = useApexStore();
+  const domainSelectorOpen = useApexStore((s) => s.domainSelectorOpen);
+  const setDomainSelectorOpen = useApexStore((s) => s.setDomainSelectorOpen);
+  const setIsMultiDomainMode = useApexStore((s) => s.setIsMultiDomainMode);
+  const setSelectedDomains = useApexStore((s) => s.setSelectedDomains);
+  const setVisibleCategories = useApexStore((s) => s.setVisibleCategories);
+  const setVisibleDiscoverySources = useApexStore((s) => s.setVisibleDiscoverySources);
+  const setSelectedDataSources = useApexStore((s) => s.setSelectedDataSources);
+  const setGraphData = useApexStore((s) => s.setGraphData);
+  const activePersonaRaw = useApexStore((s) => s.activePersona) as string;
+  const setActivePersona = useApexStore((s) => s.setActivePersona);
+
+  // Migrate legacy "analyst" value (pre-subdivision) to the new default.
+  const activePersona: Persona = (
+    PERSONAS.some((p) => p.id === activePersonaRaw)
+      ? activePersonaRaw
+      : "financial"
+  ) as Persona;
 
   const [localSelected, setLocalSelected] = useState<string[]>([]);
   const [localMulti, setLocalMulti] = useState(false);
@@ -348,27 +374,22 @@ export default function DomainSelector() {
   const [localSources, setLocalSources] = useState<Set<string>>(new Set());
   const [showDataLayers, setShowDataLayers] = useState(false);
 
-  // Cards visible for the active persona
-  const allowedDatasets = PERSONA_DATASETS[activePersona];
-  const visibleGroups = DOMAIN_GROUPS.map((g) => ({
-    ...g,
-    domains: g.domains.filter((d) => allowedDatasets.has(d.dataset)),
-  })).filter((g) => g.domains.length > 0);
+  // Cards visible for the active persona (filtered by domain group)
+  const allowedGroups = PERSONA_GROUPS[activePersona];
+  const visibleGroups = DOMAIN_GROUPS
+    .filter((g) => allowedGroups.has(g.label));
 
   const switchPersona = useCallback(
     (persona: Persona) => {
       setActivePersona(persona);
-      const allowed = PERSONA_DATASETS[persona];
-      // Drop any currently-selected cards that don't belong to the new persona's datasets
-      setLocalSelected((prev) =>
-        prev.filter((id) => {
-          const card = DOMAIN_CARDS.find((d) => d.id === id);
-          return card && allowed.has(card.dataset);
-        })
+      const allowed = PERSONA_GROUPS[persona];
+      // Drop any currently-selected cards that don't belong to the new persona's groups
+      const allowedCardIds = new Set(
+        DOMAIN_GROUPS
+          .filter((g) => allowed.has(g.label))
+          .flatMap((g) => g.domains.map((d) => d.id))
       );
-      // Cross-domain is the only persona that allows cross-dataset multi-select;
-      // others still allow multi-select within their own family.
-      // We don't force single-select on switch — just drop out-of-persona cards.
+      setLocalSelected((prev) => prev.filter((id) => allowedCardIds.has(id)));
     },
     [setActivePersona]
   );
@@ -378,8 +399,8 @@ export default function DomainSelector() {
       setLocalSelected((prev) => {
         if (prev.includes(id)) return prev.filter((d) => d !== id);
         if (!localMulti) return [id];
-        // In Analyst/Scientist personas, multi-select is allowed within the same
-        // dataset family only. In Cross-Domain, any combination is allowed.
+        // Focused personas restrict multi-select to a single dataset family to
+        // keep the rendered graph coherent. CROSS-DOMAIN is the escape hatch.
         if (activePersona !== "cross") {
           const card = DOMAIN_CARDS.find((d) => d.id === id);
           const filtered = card

--- a/src/stores/useApexStore.ts
+++ b/src/stores/useApexStore.ts
@@ -163,8 +163,22 @@ interface ApexState {
   setDomainSelectorOpen: (open: boolean) => void;
 
   // Persona
-  activePersona: "scientist" | "analyst" | "cross";
-  setActivePersona: (persona: "scientist" | "analyst" | "cross") => void;
+  activePersona:
+    | "scientist"
+    | "financial"
+    | "macro"
+    | "geopolitical"
+    | "cross"
+    | "analyst"; // "analyst" retained only to tolerate legacy persisted values
+  setActivePersona: (
+    persona:
+      | "scientist"
+      | "financial"
+      | "macro"
+      | "geopolitical"
+      | "cross"
+      | "analyst",
+  ) => void;
 
   // Data source selection (which datasets to load)
   selectedDataSources: string[];
@@ -506,8 +520,8 @@ export const useApexStore = create<ApexState>((set, get) => ({
   setIsMultiDomainMode: (multi) => set({ isMultiDomainMode: multi }),
   setDomainSelectorOpen: (open) => set({ domainSelectorOpen: open }),
 
-  // Persona
-  activePersona: "analyst",
+  // Persona (default: financial — more specific than the prior "analyst")
+  activePersona: "financial",
   setActivePersona: (persona) => set({ activePersona: persona }),
 
   // Data sources


### PR DESCRIPTION
## Summary
- Subdivide the broad **ANALYST** persona into three more specific personas: **FINANCIAL** (Markets · Credit · Sovereign), **MACRO** (Growth · Inflation · Policy), **GEOPOLITICAL** (Energy · Infra · Defense). SCIENTIST and CROSS-DOMAIN unchanged.
- Fix the active-pill highlight bug (clicking a non-analyst persona left ANALYST visually active) by switching `DomainSelector` from a full-store destructure to fine-grained Zustand selectors, so the component is guaranteed to re-render when `activePersona` flips.
- Persona filter moved from *dataset families* (`main` / `athena` / `t1d`) to *domain-group labels* — so each persona's visible cards map directly to the user-facing buckets in the modal (MENA ENERGY, FINANCIAL & SOVEREIGN, etc.), instead of a technical dataset key.

## Persona → groups map
| Persona | Visible groups |
|---|---|
| FINANCIAL | Financial & Sovereign, MENA Energy & Commodities |
| MACRO | Macro Impact, Financial & Sovereign |
| GEOPOLITICAL | MENA Energy, Infrastructure & Defense, Financial & Sovereign |
| SCIENTIST | Life Sciences, Frontier |
| CROSS-DOMAIN | All |

Default persona bumped from legacy `"analyst"` → `"financial"`. The type union retains `"analyst"` as a tolerated legacy value so any stale in-memory state doesn't throw.

## Test plan
- [ ] On landing, default persona is **FINANCIAL** (pill highlighted, correct groups visible).
- [ ] Click MACRO / GEOPOLITICAL / SCIENTIST — old highlight clears, clicked pill highlights.
- [ ] Switching personas drops out-of-scope selections (e.g. FINANCIAL → SCIENTIST clears any selected financial cards).
- [ ] Multi-select within a persona is constrained to one dataset family; CROSS-DOMAIN allows any combination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)