### PR TITLE
feat(discovery): surface DiscoveryRun results inside the SPIRTES module

### DIFF
--- a/public/discovery-runs/d1namo-lag-correlation-v0-1-0.json
+++ b/public/discovery-runs/d1namo-lag-correlation-v0-1-0.json
@@ -1,0 +1,155 @@
+{
+  "id": "c59ff404-56ac-4e0c-9403-fb51d5b92df6",
+  "cohortId": "d1namo-2018",
+  "cohortSourceHash": "89db2ac2dc915929514bae3eae06dcff3e3870d21b5ff4531f80d09eadb7101d",
+  "algorithm": {
+    "id": "lag-correlation",
+    "version": "0.1.0"
+  },
+  "params": {
+    "maxLagSeconds": 1800,
+    "gridSeconds": 300,
+    "alpha": 0.05,
+    "minAbsR": 0.1,
+    "minSubjects": 2,
+    "minGridPoints": 50
+  },
+  "startedAt": "2026-04-30T02:48:48.904Z",
+  "completedAt": "2026-04-30T02:48:48.925Z",
+  "status": "succeeded",
+  "result": {
+    "variables": [
+      "cgm_glucose_mgdl",
+      "meal_event",
+      "insulin_fast_units",
+      "insulin_slow_units"
+    ],
+    "edges": [
+      {
+        "source": "cgm_glucose_mgdl",
+        "target": "insulin_fast_units",
+        "lag": 1800,
+        "strength": 0.09193329212381592,
+        "pValue": 5.121147950148952e-11,
+        "evidence": "Fisher meta r=0.092 across 9 subjects at lag 1800s; BH-adjusted p=5.12e-11."
+      },
+      {
+        "source": "cgm_glucose_mgdl",
+        "target": "insulin_fast_units",
+        "lag": 1500,
+        "strength": 0.0902553945305092,
+        "pValue": 8.569855936002568e-11,
+        "evidence": "Fisher meta r=0.090 across 9 subjects at lag 1500s; BH-adjusted p=8.57e-11."
+      },
+      {
+        "source": "cgm_glucose_mgdl",
+        "target": "insulin_fast_units",
+        "lag": 1200,
+        "strength": 0.0884045076770615,
+        "pValue": 2.0480654209601804e-10,
+        "evidence": "Fisher meta r=0.088 across 9 subjects at lag 1200s; BH-adjusted p=2.05e-10."
+      },
+      {
+        "source": "cgm_glucose_mgdl",
+        "target": "insulin_fast_units",
+        "lag": 900,
+        "strength": 0.08647094406182344,
+        "pValue": 5.527771573810014e-10,
+        "evidence": "Fisher meta r=0.086 across 9 subjects at lag 900s; BH-adjusted p=5.53e-10."
+      },
+      {
+        "source": "cgm_glucose_mgdl",
+        "target": "insulin_fast_units",
+        "lag": 600,
+        "strength": 0.0844968881602059,
+        "pValue": 1.5538198283593375e-9,
+        "evidence": "Fisher meta r=0.084 across 9 subjects at lag 600s; BH-adjusted p=1.55e-9."
+      },
+      {
+        "source": "cgm_glucose_mgdl",
+        "target": "insulin_fast_units",
+        "lag": 300,
+        "strength": 0.08265773149523782,
+        "pValue": 4.06333588998109e-9,
+        "evidence": "Fisher meta r=0.083 across 9 subjects at lag 300s; BH-adjusted p=4.06e-9."
+      },
+      {
+        "source": "cgm_glucose_mgdl",
+        "target": "insulin_fast_units",
+        "lag": 0,
+        "strength": 0.08086926200914961,
+        "pValue": 8.872709789109479e-9,
+        "evidence": "Fisher meta r=0.081 across 9 subjects at lag 0s; BH-adjusted p=8.87e-9."
+      },
+      {
+        "source": "insulin_fast_units",
+        "target": "cgm_glucose_mgdl",
+        "lag": 0,
+        "strength": 0.08086926200914961,
+        "pValue": 8.872709789109479e-9,
+        "evidence": "Fisher meta r=0.081 across 9 subjects at lag 0s; BH-adjusted p=8.87e-9."
+      },
+      {
+        "source": "insulin_fast_units",
+        "target": "cgm_glucose_mgdl",
+        "lag": 300,
+        "strength": 0.07876019434624444,
+        "pValue": 2.7154255436793544e-8,
+        "evidence": "Fisher meta r=0.079 across 9 subjects at lag 300s; BH-adjusted p=2.72e-8."
+      },
+      {
+        "source": "insulin_fast_units",
+        "target": "cgm_glucose_mgdl",
+        "lag": 600,
+        "strength": 0.07678604772826286,
+        "pValue": 7.436068161226217e-8,
+        "evidence": "Fisher meta r=0.077 across 9 subjects at lag 600s; BH-adjusted p=7.44e-8."
+      },
+      {
+        "source": "insulin_fast_units",
+        "target": "cgm_glucose_mgdl",
+        "lag": 900,
+        "strength": 0.07626806238992813,
+        "pValue": 8.146771806655745e-8,
+        "evidence": "Fisher meta r=0.076 across 9 subjects at lag 900s; BH-adjusted p=8.15e-8."
+      },
+      {
+        "source": "insulin_fast_units",
+        "target": "cgm_glucose_mgdl",
+        "lag": 1200,
+        "strength": 0.07578021374326102,
+        "pValue": 8.856032899610493e-8,
+        "evidence": "Fisher meta r=0.076 across 9 subjects at lag 1200s; BH-adjusted p=8.86e-8."
+      },
+      {
+        "source": "insulin_fast_units",
+        "target": "cgm_glucose_mgdl",
+        "lag": 1500,
+        "strength": 0.07531730569017252,
+        "pValue": 9.696090901119175e-8,
+        "evidence": "Fisher meta r=0.075 across 9 subjects at lag 1500s; BH-adjusted p=9.70e-8."
+      },
+      {
+        "source": "insulin_fast_units",
+        "target": "cgm_glucose_mgdl",
+        "lag": 1800,
+        "strength": 0.07480038142302416,
+        "pValue": 1.1186239157190414e-7,
+        "evidence": "Fisher meta r=0.075 across 9 subjects at lag 1800s; BH-adjusted p=1.12e-7."
+      }
+    ],
+    "diagnostics": {
+      "nSubjectsUsed": 9,
+      "nCandidates": 14,
+      "nEdgesAfterFDR": 14,
+      "params": {
+        "maxLagSeconds": 1800,
+        "gridSeconds": 300,
+        "alpha": 0.05,
+        "minAbsR": 0.1,
+        "minSubjects": 2,
+        "minGridPoints": 50
+      }
+    }
+  }
+}

