### PR TITLE
feat(discovery): foundation — cohort schema, run record, ingester/algorithm interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,9 @@ next-env.d.ts
 /research/datasets/_cache/
 __pycache__/
 *.pyc
+
+# discovery — raw cohort data and run artefacts NEVER committed.
+# Adapters read source files from /research/datasets/<cohort-id>/raw/;
+# discovery runs land as JSON under /research/runs/. Both local-only.
+/research/datasets/*/raw/
+/research/runs/

--- a/src/lib/discovery/README.md
+++ b/src/lib/discovery/README.md
@@ -1,0 +1,141 @@
+# Discovery — Causal Structure Discovery from Real Cohorts
+
+The `src/lib/discovery/` module is Manifold's pipeline for taking a
+real longitudinal cohort and producing a set of discovered causal
+edges with provenance. It's how we move from "curated graphs from
+literature" to "edges learned from data" — the foundation for the
+**Spirtes** module's actual structure-discovery promise.
+
+## What lives here
+
+```
+src/lib/discovery/
+├── cohort-types.ts         — normalised cohort schema (the lingua franca)
+├── run-types.ts            — discovery run + edge records (the audit unit)
+├── ingester-interface.ts   — adapter contract for source-format → Cohort
+├── algorithm-interface.ts  — discovery algorithm contract
+├── ingesters/              — one file per source format (OhioT1DM, JAEB, …)
+├── algorithms/             — one file per algorithm (PCMCI+, FCI, …)
+└── __tests__/              — schema sanity + end-to-end fixtures
+```
+
+## The pipeline
+
+```
+  raw source files          ┌─ ingester ──┐    ┌─ algorithm ──┐    DiscoveryRun
+  (XML / CSV / parquet) ──→ │  (de-id)    │ ──→│  (pure fn)   │ ──→  + JSON record
+                            └─────────────┘    └──────────────┘      + edges
+                                  Cohort           DiscoveryResult       │
+                                                                         ▼
+                                                             ┌─ UI: discovered edges
+                                                             ├─ API: GET /api/runs/<id>
+                                                             └─ audit log
+```
+
+Three contracts make the pipeline composable:
+
+1. **`Cohort`** — the normalised data shape. Every adapter writes one;
+   every algorithm reads one. Adapters never see source files; the
+   algorithm layer never sees raw data.
+2. **`CohortIngester`** — adapter interface. New data source = new file
+   in `ingesters/`. The de-identification contract is in the type
+   system: `Cohort.source.containsPHI` is hard-typed `false`.
+3. **`DiscoveryAlgorithm<P>`** — algorithm interface. New algorithm =
+   new file in `algorithms/`. Pure function — no side effects.
+
+## Privacy contract
+
+The schema has nowhere for direct identifiers to live. Adapters that
+read from PHI sources do their own de-identification before returning a
+`Cohort`. The `containsPHI: false` flag is a hard literal type — code
+downstream of the schema (UI, API, serializers) can treat anything
+wearing the `Cohort` type as safe to surface.
+
+For sensitive personal data (e.g. a family member's CGM):
+- Source files live under `research/datasets/<cohort-id>/raw/` —
+  **gitignored at every level**.
+- The adapter de-identifies on read; only the normalised `Cohort` is
+  ever in memory after that.
+- Discovery output (the `DiscoveryRun`) contains abstract structure
+  only — variable ids, edges, lags, p-values. Never raw measurements.
+- `DiscoveryRun` JSON files live under `research/runs/` — also
+  gitignored, but the *abstract structure* in them can be safely
+  shared (e.g. with a clinician) because it doesn't reconstruct the
+  underlying trace.
+
+## Enterprise ladder
+
+This module is designed for solo use today and multi-tenant /
+production deployment tomorrow. The ladder:
+
+| Capability | Today | Tomorrow | Schema change? |
+|---|---|---|---|
+| Ingestion | Local file path | API upload / OAuth pull | None — only `ingest()` body changes |
+| Multi-tenancy | Single user | RBAC + tenant isolation | None — namespace via `cohort.id` |
+| Audit log | JSON files in `research/runs/` | Append-only store (S3 / SOC2-compliant DB) | None — `DiscoveryRun` is already the audit record |
+| Algorithm execution | Sync, in-process | Async worker queue | None — algorithm interface is pure |
+| Discovery output | UI tile | UI + API + downstream consumers | None — `DiscoveryResult` is API-shaped already |
+| Reproducibility | Adapter version + cohortSourceHash | Same | Already wired |
+
+The point: every load-bearing decision (the schema, the contracts,
+the privacy flag, the provenance fields) is made *now* so future
+enterprise work is plumbing, not architecture.
+
+## How to add an adapter
+
+```ts
+// src/lib/discovery/ingesters/my-source.ts
+import type { CohortIngester } from "../ingester-interface";
+import type { Cohort } from "../cohort-types";
+
+export const myAdapter: CohortIngester = {
+  id: "my-source",
+  version: "0.1.0",
+  description: "Reads <SOURCE> and produces a normalised cohort.",
+  conceptSystems: ["LOINC"],
+  async ingest(sourcePath, options) {
+    // 1. Parse source
+    // 2. De-identify subject ids
+    // 3. Map to Variable[] / Subject[] / Measurement[]
+    // 4. Compute sourceHash
+    // 5. Return Cohort with containsPHI: false
+  },
+};
+```
+
+## How to add an algorithm
+
+```ts
+// src/lib/discovery/algorithms/my-algo.ts
+import type { DiscoveryAlgorithm } from "../algorithm-interface";
+
+interface MyAlgoParams { alpha: number; maxLag: number; }
+
+export const myAlgo: DiscoveryAlgorithm<MyAlgoParams> = {
+  id: "my-algo",
+  version: "0.1.0",
+  description: "Discovers edges via <METHOD>.",
+  defaultParams: { alpha: 0.05, maxLag: 12 },
+  run(cohort, params) {
+    const p = { ...this.defaultParams, ...params };
+    // Pure: read cohort, return DiscoveryResult.
+  },
+};
+```
+
+## Roadmap
+
+- **Now (this PR):** schemas + interfaces + sanity test.
+- **PR+1:** synthetic cohort fixture + stub `lag-correlation` algorithm.
+  Proves the loop end-to-end.
+- **PR+2:** OhioT1DM ingester adapter. Real T1D data flowing in.
+- **PR+3:** UI surface — discovered edges merge into the existing DAG
+  view tagged `discoverySource: "<algorithm-id>"`.
+- **PR+4:** `POST /api/discovery/run` and `GET /api/discovery/runs/<id>`.
+  The API hook that lets a customer call Manifold from their pipeline.
+- **Later:** PCMCI+ and FCI proper (the algorithms the Spirtes module
+  promises in the Joslin / Mt Sinai / DRI Miami briefs).
+
+The roadmap is one-PR-per-step on purpose: each step is a clean
+mergeable unit, and any of them can be deprioritised without
+unwinding earlier work.

--- a/src/lib/discovery/__tests__/foundation.test.ts
+++ b/src/lib/discovery/__tests__/foundation.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildDiscoveryRun,
+  type Cohort,
+  type DiscoveryAlgorithm,
+  type DiscoveryResult,
+} from "../index";
+
+// ─── Test fixture: minimal in-memory cohort + stub algorithm ───────────
+//
+// This file deliberately does NOT depend on any ingester adapter or
+// real algorithm. Its job is to assert the type contracts and the
+// run-record builder behave the way the README claims they do — so a
+// future PR adding the first real adapter / algorithm can rely on the
+// foundation being honest.
+
+function makeFixtureCohort(): Cohort {
+  return {
+    id: "test-cohort-001",
+    label: "Synthetic 3-variable / 2-subject sanity cohort",
+    source: {
+      adapter: "test-fixture",
+      adapterVersion: "0.0.1",
+      sourceHash: "deadbeef",
+      ingestedAt: "2026-04-29T00:00:00Z",
+      containsPHI: false,
+    },
+    variables: [
+      { id: "x", label: "X", kind: "continuous" },
+      { id: "y", label: "Y", kind: "continuous" },
+      { id: "z", label: "Z", kind: "continuous" },
+    ],
+    subjects: [
+      {
+        id: "s001",
+        measurements: [
+          { variableId: "x", t: 0, value: 1.0 },
+          { variableId: "y", t: 0, value: 2.0 },
+          { variableId: "z", t: 0, value: 3.0 },
+        ],
+      },
+      {
+        id: "s002",
+        measurements: [
+          { variableId: "x", t: 0, value: 1.5 },
+          { variableId: "y", t: 0, value: 2.5 },
+          { variableId: "z", t: 0, value: 3.5 },
+        ],
+      },
+    ],
+    timeAxis: { zeroConvention: "session-start", displayUnit: "seconds" },
+    metadata: {
+      description: "Fixture cohort for foundation tests.",
+      accessTier: "public",
+    },
+  };
+}
+
+interface StubParams {
+  /** Edge strength to emit on the single fake edge. */
+  strength: number;
+}
+
+const stubAlgorithm: DiscoveryAlgorithm<StubParams> = {
+  id: "stub-test-algo",
+  version: "0.0.1",
+  description: "Returns one fixed edge for foundation testing.",
+  defaultParams: { strength: 0.5 },
+  run(cohort, params): DiscoveryResult {
+    const p = { ...this.defaultParams, ...params };
+    return {
+      variables: cohort.variables.map((v) => v.id),
+      edges: [
+        {
+          source: "x",
+          target: "y",
+          strength: p.strength,
+          evidence: "Stub algorithm — fixed edge for testing.",
+        },
+      ],
+    };
+  },
+};
+
+describe("discovery foundation — schema + run builder", () => {
+  it("Cohort source.containsPHI is hard-typed false", () => {
+    const c = makeFixtureCohort();
+    // Type-level assertion: the next line would fail to compile if
+    // containsPHI were not the literal `false`.
+    const isFalse: false = c.source.containsPHI;
+    expect(isFalse).toBe(false);
+  });
+
+  it("stub algorithm returns variables ⊆ cohort.variables", () => {
+    const cohort = makeFixtureCohort();
+    const result = stubAlgorithm.run(cohort);
+    const cohortVars = new Set(cohort.variables.map((v) => v.id));
+    for (const v of result.variables) {
+      expect(cohortVars.has(v)).toBe(true);
+    }
+  });
+
+  it("every discovered edge references variables that appear in result.variables", () => {
+    const cohort = makeFixtureCohort();
+    const result = stubAlgorithm.run(cohort);
+    const resultVars = new Set(result.variables);
+    for (const edge of result.edges) {
+      expect(resultVars.has(edge.source)).toBe(true);
+      expect(resultVars.has(edge.target)).toBe(true);
+    }
+  });
+
+  it("stub algorithm honours param overrides", () => {
+    const cohort = makeFixtureCohort();
+    const result = stubAlgorithm.run(cohort, { strength: 0.91 });
+    expect(result.edges[0].strength).toBeCloseTo(0.91, 6);
+  });
+
+  it("buildDiscoveryRun assembles a complete record from inputs", () => {
+    const cohort = makeFixtureCohort();
+    const result = stubAlgorithm.run(cohort);
+    const run = buildDiscoveryRun({
+      id: "run-001",
+      cohort,
+      algorithm: { id: stubAlgorithm.id, version: stubAlgorithm.version },
+      params: { strength: 0.5 },
+      startedAt: "2026-04-29T00:00:00Z",
+      completedAt: "2026-04-29T00:00:01Z",
+      result,
+    });
+
+    expect(run.id).toBe("run-001");
+    expect(run.cohortId).toBe(cohort.id);
+    expect(run.cohortSourceHash).toBe("deadbeef");
+    expect(run.status).toBe("succeeded");
+    expect(run.algorithm.id).toBe(stubAlgorithm.id);
+    expect(run.result.edges).toHaveLength(1);
+  });
+
+  it("a run record is JSON-serialisable (the audit format)", () => {
+    const cohort = makeFixtureCohort();
+    const run = buildDiscoveryRun({
+      id: "run-002",
+      cohort,
+      algorithm: { id: stubAlgorithm.id, version: stubAlgorithm.version },
+      params: {},
+      startedAt: "2026-04-29T00:00:00Z",
+      completedAt: "2026-04-29T00:00:01Z",
+      result: stubAlgorithm.run(cohort),
+    });
+
+    const json = JSON.stringify(run);
+    const parsed = JSON.parse(json);
+    expect(parsed.id).toBe("run-002");
+    expect(parsed.cohortId).toBe(cohort.id);
+    expect(parsed.result.edges[0].source).toBe("x");
+  });
+});

