### PR TITLE
fix(build): enable Turbopack system TLS certs to fix Vercel font fetches

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,12 +12,16 @@ const nextConfig: NextConfig = {
   },
 
   // Inline critical CSS to cut render-blocking stylesheets.
+  //
   // turbopackUseSystemTlsCerts: Next 16's default Turbopack builder
   // hits a TLS-cert resolution bug when fetching Google Fonts during
   // production build, causing Vercel deploys to fail with
   // "Failed to fetch `<font>` from Google Fonts" on every PR. Setting
-  // this flag points Turbopack at the system CA bundle and resolves
-  // the fetch. See PR #129 / commit history of #127 #128 for context.
+  // this flag points Turbopack at the system CA bundle. The build
+  // script also passes --webpack as a belt-and-suspenders fallback
+  // (Next 16 supports --webpack to opt out of Turbopack entirely),
+  // so production deploys bypass the bug regardless of whether
+  // this flag takes effect in the Vercel build environment.
   experimental: {
     optimizeCss: true,
     turbopackUseSystemTlsCerts: true,

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,9 +11,16 @@ const nextConfig: NextConfig = {
     imageSizes: [16, 32, 48, 64, 96, 128, 256],
   },
 
-  // Inline critical CSS to cut render-blocking stylesheets
+  // Inline critical CSS to cut render-blocking stylesheets.
+  // turbopackUseSystemTlsCerts: Next 16's default Turbopack builder
+  // hits a TLS-cert resolution bug when fetching Google Fonts during
+  // production build, causing Vercel deploys to fail with
+  // "Failed to fetch `<font>` from Google Fonts" on every PR. Setting
+  // this flag points Turbopack at the system CA bundle and resolves
+  // the fetch. See PR #129 / commit history of #127 #128 for context.
   experimental: {
     optimizeCss: true,
+    turbopackUseSystemTlsCerts: true,
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build --webpack",
     "prebuild": "vitest run",
     "start": "next start",
     "lint": "eslint",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "buildCommand": "npm run build",
+  "installCommand": "npm install"
+}


### PR DESCRIPTION
## Closing — root cause was different and the real fix already landed via #137

**Original theory:** Vercel deploys were failing on Turbopack's TLS-cert resolution while fetching Google Fonts; this PR's three attempts (turbopackUseSystemTlsCerts, --webpack switch, vercel.json) were all aimed at that.

**Actual cause** (revealed by the deploy logs Junaid pulled): the `prebuild: vitest run` step was failing on two discovery test files that imported `node:`-prefixed built-ins. Vitest in Vercel's build env was treating those as browser-incompatible and crashing with `Error: No such built-in module: node:`. The Google Fonts warning in my local repro was a sandbox-only red herring.

**Real fix** already landed:
- `d25001e` (#137) — pinned vite to 8.0.0 + rolldown to 1.0.0-rc.9
- `4fe90ba` — dropped `node:` prefix from discovery imports
- `af144af` — added `// @vitest-environment node` directive to the two failing test files

Main is deploying cleanly again. Closing this PR; the changes here (next.config.ts flag, --webpack build, vercel.json) are not needed.

Note: I've rebased PRs #129, #134, #165, #169 onto current main so they pick up the real fix.