### PR TITLE
feat(discovery): D1NAMO ingester + lag-correlation algorithm — first real-data discovery loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,10 @@ __pycache__/
 *.pyc
 
 # discovery — raw cohort data and run artefacts NEVER committed.
-# Adapters read source files from /research/datasets/<cohort-id>/raw/;
-# discovery runs land as JSON under /research/runs/. Both local-only.
-/research/datasets/*/raw/
+# Anything in a /research/datasets/<cohort-id>/ subdirectory is treated
+# as local-only data (raw zips, parsed cohort.json, intermediate
+# manifests). The Python loader scripts live at /research/datasets/*.py
+# (top-level), which is NOT gitignored. Discovery runs land as JSON
+# under /research/runs/, also local-only.
+/research/datasets/*/
 /research/runs/

--- a/research/sample-runs/d1namo-lag-correlation-v0-1-0.json
+++ b/research/sample-runs/d1namo-lag-correlation-v0-1-0.json
@@ -1,0 +1,155 @@
+{
+  "id": "c59ff404-56ac-4e0c-9403-fb51d5b92df6",
+  "cohortId": "d1namo-2018",
+  "cohortSourceHash": "89db2ac2dc915929514bae3eae06dcff3e3870d21b5ff4531f80d09eadb7101d",
+  "algorithm": {
+    "id": "lag-correlation",
+    "version": "0.1.0"
+  },
+  "params": {
+    "maxLagSeconds": 1800,
+    "gridSeconds": 300,
+    "alpha": 0.05,
+    "minAbsR": 0.1,
+    "minSubjects": 2,
+    "minGridPoints": 50
+  },
+  "startedAt": "2026-04-30T02:48:48.904Z",
+  "completedAt": "2026-04-30T02:48:48.925Z",
+  "status": "succeeded",
+  "result": {
+    "variables": [
+      "cgm_glucose_mgdl",
+      "meal_event",
+      "insulin_fast_units",
+      "insulin_slow_units"
+    ],
+    "edges": [
+      {
+        "source": "cgm_glucose_mgdl",
+        "target": "insulin_fast_units",
+        "lag": 1800,
+        "strength": 0.09193329212381592,
+        "pValue": 5.121147950148952e-11,
+        "evidence": "Fisher meta r=0.092 across 9 subjects at lag 1800s; BH-adjusted p=5.12e-11."
+      },
+      {
+        "source": "cgm_glucose_mgdl",
+        "target": "insulin_fast_units",
+        "lag": 1500,
+        "strength": 0.0902553945305092,
+        "pValue": 8.569855936002568e-11,
+        "evidence": "Fisher meta r=0.090 across 9 subjects at lag 1500s; BH-adjusted p=8.57e-11."
+      },
+      {
+        "source": "cgm_glucose_mgdl",
+        "target": "insulin_fast_units",
+        "lag": 1200,
+        "strength": 0.0884045076770615,
+        "pValue": 2.0480654209601804e-10,
+        "evidence": "Fisher meta r=0.088 across 9 subjects at lag 1200s; BH-adjusted p=2.05e-10."
+      },
+      {
+        "source": "cgm_glucose_mgdl",
+        "target": "insulin_fast_units",
+        "lag": 900,
+        "strength": 0.08647094406182344,
+        "pValue": 5.527771573810014e-10,
+        "evidence": "Fisher meta r=0.086 across 9 subjects at lag 900s; BH-adjusted p=5.53e-10."
+      },
+      {
+        "source": "cgm_glucose_mgdl",
+        "target": "insulin_fast_units",
+        "lag": 600,
+        "strength": 0.0844968881602059,
+        "pValue": 1.5538198283593375e-9,
+        "evidence": "Fisher meta r=0.084 across 9 subjects at lag 600s; BH-adjusted p=1.55e-9."
+      },
+      {
+        "source": "cgm_glucose_mgdl",
+        "target": "insulin_fast_units",
+        "lag": 300,
+        "strength": 0.08265773149523782,
+        "pValue": 4.06333588998109e-9,
+        "evidence": "Fisher meta r=0.083 across 9 subjects at lag 300s; BH-adjusted p=4.06e-9."
+      },
+      {
+        "source": "cgm_glucose_mgdl",
+        "target": "insulin_fast_units",
+        "lag": 0,
+        "strength": 0.08086926200914961,
+        "pValue": 8.872709789109479e-9,
+        "evidence": "Fisher meta r=0.081 across 9 subjects at lag 0s; BH-adjusted p=8.87e-9."
+      },
+      {
+        "source": "insulin_fast_units",
+        "target": "cgm_glucose_mgdl",
+        "lag": 0,
+        "strength": 0.08086926200914961,
+        "pValue": 8.872709789109479e-9,
+        "evidence": "Fisher meta r=0.081 across 9 subjects at lag 0s; BH-adjusted p=8.87e-9."
+      },
+      {
+        "source": "insulin_fast_units",
+        "target": "cgm_glucose_mgdl",
+        "lag": 300,
+        "strength": 0.07876019434624444,
+        "pValue": 2.7154255436793544e-8,
+        "evidence": "Fisher meta r=0.079 across 9 subjects at lag 300s; BH-adjusted p=2.72e-8."
+      },
+      {
+        "source": "insulin_fast_units",
+        "target": "cgm_glucose_mgdl",
+        "lag": 600,
+        "strength": 0.07678604772826286,
+        "pValue": 7.436068161226217e-8,
+        "evidence": "Fisher meta r=0.077 across 9 subjects at lag 600s; BH-adjusted p=7.44e-8."
+      },
+      {
+        "source": "insulin_fast_units",
+        "target": "cgm_glucose_mgdl",
+        "lag": 900,
+        "strength": 0.07626806238992813,
+        "pValue": 8.146771806655745e-8,
+        "evidence": "Fisher meta r=0.076 across 9 subjects at lag 900s; BH-adjusted p=8.15e-8."
+      },
+      {
+        "source": "insulin_fast_units",
+        "target": "cgm_glucose_mgdl",
+        "lag": 1200,
+        "strength": 0.07578021374326102,
+        "pValue": 8.856032899610493e-8,
+        "evidence": "Fisher meta r=0.076 across 9 subjects at lag 1200s; BH-adjusted p=8.86e-8."
+      },
+      {
+        "source": "insulin_fast_units",
+        "target": "cgm_glucose_mgdl",
+        "lag": 1500,
+        "strength": 0.07531730569017252,
+        "pValue": 9.696090901119175e-8,
+        "evidence": "Fisher meta r=0.075 across 9 subjects at lag 1500s; BH-adjusted p=9.70e-8."
+      },
+      {
+        "source": "insulin_fast_units",
+        "target": "cgm_glucose_mgdl",
+        "lag": 1800,
+        "strength": 0.07480038142302416,
+        "pValue": 1.1186239157190414e-7,
+        "evidence": "Fisher meta r=0.075 across 9 subjects at lag 1800s; BH-adjusted p=1.12e-7."
+      }
+    ],
+    "diagnostics": {
+      "nSubjectsUsed": 9,
+      "nCandidates": 14,
+      "nEdgesAfterFDR": 14,
+      "params": {
+        "maxLagSeconds": 1800,
+        "gridSeconds": 300,
+        "alpha": 0.05,
+        "minAbsR": 0.1,
+        "minSubjects": 2,
+        "minGridPoints": 50
+      }
+    }
+  }
+}