--- a/src/lib/discovery/algorithm-interface.ts
+++ b/src/lib/discovery/algorithm-interface.ts
@@ -1,0 +1,47 @@
+// ─── Discovery — Algorithm Interface ─────────────────────────────────
+//
+// A discovery algorithm reads a `Cohort` and produces a
+// `DiscoveryResult`. Algorithms live in
+// `src/lib/discovery/algorithms/<name>.ts`.
+//
+// Contract:
+//  - The algorithm MUST NOT mutate the input cohort
+//  - The algorithm MUST NOT have side effects (no fs writes, no
+//    network calls). Persistence is the caller's job.
+//  - The returned DiscoveryResult.variables MUST be a subset of
+//    cohort.variables.map(v => v.id)
+//  - DiscoveredEdge.source/target MUST appear in result.variables
+//
+// The generic `P` carries the algorithm's parameter shape so callers
+// get type-safe param overrides.
+//
+// ENTERPRISE LADDER
+// -----------------
+// Today an algorithm runs synchronously in-process. Tomorrow the same
+// interface backs an async worker (`POST /api/discovery/run` enqueues
+// a job, the worker invokes the algorithm, the run record drops in the
+// audit store). Nothing about the algorithm code needs to change.
+
+import type { Cohort } from "./cohort-types";
+import type { DiscoveryResult } from "./run-types";
+
+/**
+ * One discovery algorithm. Generic `P` is the param shape; defaults
+ * to `Record<string, unknown>` for algorithms that don't expose
+ * structured params.
+ */
+export interface DiscoveryAlgorithm<P = Record<string, unknown>> {
+  /** Algorithm id (e.g. "pcmci-plus"). Stable across versions. */
+  id: string;
+  /** Implementation version (semver). */
+  version: string;
+  /** Human description. */
+  description: string;
+  /** Default parameters. Callers can spread `defaultParams` then override. */
+  defaultParams: P;
+  /**
+   * Run the algorithm. Pure function — no fs/network/randomness
+   * leakage outside what's documented in `params`.
+   */
+  run(cohort: Cohort, params?: Partial<P>): DiscoveryResult;
+}

