### PR TITLE
fix(middleware): let /api/webhooks/* bypass Supabase auth

### DIFF
--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -32,7 +32,7 @@ export async function updateSession(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
 
   // Public routes — no auth required
-  const publicRoutes = ["/login", "/trial-signup", "/trusted-signup", "/api/trusted-signup", "/expired", "/forgot-password", "/reset-password", "/auth"];
+  const publicRoutes = ["/login", "/trial-signup", "/trusted-signup", "/api/trusted-signup", "/api/webhooks", "/expired", "/forgot-password", "/reset-password", "/auth"];
   const isPublic =
     publicRoutes.some((r) => pathname.startsWith(r)) ||
     pathname.startsWith("/_next") ||


### PR DESCRIPTION
## Summary
GitHub webhooks targeted at `/api/webhooks/github` have been silently failing since the feature was added. The Supabase auth middleware was intercepting webhook POSTs and redirecting them to `/login` (307). GitHub does not follow redirects on webhook POSTs, so every delivery failed, and after enough consecutive failures GitHub auto-deactivated the hook (`active: false`, `last_response.code: 307`).

This is why row #2 stayed `approved` after PR #85 merged — the `pull_request.closed` event never reached our handler.

## Fix
Add `/api/webhooks` to the `publicRoutes` allowlist in `src/lib/supabase/middleware.ts`, alongside the existing `/api/trusted-signup`. The webhook handler's own HMAC-SHA256 signature verification (already in place) is the correct auth for public endpoints — the session middleware should not sit in front of them.

## Verification on dev server
- Before: `POST /api/webhooks/github` returned 307 redirect to `/login`.
- After: returns 401 from the handler's own signature check (expected — unsigned request rejected by handler, not by middleware).

## After this merges
1. Re-enable the auto-disabled webhook in repo settings.
2. Redeliver the failed `pull_request.closed` event for PR #85 so row #2 flips to `in_progress`.
3. Vercel's next successful production deploy will emit `deployment_status` → row flips to `shipped`.

Generated with Claude Code
