### PR TITLE
feat(pearl): wire VX-880 trial fits as survival prior into MC forecast

### DIFF
--- a/src/components/MonteCarloForecast.tsx
+++ b/src/components/MonteCarloForecast.tsx
@@ -15,6 +15,7 @@ function ForecastChart({
   interventionStats,
   baselinePaths,
   interventionPaths,
+  pathAccessor,
   horizonEpochs,
   metric,
   expanded,
@@ -23,6 +24,7 @@ function ForecastChart({
   interventionStats: EpochStats[];
   baselinePaths: MCPath[];
   interventionPaths: MCPath[];
+  pathAccessor: (p: MCPath) => number[];
   horizonEpochs: number;
   metric: string;
   expanded: boolean;
@@ -137,7 +139,7 @@ function ForecastChart({
           {baselinePaths.map((p, idx) => (
             <path
               key={`b${idx}`}
-              d={pathLine(p.omegaBufferSeries)}
+              d={pathLine(pathAccessor(p))}
               fill="none"
               stroke="rgba(200,200,220,1)"
               strokeWidth={0.4}
@@ -148,7 +150,7 @@ function ForecastChart({
           {interventionPaths.map((p, idx) => (
             <path
               key={`i${idx}`}
-              d={pathLine(p.omegaBufferSeries)}
+              d={pathLine(pathAccessor(p))}
               fill="none"
               stroke="rgba(0,229,255,1)"
               strokeWidth={0.4}
@@ -325,11 +327,17 @@ export default function MonteCarloForecast({
     severedEdges,
     lastInterdictionResult,
   } = useApexStore();
+  const trialPrior = useApexStore((s) => s.trialPrior);
 
   const [numPaths, setNumPaths] = useState(200);
   const [horizon, setHorizon] = useState(60);
   const [isRunning, setIsRunning] = useState(false);
   const [result, setResult] = useState<MCForecastResult | null>(null);
+  // Metric toggle — "omega" shows the default Ω-buffer resilience fan,
+  // "survival" shows the literature-calibrated P(event by t) fan built
+  // from the active trial prior. When no prior is published (e.g. the
+  // VX-880 panel isn't mounted) the toggle is disabled and forced to omega.
+  const [metric, setMetric] = useState<"omega" | "survival">("omega");
 
   // Derive intervention inputs from interdiction results (if any):
   //  • node cuts → candidate do(X) target (top-ranked first)
@@ -381,7 +389,11 @@ export default function MonteCarloForecast({
         graphData,
         effectiveTarget,
         mergedSevered,
-        { numPaths, horizonEpochs: horizon }
+        {
+          numPaths,
+          horizonEpochs: horizon,
+          survivalPrior: trialPrior ?? undefined,
+        }
       );
       if (cancelled) return;
       setResult(r);
@@ -391,13 +403,41 @@ export default function MonteCarloForecast({
       cancelled = true;
       clearTimeout(timer);
     };
-  }, [effectiveTarget, graphData, severedEdges, interdictionEdgeCuts, numPaths, horizon]);
+  }, [effectiveTarget, graphData, severedEdges, interdictionEdgeCuts, numPaths, horizon, trialPrior]);
+
+  // Effective metric — derived, not stored. When the prior is absent we
+  // can't render a survival fan regardless of the toggle's internal state,
+  // so collapse it to "omega" at the read site. This avoids a setState-in-
+  // effect when the user navigates away from a VX-880-style panel.
+  const effectiveMetric: "omega" | "survival" = trialPrior ? metric : "omega";
+
+  // Resolve active stats based on the selected metric — falls back to the
+  // Ω-buffer fan when the survival arrays aren't present.
+  const activeStats = useMemo(() => {
+    if (!result) return null;
+    if (
+      effectiveMetric === "survival" &&
+      result.baselineSurvivalStats &&
+      result.interventionSurvivalStats
+    ) {
+      return {
+        baseline: result.baselineSurvivalStats,
+        intervention: result.interventionSurvivalStats,
+        accessor: (p: MCPath) => p.survivalSeries ?? [],
+      };
+    }
+    return {
+      baseline: result.baselineStats,
+      intervention: result.interventionStats,
+      accessor: (p: MCPath) => p.omegaBufferSeries,
+    };
+  }, [result, effectiveMetric]);
 
   // Get median endpoint stats for summary
   const summary = useMemo(() => {
-    if (!result) return null;
-    const baseLast = result.baselineStats[result.baselineStats.length - 1];
-    const intLast = result.interventionStats[result.interventionStats.length - 1];
+    if (!activeStats) return null;
+    const baseLast = activeStats.baseline[activeStats.baseline.length - 1];
+    const intLast = activeStats.intervention[activeStats.intervention.length - 1];
     return {
       baselineMedian: baseLast.p50,
       interventionMedian: intLast.p50,
@@ -405,7 +445,7 @@ export default function MonteCarloForecast({
       baselineP10: baseLast.p10,
       interventionP10: intLast.p10,
     };
-  }, [result]);
+  }, [activeStats]);
 
   const hasInterdiction = Boolean(lastInterdictionResult);
   const interdictionNodeCount = lastInterdictionResult?.interventions.filter((iv) => iv.target.type === "node").length ?? 0;
@@ -423,8 +463,10 @@ export default function MonteCarloForecast({
         MONTE CARLO FORECAST
       </div>
       <div className="text-[8px] font-mono text-text-muted">
-        Stochastic simulation of {"\u03A9"}-buffer trajectories. Auto-runs whenever
-        interdiction cuts or configuration change \u2014 no manual trigger.
+        Stochastic simulation of {"\u03A9"}-buffer trajectories
+        {trialPrior ? ` + literature-calibrated P(${trialPrior.label}) survival fan` : ""}
+        . Auto-runs whenever interdiction cuts or configuration change
+        {" \u2014 "}no manual trigger.
       </div>
 
       {hasInterdiction && effectiveTarget && targetNode && (
@@ -486,20 +528,64 @@ export default function MonteCarloForecast({
       )}
 
       {/* Results */}
-      {result && summary && (
+      {result && summary && activeStats && (
         <div className="space-y-2">
+          {/* Metric toggle — only exposed when a survival prior is live */}
+          {trialPrior && (
+            <div className="flex items-center gap-2 text-[8px] font-mono">
+              <span className="text-text-muted tracking-wider">VIEW</span>
+              <div className="inline-flex border border-border rounded overflow-hidden">
+                <button
+                  type="button"
+                  onClick={() => setMetric("omega")}
+                  className={`px-2 py-0.5 transition-colors ${
+                    metric === "omega"
+                      ? "bg-accent-cyan/15 text-accent-cyan"
+                      : "text-text-muted hover:bg-surface-elevated"
+                  }`}
+                >
+                  {"\u03A9"}-BUFFER
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setMetric("survival")}
+                  className={`px-2 py-0.5 transition-colors border-l border-border ${
+                    metric === "survival"
+                      ? "bg-accent-cyan/15 text-accent-cyan"
+                      : "text-text-muted hover:bg-surface-elevated"
+                  }`}
+                >
+                  P(INDEP) {"\u00B7"} S(t)
+                </button>
+              </div>
+              <span className="text-[7px] text-text-muted ml-auto truncate">
+                {effectiveMetric === "survival"
+                  ? `${trialPrior.label} \u00B7 ${trialPrior.source}`
+                  : "system-wide resilience"}
+              </span>
+            </div>
+          )}
+
           {/* Summary stats */}
           <div className="grid grid-cols-3 gap-1.5">
             <div className="p-1.5 rounded border border-border bg-surface-elevated text-center">
-              <div className="text-[7px] font-mono text-text-muted">{"\u03A9"}-BUFFER (BASE)</div>
+              <div className="text-[7px] font-mono text-text-muted">
+                {effectiveMetric === "survival" ? "P(EVENT) BASE" : `${"\u03A9"}-BUFFER (BASE)`}
+              </div>
               <div className="text-[11px] font-mono text-foreground">
-                {summary.baselineMedian.toFixed(1)}
+                {effectiveMetric === "survival"
+                  ? `${summary.baselineMedian.toFixed(1)}%`
+                  : summary.baselineMedian.toFixed(1)}
               </div>
             </div>
             <div className="p-1.5 rounded border border-accent-cyan/30 bg-accent-cyan/5 text-center">
-              <div className="text-[7px] font-mono text-accent-cyan">{"\u03A9"}-BUFFER (do(X))</div>
+              <div className="text-[7px] font-mono text-accent-cyan">
+                {effectiveMetric === "survival" ? "P(EVENT) do(X)" : `${"\u03A9"}-BUFFER (do(X))`}
+              </div>
               <div className="text-[11px] font-mono text-accent-cyan">
-                {summary.interventionMedian.toFixed(1)}
+                {effectiveMetric === "survival"
+                  ? `${summary.interventionMedian.toFixed(1)}%`
+                  : summary.interventionMedian.toFixed(1)}
               </div>
             </div>
             <div className="p-1.5 rounded border border-border bg-surface-elevated text-center">
@@ -508,13 +594,19 @@ export default function MonteCarloForecast({
                 color: summary.delta > 1 ? "#00e676" : summary.delta < -1 ? "#ff1744" : "var(--text-muted)",
               }}>
                 {summary.delta > 0 ? "+" : ""}{summary.delta.toFixed(1)}
+                {effectiveMetric === "survival" ? " pp" : ""}
               </div>
             </div>
           </div>
 
           {/* Tail risk comparison */}
           <div className="flex justify-between text-[7px] font-mono text-text-muted px-1">
-            <span>P10 tail: baseline {summary.baselineP10.toFixed(1)} → do(X) {summary.interventionP10.toFixed(1)}</span>
+            <span>
+              P10 tail: baseline {summary.baselineP10.toFixed(1)}
+              {effectiveMetric === "survival" ? "%" : ""} {"\u2192"} do(X){" "}
+              {summary.interventionP10.toFixed(1)}
+              {effectiveMetric === "survival" ? "%" : ""}
+            </span>
             <span>{numPaths} paths</span>
           </div>
 
@@ -530,12 +622,17 @@ export default function MonteCarloForecast({
             </div>
             <div className="p-1">
               <ForecastChart
-                baselineStats={result.baselineStats}
-                interventionStats={result.interventionStats}
+                baselineStats={activeStats.baseline}
+                interventionStats={activeStats.intervention}
                 baselinePaths={result.baselinePaths}
                 interventionPaths={result.interventionPaths}
+                pathAccessor={activeStats.accessor}
                 horizonEpochs={result.horizonEpochs}
-                metric={`\u03A9-BUFFER TRAJECTORY \u2014 ${horizon} EPOCHS`}
+                metric={
+                  effectiveMetric === "survival"
+                    ? `P(INSULIN INDEPENDENCE) \u00B7 ${horizon} EPOCHS \u00B7 ${trialPrior?.source ?? ""}`
+                    : `\u03A9-BUFFER TRAJECTORY \u2014 ${horizon} EPOCHS`
+                }
                 expanded={expanded}
               />
             </div>
@@ -588,11 +685,17 @@ export default function MonteCarloForecast({
               INTERPRETATION
             </div>
             <div className="text-[8px] font-mono text-text-muted leading-relaxed">
-              {summary.delta > 2
-                ? `Structural intervention on ${targetNode?.shortLabel} improves system resilience. The \u03A9-buffer recovers ${summary.delta.toFixed(1)} points above baseline by t${horizon}, with tightened tail risk (P10: ${summary.interventionP10.toFixed(1)} vs ${summary.baselineP10.toFixed(1)}).`
-                : summary.delta < -2
-                  ? `Warning: do(${targetNode?.shortLabel}) degrades system stability. The \u03A9-buffer drops ${Math.abs(summary.delta).toFixed(1)} points below baseline, indicating the intervention propagates fragility downstream.`
-                  : `The intervention has marginal effect on aggregate \u03A9-buffer (\u0394 = ${summary.delta.toFixed(1)}). The structural isolation of ${targetNode?.shortLabel} does not significantly alter system trajectory over the ${horizon}-epoch horizon.`}
+              {effectiveMetric === "survival" && trialPrior
+                ? (summary.delta < -2
+                    ? `do(${targetNode?.shortLabel}) suppresses ${trialPrior.label}: P(event by t${horizon}) drops ${Math.abs(summary.delta).toFixed(1)} pp below baseline. The structural intervention is routing the attack away from the outcome node — the \u03B2* prior (${trialPrior.beta.toFixed(2)} \u00B1 ${trialPrior.se.toFixed(2)}) survives more of the cascade.`
+                    : summary.delta > 2
+                      ? `do(${targetNode?.shortLabel}) accelerates ${trialPrior.label}: P(event by t${horizon}) rises ${summary.delta.toFixed(1)} pp above baseline — the intervention protects the outcome node from cascade attenuation, letting the full treatment effect express.`
+                      : `The intervention leaves the survival fan roughly unchanged (\u0394 = ${summary.delta.toFixed(1)} pp). The cascade attack on "${trialPrior.outcomeNodeId}" was already low under baseline, so attenuation of the \u03B2* treatment effect is minimal in either arm.`)
+                : summary.delta > 2
+                  ? `Structural intervention on ${targetNode?.shortLabel} improves system resilience. The \u03A9-buffer recovers ${summary.delta.toFixed(1)} points above baseline by t${horizon}, with tightened tail risk (P10: ${summary.interventionP10.toFixed(1)} vs ${summary.baselineP10.toFixed(1)}).`
+                  : summary.delta < -2
+                    ? `Warning: do(${targetNode?.shortLabel}) degrades system stability. The \u03A9-buffer drops ${Math.abs(summary.delta).toFixed(1)} points below baseline, indicating the intervention propagates fragility downstream.`
+                    : `The intervention has marginal effect on aggregate \u03A9-buffer (\u0394 = ${summary.delta.toFixed(1)}). The structural isolation of ${targetNode?.shortLabel} does not significantly alter system trajectory over the ${horizon}-epoch horizon.`}
             </div>
           </div>
         </div>

--- a/src/components/VX880TrialPanel.tsx
+++ b/src/components/VX880TrialPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useApexStore } from "@/stores/useApexStore";
 import { nlmeFit } from "@/lib/estimators/nlme";
 import { coxFit } from "@/lib/estimators/cox";
@@ -8,7 +8,10 @@ import {
   getNaturalHistoryCpeptideCohort,
   getInsulinIndependenceTte,
   VX880_LITERATURE_ANCHORS,
+  VX880_TRIAL_PRIOR_META,
 } from "@/lib/vx880-trial-data";
+import { solveInterdiction } from "@/lib/interdiction-engine";
+import type { CausalShock } from "@/lib/types";
 
 // ─── C-peptide trajectory chart ─────────────────────────────────────
 //
@@ -200,6 +203,12 @@ function CpeptideChart({
 
 export default function VX880TrialPanel() {
   const graphData = useApexStore((s) => s.graphData);
+  const severedEdges = useApexStore((s) => s.severedEdges);
+  const setTrialPrior = useApexStore((s) => s.setTrialPrior);
+  const setLastInterdictionResult = useApexStore(
+    (s) => s.setLastInterdictionResult,
+  );
+  const lastInterdictionResult = useApexStore((s) => s.lastInterdictionResult);
 
   // Only render when the VX-880 flagship subgraph is loaded.
   const hasVx880 = useMemo(
@@ -247,6 +256,79 @@ export default function VX880TrialPanel() {
       controlN,
     };
   }, [hasVx880]);
+
+  // Publish the fitted prior to the store so the MC engine can consume
+  // it. Republished on every analysis change; cleared when the VX-880
+  // subgraph is no longer loaded so other domains don't accidentally
+  // inherit a stale survival fan.
+  useEffect(() => {
+    if (!analysis) {
+      setTrialPrior(null);
+      return;
+    }
+    setTrialPrior({
+      label: VX880_TRIAL_PRIOR_META.label,
+      beta: analysis.cox.beta[0],
+      se: analysis.cox.se[0],
+      outcomeNodeId: VX880_TRIAL_PRIOR_META.outcomeNodeId,
+      baselineHazardPerEpoch: VX880_TRIAL_PRIOR_META.baselineHazardPerEpoch,
+      popK: analysis.popK,
+      tauK: analysis.tauK,
+      source: VX880_TRIAL_PRIOR_META.source,
+    });
+    return () => {
+      // Clear when this panel unmounts or the analysis goes away.
+      setTrialPrior(null);
+    };
+  }, [analysis, setTrialPrior]);
+
+  // ── Counterfactual HR under the current interdiction ──
+  // Maps the solver's reductionPct (fraction of cascade damage
+  // prevented) into a fraction of the treatment effect that survives:
+  //   effectiveβ = β × (reductionPct / 100)
+  // reductionPct = 100% (perfect protection) → full HR restored.
+  // reductionPct = 0%  (no protection)      → HR collapses toward 1.
+  const counterfactualHR = useMemo(() => {
+    if (!analysis) return null;
+    if (!lastInterdictionResult) return null;
+    const { reductionPct, bestDamage, baselineDamage } = lastInterdictionResult;
+    if (baselineDamage <= 0 || !Number.isFinite(reductionPct)) return null;
+    const frac = Math.max(0, Math.min(1, reductionPct / 100));
+    const effectiveBeta = analysis.cox.beta[0] * frac;
+    const hr = Math.exp(effectiveBeta);
+    return {
+      hr,
+      frac,
+      reductionPct,
+      bestDamage,
+      baselineDamage,
+    };
+  }, [analysis, lastInterdictionResult]);
+
+  // ── "Protect graft β-mass" preset chip ──
+  // One-click demo path that (i) seeds a combined graft-attack shock
+  // on the VX-880 subgraph, (ii) runs the edge-cut interdiction solver
+  // against it, and (iii) publishes the result to the store so the MC
+  // fan chart and the counterfactual HR block above both update.
+  const runGraftProtectPreset = useCallback(() => {
+    if (!hasVx880) return;
+    const shock: CausalShock = {
+      id: "vx880_graft_attack_preset",
+      name: "Combined graft-\u03B2-mass attack",
+      severity: 0.75,
+      category: "health",
+      description:
+        "IBMIR + autoimmune recurrence + alloimmune rejection converging on the grafted \u03B2-cell mass — the dominant failure mode on the VX-880 subgraph.",
+    };
+    const result = solveInterdiction(
+      graphData,
+      [shock],
+      severedEdges,
+      3,
+      "edge",
+    );
+    setLastInterdictionResult(result);
+  }, [hasVx880, graphData, severedEdges, setLastInterdictionResult]);
 
   if (!hasVx880 || !analysis) return null;
 
@@ -362,12 +444,23 @@ export default function VX880TrialPanel() {
               β={analysis.cox.beta[0].toFixed(2)} ± {analysis.cox.se[0].toFixed(2)}
             </span>
           </div>
-          <div className="text-[14px] font-mono text-accent-amber pt-0.5">
-            {analysis.hazardRatio.toFixed(2)}
-            <span className="text-[8px] text-text-muted ml-1.5">
+          <div className="text-[14px] font-mono text-accent-amber pt-0.5 flex items-baseline gap-2">
+            <span>{analysis.hazardRatio.toFixed(2)}</span>
+            <span className="text-[8px] text-text-muted">
               (95% CI {analysis.hazardRatioLo.toFixed(2)}–
               {analysis.hazardRatioHi.toFixed(2)})
             </span>
+            {counterfactualHR && (
+              <span className="text-[10px] font-mono text-accent-cyan ml-auto">
+                {"\u2192"} HR{"\u02E2"}{" "}
+                <span className="text-[13px]">
+                  {counterfactualHR.hr.toFixed(2)}
+                </span>
+                <span className="text-[7px] text-text-muted ml-1">
+                  (after interdiction)
+                </span>
+              </span>
+            )}
           </div>
           <div className="text-[7px] font-mono text-text-muted pt-0.5 leading-relaxed">
             Treatment increases the instantaneous hazard of achieving insulin
@@ -379,17 +472,44 @@ export default function VX880TrialPanel() {
             </span>
             .
           </div>
+          {counterfactualHR && (
+            <div className="text-[7px] font-mono text-accent-cyan/80 pt-1 mt-1 border-t border-accent-cyan/20 leading-relaxed">
+              Counterfactual: the current interdiction prevents{" "}
+              <strong>{counterfactualHR.reductionPct.toFixed(0)}%</strong> of
+              cascade damage on the VX-880 subgraph. Treating that as the
+              fraction of β surviving the attack collapses HR from{" "}
+              {analysis.hazardRatio.toFixed(2)} to{" "}
+              <strong>{counterfactualHR.hr.toFixed(2)}</strong> — the
+              treatment effect the graft can still deliver after the
+              solver{"\u2019"}s cuts absorb the upstream assault.
+            </div>
+          )}
         </div>
       </div>
 
+      {/* ── Preset demo path ─────────────────────────────────────── */}
+      <div className="flex items-center gap-2 pt-1 border-t border-border/30">
+        <button
+          type="button"
+          onClick={runGraftProtectPreset}
+          className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-accent-cyan border border-accent-cyan/40 bg-accent-cyan/5 hover:bg-accent-cyan/15 hover:border-accent-cyan/70 rounded px-2 py-1 transition-colors"
+        >
+          {"\u25B6"} PROTECT GRAFT {"\u03B2"}-MASS
+        </button>
+        <span className="text-[7px] font-mono text-text-muted leading-tight">
+          Seeds a combined graft-attack shock (IBMIR + autoimmune recurrence
+          + alloimmune rejection) and runs 3-cut edge interdiction — the MC
+          forecast below and the counterfactual HR above update in place.
+        </span>
+      </div>
+
       {/* ── Bridge to the MC forecast below ─────────────────────── */}
-      <div className="text-[7px] font-mono text-text-muted leading-relaxed pt-1 border-t border-border/30">
-        Next: pick a node on the DAG or run interdiction from the copilot
-        and the Monte Carlo forecast below will simulate the Ω-buffer
-        trajectory under that structural intervention. The VX-880 subgraph
-        encodes the mechanistic routes — IBMIR, autoimmune recurrence,
-        alloimmune rejection — through which any intervention propagates
-        to these same endpoints.
+      <div className="text-[7px] font-mono text-text-muted leading-relaxed">
+        Or pick any node on the DAG / run interdiction from the copilot
+        and the Monte Carlo forecast will simulate the Ω-buffer trajectory
+        alongside a literature-calibrated P(insulin-independence) survival
+        fan built from the Cox fit above (β = {analysis.cox.beta[0].toFixed(2)},
+        SE = {analysis.cox.se[0].toFixed(2)}).
       </div>
     </div>
   );

--- a/src/lib/monte-carlo-engine.ts
+++ b/src/lib/monte-carlo-engine.ts
@@ -4,6 +4,7 @@ import type {
   CausalNode,
   OmegaFragilityProfile,
 } from "./types";
+import type { TrialPrior } from "./trial-prior";
 
 // ─── Types ─────────────────────────────────────────────────────
 export interface MCConfig {
@@ -13,6 +14,13 @@ export interface MCConfig {
   forgettingRate: number;
   noiseScale: number;      // stochastic perturbation magnitude
   omegaShockScale: number;
+  /**
+   * Optional survival prior — when set, each path additionally emits a
+   * P(event by t) trajectory built from a per-path β* ~ N(prior.beta,
+   * prior.se²) draw, attenuated by the cascade intensity reaching
+   * `prior.outcomeNodeId`. See `TrialPrior` in lib/trial-prior.ts.
+   */
+  survivalPrior?: TrialPrior;
 }
 
 export interface MCPath {
@@ -22,6 +30,12 @@ export interface MCPath {
   targetOmegaSeries: number[];
   /** Per-epoch omega composite for each tracked downstream node */
   downstreamSeries: Map<string, number[]>;
+  /**
+   * Per-epoch P(event by t) × 100 in [0, 100] — only populated when
+   * `config.survivalPrior` is set. Scaled to 0-100 so the existing
+   * fan-chart y-axis renders it without reshaping.
+   */
+  survivalSeries?: number[];
 }
 
 export interface MCForecastResult {
@@ -32,6 +46,12 @@ export interface MCForecastResult {
   /** Summary statistics per epoch */
   baselineStats: EpochStats[];
   interventionStats: EpochStats[];
+  /**
+   * Survival stats per epoch, only populated when `config.survivalPrior`
+   * was set. Units: P(event by t) × 100 in [0, 100].
+   */
+  baselineSurvivalStats?: EpochStats[];
+  interventionSurvivalStats?: EpochStats[];
   /** The node IDs tracked (target + top downstream) */
   trackedNodeIds: string[];
   /** Horizon used */
@@ -145,6 +165,18 @@ function simulatePath(
   const downstreamSeries = new Map<string, number[]>();
   for (const id of trackedIds) downstreamSeries.set(id, []);
 
+  // ── Survival-prior setup (one β* per path) ──
+  // The prior acts as a literature-calibrated overlay on top of the
+  // cascade simulation. Each path draws its own β* so the fan width
+  // at horizon is driven by the Cox SE — tightening when the fit is
+  // precise, widening when it isn't. Hazard is attenuated epoch-by-
+  // epoch by the cascade intensity at the outcome node: when the
+  // attack reaches the outcome, the treatment effect is washed out.
+  const prior = config.survivalPrior;
+  const betaStar = prior ? normalSample(rng, prior.beta, prior.se) : 0;
+  const survivalSeries: number[] | undefined = prior ? [] : undefined;
+  let cumulativeHazard = 0;
+
   // Delay buffers: edgeKey → queued signals
   const delayQueue = new Map<string, { deliverEpoch: number; signal: number }[]>();
 
@@ -239,9 +271,23 @@ function simulatePath(
       const omega = Math.min(10, base.composite * (1 + si * config.omegaShockScale));
       downstreamSeries.get(id)!.push(omega);
     }
+
+    // Survival prior → P(event by t) × 100
+    if (prior && survivalSeries) {
+      // Attack intensity reaching the outcome node in [0, 1].
+      const outcomeIntensity = shockIntensity.get(prior.outcomeNodeId) || 0;
+      // Treatment effect survives only to the extent the outcome node
+      // hasn't been captured by the cascade. When outcomeIntensity = 0
+      // the full β* is applied; at 1 the treatment effect is gone.
+      const effectiveBeta = betaStar * (1 - outcomeIntensity);
+      const hazardThisEpoch = prior.baselineHazardPerEpoch * Math.exp(effectiveBeta);
+      cumulativeHazard += hazardThisEpoch;
+      const P = 1 - Math.exp(-cumulativeHazard);
+      survivalSeries.push(Math.max(0, Math.min(100, P * 100)));
+    }
   }
 
-  return { omegaBufferSeries, targetOmegaSeries, downstreamSeries };
+  return { omegaBufferSeries, targetOmegaSeries, downstreamSeries, survivalSeries };
 }
 
 // ─── Compute Percentile Statistics ─────────────────────────────
@@ -304,11 +350,21 @@ export function runMonteCarloForecast(
   const baselineStats = computeStats(baselinePaths, (p) => p.omegaBufferSeries);
   const interventionStats = computeStats(interventionPaths, (p) => p.omegaBufferSeries);
 
+  // Survival stats — only when the prior was set
+  const baselineSurvivalStats = cfg.survivalPrior
+    ? computeStats(baselinePaths, (p) => p.survivalSeries ?? [])
+    : undefined;
+  const interventionSurvivalStats = cfg.survivalPrior
+    ? computeStats(interventionPaths, (p) => p.survivalSeries ?? [])
+    : undefined;
+
   return {
     baselinePaths,
     interventionPaths,
     baselineStats,
     interventionStats,
+    baselineSurvivalStats,
+    interventionSurvivalStats,
     trackedNodeIds: trackedIds,
     horizonEpochs: cfg.horizonEpochs,
   };

--- a/src/lib/trial-prior.ts
+++ b/src/lib/trial-prior.ts
@@ -1,0 +1,56 @@
+// ─── Trial-Grounded Prior ────────────────────────────────────────────
+//
+// A minimal interface for dataset-specific analysis panels (VX-880 today,
+// other flagship subgraphs later) to publish a parametric readout that
+// downstream Pearl-stage computations — notably the Monte Carlo forecast
+// — can consume as a prior.
+//
+// The shape is deliberately narrow: a single Cox-style treatment-effect
+// log-hazard-ratio `beta` with its standard error `se`, a tagged outcome
+// node in the active causal graph, and a baseline per-epoch hazard for
+// that outcome in the control arm. That's enough for the MC engine to
+// draw β* ~ N(β, SE²) per path, attenuate it by cascade attack on the
+// outcome, and produce a survival trajectory S(t) alongside the existing
+// Ω-buffer fan chart — which turns the fan chart into a literature-
+// calibrated "P(event by t)" curve that visibly responds to interdiction
+// cuts and estimator uncertainty.
+//
+// Keeping the type graph-agnostic (just an `outcomeNodeId` string) means
+// the MC engine never has to know about VX-880 specifically; any future
+// trial panel can publish its own prior and the same machinery lights up.
+
+export interface TrialPrior {
+  /** Human-readable label for UI ("VX-880 insulin independence"). */
+  label: string;
+  /**
+   * Log hazard ratio for the treatment effect (β from a Cox fit).
+   * Positive β means treatment raises the hazard of the *desirable*
+   * outcome event (e.g. sustained insulin independence).
+   */
+  beta: number;
+  /** Standard error on β. Feeds the MC fan width. */
+  se: number;
+  /**
+   * Id of the causal-graph node that represents the outcome event.
+   * The MC engine watches this node's cascade intensity to attenuate
+   * the treatment effect — when the cascade reaches the outcome,
+   * the treatment effect is washed out.
+   */
+  outcomeNodeId: string;
+  /**
+   * Baseline hazard in the control arm, per MC epoch. Calibrated so
+   * that `1 - exp(-baselineHazardPerEpoch * horizonEpochs)` matches
+   * the published control-arm event rate at the reporting horizon.
+   */
+  baselineHazardPerEpoch: number;
+  /**
+   * Optional per-year β-cell decay rate (NLME `k`) and its between-
+   * subject SD (τ_k). Not consumed by the MC today but kept on the
+   * prior so a future wiring can modulate graft-node forgetting
+   * without reshaping this interface.
+   */
+  popK?: number;
+  tauK?: number;
+  /** Source citation for the prior — shown in the fan-chart legend. */
+  source: string;
+}

--- a/src/lib/vx880-trial-data.ts
+++ b/src/lib/vx880-trial-data.ts
@@ -140,6 +140,33 @@ export function getInsulinIndependenceTte(): {
   };
 }
 
+// ─── Trial-prior scaffold (consumed by MC engine) ───────────────────
+
+/**
+ * Fixed pieces of the VX-880 trial prior that the MC engine needs but
+ * that aren't produced by the NLME/Cox fits themselves. Combined at
+ * runtime with the fit outputs (β, SE, popK, τ_k) to form the full
+ * TrialPrior published to useApexStore.
+ *
+ * `outcomeNodeId` is the id of the insulin-independence endpoint in
+ * `t1d-vx880-graph-data.ts` — the MC engine watches its cascade
+ * intensity to attenuate the treatment effect when the attack path
+ * reaches the outcome.
+ *
+ * `baselineHazardPerEpoch` is calibrated to the control arm: 1 partial-
+ * response event in 12 subjects at month 11 gives an empirical per-
+ * month hazard ≈ 1 / (12 * 11) ≈ 0.0076. With the MC's default 60-
+ * epoch horizon mapped to 12 trial months this is 5 epochs/month, so
+ * ≈ 0.0015 per epoch. Rounding to 0.002 keeps the control-arm fan
+ * landing near the reported ~8% 12-month event rate.
+ */
+export const VX880_TRIAL_PRIOR_META = {
+  label: "VX-880 insulin independence",
+  outcomeNodeId: "vx880_insulin_indep",
+  baselineHazardPerEpoch: 0.002,
+  source: "Reichman NEJM 2023 · DCCT/EDIC",
+} as const;
+
 // ─── Literature-grounded targets (for display) ──────────────────────
 
 /**

--- a/src/stores/useApexStore.ts
+++ b/src/stores/useApexStore.ts
@@ -12,6 +12,7 @@ import {
   TimelineId,
 } from "@/lib/types";
 import type { InterdictionResult } from "@/lib/interdiction-engine";
+import type { TrialPrior } from "@/lib/trial-prior";
 import type { SystemStateSnapshot } from "@/lib/snapshots/types";
 import { validateSnapshot } from "@/lib/snapshots/tarski-validator";
 import {
@@ -117,6 +118,13 @@ interface ApexState {
   // Interdiction (chat-based)
   lastInterdictionResult: InterdictionResult | null;
   setLastInterdictionResult: (result: InterdictionResult | null) => void;
+
+  // Trial-grounded prior (published by domain-specific analysis panels,
+  // e.g. VX880TrialPanel → MonteCarloForecast). Lets a fitted survival
+  // model act as a shared prior across the Pearl stack without coupling
+  // the MC engine to any specific dataset.
+  trialPrior: TrialPrior | null;
+  setTrialPrior: (prior: TrialPrior | null) => void;
 
   // Tarski axiom filter
   axiomLevelFilter: "all" | 0 | 1 | 2;
@@ -423,6 +431,9 @@ export const useApexStore = create<ApexState>((set, get) => ({
   // Interdiction (chat-based)
   lastInterdictionResult: null,
   setLastInterdictionResult: (result) => set({ lastInterdictionResult: result }),
+
+  trialPrior: null,
+  setTrialPrior: (prior) => set({ trialPrior: prior }),
 
   axiomLevelFilter: "all",
   setAxiomLevelFilter: (f) => set({ axiomLevelFilter: f }),


### PR DESCRIPTION
## Summary

Closes the loop between the VX-880 trial-cohort analysis and the Monte Carlo forecast that used to sit next to it in the Pearl module without being coupled. The Cox β becomes a literature-calibrated prior the MC actually consumes; interdiction cuts echo back into the trial panel as a counterfactual HR.

- **Trial panel publishes fit** → new `trialPrior` store slice carries β, SE, popK, τ_k, outcome-node id, baseline per-epoch hazard.
- **MC engine consumes prior** → per-path β\* ~ N(β, SE²), hazard attenuated by cascade intensity at the outcome node, emits P(event by t) × 100 series.
- **MC forecast toggles axis** → Ω-BUFFER ↔ P(INDEP) switch, summary tiles + hover + interpretation all swap units.
- **Trial panel echoes ΔHR** → counterfactual block shows HRˢ = exp(β × reductionPct/100) after any interdiction run.
- **"Protect graft β-mass" preset** → one-click chip seeds combined IBMIR/autoimmune/alloimmune shock and runs 3-cut edge interdiction.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] 283/283 vitest tests pass
- [x] No new lint errors (pre-existing only)
- [ ] Verify Vercel deploy renders VX-880 module with:
  - [ ] Prior publishes on mount (check MC forecast header includes "literature-calibrated P(VX-880 insulin independence) survival fan")
  - [ ] Metric toggle appears and switches the fan between Ω-buffer and P(event)
  - [ ] "Protect graft β-mass" chip seeds shock + runs interdiction + updates both HR echo and MC fan
  - [ ] Counterfactual HR block renders below the Cox HR when an interdiction is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)