--- a/src/lib/discovery/cohort-types.ts
+++ b/src/lib/discovery/cohort-types.ts
@@ -1,0 +1,165 @@
+// ─── Discovery — Normalised Cohort Schema ────────────────────────────
+//
+// A `Cohort` is the lingua franca every ingester writes to and every
+// discovery algorithm reads from. Adapters (OhioT1DM, JAEB, Tidepool,
+// Joslin, etc.) translate their source format into this shape; the
+// algorithms above never touch raw source files.
+//
+// PRIVACY CONTRACT
+// ----------------
+// The `Cohort` schema deliberately has no place for direct identifiers.
+// `Subject.id` MUST be opaque/hashed by the time it reaches a Cohort
+// object — adapters that pull from PHI sources do their own
+// de-identification. The `containsPHI` field is hard-flagged false so
+// downstream code (UI, serializer, API) can assert that anything wearing
+// this type is safe to surface.
+//
+// ENTERPRISE LADDER
+// -----------------
+// This schema was designed for solo use today and multi-tenant tomorrow.
+// Every cohort is namespaced by `id`; multi-tenant separation is just a
+// naming convention layered on top (e.g. `<tenant>__<cohort>`). No
+// schema migration needed when the deployment shape changes.
+
+/**
+ * Concept-coding so cohorts speak in standard medical vocabularies.
+ * SNOMED-CT for clinical entities and events, LOINC for measurements,
+ * ICD-10 for diagnoses. Optional today; required when an institutional
+ * partner cohort is loaded so cross-cohort joins become possible.
+ */
+export interface ConceptCode {
+  system: "LOINC" | "SNOMED-CT" | "ICD-10" | "RxNorm" | "UCUM";
+  code: string;
+}
+
+/**
+ * One column / signal in a cohort. The variable set is shared across
+ * subjects — every subject is sampled on the same `Variable[]`, even
+ * if some subjects have missing measurements for a given variable.
+ */
+export interface Variable {
+  /** Machine id, stable across runs (e.g. "cgm_glucose_mgdl"). */
+  id: string;
+  /** Human label for UI display. */
+  label: string;
+  /** Standard concept coding — required when cross-cohort join is needed. */
+  conceptCode?: ConceptCode;
+  /** UCUM-style unit (e.g. "mg/dL", "U/h", "boolean"). */
+  unit?: string;
+  /** Distinguishes scalar measurements from categorical/event signals. */
+  kind: "continuous" | "discrete" | "event" | "binary";
+  /**
+   * Sampling cadence in seconds. CGM at 5-minute cadence = 300; visit-
+   * level labs are bursty and pass `undefined`. Algorithms use this to
+   * pick lag windows automatically.
+   */
+  cadenceSeconds?: number;
+}
+
+/**
+ * A single measurement: which variable, when, what value. `t` is in the
+ * cohort's time-axis units (see `TimeAxis.displayUnit`) but stored as
+ * seconds since the cohort's time-zero so cross-cadence math is
+ * dimensionally clean.
+ */
+export interface Measurement {
+  variableId: string;
+  /** Seconds since the cohort's time-zero (set by `TimeAxis.zeroConvention`). */
+  t: number;
+  /** Numeric for continuous/binary; string token for categorical. */
+  value: number | string;
+}
+
+/**
+ * One subject. `id` is opaque — the adapter is responsible for
+ * de-identification before returning a Cohort. `demographics` may
+ * carry low-cardinality, non-PHI summary fields (age band, biological
+ * sex) but never anything that could re-identify a subject.
+ */
+export interface Subject {
+  id: string;
+  demographics?: Record<string, string | number>;
+  measurements: Measurement[];
+}
+
+/**
+ * Cohort-level time-axis convention — every measurement is offset from
+ * a single time-zero. This stays opaque to the algorithm layer; it's
+ * carried through so the UI can re-display in human units.
+ */
+export interface TimeAxis {
+  /**
+   * What does t=0 mean for this cohort? Examples:
+   *   - "session-start"      — first measurement of the recording session
+   *   - "diagnosis-date"     — date of T1D diagnosis
+   *   - "trial-randomization"
+   *   - "infusion-day-zero"
+   */
+  zeroConvention: string;
+  /** UI display unit. Conversion factor against seconds is implicit. */
+  displayUnit: "seconds" | "minutes" | "hours" | "days";
+}
+
+/**
+ * Provenance of the cohort: which adapter produced it, what source it
+ * was built from, when it landed. Hashes let us detect data drift
+ * across re-runs.
+ */
+export interface CohortSource {
+  /** Adapter id (e.g. "ohio-t1dm-xml"). */
+  adapter: string;
+  /** Adapter version for reproducibility. */
+  adapterVersion: string;
+  /**
+   * SHA-256 of the underlying source files (or a manifest of them).
+   * Optional but recommended — discovery results are reproducible only
+   * if the source bytes are too.
+   */
+  sourceHash?: string;
+  /** ISO 8601 timestamp of when this Cohort object was assembled. */
+  ingestedAt: string;
+  /**
+   * Hard-flag: does this cohort carry direct identifiers?
+   *
+   * Always `false` — the schema has nowhere for PHI to live, and the
+   * type system enforces that any adapter producing a Cohort has
+   * de-identified its output. UI / serializer / API code can rely on
+   * this to assert "anything wearing this type is safe to surface."
+   */
+  containsPHI: false;
+}
+
+/**
+ * Free-form study metadata for the cohort. Lives separately from the
+ * data so a UI can render a study card without loading the measurement
+ * payload.
+ */
+export interface CohortMetadata {
+  description: string;
+  citation?: string;
+  irbStatement?: string;
+  /** How is the cohort licensed? Public, DUA-restricted, internal-only. */
+  accessTier: "public" | "dua-restricted" | "internal-only";
+}
+
+/**
+ * The unit of ingestion. Every adapter returns one of these; every
+ * algorithm reads one of these. Nothing else has access to the raw
+ * source.
+ */
+export interface Cohort {
+  /** Stable cohort id (e.g. "ohio-t1dm-2018"). */
+  id: string;
+  /** Human-readable label for the UI. */
+  label: string;
+  /** Provenance — where this came from. */
+  source: CohortSource;
+  /** Variable set every subject is sampled on. */
+  variables: Variable[];
+  /** Subject records. */
+  subjects: Subject[];
+  /** Time-axis convention. */
+  timeAxis: TimeAxis;
+  /** Study-level metadata. */
+  metadata: CohortMetadata;
+}

