### PR TITLE
fix(feedback): treat id as UUID string, not number

### DIFF
--- a/src/app/admin/feedback/FeedbackAdminList.tsx
+++ b/src/app/admin/feedback/FeedbackAdminList.tsx
@@ -4,7 +4,7 @@ import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 
 type FeedbackRow = {
-  id: number;
+  id: string;
   created_at: string;
   updated_at: string | null;
   type: string;
@@ -37,7 +37,7 @@ const STATUS_FILTERS: Array<FeedbackRow["status"] | "all"> = [
 
 export default function FeedbackAdminList({ rows }: { rows: FeedbackRow[] }) {
   const router = useRouter();
-  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
   const [filter, setFilter] = useState<FeedbackRow["status"] | "all">("all");
   const [notes, setNotes] = useState("");
   const [pending, startTransition] = useTransition();
@@ -46,7 +46,7 @@ export default function FeedbackAdminList({ rows }: { rows: FeedbackRow[] }) {
   const visibleRows = rows.filter((r) => filter === "all" || r.status === filter);
   const selected = rows.find((r) => r.id === selectedId) ?? null;
 
-  async function act(id: number, action: "approve" | "reject", adminNotes?: string) {
+  async function act(id: string, action: "approve" | "reject", adminNotes?: string) {
     setActionError(null);
     try {
       const res = await fetch(`/api/admin/feedback/${id}/${action}`, {

--- a/src/app/admin/feedback/page.tsx
+++ b/src/app/admin/feedback/page.tsx
@@ -4,7 +4,7 @@ import FeedbackAdminList from "./FeedbackAdminList";
 export const dynamic = "force-dynamic";
 
 type FeedbackRow = {
-  id: number;
+  id: string;
   created_at: string;
   updated_at: string | null;
   type: string;

--- a/src/app/api/admin/feedback/[id]/approve/route.ts
+++ b/src/app/api/admin/feedback/[id]/approve/route.ts
@@ -17,9 +17,8 @@ export async function POST(
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
 
-  const { id } = await params;
-  const feedbackId = Number(id);
-  if (!Number.isInteger(feedbackId) || feedbackId <= 0) {
+  const { id: feedbackId } = await params;
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(feedbackId)) {
     return NextResponse.json({ error: "Invalid feedback id" }, { status: 400 });
   }
 

--- a/src/app/api/admin/feedback/[id]/reject/route.ts
+++ b/src/app/api/admin/feedback/[id]/reject/route.ts
@@ -16,9 +16,8 @@ export async function POST(
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
 
-  const { id } = await params;
-  const feedbackId = Number(id);
-  if (!Number.isInteger(feedbackId) || feedbackId <= 0) {
+  const { id: feedbackId } = await params;
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(feedbackId)) {
     return NextResponse.json({ error: "Invalid feedback id" }, { status: 400 });
   }
 

--- a/src/app/api/webhooks/github/route.ts
+++ b/src/app/api/webhooks/github/route.ts
@@ -23,12 +23,12 @@ function verifySignature(payload: string, signature: string | null): boolean {
   }
 }
 
-function extractFeedbackId(text: string | null | undefined): number | null {
+function extractFeedbackId(text: string | null | undefined): string | null {
   if (!text) return null;
-  const match = text.match(/Feedback-ID:\s*(\d+)/i);
-  if (!match) return null;
-  const n = Number(match[1]);
-  return Number.isInteger(n) && n > 0 ? n : null;
+  const match = text.match(
+    /Feedback-ID:\s*([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i,
+  );
+  return match ? match[1].toLowerCase() : null;
 }
 
 type PullRequestEvent = {

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -28,7 +28,7 @@ export type CreatedIssue = {
 };
 
 export async function createFeedbackIssue(args: {
-  feedbackId: number;
+  feedbackId: string;
   type: string;
   message: string;
   adminNotes: string | null;
@@ -36,7 +36,8 @@ export async function createFeedbackIssue(args: {
 }): Promise<CreatedIssue> {
   const { owner, name } = repo();
 
-  const title = `[feedback #${args.feedbackId}] ${args.type}: ${args.message
+  const shortId = args.feedbackId.slice(0, 8);
+  const title = `[feedback ${shortId}] ${args.type}: ${args.message
     .slice(0, 70)
     .replace(/\s+/g, " ")
     .trim()}${args.message.length > 70 ? "…" : ""}`;


### PR DESCRIPTION
## Summary

- The feedback table's primary key is a UUID (`gen_random_uuid`), but the admin UI, API routes, and GitHub webhook handler treated it as `number`.
- First real approve click returned "Invalid feedback id" because `Number("<uuid>")` is `NaN`.
- Flipped types from `number` → `string`, swapped `Number()`+integer validation for a UUID regex, and updated the `Feedback-ID:` trailer regex in the webhook.
- GH issue titles are shortened to `[feedback <first-8-of-uuid>]` for readability; full UUID still lives in the body trailer (what the webhook matches on).

## Test plan

- [x] Deploy to prod
- [ ] Approve a real feedback row from `/admin/feedback`
- [ ] Row flips to `approved`, `github_issue_url` populates
- [ ] New issue appears with `feedback-approved` label
