### PR TITLE
fix(2d,map): refit viewport when visible node set changes, not just count

### DIFF
--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -224,25 +224,28 @@ function EdgeInspector({
 const nodeTypes = { causal: CausalNode2D };
 
 /**
- * Helper: re-fits the viewport when the 2D view becomes visible
- * (both views are always mounted; display: none/block toggles visibility).
- * Also re-fits when topology changes (nodes added/removed).
+ * Re-fits the viewport whenever the *set* of visible nodes changes — not just
+ * the count. Keying off count alone leaves the viewport stuck on the previous
+ * framing when the user swaps one isolated selection for another of equal size
+ * (e.g., 3 → different 3 nodes in isolate mode), which read as a "pre-filter
+ * snapshot" bug.
  */
-function FitViewOnVisible({ nodeCount }: { nodeCount: number }) {
+function FitViewOnVisible({ visibleKey, isEmpty }: { visibleKey: string; isEmpty: boolean }) {
   const { fitView } = useReactFlow();
   const viewMode = useApexStore((s) => s.viewMode);
   const prevViewMode = useRef(viewMode);
-  const prevNodeCount = useRef(nodeCount);
+  const prevKey = useRef(visibleKey);
   const hasFittedOnce = useRef(false);
 
   useEffect(() => {
     const becameVisible = prevViewMode.current !== "2d" && viewMode === "2d";
-    const topologyChanged = prevNodeCount.current !== nodeCount;
-    const firstMount = !hasFittedOnce.current && viewMode === "2d" && nodeCount > 0;
+    const visibleSetChanged = prevKey.current !== visibleKey;
+    const firstMount = !hasFittedOnce.current && viewMode === "2d" && !isEmpty;
     prevViewMode.current = viewMode;
-    prevNodeCount.current = nodeCount;
+    prevKey.current = visibleKey;
 
-    if (becameVisible || topologyChanged || firstMount) {
+    if (isEmpty) return;
+    if (becameVisible || visibleSetChanged || firstMount) {
       hasFittedOnce.current = true;
       // Small delay to let ReactFlow finish rendering the nodes
       const timer = setTimeout(() => {
@@ -250,7 +253,7 @@ function FitViewOnVisible({ nodeCount }: { nodeCount: number }) {
       }, 50);
       return () => clearTimeout(timer);
     }
-  }, [viewMode, nodeCount, fitView]);
+  }, [viewMode, visibleKey, isEmpty, fitView]);
 
   return null;
 }
@@ -458,6 +461,14 @@ function CausalDAG2DInner() {
     return edges.filter((e) => selSet.has(e.source) && selSet.has(e.target));
   }, [edges, isolateSelection, multiSelectedNodes]);
 
+  // Stable key over the *set* of rendered node ids — drives FitViewOnVisible so
+  // the viewport re-centers whenever the visible set changes, including
+  // swaps where the count stays the same (e.g. changing the isolated selection).
+  const visibleKey = useMemo(
+    () => visibleNodes.map((n) => n.id).sort().join("|"),
+    [visibleNodes],
+  );
+
   const onInit = useCallback(() => {}, []);
 
   const onEdgeClick: EdgeMouseHandler = useCallback(
@@ -529,7 +540,7 @@ function CausalDAG2DInner() {
       >
         <Background variant={BackgroundVariant.Dots} gap={20} size={1} color="#1a1c2e" />
         <Controls showInteractive={false} position="bottom-right" />
-        <FitViewOnVisible nodeCount={visibleNodes.length} />
+        <FitViewOnVisible visibleKey={visibleKey} isEmpty={visibleNodes.length === 0} />
       </ReactFlow>
       {selectedNodesCount > 0 && (
         <div className="absolute bottom-14 left-1/2 -translate-x-1/2 z-50 px-3 py-1.5 rounded border border-accent-cyan/40 bg-background/90 backdrop-blur-sm">

--- a/src/components/CausalDAGMap.tsx
+++ b/src/components/CausalDAGMap.tsx
@@ -459,12 +459,42 @@ function CausalDAGMapInner() {
     ? activeGraph.nodes.find((n) => n.id === selectedEdge.target)?.label ?? selectedEdge.target
     : "";
 
-  // Fit bounds to data on first load
+  // Nodes the map should currently frame. When isolating with a selection,
+  // frame only the selected subset (matches 3D isolate semantics); otherwise
+  // frame the full filtered graph.
+  const nodesToFit = useMemo(() => {
+    if (isolateSelection && selectedNodes.length > 0) {
+      const sel = new Set(selectedNodes);
+      return activeGraph.nodes.filter((n) => sel.has(n.id));
+    }
+    return activeGraph.nodes;
+  }, [activeGraph.nodes, isolateSelection, selectedNodes]);
+
+  // Stable key over the *set* of framed node ids. Re-fits when the set of
+  // visible nodes changes, including count-preserving swaps (e.g. changing
+  // which nodes are isolated) that the previous length-only check missed.
+  const fitKey = useMemo(
+    () => nodesToFit.map((n) => n.id).sort().join("|"),
+    [nodesToFit],
+  );
+
+  const nodesToFitRef = useRef(nodesToFit);
   useEffect(() => {
-    if (!mapRef.current || nodeGeoJSON.features.length === 0) return;
-    const coords = nodeGeoJSON.features.map(
-      (f) => f.geometry.coordinates as [number, number],
+    nodesToFitRef.current = nodesToFit;
+  }, [nodesToFit]);
+
+  useEffect(() => {
+    const nodes = nodesToFitRef.current;
+    if (!mapRef.current || nodes.length === 0) return;
+    const coords = nodes.map((n) =>
+      getNodeCoordinates(n.id, n.globalConcentration ?? "", n.domain),
     );
+
+    if (coords.length === 1) {
+      mapRef.current.flyTo({ center: coords[0], zoom: 6, duration: 800 });
+      return;
+    }
+
     const lngs = coords.map((c) => c[0]);
     const lats = coords.map((c) => c[1]);
     const minLng = Math.min(...lngs);
@@ -477,9 +507,9 @@ function CausalDAGMapInner() {
         [minLng - 5, minLat - 5],
         [maxLng + 5, maxLat + 5],
       ],
-      { duration: 1000, padding: 60 },
+      { duration: 800, padding: 60 },
     );
-  }, [nodeGeoJSON.features.length]);
+  }, [fitKey]);
 
   // Dark map style matching the app theme
   const mapStyle = useMemo(


### PR DESCRIPTION
## Summary

Fixes the "pre-filter snapshot" rendering bug in the 2D and geographic-map views flagged in the 4/19 review: when the user swapped one isolated selection for another of the same size (e.g., 3 → different 3 nodes), or toggled isolation while the filtered count happened to match, the viewport stayed framed on the previous set instead of re-centering on what was actually visible.

Root cause: both views only refit on node **count** change. Set swaps that preserve count were ignored.

### Changes

- **`CausalDAG2D.tsx`** — `FitViewOnVisible` now keys on a stable join of the visible node ids (`visibleKey`). Count-preserving set swaps now refit correctly.
- **`CausalDAGMap.tsx`** — Introduces `nodesToFit`, which frames the isolated subset when `isolateSelection && selectedNodes.length > 0`, otherwise the full filtered graph. Refit keys on the set of framed node ids. Single-node framing uses `flyTo` with a sensible zoom rather than a degenerate 10°×10° bounding box.

Behaviorally:
- Filter domain/category/discovery source → refits to remaining nodes (same as before).
- Enter isolate with a selection → refits to that selection.
- Change selection while isolated (same count, different nodes) → **refits** (was broken).
- Exit isolate → refits to the full filtered graph.

### Evaluation: should distance measures persist in 2D?

Per the 4/19 discussion, I evaluated whether the 2D view should reflect causal/Omega distance instead of the current deterministic id-hash grid. **Not changing it here** — switching 2D to a force-directed or causal-distance layout would materially change the visual character of the view and read patterns users have built up against the grid. Punting that as a separate design decision rather than smuggling it into a bug-fix PR. Current tradeoffs:

| View | Distance semantics |
|---|---|
| 3D | Force-directed layout driven by edges + Omega deltas |
| 2D | Deterministic grid (id-hash + column/row slots) — distance has no meaning |
| Map | Real geographic lat/lng |

If we do want causal distance in 2D, happy to scope that as its own PR.

## Test plan
- [ ] 2D view: apply a domain filter — viewport refits to remaining nodes.
- [ ] 2D view: shift+drag to select ~3 nodes, toggle isolate — viewport zooms into those 3.
- [ ] 2D view: with isolate on, swap selection to a different 3 nodes — viewport refits (previously broken).
- [ ] 2D view: toggle isolate off — viewport refits to full filtered graph.
- [ ] Map view: same four scenarios as above.
- [ ] Map view: isolate a single node — `flyTo` zooms appropriately (not a tiny degenerate box).
- [ ] View-switch: switching 3D → 2D → map → 2D still refits on entry.
- [ ] Timeline scrub: scrubbing does not trigger spurious refits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)