### PR TITLE
feat: category dropdown + cross-domain cascade fix + remove data layers

### DIFF
--- a/src/components/CategoryFilterDropdown.tsx
+++ b/src/components/CategoryFilterDropdown.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import { useApexStore } from "@/stores/useApexStore";
+import { NODE_CATEGORIES } from "./DomainSelector";
+
+export default function CategoryFilterDropdown() {
+  const visibleCategories = useApexStore((s) => s.visibleCategories);
+  const setVisibleCategories = useApexStore((s) => s.setVisibleCategories);
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  const toggle = useCallback(
+    (id: string) => {
+      const next = new Set(visibleCategories);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      setVisibleCategories(next);
+    },
+    [visibleCategories, setVisibleCategories]
+  );
+
+  const clear = useCallback(() => setVisibleCategories(new Set()), [setVisibleCategories]);
+
+  const count = visibleCategories.size;
+  const triggerLabel = count === 0 ? "ALL CATEGORIES" : `${count} CATEGOR${count === 1 ? "Y" : "IES"}`;
+
+  return (
+    <div ref={containerRef} className="relative shrink-0">
+      <button
+        onClick={() => setOpen((p) => !p)}
+        className="flex items-center gap-1.5 px-2 py-1 rounded border border-border hover:border-accent-cyan/40 transition-colors group"
+        title="Filter visible node categories"
+        data-tour="category-filter"
+      >
+        <span className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted group-hover:text-accent-cyan transition-colors">
+          {triggerLabel}
+        </span>
+        <span
+          className="text-[8px] text-text-muted group-hover:text-accent-cyan transition-all"
+          style={{ transform: open ? "rotate(180deg)" : "rotate(0deg)" }}
+        >
+          ▾
+        </span>
+      </button>
+      {open && (
+        <div className="absolute top-full left-0 mt-1 z-50 w-56 rounded border border-border bg-surface-elevated shadow-lg p-2">
+          <div className="text-[7px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted/60 mb-1.5 px-1">
+            NODE CATEGORIES
+            <span className="ml-2 text-[7px] font-mono text-text-muted/40">
+              {count === 0 ? "showing all" : `${count} selected`}
+            </span>
+          </div>
+          <div className="flex flex-col gap-0.5">
+            {NODE_CATEGORIES.map((cat) => {
+              const checked = visibleCategories.has(cat.id);
+              return (
+                <button
+                  key={cat.id}
+                  onClick={() => toggle(cat.id)}
+                  className="flex items-center gap-2 px-2 py-1 rounded text-[9px] font-mono hover:bg-border/30 transition-colors text-left"
+                  style={{
+                    color: count === 0 || checked ? "var(--foreground)" : "var(--text-muted)",
+                    opacity: count === 0 || checked ? 1 : 0.5,
+                  }}
+                >
+                  <span
+                    className="w-3 h-3 rounded-sm border flex items-center justify-center text-[8px]"
+                    style={{
+                      borderColor: checked ? "var(--accent-cyan)" : "var(--border)",
+                      backgroundColor: checked ? "rgba(0,229,255,0.15)" : "transparent",
+                      color: "var(--accent-cyan)",
+                    }}
+                  >
+                    {checked ? "✓" : ""}
+                  </span>
+                  <span>{cat.icon}</span>
+                  <span>{cat.label}</span>
+                </button>
+              );
+            })}
+          </div>
+          {count > 0 && (
+            <button
+              onClick={clear}
+              className="mt-2 w-full px-2 py-1 text-[8px] font-mono text-accent-cyan/60 hover:text-accent-cyan transition-colors text-left"
+            >
+              ✕ CLEAR FILTERS
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/DomainSelector.tsx
+++ b/src/components/DomainSelector.tsx
@@ -10,7 +10,7 @@ import { VX880_GRAPH } from "@/lib/t1d-vx880-graph-data";
 import { mergeGraphs } from "@/lib/import/merge";
 import type { NodeCategory, CausalGraph } from "@/lib/types";
 
-const NODE_CATEGORIES: { id: NodeCategory; label: string; icon: string }[] = [
+export const NODE_CATEGORIES: { id: NodeCategory; label: string; icon: string }[] = [
   { id: "economic", label: "ECONOMIC", icon: "📊" },
   { id: "finance", label: "FINANCE", icon: "💰" },
   { id: "energy", label: "ENERGY", icon: "⚡" },
@@ -20,13 +20,6 @@ const NODE_CATEGORIES: { id: NodeCategory; label: string; icon: string }[] = [
   { id: "geopolitical", label: "GEOPOLITICAL", icon: "🌐" },
   { id: "communications", label: "COMMUNICATIONS", icon: "📡" },
   { id: "science", label: "SCIENCE", icon: "🔬" },
-];
-
-const DISCOVERY_SOURCES = [
-  { id: "DCD", label: "DCD / NOTEARS", desc: "Structural" },
-  { id: "PCMCI+", label: "PCMCI+", desc: "Temporal" },
-  { id: "FCI", label: "FCI", desc: "Latent confounders" },
-  { id: "merged", label: "MERGED", desc: "Cross-engine" },
 ];
 
 // ─── Grouped domain structure ────────────────────────────────────
@@ -294,8 +287,6 @@ export default function DomainSelector() {
   const setDomainSelectorOpen = useApexStore((s) => s.setDomainSelectorOpen);
   const setIsMultiDomainMode = useApexStore((s) => s.setIsMultiDomainMode);
   const setSelectedDomains = useApexStore((s) => s.setSelectedDomains);
-  const setVisibleCategories = useApexStore((s) => s.setVisibleCategories);
-  const setVisibleDiscoverySources = useApexStore((s) => s.setVisibleDiscoverySources);
   const setSelectedDataSources = useApexStore((s) => s.setSelectedDataSources);
   const setGraphData = useApexStore((s) => s.setGraphData);
   const activePersonaRaw = useApexStore((s) => s.activePersona) as string;
@@ -310,9 +301,6 @@ export default function DomainSelector() {
 
   const [localSelected, setLocalSelected] = useState<string[]>([]);
   const [localMulti, setLocalMulti] = useState(false);
-  const [localCategories, setLocalCategories] = useState<Set<string>>(new Set());
-  const [localSources, setLocalSources] = useState<Set<string>>(new Set());
-  const [showDataLayers, setShowDataLayers] = useState(false);
 
   // Cards visible for the active persona (filtered by domain group)
   const allowedGroups = PERSONA_GROUPS[activePersona];
@@ -367,24 +355,6 @@ export default function DomainSelector() {
     []
   );
 
-  const toggleCategory = useCallback((id: string) => {
-    setLocalCategories((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  }, []);
-
-  const toggleSource = useCallback((id: string) => {
-    setLocalSources((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  }, []);
-
   const handleLaunch = useCallback(() => {
     if (localSelected.length === 0) return;
     // Auto-build graph from selected domains (loads correct datasets)
@@ -400,10 +370,8 @@ export default function DomainSelector() {
     setSelectedDataSources(datasets);
     setSelectedDomains(localSelected);
     setIsMultiDomainMode(localMulti);
-    setVisibleCategories(localCategories);
-    setVisibleDiscoverySources(localSources);
     setDomainSelectorOpen(false);
-  }, [localSelected, localMulti, localCategories, localSources, setGraphData, setSelectedDataSources, setSelectedDomains, setIsMultiDomainMode, setVisibleCategories, setVisibleDiscoverySources, setDomainSelectorOpen]);
+  }, [localSelected, localMulti, setGraphData, setSelectedDataSources, setSelectedDomains, setIsMultiDomainMode, setDomainSelectorOpen]);
 
   // Compute which datasets will be loaded based on current selection
   const selectedCards = localSelected.map((id) => DOMAIN_CARDS.find((d) => d.id === id)).filter(Boolean) as DomainCard[];
@@ -566,102 +534,6 @@ export default function DomainSelector() {
                   </div>
                 </div>
               ))}
-            </div>
-
-            {/* Data Layers */}
-            <div className="px-6 pb-2">
-              <button
-                onClick={() => setShowDataLayers((p) => !p)}
-                className="flex items-center gap-2 text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted hover:text-accent-cyan transition-colors"
-              >
-                <span style={{ transform: showDataLayers ? "rotate(90deg)" : "rotate(0deg)", transition: "transform 0.15s", display: "inline-block" }}>▶</span>
-                DATA LAYERS
-                <span className="text-[7px] font-mono text-text-muted/50">
-                  {localCategories.size === 0 && localSources.size === 0 ? "ALL" : `${localCategories.size + localSources.size} filters`}
-                </span>
-              </button>
-              <AnimatePresence>
-                {showDataLayers && (
-                  <motion.div
-                    initial={{ height: 0, opacity: 0 }}
-                    animate={{ height: "auto", opacity: 1 }}
-                    exit={{ height: 0, opacity: 0 }}
-                    transition={{ duration: 0.15 }}
-                    className="overflow-hidden"
-                  >
-                    <div className="mt-2 space-y-3">
-                      {/* Node Categories */}
-                      <div>
-                        <div className="text-[7px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted/60 mb-1.5">
-                          NODE CATEGORIES
-                          <span className="ml-2 text-[7px] font-mono text-text-muted/40">
-                            {localCategories.size === 0 ? "showing all" : `${localCategories.size} selected`}
-                          </span>
-                        </div>
-                        <div className="flex flex-wrap gap-1">
-                          {NODE_CATEGORIES.map((cat) => {
-                            const active = localCategories.size === 0 || localCategories.has(cat.id);
-                            return (
-                              <button
-                                key={cat.id}
-                                onClick={() => toggleCategory(cat.id)}
-                                className="px-2 py-1 rounded border text-[8px] font-mono transition-all"
-                                style={{
-                                  borderColor: localCategories.has(cat.id) ? "var(--accent-cyan)" : "var(--border)",
-                                  backgroundColor: localCategories.has(cat.id) ? "rgba(0,229,255,0.08)" : "transparent",
-                                  color: active ? "var(--foreground)" : "var(--text-muted)",
-                                  opacity: active ? 1 : 0.4,
-                                }}
-                              >
-                                {cat.icon} {cat.label}
-                              </button>
-                            );
-                          })}
-                        </div>
-                      </div>
-
-                      {/* Discovery Sources */}
-                      <div>
-                        <div className="text-[7px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted/60 mb-1.5">
-                          DISCOVERY ENGINES
-                          <span className="ml-2 text-[7px] font-mono text-text-muted/40">
-                            {localSources.size === 0 ? "showing all" : `${localSources.size} selected`}
-                          </span>
-                        </div>
-                        <div className="flex flex-wrap gap-1">
-                          {DISCOVERY_SOURCES.map((src) => {
-                            const active = localSources.size === 0 || localSources.has(src.id);
-                            return (
-                              <button
-                                key={src.id}
-                                onClick={() => toggleSource(src.id)}
-                                className="px-2 py-1 rounded border text-[8px] font-mono transition-all"
-                                style={{
-                                  borderColor: localSources.has(src.id) ? "var(--accent-cyan)" : "var(--border)",
-                                  backgroundColor: localSources.has(src.id) ? "rgba(0,229,255,0.08)" : "transparent",
-                                  color: active ? "var(--foreground)" : "var(--text-muted)",
-                                  opacity: active ? 1 : 0.4,
-                                }}
-                              >
-                                {src.label} <span className="text-text-muted/50">{src.desc}</span>
-                              </button>
-                            );
-                          })}
-                        </div>
-                      </div>
-
-                      {(localCategories.size > 0 || localSources.size > 0) && (
-                        <button
-                          onClick={() => { setLocalCategories(new Set()); setLocalSources(new Set()); }}
-                          className="text-[7px] font-mono text-accent-cyan/60 hover:text-accent-cyan transition-colors"
-                        >
-                          ✕ CLEAR ALL FILTERS
-                        </button>
-                      )}
-                    </div>
-                  </motion.div>
-                )}
-              </AnimatePresence>
             </div>
 
             {/* Footer */}

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -8,6 +8,7 @@ import { createClient } from "@/lib/supabase/client";
 import CDOmegaMonitor from "./CDOmegaMonitor";
 import ImportButton from "./import/ImportButton";
 import TextSizeToggle from "./TextSizeToggle";
+import CategoryFilterDropdown from "./CategoryFilterDropdown";
 import { ModuleId } from "@/lib/types";
 import { DOMAIN_CARDS } from "./DomainSelector";
 import { GEOPOLITICAL_PROFILE } from "@/lib/domain-profiles";
@@ -92,6 +93,14 @@ export default function HeaderBar() {
                 {selectedDomains.length > 1 ? "MULTI" : "SINGLE"}
               </span>
             </button>
+            <div className="h-8 w-px bg-border hidden md:block" />
+          </>
+        )}
+
+        {/* Category filter (replaces the old DATA LAYERS section in DomainSelector) */}
+        {selectedDomains.length > 0 && (
+          <>
+            <CategoryFilterDropdown />
             <div className="h-8 w-px bg-border hidden md:block" />
           </>
         )}

--- a/src/hooks/useFilteredGraph.ts
+++ b/src/hooks/useFilteredGraph.ts
@@ -46,7 +46,6 @@ export function useFilteredGraph(): CausalGraph {
   const baseGraphData = useApexStore((s) => s.graphData);
   const selectedDomains = useApexStore((s) => s.selectedDomains);
   const visibleCategories = useApexStore((s) => s.visibleCategories);
-  const visibleDiscoverySources = useApexStore((s) => s.visibleDiscoverySources);
   const { graph: temporalGraph, isTemporalActive } = useTemporalGraph();
 
   // Use temporal graph when available and scrubbed; fall back to base
@@ -64,23 +63,24 @@ export function useFilteredGraph(): CausalGraph {
         if (mapped) mapped.forEach((d) => allowedDomains.add(d));
       }
 
-      // Always include cross-domain connectors (Geopolitical, Energy Grid)
-      // if any of their upstream/downstream domains are selected
-      const crossDomainNodes = ["Geopolitical", "Energy Grid"];
-      for (const cd of crossDomainNodes) {
-        if (!allowedDomains.has(cd)) {
-          const hasCrossEdge = edges.some((e) => {
-            const srcNode = nodes.find((n) => n.id === e.source);
-            const tgtNode = nodes.find((n) => n.id === e.target);
-            if (!srcNode || !tgtNode) return false;
-            return (
-              (srcNode.domain === cd && allowedDomains.has(tgtNode.domain)) ||
-              (tgtNode.domain === cd && allowedDomains.has(srcNode.domain))
-            );
-          });
-          if (hasCrossEdge) allowedDomains.add(cd);
-        }
+      // Auto-include any domain that bridges to a selected domain via at least
+      // one edge — keeps cross-domain cascade paths intact instead of pruning
+      // bridge nodes and making the cascade signal appear to teleport. The
+      // previous hardcoded list (Geopolitical, Energy Grid) only covered
+      // main-graph bridges and silently broke paths through new datasets
+      // (Athena ISR, T1D, VX-880).
+      const nodeDomainById = new Map(nodes.map((n) => [n.id, n.domain]));
+      const bridgedDomains = new Set<string>();
+      for (const e of edges) {
+        const srcDomain = nodeDomainById.get(e.source);
+        const tgtDomain = nodeDomainById.get(e.target);
+        if (!srcDomain || !tgtDomain || srcDomain === tgtDomain) continue;
+        const srcIn = allowedDomains.has(srcDomain);
+        const tgtIn = allowedDomains.has(tgtDomain);
+        if (srcIn && !tgtIn) bridgedDomains.add(tgtDomain);
+        else if (tgtIn && !srcIn) bridgedDomains.add(srcDomain);
       }
+      bridgedDomains.forEach((d) => allowedDomains.add(d));
 
       nodes = nodes.filter((n) => allowedDomains.has(n.domain));
     }
@@ -88,11 +88,6 @@ export function useFilteredGraph(): CausalGraph {
     // Filter by node category (empty set = show all)
     if (visibleCategories.size > 0) {
       nodes = nodes.filter((n) => visibleCategories.has(n.category));
-    }
-
-    // Filter by discovery source (empty set = show all)
-    if (visibleDiscoverySources.size > 0) {
-      nodes = nodes.filter((n) => visibleDiscoverySources.has(n.discoverySource));
     }
 
     // Rebuild edges to match remaining nodes
@@ -112,5 +107,5 @@ export function useFilteredGraph(): CausalGraph {
             : 0,
       },
     };
-  }, [graphData, selectedDomains, visibleCategories, visibleDiscoverySources]);
+  }, [graphData, selectedDomains, visibleCategories]);
 }

--- a/src/stores/useApexStore.ts
+++ b/src/stores/useApexStore.ts
@@ -192,11 +192,9 @@ interface ApexState {
   selectedDataSources: string[];
   setSelectedDataSources: (sources: string[]) => void;
 
-  // Data layer filters (what to show in the 3D universe)
-  visibleCategories: Set<string>; // node categories to show (empty = all)
-  visibleDiscoverySources: Set<string>; // discovery sources to show (empty = all)
+  // Category filter (what to show in the 3D universe — empty = all)
+  visibleCategories: Set<string>;
   setVisibleCategories: (categories: Set<string>) => void;
-  setVisibleDiscoverySources: (sources: Set<string>) => void;
 
   // Import modal
   importModalOpen: boolean;
@@ -539,11 +537,9 @@ export const useApexStore = create<ApexState>((set, get) => ({
   selectedDataSources: ["middle-east-playbooks"],
   setSelectedDataSources: (sources) => set({ selectedDataSources: sources }),
 
-  // Data layer filters
+  // Category filter
   visibleCategories: new Set<string>(),
-  visibleDiscoverySources: new Set<string>(),
   setVisibleCategories: (categories) => set({ visibleCategories: categories }),
-  setVisibleDiscoverySources: (sources) => set({ visibleDiscoverySources: sources }),
 
   // Import
   importModalOpen: false,


### PR DESCRIPTION
## Summary

Bundled set of three changes from the 2026-04-19 review.

**1. Category display → dropdown.** The 9-pill NODE CATEGORIES grid that
lived inside DomainSelector's collapsible DATA LAYERS section is gone.
Categories are now exposed via a compact `CategoryFilterDropdown` that
appears in HeaderBar after a domain is selected — same multi-select
semantics on `visibleCategories`, just in a place users can reach
without re-opening the launch menu.

**2. Fix cross-domain cascade paths.** `useFilteredGraph` had a
hardcoded auto-include list `["Geopolitical", "Energy Grid"]` for
cross-domain connectors. New datasets (Athena ISR, T1D β-cell, VX-880)
have their own bridge domains that weren't on the list, so cross-domain
edges were silently pruned and the cascade signal appeared to teleport
across domain boundaries during replay. Replaced with a data-driven
one-hop expansion: any domain with at least one edge to a selected
domain is auto-included.

**3. Remove DATA LAYERS section (overview / launch menu).** The whole
collapsible section is deleted from DomainSelector, including the
DISCOVERY ENGINES pill grid and the `visibleDiscoverySources` store
key + filter. Node-level `discoverySource` field is preserved because
the copilot context strings still reference it.

### Files

| File | Change |
|---|---|
| `src/components/CategoryFilterDropdown.tsx` | New — click-outside-to-close dropdown wired to `visibleCategories` |
| `src/components/HeaderBar.tsx` | Render dropdown when `selectedDomains.length > 0` |
| `src/components/DomainSelector.tsx` | Strip DATA LAYERS section, `localCategories`/`localSources`/`showDataLayers` state, `toggleCategory`/`toggleSource`, `DISCOVERY_SOURCES` const, `visibleDiscoverySources` setter call. Export `NODE_CATEGORIES` for the dropdown. |
| `src/stores/useApexStore.ts` | Drop `visibleDiscoverySources` state + setter |
| `src/hooks/useFilteredGraph.ts` | Drop discovery-source filter; replace hardcoded cross-domain allowlist with one-hop expansion |

## Verification

- `tsc --noEmit` clean
- 330/330 vitest pass (including the existing `cascade-simulator` suite)
- Lint: no new errors in the touched files
- **Browser smoke test not run**: local dev server is currently
  blocked by a pre-existing missing `critters` dependency
  (Next 16's `optimizeCss` experiment). Reviewer should exercise the
  flows below in a working environment.

## Test plan

- [ ] Launch with a single domain → header shows new dropdown trigger labeled `ALL CATEGORIES`
- [ ] Click dropdown → checkbox list of 9 categories appears, click outside closes it
- [ ] Toggle 1–2 categories → 3D/2D/Map views filter accordingly; trigger label updates to `1 CATEGORY` / `2 CATEGORIES`
- [ ] Click `✕ CLEAR FILTERS` → all categories visible again
- [ ] Reopen launch menu → DATA LAYERS section is gone (no NODE CATEGORIES, no DISCOVERY ENGINES, no toggle chevron)
- [ ] Multi-domain mode (e.g. T1D β-Cell + VX-880, or any cross-dataset combo): start a cascade replay → bridge nodes are no longer pruned and the cascade signal traces across domain boundaries instead of teleporting
- [ ] Single-domain mode (e.g. only Energy Systems): bridge nodes still appear when their other endpoint is in a selected domain (no regression on the previous Geopolitical / Energy Grid behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)