--- a/src/lib/discovery/index.ts
+++ b/src/lib/discovery/index.ts
@@ -1,0 +1,31 @@
+// ─── Discovery — Public Entry Point ──────────────────────────────────
+//
+// Re-exports the schema and interfaces. Adapters and algorithms import
+// types from here; the rest of the codebase imports nothing else from
+// `src/lib/discovery/`.
+
+export type {
+  Cohort,
+  CohortMetadata,
+  CohortSource,
+  ConceptCode,
+  Measurement,
+  Subject,
+  TimeAxis,
+  Variable,
+} from "./cohort-types";
+
+export type {
+  AlgorithmDescriptor,
+  DiscoveredEdge,
+  DiscoveryDiagnostics,
+  DiscoveryResult,
+  DiscoveryRun,
+  DiscoveryRunInputs,
+} from "./run-types";
+
+export { buildDiscoveryRun } from "./run-types";
+
+export type { CohortIngester, IngestOptions } from "./ingester-interface";
+
+export type { DiscoveryAlgorithm } from "./algorithm-interface";

--- a/src/lib/discovery/ingester-interface.ts
+++ b/src/lib/discovery/ingester-interface.ts
@@ -1,0 +1,65 @@
+// ─── Discovery — Cohort Ingester Interface ───────────────────────────
+//
+// An ingester adapter reads a source format (XML, CSV, parquet, API)
+// and produces a normalised `Cohort`. Adapters live in
+// `src/lib/discovery/ingesters/<name>.ts` and are responsible for:
+//
+//  - Parsing the source format
+//  - De-identifying subjects (Subject.id MUST be opaque)
+//  - Mapping source variables to a stable variable id + concept code
+//  - Computing a sourceHash for drift detection
+//  - Returning a Cohort with `containsPHI: false`
+//
+// Adapters are NOT responsible for:
+//  - Discovery algorithms (those live in algorithms/)
+//  - UI rendering
+//  - Persistence (the caller writes the Cohort wherever it wants)
+//
+// ENTERPRISE LADDER
+// -----------------
+// Today an adapter reads from a local file path. Tomorrow the same
+// interface backs API ingestion (`POST /api/discovery/ingest` with a
+// multipart upload), pull-from-bucket flows (S3 / GCS), and direct
+// EHR/Tidepool/Dexcom OAuth pulls. The interface stays the same — only
+// the `ingest()` body changes per adapter.
+
+import type { Cohort } from "./cohort-types";
+
+/**
+ * Options every adapter accepts. Adapters can extend this with their
+ * own params via the generic on `CohortIngester`.
+ */
+export interface IngestOptions {
+  /** Override the default cohort id. */
+  cohortIdOverride?: string;
+  /** Limit to first N subjects (smoke-test mode). */
+  maxSubjects?: number;
+  /** Override the timestamp used in CohortSource.ingestedAt. */
+  ingestedAt?: string;
+}
+
+/**
+ * One ingester adapter. Generic `O` lets a specific adapter add its
+ * own ingest options without losing the shared base.
+ */
+export interface CohortIngester<O extends IngestOptions = IngestOptions> {
+  /** Adapter id (e.g. "ohio-t1dm"). Stable across versions. */
+  id: string;
+  /** Adapter implementation version (semver). */
+  version: string;
+  /** What this adapter ingests, in plain English. */
+  description: string;
+  /** Concept-coding systems this adapter populates (LOINC/SNOMED/etc.). */
+  conceptSystems: ReadonlyArray<"LOINC" | "SNOMED-CT" | "ICD-10" | "RxNorm" | "UCUM">;
+  /**
+   * Read source files from `sourcePath` and produce a normalised
+   * Cohort.
+   *
+   * Contract:
+   *  - Throws if the source is malformed or missing
+   *  - Returned Cohort.source.containsPHI MUST be `false`
+   *  - All Subject.id values MUST be opaque (hashed / random / index)
+   *  - sourceHash should be populated when feasible
+   */
+  ingest(sourcePath: string, options?: O): Promise<Cohort>;
+}

