### PR TITLE
fix(admin): service-role on /admin/feedback so rows render

### DIFF
--- a/src/app/admin/feedback/page.tsx
+++ b/src/app/admin/feedback/page.tsx
@@ -1,4 +1,4 @@
-import { createClient } from "@/lib/supabase/server";
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
 import FeedbackAdminList from "./FeedbackAdminList";
 
 export const dynamic = "force-dynamic";
@@ -19,7 +19,13 @@ type FeedbackRow = {
 };
 
 export default async function FeedbackAdminPage() {
-  const supabase = await createClient();
+  // Middleware gates /admin/* to ADMIN_EMAILS allowlist, so it's safe to bypass
+  // RLS here with the service-role client — otherwise the anon-session client
+  // hits row-level security on the feedback table and sees zero rows.
+  const supabase = createSupabaseClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
   const { data, error } = await supabase
     .from("feedback")
     .select(


### PR DESCRIPTION
## Summary

- The `/admin/feedback` page currently uses the anon-session Supabase client. RLS on the `feedback` table blocks reads, so allowlisted admins see `0 total · 0 new` even when rows exist.
- Middleware already gates `/admin/*` to `ADMIN_EMAILS`, so bypassing RLS with the service-role client here is safe — and matches how the approve/reject API routes already talk to Supabase.

## Test plan

- [x] Deploy to prod
- [ ] Sign in as an allowlisted admin
- [ ] Visit `/admin/feedback`
- [ ] Confirm feedback rows are listed (previously empty)
