### PR TITLE
fix(2d): keep marquee selection alive when ISOLATE clicked

### DIFF
--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -386,11 +386,16 @@ function CausalDAG2DInner() {
     });
   }, [graphData, truthFilter, currentSnapshot, idHash]);
 
-  // Filter nodes for isolation mode
+  // Filter nodes for isolation mode + reflect store selection on each node.
+  // Controlling `selected` from the store (instead of letting React Flow
+  // manage it internally) keeps the marquee selection alive across the
+  // re-render that ISOLATE triggers — otherwise RF sometimes drops its
+  // internal selection state when we hand it a new nodes array.
   const visibleNodes = useMemo(() => {
-    if (!isolateSelection || multiSelectedNodes.length === 0) return nodes;
     const selSet = new Set(multiSelectedNodes);
-    return nodes.filter((n) => selSet.has(n.id));
+    const decorated = nodes.map((n) => ({ ...n, selected: selSet.has(n.id) }));
+    if (!isolateSelection || multiSelectedNodes.length === 0) return decorated;
+    return decorated.filter((n) => selSet.has(n.id));
   }, [nodes, isolateSelection, multiSelectedNodes]);
 
   const edges: Edge[] = useMemo(


### PR DESCRIPTION
## Summary

Follow-up to #101. After that PR, shift+drag in 2D **does** draw a marquee and the "X NODES SELECTED" panel does appear — but clicking **ISOLATE** doesn't actually filter the view. The list of selected nodes blinks to empty the moment isolation toggles.

## Root cause

React Flow manages selection state internally. When ISOLATE toggles `isolateSelection`, `CausalDAG2DInner` re-renders and hands RF a new `nodes` array. RF reconciles, and in some cases drops its internal selection during the reconcile — `onSelectionChange` fires with `[]`, the store clears `selectedNodes`, and `visibleNodes` falls back to "show everything" because the guard hits `multiSelectedNodes.length === 0`. End result: ISOLATE looks broken even though selection initially worked.

3D doesn't hit this because 3D uses a hand-rolled `ShiftDragSelect` and writes directly to the store — RF isn't in the loop.

## Fix

Make selection **controlled** from the Zustand store. Each RF node now carries `selected: multiSelectedNodes.includes(n.id)`. RF's internal state is driven by props instead of being authoritative, so re-renders can't drop the selection.

```diff
- if (!isolateSelection || multiSelectedNodes.length === 0) return nodes;
  const selSet = new Set(multiSelectedNodes);
- return nodes.filter((n) => selSet.has(n.id));
+ const decorated = nodes.map((n) => ({ ...n, selected: selSet.has(n.id) }));
+ if (!isolateSelection || multiSelectedNodes.length === 0) return decorated;
+ return decorated.filter((n) => selSet.has(n.id));
```

## Test plan

- [ ] 2D view → shift+drag a cluster → marquee + "N NODES SELECTED" panel appears.
- [ ] Click ISOLATE → graph filters to just the selected cluster (was: did nothing).
- [ ] Click SHOW ALL → graph returns to full view, selection still highlighted.
- [ ] Pan with plain left-drag still works (no regression on PR #101).
- [ ] 3D shift+drag → switch to 2D → ISOLATE still works (regression check on the existing working path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
