### PR TITLE
feat(pareto): always render F.E.G.S breakdown, collapsible sections, formula in header

### DIFF
--- a/src/components/ModulePanel.tsx
+++ b/src/components/ModulePanel.tsx
@@ -820,11 +820,17 @@ function ParetoPanel({
 
   // Mean omegaComposite trajectory across the scoped nodes, normalized 0–1.
   // Single source of truth shared with the bottom ΩF TIME SERIES cards.
+  //
+  // Histories are filtered to length ≥ 5 before the min-clip — a single node
+  // with one entry would otherwise collapse the trajectory to T=1 and starve
+  // every live estimator (CSD's AR(1) fit needs n≥5). 5 matches the smallest
+  // n at which any criticality model can produce a non-degenerate result.
   const scopedOmegaSeries = useMemo<number[]>(() => {
     if (!temporalData || scopedNodeIds.length === 0) return [];
+    const MIN_USEFUL_HISTORY = 5;
     const histories = scopedNodeIds
       .map((id) => temporalData.nodes.get(id)?.history ?? [])
-      .filter((h) => h.length > 0);
+      .filter((h) => h.length >= MIN_USEFUL_HISTORY);
     if (histories.length === 0) return [];
     const T = Math.min(...histories.map((h) => h.length));
     const series: number[] = [];

--- a/src/components/ModulePanel.tsx
+++ b/src/components/ModulePanel.tsx
@@ -1102,19 +1102,23 @@ function ParetoPanel({
     const edgeCount = graphData.edges.filter((e) => !e.isSevered).length;
     const nodeCount = graphData.nodes.length;
 
-    if (csdData.modelSeries) {
-      inputs.push({
-        key: "csd",
-        observed: csdData.observedSeries ?? csdData.timeSeries,
-        modelSeries: csdData.modelSeries,
-        freeParams: 2, // α and μ
-        gate: csdRegimeGate({
-          observed: csdData.observedSeries ?? csdData.timeSeries,
-          lambdaMax: csdData.lambdaMax,
-        }),
-        sufficiency: trajectorySufficiency(csdData.sampleSize, edgeCount),
-      });
-    }
+    // Always push live estimators into the relevance batch — even when the
+    // trajectory is too thin to fit. The sub-score helpers handle insufficient
+    // data internally (F → 0 with "need ≥5", E → 0 with "Insufficient data"),
+    // so the breakdown UI renders consistently across all three tabs and the
+    // user sees *why* a model can't score rather than a silent fallback.
+    const csdObserved = csdData.observedSeries ?? csdData.timeSeries ?? [];
+    inputs.push({
+      key: "csd",
+      observed: csdObserved,
+      modelSeries: csdData.modelSeries ?? [],
+      freeParams: 2, // α and μ
+      gate: csdRegimeGate({
+        observed: csdObserved,
+        lambdaMax: csdData.lambdaMax,
+      }),
+      sufficiency: trajectorySufficiency(csdData.sampleSize, edgeCount),
+    });
 
     if (phData.modelSeries) {
       inputs.push({
@@ -1131,19 +1135,19 @@ function ParetoPanel({
       });
     }
 
-    if (lpplsData.observedSeries && lpplsData.observedSeries.length > 0) {
-      inputs.push({
-        key: "lppls",
-        observed: lpplsData.observedSeries,
-        modelSeries: lpplsData.modelSeries.slice(0, lpplsData.observedSeries.length),
-        freeParams: 3, // ω, m, tc
-        gate: lpplsRegimeGate({
-          observed: lpplsData.observedSeries,
-          modelSeries: lpplsData.modelSeries.slice(0, lpplsData.observedSeries.length),
-        }),
-        sufficiency: trajectorySufficiency(lpplsData.sampleSize, edgeCount),
-      });
-    }
+    const lpplsObserved = lpplsData.observedSeries ?? lpplsData.timeSeries ?? [];
+    const lpplsModel = lpplsData.modelSeries.slice(0, Math.max(lpplsObserved.length, 1));
+    inputs.push({
+      key: "lppls",
+      observed: lpplsObserved,
+      modelSeries: lpplsModel,
+      freeParams: 3, // ω, m, tc
+      gate: lpplsRegimeGate({
+        observed: lpplsObserved,
+        modelSeries: lpplsModel,
+      }),
+      sufficiency: trajectorySufficiency(lpplsData.sampleSize, edgeCount),
+    });
 
     const result = computeRelevanceBatch(inputs, {
       previous: prevCompositesRef.current,
@@ -2393,6 +2397,10 @@ function CriticalityCard({
   const isEmpty = !!emptyState;
   const headlineLabel = relevance ? "rel" : "conf";
   const sectionLabel = relevance ? "MODEL RELEVANCE" : "MODEL CONFIDENCE";
+  // Subsection collapse state — breakdown open by default (it's the headline
+  // justification), methodology closed (long prose, mostly read-once).
+  const [breakdownOpen, setBreakdownOpen] = useState(true);
+  const [methodologyOpen, setMethodologyOpen] = useState(false);
   return (
     <div
       className="border rounded overflow-hidden transition-all duration-300"
@@ -2526,10 +2534,18 @@ function CriticalityCard({
                 </div>
               </div>
 
-              {/* Relevance / confidence gauge */}
+              {/* Relevance / confidence gauge — header carries the formula
+                  so the headline % visibly ties to the four sub-scores below. */}
               <div>
-                <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted mb-1">
-                  {sectionLabel}
+                <div className="flex items-baseline gap-2 mb-1 flex-wrap">
+                  <span className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted">
+                    {sectionLabel}
+                  </span>
+                  {relevance && (
+                    <span className="text-[8px] font-mono text-text-muted/60">
+                      = S · G · (0.6·F + 0.4·E)
+                    </span>
+                  )}
                 </div>
                 <div className="flex items-center gap-2">
                   <div className="flex-1 h-1.5 bg-border rounded overflow-hidden">
@@ -2554,72 +2570,103 @@ function CriticalityCard({
                 </div>
               </div>
 
-              {/* F · E · G · S breakdown — only when a relevance computation
-                  is available. Headline = S · G · (0.6·F + 0.4·E), EMA-smoothed. */}
+              {/* F · E · G · S breakdown — collapsible, open by default.
+                  Always rendered when a relevance computation exists; rows
+                  showing 0% with an "insufficient" detail tell the user
+                  *why* a model can't score (data gap, not a bug). */}
               {relevance && (
                 <div>
-                  <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted mb-1">
-                    RELEVANCE BREAKDOWN
-                  </div>
-                  <div className="space-y-1">
-                    {([
-                      { code: "F", label: "FIT", sub: relevance.F },
-                      { code: "E", label: "EVIDENCE", sub: relevance.E },
-                      { code: "G", label: "REGIME", sub: relevance.G },
-                      { code: "S", label: "SUFFICIENCY", sub: relevance.S },
-                    ] as const).map(({ code, label, sub }) => {
-                      const pct = Math.round(sub.score * 100);
-                      const barColor = pct >= 70 ? "#00e676" : pct >= 40 ? "#ffab00" : "#ff5252";
-                      return (
-                        <div key={code} className="flex items-center gap-2">
-                          <div className="w-3 text-[9px] font-[family-name:var(--font-michroma)] text-text-muted">
-                            {code}
-                          </div>
-                          <div className="w-14 text-[7px] font-mono text-text-muted/80 tracking-wider">
-                            {label}
-                          </div>
-                          <div className="flex-1 h-1 bg-border rounded overflow-hidden">
-                            <div className="h-full rounded transition-all duration-500" style={{
-                              width: `${pct}%`,
-                              backgroundColor: barColor,
-                              opacity: 0.8,
-                            }} />
-                          </div>
-                          <div className="w-8 text-right text-[9px] font-mono tabular-nums" style={{ color: barColor }}>
-                            {pct}%
-                          </div>
-                          <div className="flex-[2] min-w-0 text-[8px] font-mono text-text-muted/80 truncate" title={sub.detail}>
-                            {sub.detail}
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>
-                  <div className="text-[8px] font-mono text-text-muted/80 mt-1 leading-relaxed">
-                    composite = S · G · (0.6·F + 0.4·E) ={" "}
-                    {relevance.S.score.toFixed(2)} · {relevance.G.score.toFixed(2)} · ({(0.6 * relevance.F.score).toFixed(2)} + {(0.4 * relevance.E.score).toFixed(2)}) ={" "}
-                    {relevance.rawComposite.toFixed(2)}
-                    {Math.abs(relevance.composite - relevance.rawComposite) > 0.005 && (
-                      <> → smoothed {relevance.composite.toFixed(2)}</>
-                    )}
-                  </div>
+                  <button
+                    onClick={() => setBreakdownOpen((v) => !v)}
+                    className="w-full flex items-center justify-between mb-1 hover:brightness-125 transition-all"
+                  >
+                    <span className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted">
+                      RELEVANCE BREAKDOWN
+                    </span>
+                    <span
+                      className="text-[10px] text-text-muted transition-transform duration-200"
+                      style={{ transform: breakdownOpen ? "rotate(180deg)" : "rotate(0deg)" }}
+                    >
+                      {"▼"}
+                    </span>
+                  </button>
+                  {breakdownOpen && (
+                    <>
+                      <div className="space-y-1">
+                        {([
+                          { code: "F", label: "FIT", role: "×0.6", sub: relevance.F },
+                          { code: "E", label: "EVIDENCE", role: "×0.4", sub: relevance.E },
+                          { code: "G", label: "REGIME", role: "gate", sub: relevance.G },
+                          { code: "S", label: "SUFFICIENCY", role: "gate", sub: relevance.S },
+                        ] as const).map(({ code, label, role, sub }) => {
+                          const pct = Math.round(sub.score * 100);
+                          const barColor = pct >= 70 ? "#00e676" : pct >= 40 ? "#ffab00" : "#ff5252";
+                          return (
+                            <div key={code} className="flex items-center gap-2">
+                              <div className="w-3 text-[9px] font-[family-name:var(--font-michroma)] text-text-muted">
+                                {code}
+                              </div>
+                              <div className="w-14 text-[7px] font-mono text-text-muted/80 tracking-wider">
+                                {label}
+                              </div>
+                              <div className="w-8 text-[7px] font-mono text-text-muted/50 tracking-wider">
+                                {role}
+                              </div>
+                              <div className="flex-1 h-1 bg-border rounded overflow-hidden">
+                                <div className="h-full rounded transition-all duration-500" style={{
+                                  width: `${pct}%`,
+                                  backgroundColor: barColor,
+                                  opacity: 0.8,
+                                }} />
+                              </div>
+                              <div className="w-8 text-right text-[9px] font-mono tabular-nums" style={{ color: barColor }}>
+                                {pct}%
+                              </div>
+                              <div className="flex-[2] min-w-0 text-[8px] font-mono text-text-muted/80 truncate" title={sub.detail}>
+                                {sub.detail}
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                      <div className="text-[8px] font-mono text-text-muted/80 mt-1 leading-relaxed">
+                        {confPct}% = {relevance.S.score.toFixed(2)} · {relevance.G.score.toFixed(2)} · ({(0.6 * relevance.F.score).toFixed(2)} + {(0.4 * relevance.E.score).toFixed(2)}) = {relevance.rawComposite.toFixed(2)}
+                        {Math.abs(relevance.composite - relevance.rawComposite) > 0.005 && (
+                          <> → smoothed {relevance.composite.toFixed(2)}</>
+                        )}
+                      </div>
+                    </>
+                  )}
                 </div>
               )}
             </>
           )}
 
-          {/* Methodology explanation */}
+          {/* Methodology explanation — collapsible, closed by default. */}
           <div>
-            <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted mb-1">
-              METHODOLOGY
-            </div>
-            <div className="space-y-1.5">
-              {methodology.map((line, i) => (
-                <div key={i} className="text-[9px] font-mono text-text-muted leading-relaxed">
-                  {line}
-                </div>
-              ))}
-            </div>
+            <button
+              onClick={() => setMethodologyOpen((v) => !v)}
+              className="w-full flex items-center justify-between mb-1 hover:brightness-125 transition-all"
+            >
+              <span className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted">
+                METHODOLOGY
+              </span>
+              <span
+                className="text-[10px] text-text-muted transition-transform duration-200"
+                style={{ transform: methodologyOpen ? "rotate(180deg)" : "rotate(0deg)" }}
+              >
+                {"▼"}
+              </span>
+            </button>
+            {methodologyOpen && (
+              <div className="space-y-1.5">
+                {methodology.map((line, i) => (
+                  <div key={i} className="text-[9px] font-mono text-text-muted leading-relaxed">
+                    {line}
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
 
           {/* Formula */}


### PR DESCRIPTION
## Summary

Three coupled UX changes to the Pareto criticality card, addressing user feedback that the card was inconsistent and visually busy:

1. **Always render the F·E·G·S breakdown for live estimators.** Previously, when a model's trajectory was too thin (n<5 for CSD/LPPLS), the card silently fell back to legacy `% conf` with no breakdown — so PH would show the four-row table while CSD/LPPLS appeared to ignore it. Now CSD and LPPLS are unconditionally pushed into `computeRelevanceBatch`; the sub-score helpers already handle insufficient data with explicit "`n=N; need ≥5`" placeholders, so each row tells the user *why* the model can't score rather than disappearing.

2. **Collapsible RELEVANCE BREAKDOWN and METHODOLOGY sections.** Breakdown opens by default (it's the headline justification), methodology closed by default (long prose, mostly read-once). Reduces card density without hiding the math.

3. **Tie the headline percent to the equation.** The MODEL RELEVANCE gauge header now reads `MODEL RELEVANCE = S · G · (0.6·F + 0.4·E)`, each row carries a role label (`×0.6` / `×0.4` / `gate`), and the arithmetic line leads with the headline percent: `16% = 0.71 · 0.35 · (0.15 + 0.40) = 0.13 → smoothed 0.16`. Makes the calculation visible end-to-end.

## Why this matters

After #122 fixed the silent-fallback bug for the geopolitical default scope, a deeper issue surfaced on production: real temporal data is sparse (most nodes have 0–3 history points), so trajectory-based estimators routinely fail their "≥5 epochs" threshold. The previous behavior — hide the breakdown, show legacy `% conf` — made the card feel inconsistent (PH always works because it's graph-based, not trajectory-based) and didn't tell the user what was missing.

The new behavior turns that data-sparsity reality into something legible: every row, every model, every state. When the trajectory is rich, the breakdown shows real F/E/G/S. When it's thin, the same UI shows `0% — n=2; need ≥5` in the F row. No silent fallback, no surprise gaps.

## Visual verification (dev server, geopolitical default)

CSD T-10 — `16% rel`:
- F · FIT (×0.6) — 25% — Held-out NRMSE = 1.40 on last 3 of 15 pts.
- E · EVIDENCE (×0.4) — 100% — Akaike weight 100.0% of 3 models (ΔAIC = 0.00).
- G · REGIME (gate) — 35% — var↗ 0.00, autocorr↗ 0.04, λmax 5.65 → 1.00.
- S · SUFFICIENCY (gate) — 71% — n=15/30, edges=303/50.
- `16% = 0.71 · 0.35 · (0.15 + 0.40) = 0.13 → smoothed 0.16`

LPPLS T-150 — `0% rel`:
- F · FIT (×0.6) — 3% — Held-out NRMSE = 3.48 on last 3 of 15 pts.
- E · EVIDENCE (×0.4) — 0% — Akaike weight 0.0% of 3 models (ΔAIC = 86.04).
- G · REGIME (gate) — 8% — accel 0.00, residual sign-changes 1 → 0.17.
- S · SUFFICIENCY (gate) — 71% — n=15/30, edges=303/50.
- `0% = 0.71 · 0.08 · (0.02 + 0.00) = 0.00`

Empty-graph (n=0) state still renders cleanly: every row shows `0%` with the appropriate "insufficient" message; no NaN, no missing rows.

## Test plan

- [x] `vitest run` — 330/330 passing
- [x] `tsc --noEmit` — clean (pre-existing `@mozilla/readability` / `jsdom` type errors only, unrelated)
- [x] Visual review on dev server — all three tabs render the breakdown; both collapse toggles work; arithmetic matches headline; no console errors
- [ ] Vercel preview review — confirm same behavior on production-shape data (which is sparse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
