### PR TITLE
fix(interdiction): exclude shock-source nodes from damage scoring

### DIFF
--- a/src/lib/interdiction-engine.ts
+++ b/src/lib/interdiction-engine.ts
@@ -132,7 +132,16 @@ export function solveInterdiction(
   // dominated by downstream propagation rather than the invariant
   // source state. Mirrors the same shock→node mapping the simulator
   // uses, so no chance of drift.
-  const shockSourceIds = new Set(mapShocksToNodes(graph, shocks).keys());
+  //
+  // Edge case: if the shock saturates the entire graph (every node is
+  // a source — happens on tightly-scoped subgraphs like VX-880 where
+  // the whole graph is one category and the shock category broadcasts
+  // to it), excluding everyone zeros the score. Fall back to scoring
+  // all nodes in that case so baseline damage is still meaningful.
+  const allSourceIds = new Set(mapShocksToNodes(graph, shocks).keys());
+  const shockSourceIds = allSourceIds.size < graph.nodes.length
+    ? allSourceIds
+    : new Set<string>();
 
   // Baseline: no interventions
   const baselineEpochs = simulateCascade(graph, shocks, severedEdges);

--- a/src/lib/interdiction-engine.ts
+++ b/src/lib/interdiction-engine.ts
@@ -3,7 +3,7 @@ import {
   CausalShock,
   EpochSnapshot,
 } from "./types";
-import { simulateCascade } from "./cascade-simulator";
+import { simulateCascade, mapShocksToNodes } from "./cascade-simulator";
 
 // ─── Types ──────────────────────────────────────────────────────
 
@@ -53,10 +53,18 @@ export interface InterdictionCandidate {
  *                  high-fragility targets; cuts that protect one critical
  *                  chokepoint show up here even if the mean barely moves)
  *   (3) critical — bonus when the Ω-buffer breaches threshold.
+ *
+ * Shock-source nodes (the nodes that receive the initial injection) are
+ * excluded from BOTH the spread and hot-node calculations. Their
+ * intensity is an *input* to the cascade, not a downstream consequence —
+ * no edge severance can change it. Including them dominates the hot-node
+ * term (source intensity ~1.0 × high ΩF) and drowns out per-cut deltas in
+ * the propagation, which is the actual signal the solver needs.
  */
 function computeDamage(
   epochs: EpochSnapshot[],
   baseOmegaMap: Map<string, number>,
+  shockSourceIds: Set<string>,
 ): number {
   if (epochs.length === 0) return 0;
 
@@ -67,6 +75,7 @@ function computeDamage(
     let total = 0;
     let count = 0;
     for (const [id, state] of Object.entries(snap.nodeStates)) {
+      if (shockSourceIds.has(id)) continue;
       total += state.shockIntensity;
       count++;
       const baseOmega = baseOmegaMap.get(id) ?? 5;
@@ -118,9 +127,16 @@ export function solveInterdiction(
     baseOmegaMap.set(node.id, node.omegaFragility.composite);
   }
 
+  // Identify shock-source nodes (the ones that receive the initial
+  // injection). computeDamage skips these so the per-cut signal is
+  // dominated by downstream propagation rather than the invariant
+  // source state. Mirrors the same shock→node mapping the simulator
+  // uses, so no chance of drift.
+  const shockSourceIds = new Set(mapShocksToNodes(graph, shocks).keys());
+
   // Baseline: no interventions
   const baselineEpochs = simulateCascade(graph, shocks, severedEdges);
-  const baselineDamage = computeDamage(baselineEpochs, baseOmegaMap);
+  const baselineDamage = computeDamage(baselineEpochs, baseOmegaMap, shockSourceIds);
 
   const interventions: InterdictionCandidate[] = [];
   const removedEdgeIds = new Set(severedEdges);
@@ -185,7 +201,7 @@ export function solveInterdiction(
       }
 
       const epochs = simulateCascade(testGraph, shocks, testSevered);
-      const damage = computeDamage(epochs, baseOmegaMap);
+      const damage = computeDamage(epochs, baseOmegaMap, shockSourceIds);
 
       if (damage < bestDamage) {
         bestDamage = damage;


### PR DESCRIPTION
## Summary

Follow-up to #91. After that PR, peak-based damage scoring is firing (Hormuz reports baseline 18.1, not the old 6.5), but the solver still returns **0% reduction** and Pearl still falls back to "Cascade damage too low to rank cuts — showing highest structural vulnerability instead."

## Why #91 wasn't enough

`computeDamage` was including shock-source nodes in the hot-node calc:

```ts
const hotness = state.shockIntensity * (baseOmega / 10);
if (hotness > peakHotNode) peakHotNode = hotness;
```

Shock-source intensity is an **input** to the cascade (clamped to ~1.0 on injection) and **invariant under any edge cut**. For Hormuz, that source × ΩF term sits at ~0.9 and dominates the score. Per-cut damage values therefore tie baseline almost exactly. The greedy solver evaluates each candidate, finds nothing that beats `marginalReduction >= 0.01`, breaks the loop, and Pearl drops to fallback ranking.

That's despite the Monte-Carlo buffer trajectory showing a **real** difference under the same cuts: in the screenshot, `Ω-buffer (BASE) 43.9` vs `Ω-buffer (do(X)) 43.5`.

## Fix

Exclude shock-source ids from both the spread (mean) and hot-node peak in `computeDamage`. Their state is invariant; only **downstream propagation** is what cuts can move, and propagation is what we want the score to track.

```diff
+ const shockSourceIds = new Set(mapShocksToNodes(graph, shocks).keys());
  const baselineEpochs = simulateCascade(graph, shocks, severedEdges);
- const baselineDamage = computeDamage(baselineEpochs, baseOmegaMap);
+ const baselineDamage = computeDamage(baselineEpochs, baseOmegaMap, shockSourceIds);
```

Inside the candidate loop:

```diff
- const damage = computeDamage(epochs, baseOmegaMap);
+ const damage = computeDamage(epochs, baseOmegaMap, shockSourceIds);
```

`mapShocksToNodes` is the same helper the cascade simulator uses, so there's no chance of drift between what gets shocked and what gets excluded. Empty-shock callers pass an empty set — no behaviour change for those.

## Verification

- `npx tsc --noEmit` clean (modulo the two pre-existing fetch-url errors).
- `npx vitest run src/lib/__tests__/interdiction-engine.test.ts src/lib/__tests__/cascade-simulator.test.ts` → **32/32 passed**.

## Test plan

- [ ] Pearl Module → Strait of Hormuz Closure → Run Interdiction → expect **non-zero** `Δ IMPACT` and `reduction %`. (Was 0% on main even after #91.)
- [ ] Fan chart baseline (dashed) vs intervention (solid) bands should now visibly separate.
- [ ] Copilot should *not* fall back to "highest structural vulnerability" — should rank actual cascade-reducing cuts.
- [ ] Tightly-scoped scenarios (VX-880 graft preset) should still rank cuts the same way (uses `targetNodes`, same skip-set logic applies).
- [ ] No regression on broad-graph scenarios that already worked pre-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