--- a/src/lib/discovery/run-types.ts
+++ b/src/lib/discovery/run-types.ts
@@ -1,0 +1,139 @@
+// ─── Discovery — Run / Edge Schema ────────────────────────────────────
+//
+// A `DiscoveryRun` is one invocation of a discovery algorithm on a
+// cohort. It is the unit of provenance — every edge that ends up
+// surfaced in the UI traces back to a specific run via `runId`.
+//
+// Stored as JSON under `research/runs/<run-id>.json` (gitignored).
+// When the API layer lands, `POST /api/discovery/run` returns one of
+// these and `GET /api/discovery/run/<id>` re-reads it.
+//
+// AUDIT / ENTERPRISE LADDER
+// -------------------------
+// The run record carries everything an audit log needs: who/when, what
+// algorithm version, what params, what cohort source-hash. A SOC2-style
+// immutable log is then just "append every run to a write-only store"
+// — no schema change required.
+
+import type { Cohort } from "./cohort-types";
+
+/**
+ * Algorithm identifier carried in every run record. Versioning matters
+ * — discovery output is only reproducible if the algorithm is pinned.
+ */
+export interface AlgorithmDescriptor {
+  /** e.g. "pcmci-plus", "fci", "lag-correlation". */
+  id: string;
+  /** Semver-style version of the algorithm implementation. */
+  version: string;
+}
+
+/**
+ * One discovered edge. Algorithms emit many of these; the UI then
+ * merges them into the existing CausalGraph view tagged with their
+ * `discoverySource`.
+ */
+export interface DiscoveredEdge {
+  /** Source variable id (matches `Variable.id`). */
+  source: string;
+  /** Target variable id. */
+  target: string;
+  /**
+   * Lag in the cohort's time-axis units (seconds-since-t0). `undefined`
+   * for contemporaneous edges; positive for lagged source → target.
+   */
+  lag?: number;
+  /**
+   * Edge strength. Algorithm-specific; bounded to [-1, 1] for
+   * correlation-flavoured measures, |β| or partial-correlation for
+   * regression-flavoured. The UI normalises for display.
+   */
+  strength: number;
+  /** Two-sided p-value (when the algorithm produces one). */
+  pValue?: number;
+  /**
+   * Short human-readable rationale. Surfaces in the UI tooltip so a
+   * clinician can see *why* this edge was proposed without reading the
+   * algorithm internals.
+   */
+  evidence: string;
+}
+
+/**
+ * Per-algorithm diagnostics (residuals, conditioning sets, FDR-adjusted
+ * thresholds, etc.). Opaque to the UI; useful for downstream audit.
+ */
+export type DiscoveryDiagnostics = Record<string, unknown>;
+
+/**
+ * The structural payload of a run. Variables are included so a viewer
+ * can see which signals the algorithm considered — discovery often
+ * prunes some inputs as un-conditionable.
+ */
+export interface DiscoveryResult {
+  /** Variables actually used in the run (subset of cohort.variables). */
+  variables: string[];
+  /** Discovered edges. */
+  edges: DiscoveredEdge[];
+  /** Algorithm-specific diagnostics. */
+  diagnostics?: DiscoveryDiagnostics;
+}
+
+/**
+ * The full record of one algorithm-run-on-one-cohort. Persisted as
+ * JSON for reproducibility; the cohort is referenced by id rather than
+ * embedded so the file stays a few KB.
+ */
+export interface DiscoveryRun {
+  /** Stable run id (UUID v4 or content-addressed hash). */
+  id: string;
+  /** Cohort this was run against. */
+  cohortId: string;
+  /** Hash of the cohort source at run time (for drift detection). */
+  cohortSourceHash?: string;
+  /** Algorithm and version. */
+  algorithm: AlgorithmDescriptor;
+  /** Parameters the algorithm was invoked with. */
+  params: Record<string, unknown>;
+  /** ISO 8601 timestamps. */
+  startedAt: string;
+  completedAt: string;
+  /** Run terminal state. */
+  status: "succeeded" | "failed" | "partial";
+  /** Optional error string when status !== "succeeded". */
+  error?: string;
+  /** Discovered structure. */
+  result: DiscoveryResult;
+}
+
+/**
+ * Helper signature for code that constructs a run from a successful
+ * algorithm invocation. Keeps the run-record assembly in one place.
+ */
+export interface DiscoveryRunInputs {
+  id: string;
+  cohort: Cohort;
+  algorithm: AlgorithmDescriptor;
+  params: Record<string, unknown>;
+  startedAt: string;
+  completedAt: string;
+  result: DiscoveryResult;
+}
+
+/**
+ * Build a complete run record from inputs. Pulls cohortId + sourceHash
+ * from the cohort so callers don't have to thread them separately.
+ */
+export function buildDiscoveryRun(inputs: DiscoveryRunInputs): DiscoveryRun {
+  return {
+    id: inputs.id,
+    cohortId: inputs.cohort.id,
+    cohortSourceHash: inputs.cohort.source.sourceHash,
+    algorithm: inputs.algorithm,
+    params: inputs.params,
+    startedAt: inputs.startedAt,
+    completedAt: inputs.completedAt,
+    status: "succeeded",
+    result: inputs.result,
+  };
+}


