### PR TITLE
fix(pareto): require >=5 epochs before scoping a node into the omega trajectory

### DIFF
--- a/src/components/ModulePanel.tsx
+++ b/src/components/ModulePanel.tsx
@@ -820,11 +820,17 @@ function ParetoPanel({
 
   // Mean omegaComposite trajectory across the scoped nodes, normalized 0–1.
   // Single source of truth shared with the bottom ΩF TIME SERIES cards.
+  //
+  // Histories are filtered to length ≥ 5 before the min-clip — a single node
+  // with one entry would otherwise collapse the trajectory to T=1 and starve
+  // every live estimator (CSD's AR(1) fit needs n≥5). 5 matches the smallest
+  // n at which any criticality model can produce a non-degenerate result.
   const scopedOmegaSeries = useMemo<number[]>(() => {
     if (!temporalData || scopedNodeIds.length === 0) return [];
+    const MIN_USEFUL_HISTORY = 5;
     const histories = scopedNodeIds
       .map((id) => temporalData.nodes.get(id)?.history ?? [])
-      .filter((h) => h.length > 0);
+      .filter((h) => h.length >= MIN_USEFUL_HISTORY);
     if (histories.length === 0) return [];
     const T = Math.min(...histories.map((h) => h.length));
     const series: number[] = [];


### PR DESCRIPTION
## Summary

A single top-N risk node with only one history entry was collapsing the shared `scopedOmegaSeries` to `T=1` via the `min`-clip. That starved every live criticality model and forced the Pareto panel to its legacy `%` confidence fallback — silently — even though the relevance score had been wired in (#109).

Fix: filter `scopedNodes` to nodes with `history.length >= 5` (CSD's AR(1) minimum) before averaging. Matches what any of the criticality estimators can actually use.

## Test plan

- [x] Verified live: badge flips `0% conf` → `13/40/0% rel`, four-row F·E·G·S breakdown renders with arithmetic line matching the headline
- [ ] Vercel preview: confirm the same flip on prod-shape data

🤖 Generated with [Claude Code](https://claude.com/claude-code)
