### PR TITLE
feat(discovery): API — POST /api/discovery/run + GET /api/discovery/algorithms

### DIFF
--- a/src/app/api/discovery/algorithms/route.ts
+++ b/src/app/api/discovery/algorithms/route.ts
@@ -1,0 +1,15 @@
+// ─── GET /api/discovery/algorithms ───────────────────────────────────
+//
+// Returns the catalog of registered discovery algorithms — id, version,
+// description, and default params. A client uses this to discover what
+// it can call POST /api/discovery/run with.
+
+import { NextResponse } from "next/server";
+import { listAlgorithms } from "@/lib/discovery/algorithm-registry";
+
+export async function GET() {
+  return NextResponse.json(
+    { algorithms: listAlgorithms() },
+    { status: 200 },
+  );
+}

--- a/src/app/api/discovery/run/route.ts
+++ b/src/app/api/discovery/run/route.ts
@@ -1,0 +1,108 @@
+// ─── POST /api/discovery/run ─────────────────────────────────────────
+//
+// Runs a discovery algorithm against a Cohort posted in the request
+// body and returns the resulting DiscoveryRun JSON.
+//
+// Body shape:
+//   {
+//     cohort: Cohort,                    // required, validated
+//     algorithm: { id: string,
+//                  params?: object }     // required, looked up in registry
+//   }
+//
+// Response shape: DiscoveryRun (see src/lib/discovery/run-types.ts).
+//
+// PRIVACY: the cohort validator hard-rejects bodies whose
+// source.containsPHI is anything other than literal false. The API
+// surface refuses to ingest PHI even if the caller mislabels it.
+//
+// PERSISTENCE: v0 is stateless — the run is computed and returned but
+// not persisted server-side. The caller is responsible for storing
+// the run record. Persistence (Vercel KV / Supabase / S3) lands when
+// the multi-tenant deployment story does; the wire format does not
+// change.
+
+import { NextRequest, NextResponse } from "next/server";
+import { randomUUID } from "node:crypto";
+import { getAlgorithm } from "@/lib/discovery/algorithm-registry";
+import {
+  CohortValidationError,
+  validateCohort,
+} from "@/lib/discovery/cohort-validator";
+import { buildDiscoveryRun } from "@/lib/discovery/run-types";
+
+interface RunRequestBody {
+  cohort: unknown;
+  algorithm: {
+    id: string;
+    params?: Record<string, unknown>;
+  };
+}
+
+export async function POST(req: NextRequest) {
+  let body: RunRequestBody;
+  try {
+    body = (await req.json()) as RunRequestBody;
+  } catch (e) {
+    return NextResponse.json(
+      { error: `invalid json body: ${(e as Error).message}` },
+      { status: 400 },
+    );
+  }
+
+  if (!body.algorithm || typeof body.algorithm.id !== "string") {
+    return NextResponse.json(
+      { error: "algorithm.id is required" },
+      { status: 400 },
+    );
+  }
+
+  const algorithm = getAlgorithm(body.algorithm.id);
+  if (!algorithm) {
+    return NextResponse.json(
+      {
+        error: `unknown algorithm: ${body.algorithm.id}`,
+        hint: "GET /api/discovery/algorithms lists available ids",
+      },
+      { status: 404 },
+    );
+  }
+
+  // Validate the cohort. The validator enforces the privacy contract,
+  // size limits, and structural integrity before the algorithm runs.
+  let cohort;
+  try {
+    cohort = validateCohort(body.cohort);
+  } catch (e) {
+    if (e instanceof CohortValidationError) {
+      return NextResponse.json({ error: e.message }, { status: 400 });
+    }
+    throw e;
+  }
+
+  const startedAt = new Date().toISOString();
+  let result;
+  try {
+    result = algorithm.run(cohort, body.algorithm.params);
+  } catch (e) {
+    return NextResponse.json(
+      {
+        error: `algorithm ${algorithm.id} threw: ${(e as Error).message}`,
+      },
+      { status: 500 },
+    );
+  }
+  const completedAt = new Date().toISOString();
+
+  const run = buildDiscoveryRun({
+    id: randomUUID(),
+    cohort,
+    algorithm: { id: algorithm.id, version: algorithm.version },
+    params: { ...algorithm.defaultParams, ...(body.algorithm.params ?? {}) },
+    startedAt,
+    completedAt,
+    result,
+  });
+
+  return NextResponse.json(run, { status: 200 });
+}

