### PR TITLE
fix(tour): stop welcome/domain-selector modal collision on first visit

### DIFF
--- a/src/components/DomainSelector.tsx
+++ b/src/components/DomainSelector.tsx
@@ -489,6 +489,7 @@ export default function DomainSelector() {
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.95, y: 10 }}
             transition={{ duration: 0.2 }}
+            data-tour="domain-selector-modal"
             className="w-full max-w-2xl mx-4 rounded-lg border border-border bg-background shadow-2xl overflow-hidden"
           >
             {/* Header */}

--- a/src/components/SpotlightTour.tsx
+++ b/src/components/SpotlightTour.tsx
@@ -15,20 +15,12 @@ interface TourStep {
 
 const TOUR_STEPS: TourStep[] = [
   {
-    id: "welcome",
-    targetSelector: null,
-    title: "WELCOME TO MANIFOLD",
+    id: "welcome-and-domain",
+    targetSelector: '[data-tour="domain-selector-modal"]',
+    title: "WELCOME \u2014 PICK A DOMAIN",
     description:
-      "APEX Analytica MANIFOLD is a causal-inference platform for discovering, verifying, and stress-testing causal networks across multiple domains. It combines four analysis engines with an AI copilot, 2D/3D/geo graph visualization, and real-time criticality monitoring. This tour walks you through every feature \u2014 use the NEXT / BACK buttons or arrow keys to move through it, or SKIP TOUR to exit. You can relaunch it anytime from the \u201C?\u201D button in the top-right.",
-    tooltipPosition: "center",
-  },
-  {
-    id: "domain-selection",
-    targetSelector: '[data-tour="domain-selector-trigger"]',
-    title: "DOMAIN WORKSPACE",
-    description:
-      "Everything starts with a domain. The workspace button (top-left, next to the MANIFOLD logo) opens the Domain Selector. Domains are grouped by persona \u2014 Financial, Macro, Geopolitical, Scientist, Cross-Domain \u2014 and cover everything from Strait of Hormuz energy flows to Type-1 Diabetes \u03B2-cell dynamics. Pick one or several; the platform auto-builds cross-domain causal links so you can compare very different sectors inside one graph.",
-    tooltipPosition: "bottom",
+      "Welcome to APEX Analytica MANIFOLD \u2014 a causal-inference platform for discovering, verifying, and stress-testing networks across sectors. Everything starts here with a domain. Use the selector on the left to pick one or more: Financial, Macro, Geopolitical, Scientist (including Type-1 Diabetes \u03B2-cell dynamics), or Cross-Domain. Pick what fits your analysis, confirm, and the tour will continue on the platform. You can relaunch this tour anytime from the \u201C?\u201D in the top-right.",
+    tooltipPosition: "right",
   },
   {
     id: "module-tabs",
@@ -312,6 +304,8 @@ export default function SpotlightTour() {
   const tourStep = useApexStore((s) => s.tourStep);
   const setTourActive = useApexStore((s) => s.setTourActive);
   const setTourStep = useApexStore((s) => s.setTourStep);
+  const domainSelectorOpen = useApexStore((s) => s.domainSelectorOpen);
+  const sawDomainSelectorRef = useRef(false);
 
   const [cutout, setCutout] = useState<CutoutRect | null>(null);
   const [tooltipPos, setTooltipPos] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
@@ -374,6 +368,24 @@ export default function SpotlightTour() {
     if (!tourActive || !step) return;
     step.onEnter?.();
   }, [tourActive, tourStep, step]);
+
+  // Auto-advance the welcome/domain step when the user closes the selector
+  // (i.e. they've picked a domain and committed). Only fires if we observed
+  // the modal open while on this step.
+  useEffect(() => {
+    if (!tourActive || step?.id !== "welcome-and-domain") {
+      sawDomainSelectorRef.current = false;
+      return;
+    }
+    if (domainSelectorOpen) {
+      sawDomainSelectorRef.current = true;
+      return;
+    }
+    if (sawDomainSelectorRef.current && !domainSelectorOpen) {
+      sawDomainSelectorRef.current = false;
+      setTourStep(tourStep + 1);
+    }
+  }, [tourActive, step, domainSelectorOpen, tourStep, setTourStep]);
 
   useEffect(() => {
     if (!tourActive) return;


### PR DESCRIPTION
## Summary
- On first visit the domain selector opens by default — the tour's centered welcome card was stacking on top of it and colliding.
- Folded the welcome copy into a single "welcome-and-domain" step that anchors its cutout to the open modal, so welcome + domain selection read as one guided step.
- Tour auto-advances to the next step the moment the user commits a domain (modal closes).
- Tooltip falls back to center when the tour is relaunched later and the modal isn't open.

## Test plan
- [ ] Clear `localStorage["manifold:tour-seen"]`, reload — see modal + tour tooltip side-by-side (no collision).
- [ ] Pick a domain, confirm — tour auto-advances to the module-tabs step.
- [ ] With a domain already selected, click `?` — welcome step centers cleanly (no modal open, no phantom arrow).
