### PR TITLE
fix(2d): restore shift+drag marquee selection

### DIFF
--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -527,7 +527,6 @@ function CausalDAG2DInner() {
         onPaneClick={onPaneClick}
         onSelectionChange={onSelectionChange}
         selectionMode={SelectionMode.Partial}
-        selectionOnDrag
         selectionKeyCode="Shift"
         panOnDrag
         fitView


### PR DESCRIPTION
## Summary

Shift+drag marquee select in the **2D** DAG view didn't do anything — no selection, no ISOLATE popup. 3D worked fine (it uses a hand-rolled `ShiftDragSelect` pointer-event listener, not React Flow), so selecting nodes in 3D and switching to 2D also worked. But selecting directly in 2D was broken.

## Root cause

`src/components/CausalDAG2D.tsx` passed both `selectionOnDrag` **and** `panOnDrag` to `<ReactFlow>`. When both are true on the left mouse button, React Flow routes plain left-drag to pan and the shift gesture never reaches the marquee handler. `onSelectionChange` never fires, `selectedNodes` stays empty, and the ISOLATE button in `DAGOverlay` (which only renders when `selectedNodes.length > 0`) never appears.

## Fix

Drop `selectionOnDrag`. Keep `selectionKeyCode="Shift"` + `panOnDrag`. That's React Flow's documented pattern for "drag pans, shift+drag selects":

```diff
  onSelectionChange={onSelectionChange}
  selectionMode={SelectionMode.Partial}
- selectionOnDrag
  selectionKeyCode="Shift"
  panOnDrag
```

Wiring downstream (unchanged, already correct):
- `onSelectionChange` → `useApexStore.setSelectedNodes`
- `DAGOverlay` reads `selectedNodes` and renders the ISOLATE / SHOW ALL button when non-empty.

## Test plan

- [ ] 2D view → hold Shift, drag across a cluster of nodes → marquee box appears → on release, selected nodes glow cyan and the ISOLATE pill appears in the overlay.
- [ ] 2D view → plain left-drag still pans the canvas (no selection).
- [ ] 3D view → existing shift+drag marquee still works (untouched).
- [ ] Select in 3D → switch to 2D → ISOLATE still reflects carryover selection (regression check for the existing working path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
