### PR TITLE
refactor(vx880): tighten covariate-slider honesty before Spirtes pivot

### DIFF
--- a/src/components/VX880TrialPanel.tsx
+++ b/src/components/VX880TrialPanel.tsx
@@ -10,6 +10,8 @@ import {
   VX880_LITERATURE_ANCHORS,
   VX880_TRIAL_PRIOR_META,
   VX880_COVARIATE_MODIFIERS,
+  VX880_COVARIATE_BASELINE,
+  computeCovariateLogHR,
 } from "@/lib/vx880-trial-data";
 import { solveInterdiction } from "@/lib/interdiction-engine";
 import type { CausalShock } from "@/lib/types";
@@ -363,21 +365,15 @@ export default function VX880TrialPanel() {
   const toggleAblatedNode = useApexStore((s) => s.toggleAblatedNode);
 
   // Cox-covariate slider state (the do-operator surface). Each slider
-  // shifts the displayed HR multiplicatively via VX880_COVARIATE_MODIFIERS.
-  // Defaults match the trial-cohort baseline so HR equals exp(β) until
-  // the audience moves a knob.
-  const [covariates, setCovariates] = useState({
-    hlaMismatch: VX880_COVARIATE_MODIFIERS.hlaMismatch.baseline,
-    autoantibodyZ: VX880_COVARIATE_MODIFIERS.autoantibodyZ.baseline,
-    isIntensity: VX880_COVARIATE_MODIFIERS.isIntensity.baseline,
-  });
-  const resetCovariates = useCallback(() => {
-    setCovariates({
-      hlaMismatch: VX880_COVARIATE_MODIFIERS.hlaMismatch.baseline,
-      autoantibodyZ: VX880_COVARIATE_MODIFIERS.autoantibodyZ.baseline,
-      isIntensity: VX880_COVARIATE_MODIFIERS.isIntensity.baseline,
-    });
-  }, []);
+  // shifts both the displayed HR and the trialPrior.beta published to
+  // the MC engine via VX880_COVARIATE_MODIFIERS. Defaults match the
+  // trial-cohort baseline so HR equals exp(β) until the audience moves
+  // a knob.
+  const [covariates, setCovariates] = useState(VX880_COVARIATE_BASELINE);
+  const resetCovariates = useCallback(
+    () => setCovariates(VX880_COVARIATE_BASELINE),
+    [],
+  );
 
   // Only render when the VX-880 flagship subgraph is loaded.
   const hasVx880 = useMemo(
@@ -426,18 +422,21 @@ export default function VX880TrialPanel() {
     };
   }, [hasVx880]);
 
-  // Publish the fitted prior to the store so the MC engine can consume
-  // it. Republished on every analysis change; cleared when the VX-880
-  // subgraph is no longer loaded so other domains don't accidentally
-  // inherit a stale survival fan.
+  // Publish the fitted prior (adjusted by current covariate sliders) to
+  // the store so the MC engine can consume it. Republished on every
+  // analysis or covariate change so the displayed HR and the survival
+  // fan stay in lock-step when the audience drags a slider. Cleared
+  // when the VX-880 subgraph is no longer loaded so other domains don't
+  // accidentally inherit a stale survival fan.
   useEffect(() => {
     if (!analysis) {
       setTrialPrior(null);
       return;
     }
+    const covariateLogHR = computeCovariateLogHR(covariates);
     setTrialPrior({
       label: VX880_TRIAL_PRIOR_META.label,
-      beta: analysis.cox.beta[0],
+      beta: analysis.cox.beta[0] + covariateLogHR,
       se: analysis.cox.se[0],
       outcomeNodeId: VX880_TRIAL_PRIOR_META.outcomeNodeId,
       baselineHazardPerEpoch: VX880_TRIAL_PRIOR_META.baselineHazardPerEpoch,
@@ -449,7 +448,7 @@ export default function VX880TrialPanel() {
       // Clear when this panel unmounts or the analysis goes away.
       setTrialPrior(null);
     };
-  }, [analysis, setTrialPrior]);
+  }, [analysis, covariates, setTrialPrior]);
 
   // ── Counterfactual HR under the current interdiction ──
   // Maps the solver's reductionPct (fraction of cascade damage
@@ -476,10 +475,12 @@ export default function VX880TrialPanel() {
       }
     }
 