### PR DESCRIPTION
## Summary

First step of the **Spirtes pivot** — the architectural foundation that lets us ingest real T1D cohorts (OhioT1DM, JAEB, Tidepool, Joslin) and run causal-discovery algorithms (PCMCI+, FCI, NOTEARS) over them with full provenance.

**Foundation only — no algorithm implementations or adapters yet.** Schemas, interfaces, the architecture doc, and a sanity test. Doing one slot per PR keeps each merge reviewable and rollback-able.

## What's in `src/lib/discovery/`

- **`cohort-types.ts`** — `Cohort` / `Subject` / `Variable` / `Measurement` / `TimeAxis`. Privacy-by-default: `Cohort.source.containsPHI` is hard-typed `false`. Adapters de-identify before returning; downstream code (UI, API, serialiser) can rely on the type contract.
- **`run-types.ts`** — `DiscoveryRun` / `DiscoveredEdge` / `AlgorithmDescriptor`. `buildDiscoveryRun()` produces a JSON-serialisable record that doubles as the audit-log format from day one.
- **`ingester-interface.ts`** — `CohortIngester<O>`. New data source = new file in `ingesters/`. Adapter version + concept-coding declared on the interface.
- **`algorithm-interface.ts`** — `DiscoveryAlgorithm<P>`. Pure function contract: no fs, no network, no mutation.
- **`index.ts`** — public re-exports.
- **`README.md`** — architecture overview + the enterprise ladder (which decisions are load-bearing now so future work is plumbing not architecture).
- **`__tests__/foundation.test.ts`** — six cases on the schema, the algorithm contract, and the run builder.

