### PR TITLE
feat(tour): restore a prominent border around the cutout

### DIFF
--- a/src/components/SpotlightTour.tsx
+++ b/src/components/SpotlightTour.tsx
@@ -491,7 +491,7 @@ export default function SpotlightTour() {
         {/* SVG overlay with mask cutout + connector arrow */}
         <svg className="absolute inset-0 w-full h-full pointer-events-none">
           <defs>
-            <mask id="spotlight-mask">
+            <mask id="spotlight-mask" maskUnits="userSpaceOnUse">
               <rect x="0" y="0" width="100%" height="100%" fill="white" />
               {cutout && (
                 <motion.rect
@@ -499,7 +499,7 @@ export default function SpotlightTour() {
                   y={cutout.y}
                   width={cutout.width}
                   height={cutout.height}
-                  rx={6}
+                  rx={8}
                   fill="black"
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 1 }}
@@ -525,9 +525,28 @@ export default function SpotlightTour() {
             y="0"
             width="100%"
             height="100%"
-            fill="rgba(0, 0, 0, 0.75)"
+            fill="rgba(0, 0, 0, 0.78)"
             mask="url(#spotlight-mask)"
           />
+          {/* Bright border around the cutout so it reads as a clear window */}
+          {cutout && (
+            <motion.rect
+              x={cutout.x}
+              y={cutout.y}
+              width={cutout.width}
+              height={cutout.height}
+              rx={8}
+              fill="none"
+              stroke="var(--accent-cyan, #00e5ff)"
+              strokeWidth={2.5}
+              strokeOpacity={1}
+              style={{ filter: "drop-shadow(0 0 6px rgba(0, 229, 255, 0.5))" }}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ duration: 0.2 }}
+              key={`border-${step.id}`}
+            />
+          )}
           {/* Connector arrow from tooltip edge to highlighted element */}
           {arrow && (
             <motion.line


### PR DESCRIPTION
## Summary
Reverting part of [apex-terminal#95](https://github.com/ApexAnalytica/apex-terminal/pull/95). Without any border around the cutout, users couldn't see what was being highlighted — the dim alone didn't read as a clear window.

Added back a visible cyan border:
- `strokeWidth={2.5}` at full opacity
- Subtle cyan drop-shadow glow
- Corner radius bumped to 8px to match the border thickness

Also set `maskUnits="userSpaceOnUse"` explicitly on the spotlight mask so the cutout coordinates render in screen pixels regardless of browser default.

## Test plan
- [ ] `localStorage.removeItem("manifold:tour-seen")`, reload.
- [ ] Domain selector opens with a visible cyan-bordered box around it; everything else dim; contents at full brightness.
- [ ] Border stays visible and follows the target across every step.
- [ ] Clicking on the highlighted element still interacts AND advances the tour.
