### PR TITLE
fix(text-size): scale only text, not the entire app

### DIFF
--- a/docs/sessions/ux-onboarding.md
+++ b/docs/sessions/ux-onboarding.md
@@ -39,8 +39,9 @@ This session does **not** care about graph data, engines, canvas rendering, or p
 ### Text size toggle
 - `src/components/TextSizeToggle.tsx`, `src/hooks/useTextSize.ts`
 - S/M/L segmented control persisted to `localStorage["manifold:text-size"]`
-- Applied via CSS `zoom` on `<html>` (the app uses ~700 fixed px text classes so root font-size won't propagate)
+- Sets `data-text-size` on `<html>`. CSS in `src/app/globals.css` defines a `--text-mult` variable per state and overrides each text utility actually used in the codebase (every `text-[Npx]` plus the standard `text-xs/sm/base/lg/xl/2xl/3xl`) with `font-size: calc(<original> * var(--text-mult))`. When adding a new `text-[Npx]` size, add a matching override line.
 - Pre-paint inline script in `src/app/layout.tsx` prevents flash-of-wrong-size
+- This *only* scales text — layout, canvas, and icons are not affected. (Earlier implementation used `zoom` on `<html>`, which scaled everything; replaced because it was a UX bug.)
 
 ### Feedback widget
 - `src/components/FeedbackWidget.tsx`

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -55,10 +55,35 @@ body {
 
 /* User-adjustable text size. Applied via data attribute on <html> set by
  * useTextSize + a blocking inline script in RootLayout to avoid FOUC.
- * The app's UI uses fixed px sizes (700+ occurrences), so zoom is the only
- * viable knob — root font-size would be a no-op. */
-html[data-text-size="sm"] { zoom: 0.9; }
-html[data-text-size="lg"] { zoom: 1.15; }
+ * The app's UI uses 700+ fixed-px text classes (text-[Npx]), so root
+ * font-size won't propagate. We instead define a multiplier variable and
+ * override each text utility actually used in the codebase. When adding a
+ * new text-[Npx] size, add a matching override here.
+ */
+html { --text-mult: 1; }
+html[data-text-size="sm"] { --text-mult: 0.9; }
+html[data-text-size="lg"] { --text-mult: 1.15; }
+
+.text-\[6px\]  { font-size: calc(6px  * var(--text-mult)); }
+.text-\[7px\]  { font-size: calc(7px  * var(--text-mult)); }
+.text-\[8px\]  { font-size: calc(8px  * var(--text-mult)); }
+.text-\[9px\]  { font-size: calc(9px  * var(--text-mult)); }
+.text-\[10px\] { font-size: calc(10px * var(--text-mult)); }
+.text-\[11px\] { font-size: calc(11px * var(--text-mult)); }
+.text-\[12px\] { font-size: calc(12px * var(--text-mult)); }
+.text-\[13px\] { font-size: calc(13px * var(--text-mult)); }
+.text-\[14px\] { font-size: calc(14px * var(--text-mult)); }
+.text-\[15px\] { font-size: calc(15px * var(--text-mult)); }
+.text-\[22px\] { font-size: calc(22px * var(--text-mult)); }
+.text-\[28px\] { font-size: calc(28px * var(--text-mult)); }
+
+.text-xs  { font-size: calc(0.75rem  * var(--text-mult)); }
+.text-sm  { font-size: calc(0.875rem * var(--text-mult)); }
+.text-base{ font-size: calc(1rem     * var(--text-mult)); }
+.text-lg  { font-size: calc(1.125rem * var(--text-mult)); }
+.text-xl  { font-size: calc(1.25rem  * var(--text-mult)); }
+.text-2xl { font-size: calc(1.5rem   * var(--text-mult)); }
+.text-3xl { font-size: calc(1.875rem * var(--text-mult)); }
 
 /* Scrollbar styling */
 ::-webkit-scrollbar {


### PR DESCRIPTION
## Summary

S/M/L text-size toggle was scaling the entire app (canvas, icons, layout, everything) because the implementation was `zoom: 0.9 | 1.15` on `<html>`. It should only scale text.

The original justification for `zoom` was that the codebase has 700+ fixed-px text classes (`text-[Npx]`) so root `font-size` wouldn't propagate. Counted them: only **12 distinct `text-[Npx]` values** (6–28px) and **6 standard Tailwind text classes** in use (`text-xs/sm/lg/xl/2xl/3xl`). That's small enough to override directly.

- Replaced `zoom` with a CSS variable: `--text-mult: 0.9 | 1 | 1.15`
- Added one `font-size: calc(<original> * var(--text-mult))` override per text class actually used
- No component refactor

## Maintenance note

When adding a new `text-[Npx]` size in components, add a matching override line in `src/app/globals.css`. There's a comment in the file flagging this.

## Test plan

- [ ] Click S — only text shrinks; canvas, icons, modal sizes, layout stay put
- [ ] Click L — only text grows; same invariants
- [ ] Click M — text returns to baseline
- [ ] Reload — last choice persists (`localStorage["manifold:text-size"]`) without flash-of-wrong-size

https://claude.ai/code/session_016LDegKy2R7Ly91ahAnBAQX

---
_Generated by [Claude Code](https://claude.ai/code/session_016LDegKy2R7Ly91ahAnBAQX)_