## Privacy contract

The schema has nowhere for direct identifiers to live. `Cohort.source.containsPHI` is the literal type `false` — `containsPHI: true` is a type error. Combined with the gitignore rules (`/research/datasets/*/raw/`, `/research/runs/`), the architecture means raw data never hits the repo and run records carry only abstract structure (variable ids, edges, lags, p-values).

## Enterprise ladder

| Capability | Today | Tomorrow | Schema change? |
|---|---|---|---|
| Ingestion | Local file path | API upload / OAuth pull | None — only `ingest()` body changes |
| Multi-tenancy | Single user | RBAC + tenant isolation | None — namespace via `cohort.id` |
| Audit log | JSON files in `research/runs/` | Append-only store (S3 / SOC2 DB) | None — `DiscoveryRun` is the audit record |
| Algorithm execution | Sync, in-process | Async worker queue | None — algorithm interface is pure |
| Discovery output | UI tile | UI + API + downstream consumers | None — `DiscoveryResult` is API-shaped |

## Roadmap (one PR per step)

- ✅ **PR 0 (this one):** schemas + interfaces + sanity test
- ⏳ **PR+1:** synthetic cohort fixture + stub `lag-correlation` algorithm — proves the loop
- ⏳ **PR+2:** OhioT1DM ingester adapter — real data flows in
- ⏳ **PR+3:** UI surface — discovered edges merge into the existing DAG view
- ⏳ **PR+4:** `POST /api/discovery/run` + `GET /api/discovery/runs/<id>` — API hook
- ⏳ **Later:** PCMCI+ and FCI proper

## Test plan

- [x] All 342 vitest cases pass (6 new)
- [x] `tsc --noEmit` clean
- [x] No runtime code changed; no UI changes; no risk to live app
- [ ] Reviewer: scan the README and confirm the enterprise-ladder framing matches your intent before PR+1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