--- a/research/scripts/build_d1namo_cohort.py
+++ b/research/scripts/build_d1namo_cohort.py
@@ -1,0 +1,280 @@
+"""Build a D1NAMO Cohort JSON for the TS discovery pipeline.
+
+Reads the D1NAMO `diabetes_subset_pictures-glucose-food-insulin.zip`
+archive from `research/datasets/_cache/d1namo/` and emits a JSON file
+matching the TS `Cohort` schema in `src/lib/discovery/cohort-types.ts`.
+The TS-side ingester (`src/lib/discovery/ingesters/d1namo.ts`) reads this
+JSON; nothing in the TS app touches the raw zip.
+
+Why split it this way:
+  - Zip parsing + tabular reshaping is more natural in Python.
+  - The Python ETL stays in `research/`, gitignored.
+  - The TS ingester stays small and pure (JSON in → Cohort out).
+  - This is also how an enterprise pipeline works: heavy ETL in batch,
+    discovery layer consumes structured outputs.
+
+Output: `research/datasets/d1namo/cohort.json` (gitignored).
+
+Run from repo root after fetching the zip:
+    python research/scripts/build_d1namo_cohort.py
+"""
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import sys
+import zipfile
+from datetime import datetime, timezone
+from typing import Any
+
+import pandas as pd
+
+# ─── Paths ────────────────────────────────────────────────────────────
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.abspath(os.path.join(HERE, "..", ".."))
+ZIP_PATH = os.path.join(
+    REPO, "research", "datasets", "_cache", "d1namo",
+    "diabetes_subset_pictures-glucose-food-insulin.zip",
+)
+OUT_DIR = os.path.join(REPO, "research", "datasets", "d1namo")
+OUT_PATH = os.path.join(OUT_DIR, "cohort.json")
+
+# ─── Schema constants ─────────────────────────────────────────────────
+PICS_ROOT = "diabetes_subset_pictures-glucose-food-insulin"
+SUBJECTS = [f"{i:03d}" for i in range(1, 10)]  # 001..009
+MMOL_TO_MGDL = 18.018
+ADAPTER_ID = "d1namo"
+ADAPTER_VERSION = "0.1.0"
+
+# Variables we materialize. CGM is dense (~5min cadence). Insulin and
+# meals are sparse events. Carb intake is a continuous-valued event.
+VARIABLES = [
+    {
+        "id": "cgm_glucose_mgdl",
+        "label": "CGM glucose",
+        "conceptCode": {"system": "LOINC", "code": "2345-7"},
+        "unit": "mg/dL",
+        "kind": "continuous",
+        "cadenceSeconds": 300,
+    },
+    {
+        "id": "meal_event",
+        "label": "Meal logged",
+        "kind": "event",
+        "unit": "boolean",
+    },
+    {
+        "id": "insulin_fast_units",
+        "label": "Fast-acting insulin (bolus)",
+        "conceptCode": {"system": "LOINC", "code": "11000-4"},
+        "unit": "U",
+        "kind": "continuous",
+    },
+    {
+        "id": "insulin_slow_units",
+        "label": "Long-acting insulin (basal)",
+        "unit": "U",
+        "kind": "continuous",
+    },
+]
+
+
+def _sha256_of_file(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _read_csv(zf: zipfile.ZipFile, member: str) -> pd.DataFrame | None:
+    try:
+        with zf.open(member) as f:
+            return pd.read_csv(io.BytesIO(f.read()))
+    except KeyError:
+        return None
+
+
+def _parse_glucose(df: pd.DataFrame) -> pd.DataFrame:
+    df = df[df["type"].astype(str).str.lower() == "cgm"].copy()
+    df["glucose"] = pd.to_numeric(df["glucose"], errors="coerce")
+    df = df.dropna(subset=["glucose", "date", "time"])
+    df["datetime"] = pd.to_datetime(
+        df["date"].astype(str) + " " + df["time"].astype(str),
+        errors="coerce",
+    )
+    return df.dropna(subset=["datetime"]).sort_values("datetime")
+
+
+def _parse_event_csv(df: pd.DataFrame, dt_col: str = "datetime") -> pd.DataFrame:
+    if dt_col not in df.columns:
+        return pd.DataFrame(columns=[dt_col])
+    df = df.copy()
+    s = df[dt_col].astype(str)
+    # D1NAMO uses "YYYY:MM:DD HH:MM:SS" — replace first two ':' so pandas parses.
+    s = s.str.replace(":", "-", 2)
+    df[dt_col] = pd.to_datetime(s, errors="coerce")
+    return df.dropna(subset=[dt_col]).sort_values(dt_col)
+
+
+def _build_subject(zf: zipfile.ZipFile, subject: str) -> dict[str, Any] | None:
+    glu = _read_csv(zf, f"{PICS_ROOT}/{subject}/glucose.csv")
+    food = _read_csv(zf, f"{PICS_ROOT}/{subject}/food.csv")
+    insulin = _read_csv(zf, f"{PICS_ROOT}/{subject}/insulin.csv")
+    if glu is None:
+        return None
+
+    glu = _parse_glucose(glu)
+    if glu.empty:
+        return None
+
+    # Per-subject t=0 is the first CGM reading.
+    t0 = glu["datetime"].iloc[0]
+
+    measurements: list[dict[str, Any]] = []
+
+    # CGM: convert mmol/L → mg/dL so the variable stays in clinical units.
+    for ts, val in zip(glu["datetime"], glu["glucose"]):
+        t = (ts - t0).total_seconds()
+        measurements.append({
+            "variableId": "cgm_glucose_mgdl",
+            "t": float(t),
+            "value": float(val * MMOL_TO_MGDL),
+        })
+
+    # Meals: each logged meal is a unit event (value=1). Carb amount is
+    # not always present; if a `carbs` or `total_carbs` column exists,
+    # surface it as the event magnitude.
+    if food is not None:
+        food = _parse_event_csv(food, "datetime")
+        carb_col = next(
+            (c for c in ("calories", "carbs", "total_carbs") if c in food.columns),
+            None,
+        )
+        for _, row in food.iterrows():
+            t = (row["datetime"] - t0).total_seconds()
+            value: float = 1.0
+            if carb_col is not None:
+                try:
+                    v = float(row[carb_col])
+                    if pd.notna(v):
+                        value = v
+                except Exception:
+                    pass
+            measurements.append({
+                "variableId": "meal_event",
+                "t": float(t),
+                "value": float(value),
+            })
+
+    # Insulin: D1NAMO splits into fast and slow boluses with units.
+    # CSV has date + time columns (separate); recombine into a datetime.
+    if insulin is not None and "date" in insulin.columns and "time" in insulin.columns:
+        insulin = insulin.copy()
+        insulin["datetime"] = pd.to_datetime(
+            insulin["date"].astype(str) + " " + insulin["time"].astype(str),
+            errors="coerce",
+        )
+        insulin = insulin.dropna(subset=["datetime"]).sort_values("datetime")
+        for _, row in insulin.iterrows():
+            t = (row["datetime"] - t0).total_seconds()
+            for col, varname in (
+                ("fast_insulin", "insulin_fast_units"),
+                ("slow_insulin", "insulin_slow_units"),
+            ):
+                if col not in insulin.columns:
+                    continue
+                try:
+                    v = float(row[col])
+                except Exception:
+                    continue
+                if not pd.notna(v) or v == 0:
+                    continue
+                measurements.append({
+                    "variableId": varname,
+                    "t": float(t),
+                    "value": float(v),
+                })
+
+    measurements.sort(key=lambda m: (m["t"], m["variableId"]))
+    return {
+        "id": f"d1namo-{subject}",
+        "demographics": {"d1namo_subject_index": subject},
+        "measurements": measurements,
+    }
+
+
+def main() -> int:
+    if not os.path.exists(ZIP_PATH):
+        print(f"[d1namo] missing zip: {ZIP_PATH}", file=sys.stderr)
+        print(
+            "    Download from https://zenodo.org/records/5651217 "
+            "(diabetes_subset_pictures-glucose-food-insulin.zip)",
+            file=sys.stderr,
+        )
+        return 1
+
+    source_hash = _sha256_of_file(ZIP_PATH)
+    subjects: list[dict[str, Any]] = []
+    with zipfile.ZipFile(ZIP_PATH) as zf:
+        for sid in SUBJECTS:
+            sub = _build_subject(zf, sid)
+            if sub is None:
+                print(f"[d1namo] subject {sid}: skipped (no data)", file=sys.stderr)
+                continue
+            subjects.append(sub)
+            print(
+                f"[d1namo] subject {sid}: {len(sub['measurements'])} measurements"
+            )
+
+    cohort = {
+        "id": "d1namo-2018",
+        "label": "D1NAMO — 9 T1D subjects, 4 days, CGM + insulin + meals (Dubosson 2018)",
+        "source": {
+            "adapter": ADAPTER_ID,
+            "adapterVersion": ADAPTER_VERSION,
+            "sourceHash": source_hash,
+            "ingestedAt": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "containsPHI": False,
+        },
+        "variables": VARIABLES,
+        "subjects": subjects,
+        "timeAxis": {
+            "zeroConvention": "subject-session-start",
+            "displayUnit": "seconds",
+        },
+        "metadata": {
+            "description": (
+                "D1NAMO T1D subset (Dubosson et al. 2018, Informatics in Medicine "
+                "Unlocked). 9 subjects, 4 days each, Dexcom G4 CGM + insulin doses + "
+                "logged meals. Per-subject session start is t=0; cohort discovery "
+                "runs over within-subject lagged structure."
+            ),
+            "citation": (
+                "Dubosson et al. 2018, doi:10.1016/j.imu.2018.09.003"
+            ),
+            "irbStatement": (
+                "EPFL ethics-committee approved; subjects gave informed consent. "
+                "Dataset distributed under CC-BY-SA-4.0 on Zenodo."
+            ),
+            "accessTier": "public",
+        },
+    }
+
+    os.makedirs(OUT_DIR, exist_ok=True)
+    with open(OUT_PATH, "w") as f:
+        json.dump(cohort, f, indent=2)
+
+    total_meas = sum(len(s["measurements"]) for s in subjects)
+    print(
+        f"[d1namo] wrote {OUT_PATH}: "
+        f"{len(subjects)} subjects, {total_meas:,} measurements, "
+        f"sourceHash={source_hash[:12]}..."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-d1namo-discovery.ts
+++ b/scripts/run-d1namo-discovery.ts
@@ -1,0 +1,79 @@
+// Run the lag-correlation discovery algorithm on the D1NAMO cohort
+// and write a DiscoveryRun JSON to research/runs/.
+//
+// Usage:
+//   npx tsx scripts/run-d1namo-discovery.ts
+//
+// Reads:  research/datasets/d1namo/cohort.json
+// Writes: research/runs/d1namo-lag-correlation-<timestamp>.json
+//
+// Both paths are gitignored. The output contains only abstract structure
+// (variable ids, edges, lags, p-values) — no raw measurements — so it
+// is safe to share with clinicians or paste into a PR description.
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+
+import { d1namoIngester } from "../src/lib/discovery/ingesters/d1namo";
+import { lagCorrelationAlgorithm } from "../src/lib/discovery/algorithms/lag-correlation";
+import { buildDiscoveryRun } from "../src/lib/discovery/run-types";
+
+async function main() {
+  const repoRoot = process.cwd();
+  const startedAt = new Date().toISOString();
+
+  console.log("[d1namo] ingesting cohort...");
+  const cohort = await d1namoIngester.ingest(repoRoot);
+  console.log(
+    `[d1namo] cohort ${cohort.id}: ${cohort.subjects.length} subjects, ` +
+      `${cohort.subjects.reduce((a, s) => a + s.measurements.length, 0).toLocaleString()} measurements`,
+  );
+
+  console.log("[d1namo] running lag-correlation discovery...");
+  const result = lagCorrelationAlgorithm.run(cohort);
+  const completedAt = new Date().toISOString();
+
+  console.log(
+    `[d1namo] discovered ${result.edges.length} edges ` +
+      `(over ${(result.diagnostics?.nCandidates as number) ?? "?"} candidates)`,
+  );
+  for (const e of result.edges) {
+    console.log(
+      `  ${e.source} → ${e.target}` +
+        (typeof e.lag === "number" ? ` (lag ${e.lag}s)` : "") +
+        ` r=${e.strength.toFixed(3)} p=${e.pValue?.toExponential(2) ?? "—"}`,
+    );
+  }
+
+  const run = buildDiscoveryRun({
+    id: randomUUID(),
+    cohort,
+    algorithm: {
+      id: lagCorrelationAlgorithm.id,
+      version: lagCorrelationAlgorithm.version,
+    },
+    params: { ...lagCorrelationAlgorithm.defaultParams } as Record<
+      string,
+      unknown
+    >,
+    startedAt,
+    completedAt,
+    result,
+  });
+
+  const outDir = path.join(repoRoot, "research", "runs");
+  await fs.mkdir(outDir, { recursive: true });
+  const ts = startedAt.replace(/[:.]/g, "-");
+  const outPath = path.join(
+    outDir,
+    `d1namo-lag-correlation-${ts}.json`,
+  );
+  await fs.writeFile(outPath, JSON.stringify(run, null, 2));
+  console.log(`[d1namo] wrote ${path.relative(repoRoot, outPath)}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/lib/discovery/__tests__/d1namo-ingester.test.ts
+++ b/src/lib/discovery/__tests__/d1namo-ingester.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { d1namoIngester } from "../ingesters/d1namo";
+import type { Cohort } from "../cohort-types";
+
+// ─── Fixture ──────────────────────────────────────────────────────────
+//
+// Tiny in-memory cohort shape-identical to what
+// `research/scripts/build_d1namo_cohort.py` writes. Used only to drive
+// CI so tests don't depend on the 250 MB D1NAMO zip being downloaded.
+
+const FIXTURE: Cohort = {
+  id: "d1namo-2018",
+  label: "fixture",
+  source: {
+    adapter: "d1namo",
+    adapterVersion: "0.1.0",
+    sourceHash: "fixturehash",
+    ingestedAt: "2026-04-29T00:00:00Z",
+    containsPHI: false,
+  },
+  variables: [
+    {
+      id: "cgm_glucose_mgdl",
+      label: "CGM glucose",
+      kind: "continuous",
+      cadenceSeconds: 300,
+    },
+    {
+      id: "insulin_fast_units",
+      label: "Fast insulin",
+      kind: "continuous",
+    },
+  ],
+  subjects: [
+    {
+      id: "d1namo-001",
+      measurements: [
+        { variableId: "cgm_glucose_mgdl", t: 0, value: 110 },
+        { variableId: "cgm_glucose_mgdl", t: 300, value: 115 },
+      ],
+    },
+    {
+      id: "d1namo-002",
+      measurements: [
+        { variableId: "cgm_glucose_mgdl", t: 0, value: 130 },
+      ],
+    },
+    {
+      id: "d1namo-003",
+      measurements: [
+        { variableId: "cgm_glucose_mgdl", t: 0, value: 95 },
+      ],
+    },
+  ],
+  timeAxis: { zeroConvention: "subject-session-start", displayUnit: "seconds" },
+  metadata: {
+    description: "fixture",
+    accessTier: "public",
+  },
+};
+
+async function withFixture<T>(
+  cohort: Cohort,
+  fn: (rootDir: string) => Promise<T>,
+): Promise<T> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "d1namo-ingester-"));
+  try {
+    const cohortDir = path.join(dir, "research", "datasets", "d1namo");
+    await fs.mkdir(cohortDir, { recursive: true });
+    await fs.writeFile(
+      path.join(cohortDir, "cohort.json"),
+      JSON.stringify(cohort),
+    );
+    return await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("d1namoIngester", () => {
+  it("ingests a valid cohort.json and returns a Cohort object", async () => {
+    await withFixture(FIXTURE, async (root) => {
+      const cohort = await d1namoIngester.ingest(root);
+      expect(cohort.id).toBe("d1namo-2018");
+      expect(cohort.subjects).toHaveLength(3);
+      expect(cohort.source.containsPHI).toBe(false);
+    });
+  });
+
+  it("rejects a cohort whose source.containsPHI is not literal false", async () => {
+    const bad = {
+      ...FIXTURE,
+      source: { ...FIXTURE.source, containsPHI: true as unknown as false },
+    } as Cohort;
+    await withFixture(bad, async (root) => {
+      await expect(d1namoIngester.ingest(root)).rejects.toThrow(/containsPHI/);
+    });
+  });
+
+  it("rejects a cohort with a measurement referencing an unknown variable", async () => {
+    const bad: Cohort = {
+      ...FIXTURE,
+      subjects: [
+        {
+          id: "d1namo-001",
+          measurements: [
+            { variableId: "not_in_variables_list", t: 0, value: 1 },
+          ],
+        },
+      ],
+    };
+    await withFixture(bad, async (root) => {
+      await expect(d1namoIngester.ingest(root)).rejects.toThrow(/unknown variable/);
+    });
+  });
+
+  it("respects the maxSubjects override", async () => {
+    await withFixture(FIXTURE, async (root) => {
+      const cohort = await d1namoIngester.ingest(root, { maxSubjects: 1 });
+      expect(cohort.subjects).toHaveLength(1);
+    });
+  });
+
+  it("respects the cohortIdOverride", async () => {
+    await withFixture(FIXTURE, async (root) => {
+      const cohort = await d1namoIngester.ingest(root, {
+        cohortIdOverride: "d1namo-2018-test",
+      });
+      expect(cohort.id).toBe("d1namo-2018-test");
+    });
+  });
+
+  it("returns a meaningful error when cohort.json is missing", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "d1namo-empty-"));
+    try {
+      await expect(d1namoIngester.ingest(dir)).rejects.toThrow(
+        /build_d1namo_cohort\.py/,
+      );
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/lib/discovery/__tests__/lag-correlation.test.ts
+++ b/src/lib/discovery/__tests__/lag-correlation.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import { lagCorrelationAlgorithm } from "../algorithms/lag-correlation";
+import type { Cohort } from "../cohort-types";
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+//
+// Fixture cohorts large enough that the algorithm has signal but small
+// enough that the test runs in milliseconds. We DON'T use these to
+// claim "PCMCI+ works" — they exercise the implementation contract.
+
+function regularCohort(opts: {
+  nSubjects: number;
+  nSteps: number;
+  /** True lag (in steps) at which y depends on x. */
+  trueLag: number;
+  /** Coupling strength on the true edge. */
+  coupling: number;
+  noise: number;
+  seed: number;
+}): Cohort {
+  const { nSubjects, nSteps, trueLag, coupling, noise, seed } = opts;
+  // Simple deterministic LCG for repeatable tests.
+  let state = seed >>> 0;
+  const rand = () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return ((state >>> 8) / 0xffffff) * 2 - 1;
+  };
+
+  const subjects = Array.from({ length: nSubjects }, (_, si) => {
+    const x = new Array<number>(nSteps);
+    const y = new Array<number>(nSteps);
+    // X: an AR(1)-ish drift so it has structure.
+    x[0] = rand();
+    for (let i = 1; i < nSteps; i++) x[i] = 0.6 * x[i - 1] + 0.4 * rand();
+    // Y: depends on x at trueLag, plus noise.
+    for (let i = 0; i < nSteps; i++) {
+      const xLagged = i >= trueLag ? x[i - trueLag] : 0;
+      y[i] = coupling * xLagged + noise * rand();
+    }
+    const measurements = [];
+    for (let i = 0; i < nSteps; i++) {
+      measurements.push({ variableId: "x", t: i * 300, value: x[i] });
+      measurements.push({ variableId: "y", t: i * 300, value: y[i] });
+    }
+    return {
+      id: `subject-${si}`,
+      measurements,
+    };
+  });
+
+  return {
+    id: "test-cohort",
+    label: "synthetic",
+    source: {
+      adapter: "test",
+      adapterVersion: "0",
+      ingestedAt: "2026-04-29T00:00:00Z",
+      containsPHI: false,
+    },
+    variables: [
+      { id: "x", label: "X", kind: "continuous", cadenceSeconds: 300 },
+      { id: "y", label: "Y", kind: "continuous", cadenceSeconds: 300 },
+    ],
+    subjects,
+    timeAxis: { zeroConvention: "subject-session-start", displayUnit: "seconds" },
+    metadata: { description: "test", accessTier: "public" },
+  };
+}
+
+describe("lag-correlation algorithm", () => {
+  it("never produces self-edges (autocorrelation is not discovered structure)", () => {
+    const cohort = regularCohort({
+      nSubjects: 4,
+      nSteps: 200,
+      trueLag: 2,
+      coupling: 0.7,
+      noise: 0.3,
+      seed: 42,
+    });
+    const result = lagCorrelationAlgorithm.run(cohort);
+    for (const e of result.edges) {
+      expect(e.source).not.toBe(e.target);
+    }
+  });
+
+  it("recovers the true lagged edge x → y on a coupled cohort", () => {
+    const cohort = regularCohort({
+      nSubjects: 6,
+      nSteps: 200,
+      trueLag: 2,
+      coupling: 0.8,
+      noise: 0.4,
+      seed: 7,
+    });
+    const result = lagCorrelationAlgorithm.run(cohort);
+    const xToY = result.edges.find(
+      (e) => e.source === "x" && e.target === "y",
+    );
+    expect(xToY).toBeDefined();
+    // True lag was 2 steps × 300s/step = 600s.
+    expect(xToY!.lag).toBe(600);
+    expect(Math.abs(xToY!.strength)).toBeGreaterThan(0.4);
+  });
+
+  it("emits zero edges when subjects are below the minSubjects threshold", () => {
+    const cohort = regularCohort({
+      nSubjects: 1,
+      nSteps: 200,
+      trueLag: 2,
+      coupling: 0.8,
+      noise: 0.4,
+      seed: 11,
+    });
+    const result = lagCorrelationAlgorithm.run(cohort);
+    expect(result.edges).toHaveLength(0);
+    expect(result.diagnostics?.reason).toMatch(/minSubjects/);
+  });
+
+  it("respects the alpha override for FDR threshold", () => {
+    const cohort = regularCohort({
+      nSubjects: 3,
+      nSteps: 100,
+      trueLag: 2,
+      coupling: 0.3,
+      noise: 0.7, // weaker signal
+      seed: 13,
+    });
+    const lenient = lagCorrelationAlgorithm.run(cohort, { alpha: 0.5 });
+    const strict = lagCorrelationAlgorithm.run(cohort, { alpha: 0.001 });
+    expect(lenient.edges.length).toBeGreaterThanOrEqual(strict.edges.length);
+  });
+
+  it("every emitted edge references variables present in result.variables", () => {
+    const cohort = regularCohort({
+      nSubjects: 4,
+      nSteps: 150,
+      trueLag: 1,
+      coupling: 0.6,
+      noise: 0.4,
+      seed: 99,
+    });
+    const result = lagCorrelationAlgorithm.run(cohort);
+    const vars = new Set(result.variables);
+    for (const e of result.edges) {
+      expect(vars.has(e.source)).toBe(true);
+      expect(vars.has(e.target)).toBe(true);
+    }
+  });
+
+  it("diagnostics report the algorithm's effective inputs", () => {
+    const cohort = regularCohort({
+      nSubjects: 3,
+      nSteps: 150,
+      trueLag: 1,
+      coupling: 0.6,
+      noise: 0.4,
+      seed: 21,
+    });
+    const result = lagCorrelationAlgorithm.run(cohort);
+    expect(result.diagnostics?.nSubjectsUsed).toBe(3);
+    expect(typeof result.diagnostics?.nCandidates).toBe("number");
+    expect(typeof result.diagnostics?.nEdgesAfterFDR).toBe("number");
+  });
+});

--- a/src/lib/discovery/algorithms/lag-correlation.ts
+++ b/src/lib/discovery/algorithms/lag-correlation.ts
@@ -1,0 +1,362 @@
+// ─── Lag-Correlation Discovery Algorithm (v0) ────────────────────────
+//
+// HONEST FRAMING — READ FIRST
+// ----------------------------
+// This is NOT PCMCI+. It's a v0 placeholder whose only job is to push
+// real T1D data through the discovery pipeline end-to-end while we
+// build out the real algorithm.
+//
+// What it does: for each ordered (X, Y) variable pair and each integer
+// lag k ∈ [0, maxLag], compute Pearson correlation between X(t) and
+// Y(t+k) on a per-subject regular grid, then meta-analyse across
+// subjects (Fisher r-to-z), then apply Benjamini–Hochberg FDR control
+// on the resulting p-values.
+//
+// Why this is NOT enough on its own:
+//   - No conditioning sets (X→Y survives even if both depend on Z)
+//   - No partial correlation, so confounders inflate edges
+//   - No directionality test beyond temporal precedence (Granger-light)
+//   - No nonlinear dependence (mutual information / TE)
+//
+// Why it's still useful as v0:
+//   - It produces real edges from real data
+//   - The output shape is identical to what PCMCI+ will produce
+//   - Replacing this with PCMCI+ is a one-file change later
+//
+// VARIABLES & GRID
+// ----------------
+// CGM is dense (5-min cadence). Insulin and meals are sparse events.
+// We resample everything to a common regular grid (`gridSeconds` param,
+// default 300 s = 5 min) by:
+//   - Continuous variables: sample-and-hold from the nearest prior measurement
+//   - Event variables: count of events in each grid bucket
+// This gives a uniformly-sampled (n_grid, n_variables) matrix per
+// subject that the lag scan can run over.
+
+import type { Cohort, Subject, Variable } from "../cohort-types";
+import type { DiscoveryAlgorithm } from "../algorithm-interface";
+import type { DiscoveredEdge, DiscoveryResult } from "../run-types";
+
+export interface LagCorrelationParams {
+  /** Maximum lag in seconds. Default 1800 (30 min) — sane for T1D dynamics. */
+  maxLagSeconds: number;
+  /** Grid cadence in seconds. Default 300 (5 min) — matches CGM cadence. */
+  gridSeconds: number;
+  /** Two-sided FDR-adjusted p-value threshold. Default 0.05. */
+  alpha: number;
+  /** Minimum |correlation| to even consider as an edge candidate. */
+  minAbsR: number;
+  /** Minimum number of subjects an edge must appear in to count. Default 2. */
+  minSubjects: number;
+  /** Minimum number of grid points per subject — drop subjects shorter than this. */
+  minGridPoints: number;
+}
+
+const DEFAULT_PARAMS: LagCorrelationParams = {
+  maxLagSeconds: 1800,
+  gridSeconds: 300,
+  alpha: 0.05,
+  minAbsR: 0.1,
+  minSubjects: 2,
+  minGridPoints: 50,
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Resample one subject's measurements onto a uniform (n_grid × n_vars) matrix.
+ *
+ * Returns `null` if the subject has fewer than `minGridPoints` grid steps.
+ */
+function buildSubjectGrid(
+  subject: Subject,
+  variables: Variable[],
+  gridSeconds: number,
+  minGridPoints: number,
+): Float64Array[] | null {
+  if (subject.measurements.length === 0) return null;
+
+  // Find the subject's t-range.
+  let tMin = Infinity;
+  let tMax = -Infinity;
+  for (const m of subject.measurements) {
+    if (m.t < tMin) tMin = m.t;
+    if (m.t > tMax) tMax = m.t;
+  }
+  const span = tMax - tMin;
+  const nGrid = Math.floor(span / gridSeconds);
+  if (nGrid < minGridPoints) return null;
+
+  // Bucket measurements per variable.
+  const byVar = new Map<string, { t: number; value: number }[]>();
+  for (const v of variables) byVar.set(v.id, []);
+  for (const m of subject.measurements) {
+    const arr = byVar.get(m.variableId);
+    if (!arr) continue;
+    if (typeof m.value === "number" && Number.isFinite(m.value)) {
+      arr.push({ t: m.t - tMin, value: m.value });
+    }
+  }
+
+  // For each variable, materialise an nGrid-length Float64Array using
+  // the resampling rule appropriate for its kind.
+  const grid: Float64Array[] = variables.map((v) => {
+    const out = new Float64Array(nGrid);
+    const events = byVar.get(v.id) ?? [];
+    if (v.kind === "event" || v.kind === "binary") {
+      // Count events per grid bucket.
+      for (const e of events) {
+        const idx = Math.min(nGrid - 1, Math.max(0, Math.floor(e.t / gridSeconds)));
+        out[idx] += e.value;
+      }
+    } else {
+      // Continuous: sample-and-hold from the most recent prior event.
+      // (For sparse/sparse-ish series this still works — buckets without
+      // a recent prior measurement get NaN, which the corr code skips.)
+      events.sort((a, b) => a.t - b.t);
+      let lastVal = NaN;
+      let cursor = 0;
+      for (let i = 0; i < nGrid; i++) {
+        const tCenter = (i + 0.5) * gridSeconds;
+        while (cursor < events.length && events[cursor].t <= tCenter) {
+          lastVal = events[cursor].value;
+          cursor += 1;
+        }
+        out[i] = lastVal;
+      }
+    }
+    return out;
+  });
+
+  return grid;
+}
+
+/** Pearson correlation on aligned arrays, skipping NaN-pair entries. */
+function pearson(x: Float64Array, y: Float64Array): { r: number; n: number } {
+  const len = Math.min(x.length, y.length);
+  let n = 0;
+  let sx = 0;
+  let sy = 0;
+  for (let i = 0; i < len; i++) {
+    const a = x[i];
+    const b = y[i];
+    if (!Number.isFinite(a) || !Number.isFinite(b)) continue;
+    sx += a;
+    sy += b;
+    n += 1;
+  }
+  if (n < 5) return { r: 0, n };
+  const mx = sx / n;
+  const my = sy / n;
+  let num = 0;
+  let dx2 = 0;
+  let dy2 = 0;
+  for (let i = 0; i < len; i++) {
+    const a = x[i];
+    const b = y[i];
+    if (!Number.isFinite(a) || !Number.isFinite(b)) continue;
+    const da = a - mx;
+    const db = b - my;
+    num += da * db;
+    dx2 += da * da;
+    dy2 += db * db;
+  }
+  const denom = Math.sqrt(dx2 * dy2);
+  if (denom === 0) return { r: 0, n };
+  return { r: num / denom, n };
+}
+
+/** Fisher r-to-z transform. */
+function rToZ(r: number): number {
+  // Clamp to avoid atanh(±1) → ±∞.
+  const rc = Math.max(-0.9999, Math.min(0.9999, r));
+  return 0.5 * Math.log((1 + rc) / (1 - rc));
+}
+
+/**
+ * Approximate two-sided p-value for a meta-analysed Fisher-z statistic.
+ * Uses a normal-CDF approximation (Z-score with Var(z) = 1/(n-3)).
+ */
+function fisherMetaP(rs: number[], ns: number[]): { z: number; p: number } {
+  let zSum = 0;
+  let wSum = 0;
+  for (let i = 0; i < rs.length; i++) {
+    const w = Math.max(1, ns[i] - 3);
+    zSum += w * rToZ(rs[i]);
+    wSum += w;
+  }
+  if (wSum === 0) return { z: 0, p: 1 };
+  const zMean = zSum / Math.sqrt(wSum); // weighted z-score under H0
+  const p = 2 * (1 - normalCdf(Math.abs(zMean)));
+  return { z: zMean, p };
+}
+
+/** Standard normal CDF via erfc-style approximation (Abramowitz & Stegun 26.2.17). */
+function normalCdf(x: number): number {
+  const a1 = 0.254829592;
+  const a2 = -0.284496736;
+  const a3 = 1.421413741;
+  const a4 = -1.453152027;
+  const a5 = 1.061405429;
+  const p = 0.3275911;
+  const sign = x < 0 ? -1 : 1;
+  const ax = Math.abs(x) / Math.SQRT2;
+  const t = 1 / (1 + p * ax);
+  const y =
+    1 -
+    ((((a5 * t + a4) * t + a3) * t + a2) * t + a1) * t * Math.exp(-ax * ax);
+  return 0.5 * (1 + sign * y);
+}
+
+/** Benjamini–Hochberg FDR control. Returns adjusted p-values. */
+function bhAdjust(ps: number[]): number[] {
+  const n = ps.length;
+  const order = Array.from({ length: n }, (_, i) => i).sort(
+    (a, b) => ps[a] - ps[b],
+  );
+  const adj = new Array<number>(n);
+  let prev = 1;
+  for (let i = n - 1; i >= 0; i--) {
+    const orig = order[i];
+    const rank = i + 1;
+    const value = Math.min(prev, (ps[orig] * n) / rank);
+    adj[orig] = value;
+    prev = value;
+  }
+  return adj;
+}
+
+// ─── Algorithm body ───────────────────────────────────────────────────
+
+interface LagCandidate {
+  source: string;
+  target: string;
+  lagSteps: number; // grid units
+  rs: number[];
+  ns: number[];
+  z: number;
+  p: number;
+}
+
+export const lagCorrelationAlgorithm: DiscoveryAlgorithm<LagCorrelationParams> = {
+  id: "lag-correlation",
+  version: "0.1.0",
+  description:
+    "v0 placeholder: Pearson correlation X(t) vs Y(t+k) per subject, " +
+    "Fisher meta-analysed across subjects, BH-FDR controlled. Replace " +
+    "with PCMCI+ once that ports.",
+  defaultParams: DEFAULT_PARAMS,
+
+  run(cohort: Cohort, params?: Partial<LagCorrelationParams>): DiscoveryResult {
+    const p = { ...this.defaultParams, ...params };
+
+    // 1. Build per-subject regular grids.
+    const variables = cohort.variables;
+    const varIds = variables.map((v) => v.id);
+    const subjectGrids: Float64Array[][] = [];
+    for (const subj of cohort.subjects) {
+      const grid = buildSubjectGrid(
+        subj,
+        variables,
+        p.gridSeconds,
+        p.minGridPoints,
+      );
+      if (grid) subjectGrids.push(grid);
+    }
+
+    if (subjectGrids.length < p.minSubjects) {
+      return {
+        variables: varIds,
+        edges: [],
+        diagnostics: {
+          reason: "fewer than minSubjects subjects had enough grid points",
+          minSubjects: p.minSubjects,
+          gridSubjects: subjectGrids.length,
+        },
+      };
+    }
+
+    // 2. Scan every (source, target, lag) candidate. Skip ALL self-edges
+    //    — at lag=0 they are trivially r=1, and at k>0 they're just
+    //    autocorrelation (a property of any continuous time series, not
+    //    discovered structure).
+    const maxLagSteps = Math.floor(p.maxLagSeconds / p.gridSeconds);
+    const candidates: LagCandidate[] = [];
+    for (let i = 0; i < varIds.length; i++) {
+      for (let j = 0; j < varIds.length; j++) {
+        if (i === j) continue;
+        for (let k = 0; k <= maxLagSteps; k++) {
+          const rs: number[] = [];
+          const ns: number[] = [];
+          for (const grid of subjectGrids) {
+            const x = grid[i];
+            const y = grid[j];
+            // Lag the target: align x[0..N-k] with y[k..N].
+            const len = x.length - k;
+            if (len < p.minGridPoints) continue;
+            const xView = x.subarray(0, len);
+            const yView = y.subarray(k, k + len);
+            const { r, n } = pearson(xView, yView);
+            if (n >= 5 && Number.isFinite(r)) {
+              rs.push(r);
+              ns.push(n);
+            }
+          }
+          if (rs.length < p.minSubjects) continue;
+          const meanAbsR =
+            rs.reduce((a, b) => a + Math.abs(b), 0) / rs.length;
+          if (meanAbsR < p.minAbsR) continue;
+          const { z, p: pVal } = fisherMetaP(rs, ns);
+          candidates.push({
+            source: varIds[i],
+            target: varIds[j],
+            lagSteps: k,
+            rs,
+            ns,
+            z,
+            p: pVal,
+          });
+        }
+      }
+    }
+
+    // 3. BH-FDR adjust.
+    const ps = candidates.map((c) => c.p);
+    const adjPs = bhAdjust(ps);
+
+    // 4. Emit edges that pass the FDR threshold.
+    const edges: DiscoveredEdge[] = [];
+    for (let idx = 0; idx < candidates.length; idx++) {
+      if (adjPs[idx] > p.alpha) continue;
+      const c = candidates[idx];
+      const meanR = c.rs.reduce((a, b) => a + b, 0) / c.rs.length;
+      edges.push({
+        source: c.source,
+        target: c.target,
+        lag: c.lagSteps * p.gridSeconds,
+        strength: meanR,
+        pValue: adjPs[idx],
+        evidence:
+          `Fisher meta r=${meanR.toFixed(3)} across ${c.rs.length} subjects ` +
+          `at lag ${c.lagSteps * p.gridSeconds}s; BH-adjusted p=${adjPs[idx].toExponential(2)}.`,
+      });
+    }
+
+    // Sort by strongest |strength| then lowest p.
+    edges.sort((a, b) => {
+      const ds = Math.abs(b.strength) - Math.abs(a.strength);
+      return ds !== 0 ? ds : (a.pValue ?? 1) - (b.pValue ?? 1);
+    });
+
+    return {
+      variables: varIds,
+      edges,
+      diagnostics: {
+        nSubjectsUsed: subjectGrids.length,
+        nCandidates: candidates.length,
+        nEdgesAfterFDR: edges.length,
+        params: p,
+      },
+    };
+  },
+};

--- a/src/lib/discovery/ingesters/d1namo.ts
+++ b/src/lib/discovery/ingesters/d1namo.ts
@@ -1,0 +1,149 @@
+// ─── D1NAMO Ingester ─────────────────────────────────────────────────
+//
+// Reads the JSON cohort produced by
+// `research/scripts/build_d1namo_cohort.py` and validates it against
+// the `Cohort` schema before returning.
+//
+// The Python script handles the heavy lifting (zip extraction, CSV
+// parsing, datetime normalisation, subject de-identification — D1NAMO
+// is already de-identified upstream but the adapter re-asserts it).
+// This TS adapter is intentionally small: deserialise + assert + return.
+//
+// PRIVACY: the source data is CC-BY-SA-4.0 public. Subject ids are
+// already opaque numeric (`d1namo-001` … `d1namo-009`) — there is no
+// PHI to strip. The adapter still hard-asserts containsPHI=false.
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { CohortIngester, IngestOptions } from "../ingester-interface";
+import type { Cohort, Measurement, Subject, Variable } from "../cohort-types";
+
+const ADAPTER_ID = "d1namo";
+const ADAPTER_VERSION = "0.1.0";
+
+const DEFAULT_COHORT_PATH =
+  "research/datasets/d1namo/cohort.json";
+
+/**
+ * Asserts the parsed JSON conforms to the Cohort schema. Throws with
+ * a precise pointer on mismatch — better than a silent type cast.
+ */
+function assertCohort(parsed: unknown): asserts parsed is Cohort {
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("d1namo: cohort json is not an object");
+  }
+  const c = parsed as Record<string, unknown>;
+
+  for (const key of [
+    "id",
+    "label",
+    "source",
+    "variables",
+    "subjects",
+    "timeAxis",
+    "metadata",
+  ]) {
+    if (!(key in c)) {
+      throw new Error(`d1namo: cohort json missing required field "${key}"`);
+    }
+  }
+
+  const source = c.source as Record<string, unknown>;
+  if (source.containsPHI !== false) {
+    throw new Error(
+      `d1namo: source.containsPHI must be literal false, got ${JSON.stringify(source.containsPHI)}`,
+    );
+  }
+
+  if (!Array.isArray(c.variables)) {
+    throw new Error("d1namo: variables must be an array");
+  }
+  if (!Array.isArray(c.subjects)) {
+    throw new Error("d1namo: subjects must be an array");
+  }
+
+  const varIds = new Set((c.variables as Variable[]).map((v) => v.id));
+  for (const subj of c.subjects as Subject[]) {
+    if (typeof subj.id !== "string" || subj.id.length === 0) {
+      throw new Error("d1namo: subject without opaque id");
+    }
+    if (!Array.isArray(subj.measurements)) {
+      throw new Error(`d1namo: subject ${subj.id} has no measurements array`);
+    }
+    for (const m of subj.measurements as Measurement[]) {
+      if (!varIds.has(m.variableId)) {
+        throw new Error(
+          `d1namo: subject ${subj.id} references unknown variable "${m.variableId}"`,
+        );
+      }
+      if (!Number.isFinite(m.t)) {
+        throw new Error(
+          `d1namo: subject ${subj.id} has non-finite t on ${m.variableId}`,
+        );
+      }
+    }
+  }
+}
+
+export interface D1namoIngestOptions extends IngestOptions {
+  /** Optional override of the default cohort.json path (relative to cwd). */
+  cohortJsonPath?: string;
+}
+
+export const d1namoIngester: CohortIngester<D1namoIngestOptions> = {
+  id: ADAPTER_ID,
+  version: ADAPTER_VERSION,
+  description:
+    "D1NAMO subset (Dubosson 2018) — 9 T1D subjects, 4 days each, " +
+    "CGM + insulin + meals. Reads cohort.json produced by " +
+    "research/scripts/build_d1namo_cohort.py.",
+  conceptSystems: ["LOINC"],
+
+  async ingest(sourcePath: string, options?: D1namoIngestOptions): Promise<Cohort> {
+    const jsonPath =
+      options?.cohortJsonPath ??
+      path.join(sourcePath || ".", DEFAULT_COHORT_PATH);
+
+    let raw: string;
+    try {
+      raw = await fs.readFile(jsonPath, "utf8");
+    } catch (e) {
+      throw new Error(
+        `d1namo: cannot read ${jsonPath}. Did you run ` +
+          `\`python research/scripts/build_d1namo_cohort.py\` first? ` +
+          `Underlying error: ${(e as Error).message}`,
+      );
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (e) {
+      throw new Error(
+        `d1namo: cohort.json is not valid JSON: ${(e as Error).message}`,
+      );
+    }
+
+    assertCohort(parsed);
+    let cohort: Cohort = parsed;
+
+    // Apply ingest-options overrides.
+    if (options?.cohortIdOverride) {
+      cohort = { ...cohort, id: options.cohortIdOverride };
+    }
+    if (options?.ingestedAt) {
+      cohort = {
+        ...cohort,
+        source: { ...cohort.source, ingestedAt: options.ingestedAt },
+      };
+    }
+    if (options?.maxSubjects && cohort.subjects.length > options.maxSubjects) {
+      cohort = {
+        ...cohort,
+        subjects: cohort.subjects.slice(0, options.maxSubjects),
+      };
+    }
+
+    return cohort;
+  },
+};


### PR DESCRIPTION
## Summary

End-to-end real-data discovery on the **D1NAMO** T1D cohort (Dubosson et al. 2018; 9 T1D subjects × 4 days each; Dexcom G4 CGM at 5-min cadence + insulin doses + meal logs; CC-BY-SA-4.0 on Zenodo).

Builds on the discovery foundation merged in #123. Now we actually ingest a real T1D cohort and surface real edges.

```
zenodo zip (250 MB, gitignored)
     │
     ▼  research/scripts/build_d1namo_cohort.py
research/datasets/d1namo/cohort.json (gitignored)
     │
     ▼  src/lib/discovery/ingesters/d1namo.ts (validates schema)
Cohort  (9 subjects, 8,283 measurements)
     │
     ▼  src/lib/discovery/algorithms/lag-correlation.ts
DiscoveryResult  (14 edges after BH-FDR)
     │
     ▼  buildDiscoveryRun
research/runs/d1namo-lag-correlation-<ts>.json  (gitignored runtime path)
research/sample-runs/d1namo-lag-correlation-v0-1-0.json  (committed sample)
```

## What it found

Bidirectional CGM ↔ fast-acting insulin coupling at multiple lags up to 30 min (the longest measured). Strongest signal at the 30-min lag:

| Source | Target | Lag | r | BH-adj p |
|---|---|---|---|---|
| `cgm_glucose_mgdl` | `insulin_fast_units` | 1800s | +0.092 | 5.1×10⁻¹¹ |
| `insulin_fast_units` | `cgm_glucose_mgdl` | 1800s | +0.075 | 1.1×10⁻⁷ |

That's the bolus-correction loop visible in raw T1D management data: when glucose runs high, insulin doses follow at the 30-min scale; when insulin doses fire, glucose responds. r values modest (~0.08–0.09) but BH-adjusted p ≪ 0.05 because n is large.

Meals and slow-acting insulin fall below FDR threshold for v0 — that's the gap PCMCI+ closes (sparse-event handling + conditioning).

## Honest framing on the algorithm

**`lag-correlation` v0 is NOT PCMCI+.** It's a placeholder whose only job is to push real data through the pipeline end-to-end while the real algorithm gets built:

- ✅ Pearson correlation `X(t)` vs `Y(t+k)` per subject
- ✅ Fisher r-to-z meta-analysis across subjects
- ✅ Benjamini–Hochberg FDR control
- ✅ Skips all self-edges (autocorrelation is not structure)
- ❌ No conditioning sets — common causes inflate edges
- ❌ No partial correlation — direction is "temporal precedence" only
- ❌ No nonlinear dependence (mutual information / TE)

The algorithm description string, the in-source comment block, and the README all say so. The output shape is identical to PCMCI+ output, so the swap-in is a one-file change later.

## Files

- `research/scripts/build_d1namo_cohort.py` — Python ETL: zip → cohort.json. Subject ids stay opaque; SHA-256 of zip drops into `source.sourceHash` for drift detection.
- `src/lib/discovery/ingesters/d1namo.ts` — TS adapter; validates schema, asserts `containsPHI` is the literal `false`, applies overrides.
- `src/lib/discovery/algorithms/lag-correlation.ts` — v0 placeholder algorithm.
- `scripts/run-d1namo-discovery.ts` — end-to-end runner.
- `src/lib/discovery/__tests__/d1namo-ingester.test.ts` — 6 cases.
- `src/lib/discovery/__tests__/lag-correlation.test.ts` — 6 cases (true-edge recovery, no self-edges, FDR threshold).
- `research/sample-runs/d1namo-lag-correlation-v0-1-0.json` — committed sample run record (5 KB, structure-only — no raw measurements).
- `.gitignore` tightened: `/research/datasets/*/` ignores any cohort-data subdirectory; the loader scripts at `/research/datasets/*.py` stay tracked.

## Privacy verification

- Raw 250 MB D1NAMO zip → gitignored under `_cache/d1namo/`
- Built `cohort.json` → gitignored under `research/datasets/d1namo/`
- Per-run output → gitignored under `research/runs/`
- Committed sample run → 5 KB structure record only (variable ids, edges, lags, p-values; no measurements)

`git check-ignore` confirms all three.

## Test plan

- [x] 354 vitest tests pass (12 new in discovery)
- [x] `tsc --noEmit` clean
- [x] No live-app code changed; no UI changes; no Vercel risk
- [x] End-to-end run on real D1NAMO bytes produces sample artefact
- [ ] Reviewer: skim the algorithm's "HONEST FRAMING" comment block + README to confirm the v0 framing matches your standard before we wire UI / API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
