### PR TITLE
feat(ui): user-adjustable text size (S/M/L) in header bar

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -53,6 +53,13 @@ body {
   font-family: var(--font-mono), 'Courier New', monospace;
 }
 
+/* User-adjustable text size. Applied via data attribute on <html> set by
+ * useTextSize + a blocking inline script in RootLayout to avoid FOUC.
+ * The app's UI uses fixed px sizes (700+ occurrences), so zoom is the only
+ * viable knob — root font-size would be a no-op. */
+html[data-text-size="sm"] { zoom: 0.9; }
+html[data-text-size="lg"] { zoom: 1.15; }
+
 /* Scrollbar styling */
 ::-webkit-scrollbar {
   width: 4px;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,6 +18,10 @@ export const metadata: Metadata = {
   description: "by Apex Analytica — Ω-Critical AI Systems™",
 };
 
+// Runs before paint to sync the user's saved text-size with <html> so zoom
+// applies from the first frame instead of snapping in after hydration.
+const TEXT_SIZE_BOOT = `(function(){try{var v=localStorage.getItem("manifold:text-size");if(v==="sm"||v==="md"||v==="lg"){document.documentElement.dataset.textSize=v;}}catch(e){}})();`;
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -25,6 +29,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className="dark">
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: TEXT_SIZE_BOOT }} />
+      </head>
       <body
         className={`${michroma.variable} ${geistMono.variable} antialiased bg-background text-foreground`}
       >

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -7,6 +7,7 @@ import { computeOmegaState, computeDoomsdayState, computeAlertLevel } from "@/li
 import { createClient } from "@/lib/supabase/client";
 import CDOmegaMonitor from "./CDOmegaMonitor";
 import ImportButton from "./import/ImportButton";
+import TextSizeToggle from "./TextSizeToggle";
 import { ModuleId } from "@/lib/types";
 import { DOMAIN_CARDS } from "./DomainSelector";
 import { GEOPOLITICAL_PROFILE } from "@/lib/domain-profiles";
@@ -128,6 +129,7 @@ export default function HeaderBar() {
       {/* Right: Meta — z-10 so it always sits above the center section */}
       <div className="flex items-center gap-1.5 md:gap-3 shrink-0 z-10 bg-surface-elevated">
         <ImportButton />
+        <TextSizeToggle />
         <button
           onClick={() => setTourActive(true)}
           className="flex items-center justify-center w-7 h-7 rounded border border-border text-[11px] font-[family-name:var(--font-michroma)] text-text-muted hover:text-accent-cyan hover:border-accent-cyan/40 transition-colors shrink-0"

--- a/src/components/TextSizeToggle.tsx
+++ b/src/components/TextSizeToggle.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useTextSize, type TextSize } from "@/hooks/useTextSize";
+
+const OPTIONS: Array<{ value: TextSize; label: string; title: string }> = [
+  { value: "sm", label: "S", title: "Small text" },
+  { value: "md", label: "M", title: "Medium text (default)" },
+  { value: "lg", label: "L", title: "Large text" },
+];
+
+export default function TextSizeToggle() {
+  const { size, setSize } = useTextSize();
+  return (
+    <div
+      className="hidden md:flex items-center rounded border border-border overflow-hidden shrink-0"
+      role="radiogroup"
+      aria-label="Text size"
+    >
+      {OPTIONS.map((opt) => {
+        const active = size === opt.value;
+        return (
+          <button
+            key={opt.value}
+            onClick={() => setSize(opt.value)}
+            role="radio"
+            aria-checked={active}
+            title={opt.title}
+            className={`w-6 h-7 flex items-center justify-center text-[10px] font-[family-name:var(--font-michroma)] tracking-wider transition-colors ${
+              active
+                ? "bg-accent-cyan/10 text-accent-cyan"
+                : "text-text-muted hover:text-foreground"
+            }`}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/hooks/useTextSize.ts
+++ b/src/hooks/useTextSize.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export type TextSize = "sm" | "md" | "lg";
+
+const STORAGE_KEY = "manifold:text-size";
+const DEFAULT: TextSize = "md";
+
+export function isTextSize(v: unknown): v is TextSize {
+  return v === "sm" || v === "md" || v === "lg";
+}
+
+function readStored(): TextSize {
+  if (typeof window === "undefined") return DEFAULT;
+  const v = window.localStorage.getItem(STORAGE_KEY);
+  return isTextSize(v) ? v : DEFAULT;
+}
+
+function apply(size: TextSize) {
+  if (typeof document === "undefined") return;
+  document.documentElement.dataset.textSize = size;
+}
+
+export function useTextSize(): { size: TextSize; setSize: (s: TextSize) => void } {
+  const [size, setSizeState] = useState<TextSize>(DEFAULT);
+
+  useEffect(() => {
+    setSizeState(readStored());
+  }, []);
+
+  const setSize = useCallback((next: TextSize) => {
+    setSizeState(next);
+    apply(next);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      /* quota / disabled storage — ignore */
+    }
+  }, []);
+
+  return { size, setSize };
+}


### PR DESCRIPTION
## Summary
Closes [#82](https://github.com/ApexAnalytica/apex-terminal/issues/82) — user feedback that the app's text is too small on larger screens.

- The UI uses ~700 fixed px text sizes (`text-[7px]` through `text-[12px]`), so a root-`font-size` tweak would be a no-op. The only practical knob is CSS `zoom` on `<html>`.
- Add a three-step segmented control (`S / M / L`) to the right side of the header bar. Preference is persisted to `localStorage` under `manifold:text-size` and applied via a `data-text-size` attribute on `<html>`.
- A blocking inline script in the root layout reads the stored preference before first paint to eliminate flash-of-wrong-size.
- Zoom levels: `sm → 0.9`, `md → 1` (default), `lg → 1.15`.

## What I touched
- `src/app/globals.css` — CSS rules for the zoom levels.
- `src/app/layout.tsx` — inline pre-paint script.
- `src/components/HeaderBar.tsx` — render the toggle.
- `src/components/TextSizeToggle.tsx` — new segmented control.
- `src/hooks/useTextSize.ts` — new hook: reads/writes localStorage, applies the data attribute.

## Verified in the dev server
Without logging in (middleware blocks HeaderBar routes) I verified via JS eval:
- Default (no stored pref) -> zoom: 1, no data attribute.
- localStorage = "lg" + reload -> boot script sets data-text-size="lg", zoom: 1.15.
- localStorage = "sm" + reload -> zoom: 0.9.
- Dev server compiles without errors.

## Test plan
- [ ] Visual check: after deploy, the S/M/L cluster is visible in the header between the import button and the ? tour button on desktop breakpoints.
- [ ] Click L — text across the app grows noticeably. Reload — preference persists.
- [ ] Click S — text shrinks. Reload — persists.
- [ ] Click M — text returns to current default.

---

Feedback-ID: 1595dddd-d38d-4189-a7e8-aa51a2d3778d

Generated with Claude Code