-    // Covariate adjustment (literature-anchored multiplicative modifiers).
-    // Sign: HLA mismatch ↑ and autoantibody titer ↑ shrink HR toward 1;
-    // tighter immunosuppression ↑ preserves HR. Δ values are 0 at baseline
-    // so this collapses to the trial-fit HR when the sliders are untouched.
+    // Covariate adjustment (illustrative multiplicative modifiers, see
+    // VX880_COVARIATE_MODIFIERS provenance note). Sign: HLA mismatch ↑
+    // and autoantibody titer ↑ shrink HR toward 1; tighter
+    // immunosuppression ↑ preserves HR. Δ values are 0 at baseline so
+    // this collapses to the trial-fit HR when sliders are untouched.
+    // Per-pillar Δs surfaced separately for the breakdown panel below.
     const cm = VX880_COVARIATE_MODIFIERS;
     const hlaDelta =
       -cm.hlaMismatch.deltaLogHR *
@@ -490,7 +491,7 @@ export default function VX880TrialPanel() {
     const isDelta =
       cm.isIntensity.deltaLogHR *
       (covariates.isIntensity - cm.isIntensity.baseline);
-    const covariateLogHR = hlaDelta + aabDelta + isDelta;
+    const covariateLogHR = computeCovariateLogHR(covariates);
 
     const effectiveBeta = analysis.cox.beta[0] * frac + covariateLogHR;
     const hr = Math.exp(effectiveBeta);
@@ -872,14 +873,18 @@ export default function VX880TrialPanel() {
             );
           },
         )}
+        <div className="text-[7px] font-mono text-accent-amber/70 leading-relaxed border border-accent-amber/20 bg-accent-amber/5 rounded px-1.5 py-1">
+          <strong>Illustrative scaffold — not citation-grade.</strong> The δ
+          values are order-of-magnitude estimates rounded for clean math,
+          anchored in the neighbourhood of the cited families but not
+          lifted from a specific table cell. Replace per-collaborator with
+          refit values from their cohort or table values from the cited
+          papers before using in a published model.
+        </div>
         <div className="text-[7px] font-mono text-text-muted leading-relaxed">
-          Multiplicative shifts on the trial-fit log-HR. Anchors:{" "}
-          <span className="text-text-muted/70">
-            HLA {VX880_COVARIATE_MODIFIERS.hlaMismatch.citation}; aAb{" "}
-            {VX880_COVARIATE_MODIFIERS.autoantibodyZ.citation}; IS{" "}
-            {VX880_COVARIATE_MODIFIERS.isIntensity.citation}
-          </span>
-          . Sliders compose with the interdiction fraction above.
+          Sliders compose multiplicatively with the interdiction fraction
+          above and propagate to the MC survival fan via trialPrior.β.
+          Hover any slider for its anchor citation.
         </div>
       </div>
 

--- a/src/lib/__tests__/vx880-trial-data.test.ts
+++ b/src/lib/__tests__/vx880-trial-data.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect } from "vitest";
 import {
   getNaturalHistoryCpeptideCohort,
   getInsulinIndependenceTte,
+  computeCovariateLogHR,
+  VX880_COVARIATE_BASELINE,
+  VX880_COVARIATE_MODIFIERS,
 } from "../vx880-trial-data";
 import { nlmeFit } from "../estimators/nlme";
 import { coxFit } from "../estimators/cox";
@@ -61,5 +64,64 @@ describe("VX-880 trial cohort data", () => {
     const control = subjects.filter((s) => s.treatment === 0).length;
     expect(treated).toBe(12);
     expect(control).toBe(12);
+  });
+});
+
+describe("VX-880 covariate-slider math", () => {
+  it("returns 0 at baseline (no shift to displayed HR)", () => {
+    expect(computeCovariateLogHR(VX880_COVARIATE_BASELINE)).toBe(0);
+  });
+
+  it("more HLA mismatches shrink HR (negative log-HR)", () => {
+    // baseline=3, max=6 → +3 mismatches above baseline.
+    // expected delta = -0.26 * 3 = -0.78 → HR multiplier exp(-0.78) ≈ 0.46
+    const delta = computeCovariateLogHR({
+      ...VX880_COVARIATE_BASELINE,
+      hlaMismatch: 6,
+    });
+    expect(delta).toBeCloseTo(-0.26 * 3, 6);
+    expect(Math.exp(delta)).toBeGreaterThan(0.4);
+    expect(Math.exp(delta)).toBeLessThan(0.5);
+  });
+
+  it("higher autoantibody titer shrinks HR (negative log-HR)", () => {
+    // +2σ above baseline. expected delta = -0.35 * 2 = -0.70.
+    const delta = computeCovariateLogHR({
+      ...VX880_COVARIATE_BASELINE,
+      autoantibodyZ: 2,
+    });
+    expect(delta).toBeCloseTo(-0.35 * 2, 6);
+    expect(delta).toBeLessThan(0);
+  });
+
+  it("more aggressive immunosuppression preserves HR (positive log-HR)", () => {
+    // baseline=1, +1 step → expected +0.69.
+    const delta = computeCovariateLogHR({
+      ...VX880_COVARIATE_BASELINE,
+      isIntensity: 2,
+    });
+    expect(delta).toBeCloseTo(0.69, 6);
+    expect(delta).toBeGreaterThan(0);
+  });
+
+  it("composes additively across the three covariates", () => {
+    // hla=4 (+1), aab=+1, is=2 (+1)
+    const delta = computeCovariateLogHR({
+      hlaMismatch: 4,
+      autoantibodyZ: 1,
+      isIntensity: 2,
+    });
+    const expected = -0.26 * 1 + -0.35 * 1 + 0.69 * 1;
+    expect(delta).toBeCloseTo(expected, 6);
+  });
+
+  it("all modifiers are flagged as illustrative (not citation-grade)", () => {
+    // Honest provenance is a load-bearing piece of the panel — guard
+    // against accidentally upgrading the label without backing data.
+    for (const key of Object.keys(VX880_COVARIATE_MODIFIERS) as Array<
+      keyof typeof VX880_COVARIATE_MODIFIERS
+    >) {
+      expect(VX880_COVARIATE_MODIFIERS[key].provenance).toBe("illustrative");
+    }
   });
 });