--- a/src/components/DiscoveryRunsPanel.tsx
+++ b/src/components/DiscoveryRunsPanel.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import type { DiscoveryRun } from "@/lib/discovery";
+
+// ─── DiscoveryRunsPanel ──────────────────────────────────────────────
+//
+// Surfaces a `DiscoveryRun` JSON record (the structure-only audit unit
+// produced by the discovery pipeline) inside the SPIRTES module. This
+// is where edges learned from real cohort data show up to a viewer for
+// the first time — distinct from the curated CausalGraph that the rest
+// of the app renders.
+//
+// Today: loads one hard-coded sample run from `/discovery-runs/`. The
+// run record contains only abstract structure (variable ids, edges,
+// lags, p-values) — there is no raw measurement data on the wire.
+//
+// Tomorrow: same component swaps to `/api/discovery/runs/<id>` once
+// the API layer lands. The data shape is identical.
+
+const SAMPLE_RUN_URL = "/discovery-runs/d1namo-lag-correlation-v0-1-0.json";
+
+type LoadState =
+  | { kind: "loading" }
+  | { kind: "ready"; run: DiscoveryRun }
+  | { kind: "error"; message: string };
+
+export default function DiscoveryRunsPanel() {
+  const [state, setState] = useState<LoadState>({ kind: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(SAMPLE_RUN_URL)
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
+      .then((run: DiscoveryRun) => {
+        if (!cancelled) setState({ kind: "ready", run });
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setState({
+            kind: "error",
+            message: err instanceof Error ? err.message : String(err),
+          });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div className="p-4 space-y-3">
+      <div className="text-[8px] font-mono text-text-muted p-2 border border-border/50 rounded bg-surface-elevated">
+        Edges learned from a real observational cohort, separate from the
+        curated CausalGraph above. Today: one D1NAMO sample run; tomorrow:
+        live results from <code>/api/discovery/runs/&lt;id&gt;</code>.
+      </div>
+
+      {state.kind === "loading" && <LoadingTile />}
+      {state.kind === "error" && <ErrorTile message={state.message} />}
+      {state.kind === "ready" && <RunTile run={state.run} />}
+    </div>
+  );
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────
+
+function LoadingTile() {
+  return (
+    <div className="text-[8px] font-mono text-text-muted p-3 border border-border/40 rounded">
+      Loading discovery run…
+    </div>
+  );
+}
+
+function ErrorTile({ message }: { message: string }) {
+  return (
+    <div className="text-[8px] font-mono text-accent-red p-3 border border-accent-red/40 rounded bg-accent-red/5">
+      Failed to load run: {message}
+    </div>
+  );
+}
+
+function RunTile({ run }: { run: DiscoveryRun }) {
+  const r = run.result;
+  const sortedEdges = useMemo(
+    () =>
+      [...r.edges].sort(
+        (a, b) => Math.abs(b.strength) - Math.abs(a.strength),
+      ),
+    [r.edges],
+  );
+
+  return (
+    <div className="space-y-2 border border-[#40c4ff]/30 rounded bg-[#40c4ff]/5 p-3">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <span className="text-[9px] font-[family-name:var(--font-michroma)] tracking-wider text-[#40c4ff]">
+          DISCOVERY RUN
+        </span>
+        <span
+          className={`text-[7px] font-mono ${
+            run.status === "succeeded"
+              ? "text-accent-green"
+              : "text-accent-red"
+          }`}
+        >
+          {run.status.toUpperCase()}
+        </span>
+      </div>
+
+      {/* Provenance grid */}
+      <div className="grid grid-cols-2 gap-1.5">
+        <Stat label="ALGORITHM" value={`${run.algorithm.id} v${run.algorithm.version}`} />
+        <Stat label="COHORT" value={run.cohortId} />
+        <Stat label="EDGES" value={String(r.edges.length)} />
+        <Stat
+          label="VARIABLES"
+          value={String(r.variables.length)}
+        />
+      </div>
+
+      {/* Diagnostics */}
+      {r.diagnostics && (
+        <div className="text-[7px] font-mono text-text-muted leading-relaxed border-l-2 border-[#40c4ff]/30 pl-2">
+          {typeof r.diagnostics.nSubjectsUsed === "number" && (
+            <>
+              {r.diagnostics.nSubjectsUsed} subjects ·{" "}
+            </>
+          )}
+          {typeof r.diagnostics.nCandidates === "number" && (
+            <>
+              {String(r.diagnostics.nCandidates)} candidates scanned ·{" "}
+            </>
+          )}
+          {typeof r.diagnostics.nEdgesAfterFDR === "number" && (
+            <>{String(r.diagnostics.nEdgesAfterFDR)} kept after FDR</>
+          )}
+        </div>
+      )}
+
+      {/* Edges */}
+      <div className="space-y-1.5">
+        <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-foreground pt-1">
+          DISCOVERED EDGES
+        </div>
+        {sortedEdges.length === 0 ? (
+          <div className="text-[8px] font-mono text-text-muted">
+            No edges passed the FDR threshold.
+          </div>
+        ) : (
+          <ul className="space-y-1">
+            {sortedEdges.map((edge, i) => (
+              <li
+                key={i}
+                className="text-[8px] font-mono text-foreground p-1.5 rounded border border-border bg-surface-elevated"
+                title={edge.evidence}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="truncate">
+                    <span className="text-accent-cyan">{edge.source}</span>
+                    <span className="text-text-muted mx-1">{"→"}</span>
+                    <span className="text-accent-amber">{edge.target}</span>
+                    {typeof edge.lag === "number" && edge.lag > 0 && (
+                      <span className="text-text-muted ml-2">
+                        (+{edge.lag}s)
+                      </span>
+                    )}
+                  </span>
+                  <span className="text-[7px] text-text-muted shrink-0">
+                    r={edge.strength.toFixed(3)}
+                    {typeof edge.pValue === "number" && (
+                      <>
+                        {" "}
+                        · p={edge.pValue.toExponential(1)}
+                      </>
+                    )}
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Algorithm caveat — honest framing carries through to the UI */}
+      {run.algorithm.id === "lag-correlation" && (
+        <div className="text-[7px] font-mono text-accent-amber/70 leading-relaxed border border-accent-amber/20 bg-accent-amber/5 rounded px-1.5 py-1">
+          <strong>v0 algorithm.</strong> Pearson correlation with BH-FDR —
+          not PCMCI+. No conditioning sets, so common causes inflate
+          edges; direction is temporal precedence only. The output shape
+          is identical to PCMCI+ output, so swapping the algorithm is a
+          one-file change later.
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="p-1.5 rounded border border-border bg-surface text-center">
+      <div className="text-[7px] font-mono text-text-muted">{label}</div>
+      <div className="text-[9px] font-mono text-foreground truncate" title={value}>
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ModulePanel.tsx
+++ b/src/components/ModulePanel.tsx
@@ -23,6 +23,7 @@ import {
 import { fitLppls, lpplsSeries } from "@/lib/estimators/lppls-fit";
 import { fitBettiTemplate } from "@/lib/estimators/ph-fit";
 import TrinityPanel from "./TrinityPanel";
+import DiscoveryRunsPanel from "./DiscoveryRunsPanel";
 import MonteCarloForecast from "./MonteCarloForecast";
 import InterdictionPanel from "./InterdictionPanel";
 import NewsInterpreterPanel from "./NewsInterpreterPanel";
@@ -87,6 +88,7 @@ export default function ModulePanel() {
           <>
             <CascadeHeader />
             <TrinityPanel />
+            <DiscoveryRunsPanel />
           </>
         )}
 


### PR DESCRIPTION
## Summary

The SPIRTES module now renders discovered edges from real cohort data alongside the existing CascadeHeader + TrinityPanel content. First time the discovery work (#123, #127) is visible to a human viewer.

## What you'll see

Click **SPIRTES** → scroll past the existing engine cards → new "DISCOVERY RUN" tile shows:
- Algorithm id + version (`lag-correlation v0.1.0`)
- Cohort id (`d1namo-2018`)
- Edge count (14) + variable count (4)
- Diagnostics line: "9 subjects · 14 candidates scanned · 14 kept after FDR"
- Discovered edges sorted by |strength|, each with source → target, lag annotation, r value, p-value, and full evidence in the title-attribute tooltip
- Honest amber-bordered caveat: "v0 algorithm. Pearson correlation with BH-FDR — not PCMCI+. No conditioning sets, so common causes inflate edges; direction is temporal precedence only."

## Honest framing carries through

The "this is v0, not PCMCI+" disclaimer that was in the commit message and PR body of #127 is now also in the UI itself. An institutional viewer hovering the panel sees the limitation right next to the result — no rug-pull when they ask "wait, this is just lag-correlation?"

## Files

- `src/components/DiscoveryRunsPanel.tsx` — fetches `/discovery-runs/d1namo-lag-correlation-v0-1-0.json`, renders provenance + diagnostics + edges + caveat. Loading / error / ready states.
- `src/components/ModulePanel.tsx` — adds the panel under SPIRTES. Pearl / Tarski / Pareto unchanged.
- `public/discovery-runs/d1namo-lag-correlation-v0-1-0.json` — runtime copy of the structure-only sample run from #127.

## Enterprise ladder

Fetch URL is hard-coded to the sample run for now. Once `POST /api/discovery/run` + `GET /api/discovery/runs/<id>` land (PR+2 of the new track), this same component swaps to the API endpoint with no rendering changes.

## Test plan

- [x] 354 vitest tests pass; `tsc --noEmit` clean
- [x] No DOM-testing-library configured — relying on type-check + manual preview review
- [ ] On Vercel preview: open SPIRTES module, scroll, confirm DISCOVERY RUN tile renders with 14 edges
- [ ] Verify amber caveat appears on the lag-correlation algorithm
- [ ] Confirm Pearl / Tarski / Pareto modules unchanged
- [ ] (Cosmetic) check small-screen layout — the edge list is the densest section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