--- a/src/lib/discovery/__tests__/api-routes.test.ts
+++ b/src/lib/discovery/__tests__/api-routes.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/discovery/run/route";
+import { GET } from "@/app/api/discovery/algorithms/route";
+import type { Cohort } from "../cohort-types";
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+function reqJson(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/discovery/run", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function fixtureCohort(opts: {
+  nSubjects: number;
+  nSteps: number;
+  trueLag: number;
+  coupling: number;
+  noise: number;
+  seed: number;
+}): Cohort {
+  const { nSubjects, nSteps, trueLag, coupling, noise, seed } = opts;
+  let state = seed >>> 0;
+  const rand = () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return ((state >>> 8) / 0xffffff) * 2 - 1;
+  };
+  const subjects = Array.from({ length: nSubjects }, (_, si) => {
+    const x = new Array<number>(nSteps);
+    const y = new Array<number>(nSteps);
+    x[0] = rand();
+    for (let i = 1; i < nSteps; i++) x[i] = 0.6 * x[i - 1] + 0.4 * rand();
+    for (let i = 0; i < nSteps; i++) {
+      const xLagged = i >= trueLag ? x[i - trueLag] : 0;
+      y[i] = coupling * xLagged + noise * rand();
+    }
+    const measurements = [];
+    for (let i = 0; i < nSteps; i++) {
+      measurements.push({ variableId: "x", t: i * 300, value: x[i] });
+      measurements.push({ variableId: "y", t: i * 300, value: y[i] });
+    }
+    return { id: `s-${si}`, measurements };
+  });
+  return {
+    id: "api-test-cohort",
+    label: "api test",
+    source: {
+      adapter: "test",
+      adapterVersion: "0",
+      ingestedAt: "2026-04-29T00:00:00Z",
+      containsPHI: false,
+    },
+    variables: [
+      { id: "x", label: "X", kind: "continuous", cadenceSeconds: 300 },
+      { id: "y", label: "Y", kind: "continuous", cadenceSeconds: 300 },
+    ],
+    subjects,
+    timeAxis: { zeroConvention: "session-start", displayUnit: "seconds" },
+    metadata: { description: "test", accessTier: "public" },
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────
+
+describe("GET /api/discovery/algorithms", () => {
+  it("returns the catalog with at least lag-correlation registered", async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { algorithms: { id: string; version: string }[] };
+    expect(Array.isArray(data.algorithms)).toBe(true);
+    expect(data.algorithms.find((a) => a.id === "lag-correlation")).toBeDefined();
+  });
+});
+
+describe("POST /api/discovery/run", () => {
+  it("returns a DiscoveryRun on a valid coupled cohort", async () => {
+    const cohort = fixtureCohort({
+      nSubjects: 4,
+      nSteps: 200,
+      trueLag: 2,
+      coupling: 0.7,
+      noise: 0.4,
+      seed: 17,
+    });
+    const res = await POST(
+      reqJson({ cohort, algorithm: { id: "lag-correlation" } }),
+    );
+    expect(res.status).toBe(200);
+    const run = (await res.json()) as {
+      id: string;
+      status: string;
+      algorithm: { id: string; version: string };
+      cohortId: string;
+      result: { edges: { source: string; target: string; lag?: number }[] };
+    };
+    expect(run.status).toBe("succeeded");
+    expect(run.algorithm.id).toBe("lag-correlation");
+    expect(run.cohortId).toBe("api-test-cohort");
+    // Recovers the true x → y edge.
+    const xToY = run.result.edges.find(
+      (e) => e.source === "x" && e.target === "y",
+    );
+    expect(xToY).toBeDefined();
+  });
+
+  it("rejects bodies whose cohort.source.containsPHI is not literal false", async () => {
+    const cohort = fixtureCohort({
+      nSubjects: 4,
+      nSteps: 100,
+      trueLag: 1,
+      coupling: 0.5,
+      noise: 0.4,
+      seed: 1,
+    });
+    const tampered = {
+      ...cohort,
+      source: { ...cohort.source, containsPHI: true as unknown as false },
+    };
+    const res = await POST(
+      reqJson({ cohort: tampered, algorithm: { id: "lag-correlation" } }),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/containsPHI/);
+  });
+
+  it("returns 404 with hint for unknown algorithm id", async () => {
+    const cohort = fixtureCohort({
+      nSubjects: 2,
+      nSteps: 60,
+      trueLag: 1,
+      coupling: 0.5,
+      noise: 0.4,
+      seed: 2,
+    });
+    const res = await POST(
+      reqJson({ cohort, algorithm: { id: "bogus-algorithm" } }),
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string; hint: string };
+    expect(body.error).toMatch(/unknown algorithm/);
+    expect(body.hint).toMatch(/algorithms/);
+  });
+
+  it("returns 400 for malformed JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/discovery/run", {
+      method: "POST",
+      body: "{ not json",
+      headers: { "content-type": "application/json" },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when algorithm.id is missing", async () => {
+    const res = await POST(
+      reqJson({ cohort: {}, algorithm: { params: {} } }),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/algorithm\.id/);
+  });
+
+  it("honours algorithm param overrides", async () => {
+    const cohort = fixtureCohort({
+      nSubjects: 3,
+      nSteps: 200,
+      trueLag: 2,
+      coupling: 0.6,
+      noise: 0.4,
+      seed: 9,
+    });
+    const res = await POST(
+      reqJson({
+        cohort,
+        algorithm: {
+          id: "lag-correlation",
+          params: { alpha: 0.001, minAbsR: 0.5 }, // very strict
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const run = (await res.json()) as {
+      params: Record<string, unknown>;
+      result: { edges: unknown[] };
+    };
+    expect(run.params.alpha).toBe(0.001);
+    expect(run.params.minAbsR).toBe(0.5);
+  });
+});

--- a/src/lib/discovery/__tests__/cohort-validator.test.ts
+++ b/src/lib/discovery/__tests__/cohort-validator.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import {
+  CohortValidationError,
+  DEFAULT_LIMITS,
+  validateCohort,
+} from "../cohort-validator";
+import type { Cohort } from "../cohort-types";
+
+function valid(): Cohort {
+  return {
+    id: "test",
+    label: "test cohort",
+    source: {
+      adapter: "test",
+      adapterVersion: "0",
+      ingestedAt: "2026-04-29T00:00:00Z",
+      containsPHI: false,
+    },
+    variables: [
+      { id: "x", label: "X", kind: "continuous" },
+      { id: "y", label: "Y", kind: "continuous" },
+    ],
+    subjects: [
+      {
+        id: "s1",
+        measurements: [
+          { variableId: "x", t: 0, value: 1 },
+          { variableId: "y", t: 0, value: 2 },
+        ],
+      },
+    ],
+    timeAxis: { zeroConvention: "session-start", displayUnit: "seconds" },
+    metadata: { description: "test", accessTier: "public" },
+  };
+}
+
+describe("validateCohort", () => {
+  it("accepts a valid cohort", () => {
+    expect(() => validateCohort(valid())).not.toThrow();
+  });
+
+  it("rejects non-objects", () => {
+    expect(() => validateCohort(null)).toThrow(CohortValidationError);
+    expect(() => validateCohort("string")).toThrow(CohortValidationError);
+    expect(() => validateCohort(42)).toThrow(CohortValidationError);
+  });
+
+  it("rejects when source.containsPHI is anything other than literal false", () => {
+    for (const bad of [true, "false", 0, null, undefined]) {
+      const c = valid();
+      (c.source as unknown as { containsPHI: unknown }).containsPHI = bad;
+      expect(() => validateCohort(c)).toThrow(/containsPHI/);
+    }
+  });
+
+  it("rejects when a measurement references an unknown variable", () => {
+    const c = valid();
+    c.subjects[0].measurements.push({
+      variableId: "not_in_variables_list",
+      t: 0,
+      value: 1,
+    });
+    expect(() => validateCohort(c)).toThrow(/unknown variable/);
+  });
+
+  it("rejects duplicate variable ids", () => {
+    const c = valid();
+    c.variables.push({ id: "x", label: "X dup", kind: "continuous" });
+    expect(() => validateCohort(c)).toThrow(/duplicate variable/);
+  });
+
+  it("rejects duplicate subject ids", () => {
+    const c = valid();
+    c.subjects.push({
+      id: "s1",
+      measurements: [{ variableId: "x", t: 1, value: 9 }],
+    });
+    expect(() => validateCohort(c)).toThrow(/duplicate subject/);
+  });
+
+  it("rejects cohorts that exceed the measurement cap", () => {
+    const c = valid();
+    expect(() =>
+      validateCohort(c, { ...DEFAULT_LIMITS, maxMeasurements: 1 }),
+    ).toThrow(/exceeds limit/);
+  });
+
+  it("rejects measurements with non-finite t", () => {
+    const c = valid();
+    c.subjects[0].measurements[0].t = NaN;
+    expect(() => validateCohort(c)).toThrow(/non-finite/);
+  });
+
+  it("rejects empty variables array", () => {
+    const c = valid();
+    c.variables = [];
+    expect(() => validateCohort(c)).toThrow(/non-empty/);
+  });
+
+  it("rejects missing required top-level fields", () => {
+    for (const key of ["id", "label", "source", "variables", "subjects"]) {
+      const c = valid() as unknown as Record<string, unknown>;
+      delete c[key];
+      expect(() => validateCohort(c)).toThrow(new RegExp(key));
+    }
+  });
+});

--- a/src/lib/discovery/algorithm-registry.ts
+++ b/src/lib/discovery/algorithm-registry.ts
@@ -1,0 +1,43 @@
+// ─── Discovery — Algorithm Registry ──────────────────────────────────
+//
+// Central registry of available discovery algorithms. The API layer
+// (src/app/api/discovery/*) looks up algorithms by id; new algorithms
+// register here once and become callable from every entry point
+// (UI, API, scripts) automatically.
+
+import type { DiscoveryAlgorithm } from "./algorithm-interface";
+import { lagCorrelationAlgorithm } from "./algorithms/lag-correlation";
+
+// Erase the parameter generic so the registry is uniform; param shape
+// is documented per-algorithm via its description string + the source.
+const REGISTRY: Record<string, DiscoveryAlgorithm<Record<string, unknown>>> = {
+  [lagCorrelationAlgorithm.id]:
+    lagCorrelationAlgorithm as unknown as DiscoveryAlgorithm<
+      Record<string, unknown>
+    >,
+};
+
+/** Look up an algorithm by id; returns null if unknown. */
+export function getAlgorithm(
+  id: string,
+): DiscoveryAlgorithm<Record<string, unknown>> | null {
+  return REGISTRY[id] ?? null;
+}
+
+/** Public algorithm descriptor returned by GET /api/discovery/algorithms. */
+export interface AlgorithmCatalogEntry {
+  id: string;
+  version: string;
+  description: string;
+  defaultParams: Record<string, unknown>;
+}
+
+/** List all registered algorithms — the catalog API consumes this. */
+export function listAlgorithms(): AlgorithmCatalogEntry[] {
+  return Object.values(REGISTRY).map((a) => ({
+    id: a.id,
+    version: a.version,
+    description: a.description,
+    defaultParams: a.defaultParams,
+  }));
+}

--- a/src/lib/discovery/cohort-validator.ts
+++ b/src/lib/discovery/cohort-validator.ts
@@ -1,0 +1,196 @@
+// ─── Discovery — Cohort Validator ────────────────────────────────────
+//
+// Runtime validator for `Cohort` objects arriving from untrusted
+// sources (the API surface). The TS type system enforces the schema
+// at compile time; this file enforces it at runtime so a malicious or
+// malformed POST body can't bypass the privacy contract.
+//
+// Privacy contract (load-bearing):
+//   - source.containsPHI MUST be the literal `false`
+//   - subject.id MUST be a non-empty string (no PHI shape check —
+//     adapters de-identify upstream; we just enforce structural
+//     opacity here)
+//
+// Size contract:
+//   - capped subjects / variables / measurements so a runaway cohort
+//     can't OOM the worker
+
+import type { Cohort, Measurement, Subject, Variable } from "./cohort-types";
+
+export interface CohortValidatorLimits {
+  maxSubjects: number;
+  maxVariables: number;
+  maxMeasurements: number;
+}
+
+export const DEFAULT_LIMITS: CohortValidatorLimits = {
+  maxSubjects: 100,
+  maxVariables: 50,
+  maxMeasurements: 50_000,
+};
+
+export class CohortValidationError extends Error {
+  constructor(message: string) {
+    super(`cohort validation failed: ${message}`);
+    this.name = "CohortValidationError";
+  }
+}
+
+/**
+ * Validates an unknown blob as a Cohort. Throws CohortValidationError
+ * with a precise pointer on any mismatch. Returns the Cohort on
+ * success (with a refined type).
+ */
+export function validateCohort(
+  blob: unknown,
+  limits: CohortValidatorLimits = DEFAULT_LIMITS,
+): Cohort {
+  if (!blob || typeof blob !== "object") {
+    throw new CohortValidationError("body is not an object");
+  }
+  const c = blob as Record<string, unknown>;
+
+  for (const key of [
+    "id",
+    "label",
+    "source",
+    "variables",
+    "subjects",
+    "timeAxis",
+    "metadata",
+  ]) {
+    if (!(key in c)) {
+      throw new CohortValidationError(`missing required field "${key}"`);
+    }
+  }
+
+  if (typeof c.id !== "string" || c.id.length === 0) {
+    throw new CohortValidationError("id must be a non-empty string");
+  }
+  if (typeof c.label !== "string") {
+    throw new CohortValidationError("label must be a string");
+  }
+
+  // ── Source / privacy contract ──────────────────────────────────
+  const source = c.source as Record<string, unknown> | null;
+  if (!source || typeof source !== "object") {
+    throw new CohortValidationError("source must be an object");
+  }
+  if (source.containsPHI !== false) {
+    throw new CohortValidationError(
+      `source.containsPHI must be the literal false, got ${JSON.stringify(source.containsPHI)}`,
+    );
+  }
+  for (const key of ["adapter", "adapterVersion", "ingestedAt"]) {
+    if (typeof source[key] !== "string") {
+      throw new CohortValidationError(
+        `source.${key} must be a string`,
+      );
+    }
+  }
+
+  // ── Variables ──────────────────────────────────────────────────
+  if (!Array.isArray(c.variables)) {
+    throw new CohortValidationError("variables must be an array");
+  }
+  if (c.variables.length === 0) {
+    throw new CohortValidationError("variables must be non-empty");
+  }
+  if (c.variables.length > limits.maxVariables) {
+    throw new CohortValidationError(
+      `${c.variables.length} variables exceeds limit ${limits.maxVariables}`,
+    );
+  }
+  const varIds = new Set<string>();
+  const validKinds = new Set(["continuous", "discrete", "event", "binary"]);
+  for (const v of c.variables as Variable[]) {
+    if (typeof v.id !== "string" || v.id.length === 0) {
+      throw new CohortValidationError("variable.id must be a non-empty string");
+    }
+    if (varIds.has(v.id)) {
+      throw new CohortValidationError(`duplicate variable id: ${v.id}`);
+    }
+    varIds.add(v.id);
+    if (typeof v.label !== "string") {
+      throw new CohortValidationError(`variable ${v.id}: label must be a string`);
+    }
+    if (!validKinds.has(v.kind)) {
+      throw new CohortValidationError(
+        `variable ${v.id}: kind must be one of ${[...validKinds].join("/")}`,
+      );
+    }
+  }
+
+  // ── Subjects + measurements ────────────────────────────────────
+  if (!Array.isArray(c.subjects)) {
+    throw new CohortValidationError("subjects must be an array");
+  }
+  if (c.subjects.length === 0) {
+    throw new CohortValidationError("subjects must be non-empty");
+  }
+  if (c.subjects.length > limits.maxSubjects) {
+    throw new CohortValidationError(
+      `${c.subjects.length} subjects exceeds limit ${limits.maxSubjects}`,
+    );
+  }
+  let totalMeasurements = 0;
+  const subjectIds = new Set<string>();
+  for (const s of c.subjects as Subject[]) {
+    if (typeof s.id !== "string" || s.id.length === 0) {
+      throw new CohortValidationError("subject without opaque id");
+    }
+    if (subjectIds.has(s.id)) {
+      throw new CohortValidationError(`duplicate subject id: ${s.id}`);
+    }
+    subjectIds.add(s.id);
+    if (!Array.isArray(s.measurements)) {
+      throw new CohortValidationError(
+        `subject ${s.id}: measurements must be an array`,
+      );
+    }
+    for (const m of s.measurements as Measurement[]) {
+      if (!varIds.has(m.variableId)) {
+        throw new CohortValidationError(
+          `subject ${s.id}: unknown variable "${m.variableId}"`,
+        );
+      }
+      if (!Number.isFinite(m.t)) {
+        throw new CohortValidationError(
+          `subject ${s.id}: non-finite t on ${m.variableId}`,
+        );
+      }
+      if (
+        typeof m.value !== "number" &&
+        typeof m.value !== "string"
+      ) {
+        throw new CohortValidationError(
+          `subject ${s.id}: value must be number or string on ${m.variableId}`,
+        );
+      }
+    }
+    totalMeasurements += s.measurements.length;
+    if (totalMeasurements > limits.maxMeasurements) {
+      throw new CohortValidationError(
+        `total measurements (${totalMeasurements}+) exceeds limit ${limits.maxMeasurements}`,
+      );
+    }
+  }
+
+  // ── timeAxis + metadata (lighter checks) ───────────────────────
+  const timeAxis = c.timeAxis as Record<string, unknown> | null;
+  if (!timeAxis || typeof timeAxis !== "object") {
+    throw new CohortValidationError("timeAxis must be an object");
+  }
+  if (typeof timeAxis.zeroConvention !== "string") {
+    throw new CohortValidationError("timeAxis.zeroConvention must be a string");
+  }
+  const md = c.metadata as Record<string, unknown> | null;
+  if (!md || typeof md !== "object") {
+    throw new CohortValidationError("metadata must be an object");
+  }
+  if (typeof md.description !== "string") {
+    throw new CohortValidationError("metadata.description must be a string");
+  }
+
+  return blob as Cohort;
+}


### PR DESCRIPTION
## Summary

The discovery pipeline is now **callable from outside the Manifold UI** — the load-bearing piece of the enterprise ladder. Once this lands, an institutional pilot can hit the cloud endpoint with their own cohort and get a DiscoveryRun back.

## Endpoints

### `POST /api/discovery/run`

```http
POST /api/discovery/run
Content-Type: application/json

{
  "cohort": { ... Cohort schema ... },
  "algorithm": { "id": "lag-correlation", "params": { "alpha": 0.01 } }
}
```

Returns `DiscoveryRun` — same JSON shape the SPIRTES UI consumes (#128) and the runner script writes to disk (#127). One wire format end-to-end.

Status codes: `200` ok · `400` bad cohort or body · `404` unknown algorithm · `500` algorithm exception. Each error returns a useful message; `404` includes a hint pointing to the catalog endpoint.

### `GET /api/discovery/algorithms`

```http
GET /api/discovery/algorithms
```

Returns `{ algorithms: [{ id, version, description, defaultParams }] }`. Lets a client discover what's runnable before posting a cohort.

## Privacy contract enforced at the wire

`src/lib/discovery/cohort-validator.ts` runs on every POST. The compile-time `containsPHI: false` literal type that the schema enforces inside the codebase is **also enforced at the API boundary**: a tampered body forging `containsPHI: true` is hard-rejected with 400. Plus:

- All variable / subject ids must be opaque non-empty strings
- Duplicate ids rejected (variables and subjects)
- All `measurement.t` values must be finite
- Size caps: 50K measurements · 100 subjects · 50 variables (configurable per-call so on-prem deployments can raise them)

## Statelessness

V0 is stateless — the run is computed and returned but not persisted server-side. Persistence (Vercel KV / Supabase / S3) lands when the multi-tenant deployment story does. The wire format does not change when persistence arrives — `GET /api/discovery/runs/<id>` slots in alongside the existing endpoints.

## Files

- `src/lib/discovery/algorithm-registry.ts` — id → DiscoveryAlgorithm map. New algorithm = one import + one map entry; API and UI both pick it up.
- `src/lib/discovery/cohort-validator.ts` — runtime validator with named errors and configurable size limits.
- `src/app/api/discovery/run/route.ts` — POST handler.
- `src/app/api/discovery/algorithms/route.ts` — GET catalog handler.
- `src/lib/discovery/__tests__/cohort-validator.test.ts` — **10 cases**: every rejection path including the privacy guard.
- `src/lib/discovery/__tests__/api-routes.test.ts` — **7 cases**: end-to-end edge recovery, privacy rejection at API, unknown algorithm 404, malformed JSON 400, missing algorithm.id 400, param overrides, catalog response shape.

## Trying it on Vercel preview

```bash
curl https://manifold.apexanalytica.co/api/discovery/algorithms
# → { "algorithms": [{ "id": "lag-correlation", "version": "0.1.0", ... }] }

# Round-trip the D1NAMO sample run record we already publish:
curl -s https://manifold.apexanalytica.co/discovery-runs/d1namo-lag-correlation-v0-1-0.json \
  | jq '.'   # see the discovered edges
```

(POST against the API requires a valid Cohort body — easiest from the existing `scripts/run-d1namo-discovery.ts` once we wire it to call the API instead of running in-process.)

## Test plan

- [x] 371 vitest tests pass (17 new in API + validator)
- [x] `tsc --noEmit` clean
- [x] No UI changes; SPIRTES panel still reads the static sample run
- [ ] Vercel preview: `GET /api/discovery/algorithms` returns the catalog
- [ ] Vercel preview: `POST /api/discovery/run` round-trips a small fixture cohort

🤖 Generated with [Claude Code](https://claude.com/claude-code)
