### PR TITLE
docs(sessions): per-session scope docs and routing map

### DIFF
--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -1,0 +1,32 @@
+# Session Map
+
+Manifold development is split across focused sessions. Each session owns a slice of the product so context stays tight and changes don't bleed across concerns. When you spawn a new session, the first thing it should do is read its own scope file from this directory.
+
+## Routing table
+
+| Session | File | Owns |
+| --- | --- | --- |
+| UX & Onboarding | [`ux-onboarding.md`](./ux-onboarding.md) | Tour, welcome modal, persona pills, Domain Workspace, header chrome, feedback widget UX, brand vocabulary, news interpreter UI, accessibility, empty/loading states |
+| Platform | [`platform.md`](./platform.md) | Auth, Supabase plumbing, middleware, webhooks, admin/feedback triage backend, account provisioning |
+| Payments | [`payments.md`](./payments.md) | Billing, tier gating logic, payment flows |
+| Rendering | [`rendering.md`](./rendering.md) | 2D/3D/MAP canvas, layout algorithms, viewport, selection, render performance |
+| SPIRTES | [`spirtes.md`](./spirtes.md) | Causal-discovery engine (DCD/NOTEARS, PCMCI+, FCI) |
+| TARSKI | [`tarski.md`](./tarski.md) | Constraint-verification engine (PHYSICAL / REGULATORY / HEURISTIC axioms) |
+| PEARL | [`pearl.md`](./pearl.md) | Do-calculus interventions, ablations, CASCADE DEFENSE auto-interdiction |
+| PARETO | [`pareto.md`](./pareto.md) | Criticality horizons (CSD, PH, LPPLS), Ω-Fragility, shock injection |
+| Geopolitical / Macro | [`geopolitical-macro.md`](./geopolitical-macro.md) | Geopolitical / financial / macro / defense graph data (`dataset: main \| athena`) |
+| T1D / Life Sciences | [`t1d.md`](./t1d.md) | Type-1 Diabetes graph data, β-cell dynamics, T1D vocabulary (`dataset: t1d`) |
+
+## How to use this
+
+When you start a new session:
+
+1. The user names the session (e.g. `manifold-platform`) and tells the agent to read `docs/sessions/<name>.md` first.
+2. The scope doc states what the session owns and explicitly what it does *not* — including how to route out-of-scope requests.
+3. Edit the scope doc when scope shifts (e.g. "Platform now also owns the deploy-webhook chain") so future sessions pick the change up.
+
+## Cross-session etiquette
+
+- If a request straddles two sessions, the receiving session flags the boundary and asks to route — it does not absorb the work.
+- Don't duplicate code locations across scope docs. If something genuinely lives at a boundary, name it once and cross-reference.
+- Shared substrates (e.g. `useApexStore`, `DomainProfile` seam) are referenced from any session that touches them, but only one session is the canonical owner of changes — call that out in the scope doc.