--- a/src/lib/vx880-trial-data.ts
+++ b/src/lib/vx880-trial-data.ts
@@ -190,19 +190,41 @@ export const VX880_LITERATURE_ANCHORS = {
 // observed treatment HR shift if the audience changes one of those
 // covariates? We compose multiplicatively on the fitted log-HR:
 //
-//   log_HR = β_treat · interdictionFrac
-//          - δ_hla · (hlaMismatch − hlaBaseline)
-//          - δ_aab · (aabZ        − aabBaseline)
-//          + δ_is  · (isIntensity − isBaseline)
+//   log_HR = β_treat · interdictionFrac + computeCovariateLogHR(covariates)
+//
+// where the covariate term is:
+//
+//   - δ_hla · (hlaMismatch  − baseline)
+//   - δ_aab · (autoantibody − baseline)
+//   + δ_is  · (isIntensity  − baseline)
 //
 // Sign convention: HLA mismatch ↑ and autoantibody titer ↑ both attack
 // the graft → HR shrinks toward 1. Tighter immunosuppression → preserves
 // graft β-mass → HR stays closer to the trial-fit value.
 //
-// δ values are literature-anchored, not refit. The trial cohort is too
-// small (n=24, single-covariate model) to identify these in a partial-
-// likelihood refit honestly; using published HR multipliers and citing
-// them in the UI tooltip is the more credible path.
+// PROVENANCE NOTE — IMPORTANT FOR INSTITUTIONAL VIEWERS
+// =====================================================
+// The δ values below are **illustrative, not citation-grade**. They are
+// order-of-magnitude estimates rounded for clean math, anchored in the
+// neighbourhood of the cited papers but not lifted from a specific
+// table cell. The trial cohort here (n=24, single-covariate model) is
+// too small to identify these multipliers in a partial-likelihood
+// refit honestly, so the slider surface is a configurable scaffold
+// rather than a published model. A collaborator wanting a defensible
+// covariate model would replace these δ values with refit values from
+// their own cohort or with table values pulled directly from the cited
+// papers.
+//
+// The slider's job is to make the do-operator question concrete and
+// compositional with the interdiction surface, not to publish a CDE.
+export type CovariateProvenance = "illustrative" | "citation-grade";
+
+export interface CovariateState {
+  hlaMismatch: number;
+  autoantibodyZ: number;
+  isIntensity: number;
+}
+
 export const VX880_COVARIATE_MODIFIERS = {
   hlaMismatch: {
     label: "HLA mismatch",
@@ -213,10 +235,10 @@ export const VX880_COVARIATE_MODIFIERS = {
     step: 1,
     baseline: 3,
     // Per-mismatch log-HR for graft-loss-driven loss of treatment effect.
-    // Anchor: ~1.3× HR per DR/DQ mismatch in solid-organ allograft loss
-    // registries (Lefaucheur AJT 2018; Wiebe Transplantation 2017).
     deltaLogHR: 0.26,
-    citation: "Lefaucheur AJT 2018; Wiebe Transplantation 2017 (~1.3× per mismatch)",
+    citation:
+      "Anchor neighbourhood: ~1.3× HR per DR/DQ mismatch in solid-organ allograft loss registries (Lefaucheur, Wiebe, etc.)",
+    provenance: "illustrative" as CovariateProvenance,
   },
   autoantibodyZ: {
     label: "Autoantibody titer",
@@ -227,10 +249,10 @@ export const VX880_COVARIATE_MODIFIERS = {
     step: 0.5,
     baseline: 0,
     // Per-σ log-HR for autoimmune-recurrence-driven loss of treatment effect.
-    // Anchor: ~2× recurrence rate at high titer (Vendrame Diabetes Care
-    // 2010; Burke Diabetologia 2017) over a 2σ shift.
     deltaLogHR: 0.35,
-    citation: "Vendrame Diabetes Care 2010; Burke Diabetologia 2017 (~2× at +2σ)",
+    citation:
+      "Anchor neighbourhood: ~2× recurrence rate at high titer (Vendrame, Burke, et al.) over a 2σ shift",
+    provenance: "illustrative" as CovariateProvenance,
   },
   isIntensity: {
     label: "Immunosuppression intensity",
@@ -241,10 +263,42 @@ export const VX880_COVARIATE_MODIFIERS = {
     step: 1,
     baseline: 1,
     // Per-tier log-HR for IS-driven preservation of treatment effect.
-    // Anchor: ~halving of graft-loss hazard per induction step (CIBMTR
-    // registry analyses of ATG vs no-induction in haematopoietic and
-    // pancreatic islet transplants).
     deltaLogHR: 0.69,
-    citation: "CIBMTR registry / Hering Diabetes Care 2016 (~0.5× per induction step)",
+    citation:
+      "Anchor neighbourhood: ~0.5× graft-loss hazard per induction step (CIBMTR registry / Hering Diabetes Care 2016 family)",
+    provenance: "illustrative" as CovariateProvenance,
   },
 } as const;
+
+/**
+ * Default covariate state — every slider sits at its trial-cohort
+ * baseline so the panel reads "untouched = trial-fit HR" until the
+ * audience moves a knob.
+ */
+export const VX880_COVARIATE_BASELINE: CovariateState = {
+  hlaMismatch: VX880_COVARIATE_MODIFIERS.hlaMismatch.baseline,
+  autoantibodyZ: VX880_COVARIATE_MODIFIERS.autoantibodyZ.baseline,
+  isIntensity: VX880_COVARIATE_MODIFIERS.isIntensity.baseline,
+};
+
+/**
+ * Compose the slider state into a log-HR delta. Used by both the
+ * VX880TrialPanel HR readout and the trialPrior published to the MC
+ * engine — keeps the displayed HR and the survival fan in lock-step
+ * when the audience drags a slider.
+ *
+ * Returns 0 when every covariate is at baseline.
+ */
+export function computeCovariateLogHR(covariates: CovariateState): number {
+  const cm = VX880_COVARIATE_MODIFIERS;
+  const hla =
+    -cm.hlaMismatch.deltaLogHR *
+    (covariates.hlaMismatch - cm.hlaMismatch.baseline);
+  const aab =
+    -cm.autoantibodyZ.deltaLogHR *
+    (covariates.autoantibodyZ - cm.autoantibodyZ.baseline);
+  const is =
+    cm.isIntensity.deltaLogHR *
+    (covariates.isIntensity - cm.isIntensity.baseline);
+  return hla + aab + is;
+}


### PR DESCRIPTION
## Summary

Three loose ends from PR #117 fixed before pivoting to causal-discovery work on observational T1D data:

1. **Provenance label.** The slider deltas are illustrative order-of-magnitude estimates anchored in the neighbourhood of the cited paper families, not values lifted from a specific table cell. The papers (Lefaucheur, Vendrame, Hering, etc.) exist and are on the right topics, but the trial cohort here (n=24, single-covariate model) cannot identify these multipliers in a refit honestly. Surfaces this directly in the UI:
   - `VX880_COVARIATE_MODIFIERS` gains a `provenance: "illustrative"` field per entry.
   - The slider section gains an amber-bordered notice ("not citation-grade — replace per-collaborator").
   - Module-level comment explains what the scaffold is and isn't.

2. **Sliders now propagate to the MC fan.** Previously the sliders moved only the displayed HR; the MC engine kept reading the unadjusted trial-fit β, so the survival fan was static under slider drag. The trialPrior published to the store now includes `β + computeCovariateLogHR(covariates)`, so the fan shifts in lock-step with the displayed HR. Extracted `computeCovariateLogHR` / `CovariateState` / `VX880_COVARIATE_BASELINE` so the panel and the engine share one math implementation.

3. **Tests for the covariate math.** Six new vitest cases — baseline → 0, each slider direction, additive composition, and a guard that all modifiers stay flagged as illustrative (catches accidental upgrade of the label without backing data).

## Test plan

- [x] 336 vitest cases pass (6 new in covariate-slider math)
- [x] `tsc --noEmit` clean
- [ ] On Vercel preview, drag HLA mismatch slider — both the HR<sup>s</sup> readout *and* the MC survival fan visibly shift (previously fan stayed static)
- [ ] Slider section shows amber-bordered "Illustrative scaffold — not citation-grade" notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)
