### PR TITLE
fix(tour): don't strand users on first visit when they click outside the cutout

### DIFF
--- a/src/components/SpotlightTour.tsx
+++ b/src/components/SpotlightTour.tsx
@@ -418,8 +418,6 @@ export default function SpotlightTour() {
     if (preTourModuleRef.current) {
       useApexStore.getState().setActiveModule(preTourModuleRef.current as "spirtes" | "tarski" | "pearl" | "pareto");
     }
-    // Also close the domain-selector modal in case a tour step opened it
-    useApexStore.getState().setDomainSelectorOpen(false);
     try {
       window.localStorage.setItem(TOUR_STORAGE_KEY, "1");
     } catch {
@@ -543,8 +541,14 @@ export default function SpotlightTour() {
           )}
         </svg>
 
-        {/* Click-blocker on dimmed area (clicking closes tour) */}
-        <div className="absolute inset-0" onClick={close} />
+        {/* Click-blocker on dimmed area. During the welcome-and-domain step we
+            don't dismiss on backdrop click — the user is likely trying to
+            interact with the domain-selector modal visible through the cutout.
+            They can still exit via SKIP TOUR, Esc, or the X in the selector. */}
+        <div
+          className="absolute inset-0"
+          onClick={step.id === "welcome-and-domain" ? undefined : close}
+        />
 
         {/* Tooltip card */}
         <motion.div


### PR DESCRIPTION
## Summary
Two compounding bugs were stranding first-visit users on a black screen:

1. The tour's `close()` was force-closing the domain-selector modal on every tour exit. A stray backdrop click dismissed *both* the tour and the selector. With no domains picked, the workspace button never renders in the header (`HeaderBar.tsx:70`), so there was no recovery path. → Removed the `setDomainSelectorOpen(false)` from `close()`.
2. On the welcome-and-domain step, the backdrop covers most of the screen and the user is trying to interact with the modal visible through the cutout. A misclick shouldn't dismiss the tour. → On that step only, the backdrop no-ops. Users can still exit via SKIP TOUR, Esc, or the selector's own X button.

## Test plan
- [ ] `localStorage.removeItem("manifold:tour-seen")`, reload.
- [ ] Tour opens with selector visible. Click anywhere in the dimmed area — tour and selector both stay up.
- [ ] Pick a domain. Selector closes, tour auto-advances to module-tabs.
- [ ] On any subsequent step, a backdrop click still dismisses the tour (unchanged behavior).