--- a/docs/sessions/geopolitical-macro.md
+++ b/docs/sessions/geopolitical-macro.md
@@ -1,0 +1,61 @@
+# Session: Geopolitical / Macro
+
+Owns the geopolitical, financial, macro, and defense graph data and the corresponding domain profile entries. These sit under the **Analyst** persona with `dataset: main | athena`.
+
+> **Status:** session brief is being inferred from cross-references — fill in detail as the session establishes itself.
+
+## Scope summary (in)
+
+- Graph data:
+  - `src/lib/graph-data.ts` — main geopolitical/macro causal graph (`dataset: main`).
+  - `src/lib/athena-graph-data.ts` — Athena dataset (`dataset: athena`).
+- Domain profile entries in `src/lib/domain-profiles.ts` for: ENERGY SYSTEMS, FERTILIZER & AGROCHEMICAL, SUPPLY CHAIN SHOCK, FINANCIAL CONTAGION, EMERGING MARKET SOVEREIGN, FRONTIER (frontier-science), etc.
+- Persona mapping: Analyst persona — geopolitical / financial / macro / defense.
+- Domain-specific vocabulary in sidebar / inspector / pillar labels for these domains. Top-bar module tabs stay canonical SPIRTES/TARSKI/PEARL/PARETO.
+- Geo-coordinate mapping for MAP-view domains: `src/lib/geo-coordinates.ts`.
+- Domain-specific shock library (PARETO scenario injector presets — Strait of Hormuz closure, Abqaiq attack, LNG train outage, etc.). Authoring lives here; PARETO consumes.
+- Constraint authoring (REGULATORY tier — sanctions, export controls, treaties) co-authored with **TARSKI**.
+- Athena copilot engine: `src/lib/athena-copilot-engine.ts` (the *data side* — the copilot framework itself is shared).
+
+## Scope summary (out — route elsewhere)
+
+- Engine logic (SPIRTES, TARSKI, PEARL, PARETO) → respective **engine sessions**. This session supplies the graph and domain-specific constants.
+- Persona pill UX, Domain Workspace card rendering → **UX & Onboarding**. We define the domain entries; UX renders them.
+- MAP-view projection mechanics → **Rendering**. We supply geo-coordinates; Rendering projects.
+- Canvas, layout, viewport → **Rendering**.
+- Auth / API gating → **Platform**.
+
+## Boundary clarifications
+
+- **Vocabulary**: domain-specific module names / pillar labels live in the relevant `DomainProfile` entries. They flow through sidebar and inspector. They do **not** flow through the top-bar tabs (#70).
+- **Cross-domain edges**: the Cross-Domain persona allows multi-select across dataset families. Cross-domain edge logic and rendering are coordinated; this session contributes the edges, Rendering draws.
+- **Geo-coordinates**: this session owns whether a domain *has* geo-coordinates and what they are. MapLibre projection is Rendering's.
+
+## Anchor files
+
+- `src/lib/graph-data.ts`
+- `src/lib/athena-graph-data.ts`
+- `src/lib/athena-copilot-engine.ts`
+- `src/lib/domain-profiles.ts`
+- `src/lib/geo-coordinates.ts`
+- `src/lib/node-timeseries-map.ts` (geopolitical/macro entries)
+
+## Shipped PRs (representative)
+
+- TODO: fill in as the session ships work / from `git log`.
+
+## Likely upcoming themes
+
+- New domain cards as customer pilots demand them.
+- Real-world coordinate coverage for MAP-view domains.
+- Sanction / export-control axiom expansion (TARSKI co-auth).
+- Time-series coverage for currently sparse nodes.
+- TODO: fill in.
+
+## How to start a task
+
+1. Confirm in-scope (geopolitical / financial / macro / defense data and profiles).
+2. Coordinate with TARSKI when adding regulatory constraints.
+3. Coordinate with PARETO when adding scenario-injector presets.
+4. Coordinate with UX when adding/renaming domain cards or changing persona-mapped grouping.
+5. Coordinate with Rendering when changing MAP-view geo-coordinates or layout assumptions.

--- a/docs/sessions/pareto.md
+++ b/docs/sessions/pareto.md
@@ -1,0 +1,69 @@
+# Session: PARETO (Criticality Horizons & Ω-Fragility)
+
+Owns the criticality-monitoring engine: three independent signals each with a T-N countdown and confidence, plus the Ω-Fragility composite framework that drives node coloring across the app.
+
+> **Status:** session brief is being inferred from cross-references — fill in detail as the session establishes itself.
+
+## Scope summary (in)
+
+- **CSD** — Critical Slowing Down. Watches recovery-rate decay via λmax approaching 1.0.
+- **PH** — Persistent Homology. Sweeps a filtration for topological fragility holes.
+- **LPPLS** — Log-Periodic Power Law Singularity. Fits the Sornette crash model.
+- Each criticality card surfaces: observed vs model signal, formula, methodology, current assessment, expandable temporal chart with residual.
+- **Ω-Fragility** composite (0–10) on every node, broken into five pillars:
+  - Irreplaceability
+  - Restoration Latency
+  - Jurisdictional Hazard
+  - Cascade Load
+  - Tail Depth
+- Ω-Fragility Assessment summary in the panel: NOMINAL / ELEVATED / CRITICAL / OMEGA_BREACH.
+- Top critical nodes ranked by Ω-score.
+- **CDΩ Doomsday Monitor** — header strip showing buffer depletion (green → amber → red), T-Nd, regime classification (STABLE, MELT_UP, CRASH, PHASE_TRANSITION, STAGNATION), Dragon-King probability, active-shock count.
+- **Scenario Injector** — preset shocks calibrated for the active domain (Strait of Hormuz closure, Abqaiq attack, LNG train outage, insulin supply-chain disruption, etc.). Each depletes the buffer per its severity.
+- News interpreter ingestion (article → graph interventions): the *engine logic* is here — the in-app paste/URL/loading panel UX is **UX**.
+- Engine modules:
+  - `src/lib/omega-engine.ts`
+  - `src/lib/pareto-relevance.ts`
+  - `src/lib/criticality-registry.ts`
+
+## Scope summary (out — route elsewhere)
+
+- Right-panel chrome, tabs, expand-panel UX → **UX & Onboarding**.
+- Canvas color encoding of Ω-Fragility (hotter = higher Ω) → **Rendering** draws; PARETO supplies values.
+- News-interpreter UI (paste affordance, URL fetch button, loading skeletons, error copy) → **UX**.
+- Graph data → **data sessions**.
+- Interventions / Monte Carlo cascade simulation → **PEARL** (PARETO consumes intervention output to update criticality; PEARL produces it).
+- Auth / API gating → **Platform**.
+
+## Boundary clarifications
+
+- **News interpreter**: engine logic and the article→intervention transformation are PARETO. The panel where users paste a URL/article, the loading state, and the error message wording are UX.
+- **Empty-state copy** (e.g. "NO DATA — static Ω only" on ΩF SERIES cards): the *trigger condition* is PARETO; the *wording* is UX.
+
+## Anchor files
+
+- `src/lib/omega-engine.ts`
+- `src/lib/pareto-relevance.ts`
+- `src/lib/criticality-registry.ts`
+- `src/lib/cascade-simulator.ts` (shared with PEARL)
+- News interpreter UI surface: `src/components/news/*` (UX-owned chrome around PARETO logic).
+- TODO: identify any PARETO-specific API routes.
+
+## Shipped PRs (representative)
+
+- **#52** — news interpreter panel: article → graph interventions
+- **#58** — URL-fetch button: paste a link instead of full article text
+- **#109** — real F·E·G·S relevance score with LPPLS and PH grid-fits
+
+## Likely upcoming themes
+
+- Tighter LPPLS / PH fits as more time-series land.
+- Scenario library expansion per active domain.
+- Cross-domain Ω composition for multi-domain workspaces.
+- TODO: fill in as the session ships work.
+
+## How to start a task
+
+1. Confirm in-scope (criticality signals, Ω-Fragility, scenario injection, news interpretation logic).
+2. Coordinate with PEARL when intervention output should update criticality estimates.
+3. Coordinate with UX when changing user-visible copy on cards / news panel / empty states.

--- a/docs/sessions/payments.md
+++ b/docs/sessions/payments.md
@@ -1,0 +1,49 @@
+# Session: Payments
+
+Owns billing, payment processing, paid-tier gating, and any commercial-flow UI/logic. Distinct from the trial/trusted access model in **Platform** — that gate decides *whether you can sign in at all*; payments decides *what you can do once you're in*.
+
+> **Status:** session is active but the codebase doesn't yet have meaningful billing surface area as of this writing — no Stripe integration, no subscription state, no paid feature flags found in code search. Most of the scope below is forward-looking. Update this doc as work lands.
+
+## Scope summary (in)
+
+- Payment provider integration (likely Stripe — confirm when the session decides).
+- Subscription state in the database (e.g. `profiles.subscription_tier`, `subscriptions` table — TBD by this session).
+- Webhooks for payment events (Stripe checkout completed, subscription updated, invoice failed, etc.). Lives in `src/app/api/webhooks/stripe/` or similar (TBD).
+- Paywall UI — "upgrade to access this", checkout redirect, post-checkout return state.
+- Tier-gated features inside the app: which engines/datasets/seats/limits each tier unlocks.
+- Billing portal links (Stripe customer portal, invoice history).
+- Pricing copy and CTAs (the words on the pricing page; coordinate with UX for tone).
+
+## Scope summary (out — route elsewhere)
+
+- Auth, sign-up, the trial/trusted access model (`profiles.access_type`), invite codes → **Platform**. Payments builds *on top of* the user record Platform owns.
+- The mechanics of inserting/updating the user record from Stripe webhooks — the *webhook handler* lives here, but it writes through the same `profiles` schema Platform manages. Coordinate when adding columns.
+- In-app empty states / upsell modals / "this feature requires Pro" copy *positioning* → **UX & Onboarding** owns the visual treatment; Payments owns the *gating logic* and the data-driven CTA.
+- Engine logic and outputs → respective engine sessions. Whether a tier *can run* PEARL or PARETO is Payments; what PEARL or PARETO actually computes is the engine session.
+
+## Boundary clarifications
+
+- **Trial expiry vs. subscription expiry**: trial expiry is Platform (48h, hardcoded, no money involved). Subscription expiry is Payments (driven by Stripe events, money involved). They share the `profiles` table but live in different columns.
+- **Webhook chain**: Platform owns the GitHub webhook chain (feedback → PR). Payments owns the Stripe webhook chain. Both should follow the same HMAC-verification pattern; share helpers.
+- **Admin actions**: promoting a user to trusted is Platform. Comping a user with a paid tier or refunding is Payments — both touch `profiles`/related tables but for different reasons. Document clearly which admin path to use.
+
+## Anchor files (current / planned)
+
+- TODO: confirm provider (Stripe assumed).
+- Webhook route: `src/app/api/webhooks/stripe/` (planned).
+- Pricing page: `src/app/pricing/` (planned, if customer-facing).
+- Tier-gating helper: probably `src/lib/billing/` or `src/lib/tiers/` (TBD).
+- Schema additions: future `supabase-payments.sql` migration alongside the existing `supabase-setup.sql` and `supabase-feedback-pipeline.sql`.
+
+## Likely upcoming themes
+
+- First Stripe integration (checkout + customer portal + webhooks).
+- Defining tier matrix (what each tier unlocks).
+- Plumbing tier checks into engine API routes (server-side guards) and into UX (paywall modals, locked CTAs).
+- TODO: fill in once active session has more history.
+
+## How to start a task
+
+1. Confirm in-scope. Money / billing / subscription state / paid-tier gating → yes. Auth or trial mechanics → flag and route to Platform.
+2. For schema changes that touch `profiles` or related tables, coordinate with Platform — it's the canonical owner of that schema.
+3. For paywall UI, write the gating logic here and hand the visual treatment to UX (or co-author).

--- a/docs/sessions/pearl.md
+++ b/docs/sessions/pearl.md
@@ -1,0 +1,68 @@
+# Session: PEARL (Do-Calculus, Interventions, CASCADE DEFENSE)
+
+Owns the structural-intervention engine: do-calculus, manual ablations (SEVER / ABLATE), and the auto-interdiction optimizer rebranded as **CASCADE DEFENSE**.
+
+> **Status:** session brief is being inferred from cross-references — fill in detail as the session establishes itself.
+
+## Scope summary (in)
+
+- **Do-calculus** — `do(X)` interventions that isolate a node from its causes.
+- **Manual ablations** — SEVER (cuts an edge; goes amber, functionally removed but physically possible), ABLATE (deletes nodes/edges entirely).
+- **CASCADE DEFENSE** (auto-interdiction):
+  - Minimax optimization to find the cheapest set of edges whose removal maximally reduces downstream cascade damage.
+  - When attacker-defender min-cut is solvable: explicit SEVER / ABLATE buttons per recommended cut.
+  - When not: fallback to a structural-vulnerability ranking of the next-most-brittle edges.
+  - Auto-triggers a Monte Carlo forecast so the user sees the expected damage distribution before committing.
+- Counterfactual timeline support — the Time Dial gains a second timeline (BASELINE vs INTERVENTION) when an intervention exists. PEARL produces the counterfactual data; the time-dial UI mechanics are shared with Rendering.
+- VX-880 trial fits as a survival prior into Monte Carlo (ref #107).
+- Engine modules:
+  - `src/lib/intervention-engine.ts`
+  - `src/lib/ablation-engine.ts`
+  - `src/lib/interdiction-engine.ts`
+  - `src/lib/monte-carlo-engine.ts`
+  - `src/lib/cascade-simulator.ts`
+  - `src/lib/trial-prior.ts`
+
+## Scope summary (out — route elsewhere)
+
+- Vocabulary distinction between manual interdiction (PEARL) and CASCADE DEFENSE (auto) → **UX & Onboarding** owns the copy; PEARL owns the underlying mechanic.
+- Canvas state changes (amber edges, deleted nodes) → **Rendering** draws; PEARL decides the state.
+- Right-panel UI and module tabs → **UX & Onboarding**.
+- Time-dial scrubber UI → **Rendering** / **UX**; PEARL provides the counterfactual data.
+- Graph data → respective **data sessions**.
+- SPIRTES / TARSKI / PARETO outputs that feed PEARL inputs → respective engine sessions.
+
+## Boundary clarifications
+
+- **CASCADE DEFENSE rename**: vocabulary is locked at "CASCADE DEFENSE" (replacing "Interdiction") per #31. UX session enforces; PEARL respects in any new copy added inside engine output.
+- **Trial-prior plumbing**: PEARL consumes VX-880 trial data (`src/lib/vx880-trial-data.ts`). The data file itself is a data-session concern (T1D); PEARL is a consumer.
+
+## Anchor files
+
+- `src/lib/intervention-engine.ts`
+- `src/lib/ablation-engine.ts`
+- `src/lib/interdiction-engine.ts`
+- `src/lib/monte-carlo-engine.ts`
+- `src/lib/cascade-simulator.ts`
+- `src/lib/trial-prior.ts`
+- `src/components/VX880TrialPanel.tsx` (right-panel surface for trial data)
+- TODO: identify any PEARL-specific API routes.
+
+## Shipped PRs (representative)
+
+- **#31** — rename "Interdiction" → "CASCADE DEFENSE"; AI ablation interpretation engine-side
+- **#107** — wire VX-880 trial fits as a survival prior into Monte Carlo
+- **#108** — tighten PROTECT GRAFT shock; default MC target to trial outcome
+
+## Likely upcoming themes
+
+- Counterfactual visualization quality (BASELINE vs INTERVENTION clarity in the time dial).
+- Auto-interdiction performance on larger graphs.
+- More trial priors as additional T1D / other-domain trials are digitized.
+- TODO: fill in as the session ships work.
+
+## How to start a task
+
+1. Confirm in-scope (interventions, ablations, CASCADE DEFENSE, Monte Carlo, counterfactuals).
+2. Coordinate with PARETO when intervention output drives criticality changes.
+3. Coordinate with Rendering for any new visual treatment of intervened edges/nodes.

--- a/docs/sessions/platform.md
+++ b/docs/sessions/platform.md
@@ -1,0 +1,71 @@
+# Session: Platform
+
+Owns identity, access control, server-side plumbing, and the admin tooling that sits behind the in-app surfaces. Anything between "user opens the URL" and "user sees the app" is in scope; anything inside the app post-login is owned by the relevant feature session.
+
+> **Detailed reference docs already in the repo (read these first):**
+> - [`docs/AUTH.md`](../AUTH.md) — auth model, two-tier (trial/trusted), middleware, RLS, runbook for managing users.
+> - [`docs/feedback-pipeline-setup.md`](../feedback-pipeline-setup.md) — feedback → GitHub issue → agent PR → Vercel deploy chain.
+> - [`docs/DEPLOYMENT.md`](../DEPLOYMENT.md) — env vars, Vercel config.
+> - [`supabase-setup.sql`](../../supabase-setup.sql), [`supabase-feedback-pipeline.sql`](../../supabase-feedback-pipeline.sql) — schema.
+
+## Scope summary (in)
+
+### Auth & access control
+- Supabase auth provider integration
+- The two-tier access model: `trusted` (permanent, invite-code) vs `trial` (48h expiry)
+- `public.profiles` table, RLS policies
+- Edge middleware: `src/middleware.ts` (the single gate for all routes), `src/lib/supabase/middleware.ts`
+- Admin auth helpers: `src/lib/admin-auth.ts`
+- Sign-up routes: `/trusted-signup`, `/trial-signup`, `/expired`
+- Server endpoint: `POST /api/trusted-signup` (validates invite codes server-side)
+- **Account provisioning / whitelisting / promotion** — adding a user, promoting trial → trusted, revoking access. See §6.1 of `docs/AUTH.md` for the runbook.
+
+### Admin backend
+- `/admin/feedback` triage UI: `src/app/admin/feedback/`
+- Admin API routes: `src/app/api/admin/feedback/`
+- The feedback → GitHub issue → Claude agent PR → Vercel deploy webhook chain
+
+### Webhooks
+- `src/app/api/webhooks/github/` — PR-merge + deployment-status webhook handlers (HMAC-verified via `GITHUB_WEBHOOK_SECRET`)
+- Any future provider webhooks (Stripe is **Payments**, not here)
+
+### Server-side data plumbing
+- Supabase client setup: `src/lib/supabase/`
+- Server-side environment / config (`SUPABASE_SERVICE_ROLE_KEY`, `GITHUB_PIPELINE_TOKEN`, `ADMIN_EMAILS`, etc.)
+- API routes that don't belong to a specific engine: `src/app/api/trusted-signup/`, `src/app/api/webhooks/`, `src/app/api/admin/`
+
+## Scope summary (out — route elsewhere)
+
+- In-app UX (welcome modal, tour, feedback widget BUTTON & form, persona pills, header chrome, copy) → **UX & Onboarding** session. Platform owns the data/auth flow; UX owns what the user sees and clicks.
+- Billing, paywalls, tier-gated *features*, Stripe integration → **Payments** session. (Note: trial/trusted access tiers live in Platform; *paid* tier gating lives in Payments.)
+- Engine logic and the API endpoints that wrap them (`/api/compute`, `/api/copilot`, `/api/enrich`, `/api/news`, `/api/structure`) → respective **engine sessions**. Platform doesn't own the contents of those routes, just the auth/middleware that protects them.
+- Graph data, domain profiles → respective **data sessions** (Geopolitical/Macro, T1D).
+- Canvas, rendering, viewport → **Rendering** session.
+
+## Boundary clarifications
+
+- **Feedback widget**: UX owns the in-app button, form, validation, success/error toast, and the *shape* of the row written to `feedback`. Platform owns the Supabase insert mechanics, RLS, the admin triage UI, and the webhook chain that turns rows into PRs.
+- **Account provisioning**: Platform owns the entire mechanic. UX may need copy for "you're whitelisted, sign in here" emails or post-login welcome — that's a UX handoff after the row exists.
+- **Trial expiry UI**: the `/expired` page itself is Platform's (server-rendered, gated). The styling/branding alignment with the rest of the app is a UX consultation.
+- **API-route auth**: the engine sessions write the route logic; Platform writes the middleware that gates it. If an engine route needs a new auth shape (e.g. service role for an internal call), engine session asks Platform to extend the middleware.
+
+## Common task: provision a pilot user
+
+1. Confirm tier (almost always `trusted` for design partners / pilots).
+2. Insert/promote the row in `public.profiles` per `docs/AUTH.md` §6.1.
+3. Reply with: the sign-up URL the user should hit, whether they need an invite code, the email they must use, and any expiry/revocation considerations.
+
+## Likely upcoming themes
+
+- Pilot onboarding load (Sujit / Arka and similar).
+- Hardening the feedback → PR webhook chain as it gets more traffic.
+- Audit logging for admin actions (currently informal — promotions are just SQL updates).
+- Self-serve invite-code rotation (today: manual env-var update).
+- TODO: fill in once active session has more history.
+
+## How to start a task
+
+1. Confirm in-scope. Auth/Supabase/middleware/admin-backend/webhooks → yes. Anything else → flag and route per the table above.
+2. Read the relevant docs first: `docs/AUTH.md` for anything auth-shaped, `docs/feedback-pipeline-setup.md` for the agent-PR chain, `docs/DEPLOYMENT.md` for env vars.
+3. For schema changes, edit the `.sql` files in repo root and call out the migration step in the PR.
+4. For middleware changes, test that both `trusted` and `trial` flows still work, and that expired sessions still redirect to `/expired`.

--- a/docs/sessions/rendering.md
+++ b/docs/sessions/rendering.md
@@ -1,0 +1,56 @@
+# Session: Rendering
+
+Owns how the causal graph is drawn: 3D WebGL force-directed canvas, 2D React Flow canvas, MAP geographic projection, and the shared selection / viewport / camera mechanics across all three. Owns render performance.
+
+> **Status:** session brief is being inferred from cross-references — fill in detail as the session establishes itself.
+
+## Scope summary (in)
+
+- The canvas substrate that hosts all three views, mounting all three to preserve WebGL context across switches:
+  - **3D** — WebGL force-directed (default). Components: `src/components/CausalDAG3D.tsx`, `src/components/dag3d/DAGNode3D.tsx`, `src/components/dag3d/DAGEdge3D.tsx`, `src/components/dag3d/DAGOverlay.tsx`. Likely uses `@react-three/fiber` / `three`.
+  - **2D** — flat React Flow layout with animated causal flow. Component: `src/components/CausalDAG2D.tsx`.
+  - **MAP** — geographic projection via MapLibre for domains with real-world coordinates (energy infrastructure, etc.). Component: `src/components/CausalDAGMap.tsx`.
+- Top-level switcher / coordinator: `src/components/CausalDAG.tsx`.
+- Layout algorithms (force-directed, hierarchical, geo-projection) and view-mode buttons (top-right of canvas).
+- Viewport: orbit/zoom/pan, drag to orbit (3D), scroll to zoom, shift+drag for box-select.
+- Selection mechanics: click to select node and open inspector, shift+drag for subgraph selection.
+- Visual encoding: node size and color intensity for Ω-Fragility (hotter = more systemic risk), solid arrows for directed causal edges, dashed lines for confounded/latent.
+- Ancillary canvas UI: `RiskPropagationFlow.tsx` (per-node vulnerability cards above the time dial), `CanvasWatermark.tsx`.
+- Render performance — memoization, frustum culling, instancing, layout throttling, framerate budgets.
+
+## Scope summary (out — route elsewhere)
+
+- Tour anchors (`data-tour="..."`) on canvas chrome, including view-mode buttons → **UX & Onboarding** owns the anchor placement and tour mechanics; Rendering owns the underlying control. If a tour step requires a control to render/position differently, that's a Rendering ↔ UX collaboration.
+- Graph data — nodes, edges, domain profiles → respective **data sessions** (Geopolitical/Macro, T1D). Rendering consumes whatever the data layer hands it.
+- Engine outputs that drive node coloring (Ω-Fragility scores, criticality signals) → respective **engine sessions**. Rendering visualizes the values; engines compute them.
+- Inspector panel that opens on node click → **UX & Onboarding** for layout/copy; engine sessions for the per-pillar / per-criticality content inside.
+- Time-dial cascade replay scrubber → coordinated with PEARL (counterfactual timelines) and PARETO (criticality replay).
+
+## Boundary clarifications
+
+- **Tour ↔ Rendering**: anchors and overlays are UX's; the canvas controls themselves are Rendering's. Adding a `data-tour` attribute is UX. Repositioning or restyling a control to make it tour-able is Rendering.
+- **Empty / loading states on canvas**: copy is UX, presence-of-state is Rendering. If the canvas has no graph yet, Rendering renders the placeholder structure; UX writes the words.
+- **Map projection**: Rendering owns the MapLibre setup and projection math. Whether a domain *has* coordinates to project is a data-session concern.
+
+## Anchor files
+
+- `src/components/CausalDAG.tsx` — top-level switcher.
+- `src/components/CausalDAG2D.tsx` — React Flow.
+- `src/components/CausalDAG3D.tsx` + `src/components/dag3d/*` — three.js / r3f.
+- `src/components/CausalDAGMap.tsx` — MapLibre.
+- `src/components/RiskPropagationFlow.tsx` — risk cards.
+- `src/components/CanvasWatermark.tsx` — branding overlay on canvas.
+
+## Likely upcoming themes
+
+- Performance with larger graphs (>500 nodes).
+- Cross-view consistency (same selection across 3D/2D/MAP).
+- Counterfactual visualization when PEARL injects an intervention timeline.
+- Mobile/touch viewport — currently desktop-only.
+- TODO: fill in as the session ships work.
+
+## How to start a task
+
+1. Confirm in-scope (canvas, layout, viewport, selection, render perf).
+2. Be careful not to break the all-three-mounted invariant — switching views must not lose WebGL context.
+3. Coordinate with engine sessions when changing how engine outputs are visualized.

--- a/docs/sessions/spirtes.md
+++ b/docs/sessions/spirtes.md
@@ -1,0 +1,45 @@
+# Session: SPIRTES (Causal Structure Discovery)
+
+Owns the engine that discovers causal structure from data. Runs three discovery algorithms in parallel and surfaces results to the UI as edges and edge annotations.
+
+> **Status:** session brief is being inferred from cross-references — fill in detail as the session establishes itself.
+
+## Scope summary (in)
+
+- **DCD / NOTEARS** — nonlinear structure discovery.
+- **PCMCI+** — time-lagged causal effects across T-2 / T-1 / T-0 columns.
+- **FCI** — hidden-confounder detection. Latent common causes surface as dashed edges with `?` markers.
+- Cascade-header readouts driven by SPIRTES output (e.g. spectral radius λmax — below 1.0 the network is contractive and stable).
+- Discovery API endpoint: `src/app/api/structure/route.ts`.
+- Right-panel rendering of discovery results — *the engine's contribution* to the panel; the panel chrome itself is UX.
+
+## Scope summary (out — route elsewhere)
+
+- The right-panel layout, module tabs, and tab-switching UX → **UX & Onboarding**.
+- The graph data and node/edge schema → respective **data sessions** (Geopolitical/Macro, T1D).
+- Canvas rendering of edges (solid, dashed, color) → **Rendering**. SPIRTES *outputs* the edge type; Rendering draws it.
+- Constraint verification of discovered edges → **TARSKI**. SPIRTES proposes; TARSKI audits.
+- Auth / API gating → **Platform**.
+
+## Boundary clarifications
+
+- **Edge styling**: SPIRTES decides `solid` vs `dashed` vs `?` semantically. Rendering decides the visual treatment.
+- **Snapshots**: when discovery results are part of a System State Snapshot for the copilot, the snapshot mechanics are shared with PEARL/PARETO/TARSKI; agree on a common snapshot schema.
+
+## Anchor files (current / inferred — verify in session)
+
+- `src/app/api/structure/route.ts` — discovery API.
+- `src/lib/graph-data.ts`, `src/lib/athena-graph-data.ts` — graph data this engine reads. (Owned by data sessions; SPIRTES is a consumer.)
+- TODO: identify the SPIRTES-specific engine module (if any) vs. logic spread across `copilot-engine.ts` / `omega-engine.ts` and consolidate.
+
+## Likely upcoming themes
+
+- Hardening of latent-confounder detection (FCI) for production graphs.
+- Confidence/uncertainty surfacing in the right panel.
+- TODO: fill in as the session ships work.
+
+## How to start a task
+
+1. Confirm in-scope (structure discovery algorithms, their outputs, the structure API route).
+2. Coordinate with TARSKI when discovered edges affect verification.
+3. Coordinate with Rendering when changing how edge types are encoded visually.

--- a/docs/sessions/t1d.md
+++ b/docs/sessions/t1d.md
@@ -1,0 +1,64 @@
+# Session: T1D / Life Sciences
+
+Owns the Type-1 Diabetes graph data, β-cell dynamics, T1D-specific domain profile, and the vocabulary that flows through the sidebar/inspector when a T1D dataset is active.
+
+> **Status:** session brief is being inferred from cross-references — fill in detail as the session establishes itself.
+
+## Scope summary (in)
+
+- T1D graph data:
+  - `src/lib/t1d-graph-data.ts` — main T1D causal graph.
+  - `src/lib/t1d-vx880-graph-data.ts` — VX-880 trial-specific graph.
+  - `src/lib/vx880-trial-data.ts` — trial cohort data, NLME decay, Cox HR readout (#105).
+  - `src/lib/t1d-estimator-inputs.ts` — estimator input wiring.
+- T1D domain profile entries in `src/lib/domain-profiles.ts`.
+- Persona mapping: T1D datasets are **Scientist** persona under Analyst/Scientist/Cross-Domain (`dataset: t1d`).
+- T1D-specific vocabulary surfaced in sidebar / inspector / pillar labels (note: per #70, top-bar module tabs stay canonical SPIRTES/TARSKI/PEARL/PARETO regardless of profile).
+- Pillar / regulatory tier definitions specific to T1D (FDA accelerated-approval, pediatric trial restrictions, orphan designation, ex-US approval divergence).
+- Time-series mappings for T1D nodes — `src/lib/node-timeseries-map.ts` Tier-A entries (digitised published sources). Nodes without Tier-A mapping fall back to NO-DATA sparklines.
+- Trial-cohort UI surface: `src/components/VX880TrialPanel.tsx`.
+- Constraint authoring (regulatory tier definitions) co-authored with **TARSKI**.
+
+## Scope summary (out — route elsewhere)
+
+- Engine logic (SPIRTES discovery, TARSKI verification, PEARL interventions, PARETO criticality) → respective **engine sessions**. T1D supplies the data and domain-specific constants; engines compute on it.
+- Persona pill UX, Domain Workspace card layout, persona switching mechanics → **UX & Onboarding**. T1D defines the domain entries; UX renders the cards and pills.
+- Canvas, layout, viewport → **Rendering**.
+- Auth / API gating → **Platform**.
+
+## Boundary clarifications
+
+- **Vocabulary**: T1D-specific module names / pillar labels live in the T1D `DomainProfile` entry. They flow through sidebar and inspector. They do **not** flow through the top-bar tabs (those are pinned canonical labels per #70).
+- **Trial priors**: T1D owns the trial-data files (VX-880, etc.). PEARL consumes them as a survival prior into Monte Carlo (#107). Adding a new trial means updating both — coordinate.
+
+## Anchor files
+
+- `src/lib/t1d-graph-data.ts`
+- `src/lib/t1d-vx880-graph-data.ts`
+- `src/lib/vx880-trial-data.ts`
+- `src/lib/t1d-estimator-inputs.ts`
+- `src/lib/node-timeseries-map.ts` (Tier-A T1D entries)
+- `src/lib/domain-profiles.ts` (T1D profile entries)
+- `src/components/VX880TrialPanel.tsx`
+- Reference doc: [`docs/MANIFOLD_FOR_T1D.md`](../MANIFOLD_FOR_T1D.md) and the T1D restoration HTMLs under `docs/`.
+
+## Shipped PRs (representative)
+
+- **#61** — M-T1D-02 estimator suite: Python reference + TS ports (BOCPD, TE, Moran, Takens)
+- **#105** — VX-880 trial cohort analysis panel: NLME decay + Cox HR readout
+- **#106** — wire `t1d-vx880` selector id to T1D VX-880 graph domain
+- **#107** — wire VX-880 trial fits as a survival prior into Monte Carlo
+- **#108** — tighten PROTECT GRAFT shock; default MC target to trial outcome
+
+## Likely upcoming themes
+
+- Additional digitized trials (beyond VX-880) as Tier-A data lands.
+- Tier-B / Tier-C dataset onboarding (the sparkline NO-DATA fallbacks).
+- Profile-specific shock library expansion (PARETO scenario injector).
+- TODO: fill in as the session ships work.
+
+## How to start a task
+
+1. Confirm in-scope (T1D data, profile, vocabulary, trial digitization).
+2. Coordinate with the relevant engine session when adding/editing data they consume.
+3. Coordinate with UX when adding new persona-mapped domain cards.

--- a/docs/sessions/tarski.md
+++ b/docs/sessions/tarski.md
@@ -1,0 +1,47 @@
+# Session: TARSKI (Constraint Verification)
+
+Owns the engine that audits every edge in the causal graph against domain-aware axioms in three tiers: PHYSICAL, REGULATORY, HEURISTIC.
+
+> **Status:** session brief is being inferred from cross-references — fill in detail as the session establishes itself.
+
+## Scope summary (in)
+
+- The three axiom tiers:
+  - **PHYSICAL** — immutable laws.
+  - **REGULATORY** — sanctions, export controls, treaties, FDA tiers, IRB constraints.
+  - **HEURISTIC** — anomaly flags.
+- Auto-ranking constraints by relevance to active domains.
+- The VERIFY action: toggle axioms, run verification, recolor canvas (violating edges → red), expose clickable proof traces explaining which constraint failed.
+- Constraint catalog and proof-trace logic.
+- Snapshot validator: `src/lib/snapshots/tarski-validator.ts`.
+
+## Scope summary (out — route elsewhere)
+
+- Right-panel chrome and tab UX → **UX & Onboarding**.
+- Canvas recoloring of violating edges → **Rendering** does the recolor; TARSKI decides which edges violate.
+- Graph data (the edges being verified) → **data sessions**.
+- Discovery of new edges (which TARSKI then verifies) → **SPIRTES**.
+- Auth / API gating → **Platform**.
+
+## Boundary clarifications
+
+- **Constraint authoring**: domain-specific constraints (T1D regulatory tiers, geopolitical sanctions) are authored *with* the relevant data session but the verification mechanism stays here.
+- **Profile-specific axioms**: each `DomainProfile` may surface its own axioms — TARSKI consumes the profile, doesn't define it.
+
+## Anchor files (current)
+
+- `src/lib/tarski-data.ts` — constraint catalog.
+- `src/lib/snapshots/tarski-validator.ts` — verification logic for snapshots.
+- TODO: identify the verify-API route (likely under `src/app/api/`) and any UI integration files.
+
+## Likely upcoming themes
+
+- Expanding the regulatory axiom set as more domains land.
+- Per-domain auto-ranking quality.
+- TODO: fill in as the session ships work.
+
+## How to start a task
+
+1. Confirm in-scope (axioms, verification, proof traces, the VERIFY action).
+2. Coordinate with the data session whose constraints are being added/edited.
+3. Coordinate with Rendering when changing the visual representation of violations.

--- a/docs/sessions/ux-onboarding.md
+++ b/docs/sessions/ux-onboarding.md
@@ -1,0 +1,145 @@
+# Session: UX & Onboarding
+
+Owns **what users see, click, and learn before they're productive**, plus the chrome around the experience after that.
+
+## Product context
+
+Manifold (internal: Apex Terminal) is a causal-graph terminal for systemic-risk analysis. Production: https://manifold.apexanalytica.co. The same substrate renders as either a geopolitical-risk terminal or a medical-research (T1D) terminal via a `DomainProfile` seam. Most users are first-time visitors who need to be walked into a non-trivial product.
+
+This session does **not** care about graph data, engines, canvas rendering, or platform plumbing. It owns the moment-of-arrival experience and the persistent chrome.
+
+## Surfaces this session owns
+
+### First-visit flow
+- Welcome modal + Domain Workspace + auto-launching SpotlightTour
+- Component: `src/components/SpotlightTour.tsx`
+- Storage flag: `localStorage["manifold:tour-seen"]`
+- Uses `data-tour="..."` anchors throughout the app to attach steps to UI elements
+- Tour currently has 22+ steps covering persona-based domain selector, 3D/2D/MAP views, text-size toggle, PEARL manual vs CASCADE DEFENSE auto-interdiction, feedback widget, etc.
+
+### Persona gating
+- `activePersona: "scientist" | "analyst" | "cross"` in `useApexStore`, default `"analyst"`
+- Three pills in the Domain Workspace modal control which domain cards are visible:
+  - **Analyst** → geopolitical / financial / macro / defense (`dataset: main | athena`)
+  - **Scientist** → Life Sciences (`dataset: t1d`)
+  - **Cross-Domain** → all cards; only persona where multi-select across dataset families is allowed
+- Switching persona silently drops out-of-family selections
+- Within Analyst/Scientist, multi-select is restricted to the same family
+- Canonical type union lives in `useApexStore.ts`. `DomainSelector.tsx` mirrors it locally — keep them in sync.
+
+### Domain Workspace modal
+- `src/components/DomainSelector.tsx`
+- Persona pills, domain cards by group (LIFE SCIENCES / MACRO IMPACT / etc.), single vs multi-domain mode toggle, "launch workspace" CTA
+
+### Header bar chrome
+- `src/components/HeaderBar.tsx`
+- Top-bar module tabs are pinned to canonical SPIRTES/TARSKI/PEARL/PARETO labels (per #70)
+- Profile-scoped vocabulary (T1D module names, pillar labels) flows through the sidebar and inspector, *not* the top bar
+
+### Text size toggle
+- `src/components/TextSizeToggle.tsx`, `src/hooks/useTextSize.ts`
+- S/M/L segmented control persisted to `localStorage["manifold:text-size"]`
+- Applied via CSS `zoom` on `<html>` (the app uses ~700 fixed px text classes so root font-size won't propagate)
+- Pre-paint inline script in `src/app/layout.tsx` prevents flash-of-wrong-size
+
+### Feedback widget
+- `src/components/FeedbackWidget.tsx`
+- Fixed-position button + modal
+- Drops a row into Supabase `feedback` table, which feeds the admin triage → agent PR → deploy pipeline
+- The backend of that pipeline is **Platform-owned**; only the in-app widget UX is ours
+
+### Branding / labels / copy
+- "Manifold" is the primary brand title
+- "Interdiction" is renamed "CASCADE DEFENSE" (#31)
+- Manual interdiction in PEARL vs auto-interdiction is a vocabulary distinction users need to learn
+
+### News interpreter UI
+- `src/components/news/*`
+- Panel that lets users paste an article URL or text and turns it into graph interventions
+- The data flow is engine-side; the panel UX (URL fetch button, paste affordance, loading states, error display) is ours
+
+## Scope summary (in)
+
+- Tour content + step targeting + auto-launch logic + cutout/highlight/arrow behavior
+- Welcome modal, modal collisions, first-visit storage flags
+- Persona pill UX, gating logic, default-persona decisions, multi-select rules
+- Domain Workspace modal layout, card grouping, mode toggle, launch CTA
+- Header chrome (text size toggle, button placement, label pinning, FEEDBACK button conflicts)
+- Feedback widget UX (entry affordance, form, success/error states)
+- Brand vocabulary, terminology consistency, copy decisions
+- Onboarding metrics / instrumentation if/when added
+- Accessibility (keyboard nav, focus traps in modals, escape behavior, contrast for dim/cutout layers)
+- Empty states, loading states, error toasts across the app
+
+## Scope summary (out — route elsewhere)
+
+Each item routes to its own session. Do not absorb out-of-scope work; flag and route.
+
+- Graph data, nodes, edges, domain profiles (other than the persona→profile mapping) → **Geopolitical/Macro** or **T1D** session
+- Engine logic (Pearl MC, Pareto criticality, Spirtes discovery, Tarski axioms) → respective **engine sessions**
+- 2D/3D canvas, layout algorithms, viewport, selection mechanics, render perf → **Rendering** session
+- Auth, Supabase plumbing, middleware, webhooks, the `/admin/feedback` triage backend, **account provisioning / whitelisting** → **Platform** session
+- Payments, billing, tier gating logic → **Payments** session
+
+Tour UX and persona gating sometimes cross into Rendering or Platform — flag boundary cases and route.
+
+## Boundary clarifications
+
+- **Tour ↔ Rendering**: anchors and tour mechanics are ours even when they sit on canvas chrome, but if a step requires changing how a canvas control renders/positions, that's a Rendering handoff.
+- **Feedback widget ↔ Platform**: we own the button, modal, form fields, validation, success/error toast, and the *shape* of the row written to `feedback`. Platform owns the Supabase insert call, the admin triage UI, the GH-issue/agent-PR/deploy webhook chain, and any auth context attached server-side.
+- **News interpreter ↔ Pareto/engine**: we own paste-vs-URL affordance, fetch button, loading skeletons, error copy, empty state. The actual article→intervention transformation, the engine call, and the resulting graph mutation are not ours.
+- **Empty-state copy on data-driven cards** (e.g. "NO DATA — static Ω only" on ΩF SERIES): the *wording* is ours, the *condition that triggers it* belongs to the data session.
+- **Persona persistence**: currently resets on page load by design. May revisit. If a task asks to make persona persist, check first because it touches store-hydration timing other sessions care about.
+
+## Shipped PRs in this scope (history)
+
+Tour (huge investment, ~10 PRs in late April):
+- **#89** — rewrote SpotlightTour to 24 steps, auto-launches on first visit via `manifold:tour-seen`, dashed cyan connector arrow + cyan ring around cutout, added `data-tour` anchors
+- **#90** — fixed welcome/domain-selector modal collision on first visit
+- **#93** — don't strand users when they click outside the cutout on first visit
+- **#94** — auto-advance when user interacts with the highlighted element (later partially reverted in #100)
+- **#95** — let clicks reach the highlighted element; dropped the cyan ring
+- **#96** — restored a prominent border around the cutout
+- **#98** — guarantee the cutout is un-dimmed; backdrop click no longer closes the tour
+- **#99** — gate advance on domain pick; flush cutout against the modal body
+- **#100** — dual highlight on module-tabs (tabs + right panel via `secondaryTargetSelector`); migrated dim from 4 divs to an SVG mask to support multiple cutouts; removed click-to-advance
+- **#112** — replace SVG mask with `<path fill-rule="evenodd">` so the cutout is truly un-dimmed across all browsers
+
+Persona + workspace:
+- **#70** — persona pills in Domain Workspace; `activePersona` in `useApexStore`; pinned top-bar module labels to `GEOPOLITICAL_PROFILE.modules`
+- **#74** — subdivided ANALYST persona; fixed active pill highlight bug
+- **#92** — refactored `DomainSelector` to drop the static `CASCADE_EXAMPLES` lookup + panel
+
+Header chrome:
+- **#85** — text-size toggle (S/M/L) using CSS `zoom` on `<html>`, localStorage persistence, pre-paint inline script
+- **#53** — keep module panel content clear of the fixed FEEDBACK button
+
+Branding / vocabulary:
+- **#23** — Manifold branding + interactive DAG overlays
+- **#29, #30** — make MANIFOLD the primary brand title
+- **#31** — rename "Interdiction" to "CASCADE DEFENSE"
+- **#68** — removed click-to-speak affordance (deprecated voice I/O #20)
+
+Feedback widget UX:
+- **#79** — full feedback-to-prod pipeline (admin/feedback triage UI + GH issue + Claude agent PR + Vercel deploy webhook). Widget is the entry point we own.
+
+News interpreter UI:
+- **#52** — news interpreter panel: article → graph interventions
+- **#58** — URL-fetch button: paste a link instead of full article text
+
+## Likely upcoming themes
+
+- Real-user feedback from the production pipeline that lands as UX bug reports — triage and route here vs. other sessions.
+- Onboarding completion metrics (how many users finish the tour, where they drop off) — not instrumented yet.
+- Persona selection persistence (currently resets on page load).
+- Empty-state language across modules (e.g. "NO DATA — static Ω only" on ΩF SERIES; data-side trigger, our wording).
+- Mobile/tablet responsive behavior — desktop-first; likely a real UX project once a customer asks.
+
+## How to start a task
+
+When given a task in this session:
+
+1. Confirm the task is in-scope. If it sits on a boundary, flag and route rather than absorb.
+2. For tour-step changes, look for the `data-tour="..."` anchor in the target component first — adding a new anchor is often the right move before touching `SpotlightTour.tsx`.
+3. For persona logic, the canonical type union lives in `useApexStore.ts`. `DomainSelector.tsx` mirrors it locally — keep them in sync.
+4. Verify visual/interaction changes by running the dev server, clearing `localStorage["manifold:tour-seen"]` to retest first-visit flows, and snapshotting key states. Don't ask the user to check manually unless tooling truly can't.

--- a/src/components/SpotlightTour.tsx
+++ b/src/components/SpotlightTour.tsx
@@ -365,6 +365,7 @@ export default function SpotlightTour() {
 
   const [cutout, setCutout] = useState<CutoutRect | null>(null);
   const [secondaryCutout, setSecondaryCutout] = useState<CutoutRect | null>(null);
+  const [viewport, setViewport] = useState<{ w: number; h: number }>({ w: 0, h: 0 });
   const [tooltipPos, setTooltipPos] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
   const [showDomainHint, setShowDomainHint] = useState(false);
   const tooltipRef = useRef<HTMLDivElement>(null);
@@ -391,6 +392,7 @@ export default function SpotlightTour() {
     };
     setCutout(measure(step?.targetSelector ?? null));
     setSecondaryCutout(measure(step?.secondaryTargetSelector));
+    setViewport({ w: window.innerWidth, h: window.innerHeight });
   }, [step]);
 
   const updatePositions = useCallback(() => {
@@ -557,38 +559,47 @@ export default function SpotlightTour() {
     tooltipHeightRef.current,
   );
 
+  // Build a single dim path: outer viewport rect plus a rounded-rect
+  // sub-path per cutout. With fill-rule="evenodd" each inner sub-path
+  // subtracts from the fill, regardless of winding — so the highlighted
+  // element renders at full brightness. No SVG mask, no browser ambiguity.
+  const dimPath = (() => {
+    const { w, h } = viewport;
+    if (!w || !h) return "";
+    let d = `M0 0 H${w} V${h} H0 Z`;
+    const addHole = (c: CutoutRect) => {
+      const r = Math.min(8, c.width / 2, c.height / 2);
+      const x2 = c.x + c.width;
+      const y2 = c.y + c.height;
+      // Standard CW rounded rect — evenodd subtracts it regardless.
+      d += ` M${c.x + r} ${c.y}`;
+      d += ` H${x2 - r}`;
+      d += ` A${r} ${r} 0 0 1 ${x2} ${c.y + r}`;
+      d += ` V${y2 - r}`;
+      d += ` A${r} ${r} 0 0 1 ${x2 - r} ${y2}`;
+      d += ` H${c.x + r}`;
+      d += ` A${r} ${r} 0 0 1 ${c.x} ${y2 - r}`;
+      d += ` V${c.y + r}`;
+      d += ` A${r} ${r} 0 0 1 ${c.x + r} ${c.y}`;
+      d += ` Z`;
+    };
+    if (cutout) addHole(cutout);
+    if (secondaryCutout) addHole(secondaryCutout);
+    return d;
+  })();
+
   return (
     <AnimatePresence>
       <div className="fixed inset-0 z-[60]" style={{ pointerEvents: "none" }}>
-        {/* Dim + borders + arrows via a single SVG. Mask-based dim supports
-            multiple cutouts (e.g. module-tabs + module-panel). SVG is
+        {/* Dim + borders + arrows via a single SVG. The dim is one
+            evenodd-filled path with the viewport as the outer ring and each
+            cutout as a hole — supports any number of cutouts and is
+            unambiguous across browsers (the prior SVG mask had inconsistent
+            behavior in some engines, leaving the cutout looking dim). SVG is
             pointer-events-none so clicks pass through; the tour only closes
             via SKIP TOUR / Esc / finishing. */}
         <svg className="absolute inset-0 w-full h-full pointer-events-none">
           <defs>
-            <mask id="spotlight-mask" maskUnits="userSpaceOnUse">
-              <rect x="0" y="0" width="100%" height="100%" fill="white" />
-              {cutout && (
-                <rect
-                  x={cutout.x}
-                  y={cutout.y}
-                  width={cutout.width}
-                  height={cutout.height}
-                  rx={8}
-                  fill="black"
-                />
-              )}
-              {secondaryCutout && (
-                <rect
-                  x={secondaryCutout.x}
-                  y={secondaryCutout.y}
-                  width={secondaryCutout.width}
-                  height={secondaryCutout.height}
-                  rx={8}
-                  fill="black"
-                />
-              )}
-            </mask>
             <marker
               id="spotlight-arrowhead"
               viewBox="0 0 10 10"
@@ -601,14 +612,13 @@ export default function SpotlightTour() {
               <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--accent-cyan, #00e5ff)" />
             </marker>
           </defs>
-          <rect
-            x="0"
-            y="0"
-            width="100%"
-            height="100%"
-            fill="rgba(0, 0, 0, 0.78)"
-            mask="url(#spotlight-mask)"
-          />
+          {dimPath && (
+            <path
+              d={dimPath}
+              fillRule="evenodd"
+              fill="rgba(0, 0, 0, 0.78)"
+            />
+          )}
           {/* Primary border */}
           {cutout && (
             <motion.rect


### PR DESCRIPTION
## Summary

Persists session boundaries previously held only in conversation briefs into the repo, so each session can boot by reading `docs/sessions/<name>.md` instead of re-pasting context. When scope shifts, edit the doc once.

- `README.md` — routing table for all 10 sessions
- `ux-onboarding.md` — full brief (richest, ported from this session's brief)
- `platform.md` — auth, Supabase, middleware, admin/feedback backend, webhooks, account provisioning. Cross-references existing [`docs/AUTH.md`](https://github.com/ApexAnalytica/apex-terminal/blob/main/docs/AUTH.md) and [`docs/feedback-pipeline-setup.md`](https://github.com/ApexAnalytica/apex-terminal/blob/main/docs/feedback-pipeline-setup.md) instead of duplicating
- `payments.md` — billing / paid-tier gating; thin and forward-looking (no Stripe in repo yet)
- `rendering.md` — 2D/3D/MAP canvas, viewport, render perf
- `spirtes.md`, `tarski.md`, `pearl.md`, `pareto.md` — engine sessions
- `t1d.md`, `geopolitical-macro.md` — data sessions

Skeletons for non-UX sessions are inferred from cross-references and file scans — they include explicit `TODO: fill in` markers. As each session ships work, that session should own updates to its own doc.

## How to use

When opening a new session, tell the agent:

> Your scope is in `docs/sessions/<name>.md`. Read it, then: \<task\>.

That replaces the long brief that previously had to be re-pasted into each session.

## Test plan

- [ ] Verify links in `README.md` resolve
- [ ] Have one non-UX session (e.g. Platform) read its doc and confirm it's accurate enough to work from — flag inaccuracies for the responsible session to edit

https://claude.ai/code/session_016LDegKy2R7Ly91ahAnBAQX

---
_Generated by [Claude Code](https://claude.ai/code/session_016LDegKy2R7Ly91ahAnBAQX)_