### PR TITLE
feat(discovery): BOCPD vs hypoglycemia calibration on D1NAMO

### DIFF
--- a/public/discovery-runs/d1namo-bocpd-hypo-calibration-v0-1-0.json
+++ b/public/discovery-runs/d1namo-bocpd-hypo-calibration-v0-1-0.json
@@ -1,0 +1,154 @@
+{
+  "id": "4aeb2075-9505-4f42-aa1d-f2d8e18211c2",
+  "cohortId": "d1namo-2018",
+  "cohortSourceHash": "89db2ac2dc915929514bae3eae06dcff3e3870d21b5ff4531f80d09eadb7101d",
+  "algorithm": {
+    "id": "bocpd-hypo-calibration",
+    "version": "0.1.0"
+  },
+  "params": {
+    "cgmVariableId": "cgm_glucose_mgdl",
+    "hypoThresholdMgdl": 70,
+    "predictionHorizonMin": 30,
+    "gridSeconds": 300,
+    "bocpdHazard": 0.01,
+    "minPointsPerSubject": 50,
+    "nReliabilityBins": 10
+  },
+  "startedAt": "2026-05-01T02:03:19.077Z",
+  "completedAt": "2026-05-01T02:03:19.523Z",
+  "status": "succeeded",
+  "result": {
+    "variables": [
+      "cgm_glucose_mgdl"
+    ],
+    "edges": [],
+    "diagnostics": {
+      "auroc": 0.6792995172265707,
+      "brierScore": 0.18304746426400867,
+      "ece": 0.17447828871796645,
+      "baseRate": 0.11987002045974245,
+      "nPairs": 8309,
+      "nSubjects": 9,
+      "reliabilityBins": [
+        {
+          "binLow": 0,
+          "binHigh": 0.1,
+          "predictedMean": 0.013000840601088061,
+          "observedRate": 0.10299985222402837,
+          "count": 6767
+        },
+        {
+          "binLow": 0.1,
+          "binHigh": 0.2,
+          "predictedMean": 0.14299297823506782,
+          "observedRate": 0.1511627906976744,
+          "count": 172
+        },
+        {
+          "binLow": 0.2,
+          "binHigh": 0.3,
+          "predictedMean": 0.25147831096719414,
+          "observedRate": 0.1588785046728972,
+          "count": 107
+        },
+        {
+          "binLow": 0.3,
+          "binHigh": 0.4,
+          "predictedMean": 0.349254724651797,
+          "observedRate": 0.2073170731707317,
+          "count": 82
+        },
+        {
+          "binLow": 0.4,
+          "binHigh": 0.5,
+          "predictedMean": 0.4500347804322715,
+          "observedRate": 0.16129032258064516,
+          "count": 62
+        },
+        {
+          "binLow": 0.5,
+          "binHigh": 0.6,
+          "predictedMean": 0.5506616211649041,
+          "observedRate": 0.22950819672131148,
+          "count": 61
+        },
+        {
+          "binLow": 0.6,
+          "binHigh": 0.7,
+          "predictedMean": 0.6501470715779964,
+          "observedRate": 0.19607843137254902,
+          "count": 51
+        },
+        {
+          "binLow": 0.7,
+          "binHigh": 0.8,
+          "predictedMean": 0.7500852644460941,
+          "observedRate": 0.26744186046511625,
+          "count": 86
+        },
+        {
+          "binLow": 0.8,
+          "binHigh": 0.9,
+          "predictedMean": 0.8522127122352604,
+          "observedRate": 0.17525773195876287,
+          "count": 97
+        },
+        {
+          "binLow": 0.9,
+          "binHigh": 1,
+          "predictedMean": 0.9890079285304834,
+          "observedRate": 0.20024271844660194,
+          "count": 824
+        }
+      ],
+      "perSubject": [
+        {
+          "id": "d1namo-001",
+          "nPairs": 1406,
+          "nEvents": 137
+        },
+        {
+          "id": "d1namo-002",
+          "nPairs": 1049,
+          "nEvents": 202
+        },
+        {
+          "id": "d1namo-003",
+          "nPairs": 176,
+          "nEvents": 0
+        },
+        {
+          "id": "d1namo-004",
+          "nPairs": 962,
+          "nEvents": 82
+        },
+        {
+          "id": "d1namo-005",
+          "nPairs": 902,
+          "nEvents": 8
+        },
+        {
+          "id": "d1namo-006",
+          "nPairs": 1273,
+          "nEvents": 15
+        },
+        {
+          "id": "d1namo-007",
+          "nPairs": 1048,
+          "nEvents": 0
+        },
+        {
+          "id": "d1namo-008",
+          "nPairs": 1133,
+          "nEvents": 232
+        },
+        {
+          "id": "d1namo-009",
+          "nPairs": 360,
+          "nEvents": 320
+        }
+      ]
+    }
+  }
+}

--- a/research/sample-runs/d1namo-bocpd-hypo-calibration-v0-1-0.json
+++ b/research/sample-runs/d1namo-bocpd-hypo-calibration-v0-1-0.json
@@ -1,0 +1,154 @@
+{
+  "id": "4aeb2075-9505-4f42-aa1d-f2d8e18211c2",
+  "cohortId": "d1namo-2018",
+  "cohortSourceHash": "89db2ac2dc915929514bae3eae06dcff3e3870d21b5ff4531f80d09eadb7101d",
+  "algorithm": {
+    "id": "bocpd-hypo-calibration",
+    "version": "0.1.0"
+  },
+  "params": {
+    "cgmVariableId": "cgm_glucose_mgdl",
+    "hypoThresholdMgdl": 70,
+    "predictionHorizonMin": 30,
+    "gridSeconds": 300,
+    "bocpdHazard": 0.01,
+    "minPointsPerSubject": 50,
+    "nReliabilityBins": 10
+  },
+  "startedAt": "2026-05-01T02:03:19.077Z",
+  "completedAt": "2026-05-01T02:03:19.523Z",
+  "status": "succeeded",
+  "result": {
+    "variables": [
+      "cgm_glucose_mgdl"
+    ],
+    "edges": [],
+    "diagnostics": {
+      "auroc": 0.6792995172265707,
+      "brierScore": 0.18304746426400867,
+      "ece": 0.17447828871796645,
+      "baseRate": 0.11987002045974245,
+      "nPairs": 8309,
+      "nSubjects": 9,
+      "reliabilityBins": [
+        {
+          "binLow": 0,
+          "binHigh": 0.1,
+          "predictedMean": 0.013000840601088061,
+          "observedRate": 0.10299985222402837,
+          "count": 6767
+        },
+        {
+          "binLow": 0.1,
+          "binHigh": 0.2,
+          "predictedMean": 0.14299297823506782,
+          "observedRate": 0.1511627906976744,
+          "count": 172
+        },
+        {
+          "binLow": 0.2,
+          "binHigh": 0.3,
+          "predictedMean": 0.25147831096719414,
+          "observedRate": 0.1588785046728972,
+          "count": 107
+        },
+        {
+          "binLow": 0.3,
+          "binHigh": 0.4,
+          "predictedMean": 0.349254724651797,
+          "observedRate": 0.2073170731707317,
+          "count": 82
+        },
+        {
+          "binLow": 0.4,
+          "binHigh": 0.5,
+          "predictedMean": 0.4500347804322715,
+          "observedRate": 0.16129032258064516,
+          "count": 62
+        },
+        {
+          "binLow": 0.5,
+          "binHigh": 0.6,
+          "predictedMean": 0.5506616211649041,
+          "observedRate": 0.22950819672131148,
+          "count": 61
+        },
+        {
+          "binLow": 0.6,
+          "binHigh": 0.7,
+          "predictedMean": 0.6501470715779964,
+          "observedRate": 0.19607843137254902,
+          "count": 51
+        },
+        {
+          "binLow": 0.7,
+          "binHigh": 0.8,
+          "predictedMean": 0.7500852644460941,
+          "observedRate": 0.26744186046511625,
+          "count": 86
+        },
+        {
+          "binLow": 0.8,
+          "binHigh": 0.9,
+          "predictedMean": 0.8522127122352604,
+          "observedRate": 0.17525773195876287,
+          "count": 97
+        },
+        {
+          "binLow": 0.9,
+          "binHigh": 1,
+          "predictedMean": 0.9890079285304834,
+          "observedRate": 0.20024271844660194,
+          "count": 824
+        }
+      ],
+      "perSubject": [
+        {
+          "id": "d1namo-001",
+          "nPairs": 1406,
+          "nEvents": 137
+        },
+        {
+          "id": "d1namo-002",
+          "nPairs": 1049,
+          "nEvents": 202
+        },
+        {
+          "id": "d1namo-003",
+          "nPairs": 176,
+          "nEvents": 0
+        },
+        {
+          "id": "d1namo-004",
+          "nPairs": 962,
+          "nEvents": 82
+        },
+        {
+          "id": "d1namo-005",
+          "nPairs": 902,
+          "nEvents": 8
+        },
+        {
+          "id": "d1namo-006",
+          "nPairs": 1273,
+          "nEvents": 15
+        },
+        {
+          "id": "d1namo-007",
+          "nPairs": 1048,
+          "nEvents": 0
+        },
+        {
+          "id": "d1namo-008",
+          "nPairs": 1133,
+          "nEvents": 232
+        },
+        {
+          "id": "d1namo-009",
+          "nPairs": 360,
+          "nEvents": 320
+        }
+      ]
+    }
+  }
+}

--- a/scripts/run-d1namo-bocpd-calibration.ts
+++ b/scripts/run-d1namo-bocpd-calibration.ts
@@ -1,0 +1,109 @@
+// Run BOCPD-vs-hypoglycemia calibration on the D1NAMO cohort.
+//
+// This is the "calibration of an estimator's relevance score against
+// trial-CRF event labels" deliverable from the Joslin proposal,
+// executed on a public T1D cohort so the methodology is demonstrable
+// without waiting on a DUA.
+//
+// Output: research/runs/d1namo-bocpd-hypo-calibration-<ts>.json
+//
+// Usage: npx tsx scripts/run-d1namo-bocpd-calibration.ts
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+
+import { d1namoIngester } from "../src/lib/discovery/ingesters/d1namo";
+import {
+  calibrateBocpdHypo,
+  DEFAULT_PARAMS,
+} from "../src/lib/discovery/calibration/bocpd-hypo-calibrator";
+import { buildDiscoveryRun } from "../src/lib/discovery/run-types";
+
+async function main() {
+  const repoRoot = process.cwd();
+  const startedAt = new Date().toISOString();
+
+  console.log("[d1namo-cal] ingesting cohort...");
+  const cohort = await d1namoIngester.ingest(repoRoot);
+  console.log(
+    `[d1namo-cal] cohort ${cohort.id}: ${cohort.subjects.length} subjects`,
+  );
+
+  console.log("[d1namo-cal] running BOCPD hypo calibration...");
+  const cal = calibrateBocpdHypo(cohort);
+  const completedAt = new Date().toISOString();
+
+  console.log("");
+  console.log(`AUROC:        ${cal.auroc.toFixed(4)}`);
+  console.log(`Brier score:  ${cal.brierScore.toFixed(4)}`);
+  console.log(`ECE:          ${cal.ece.toFixed(4)}`);
+  console.log(`Base rate:    ${(cal.baseRate * 100).toFixed(2)}%`);
+  console.log(`N pairs:      ${cal.nPairs.toLocaleString()}`);
+  console.log(`Subjects:     ${cal.nSubjects}`);
+  console.log("");
+  console.log("Per-subject:");
+  for (const s of cal.perSubject) {
+    const rate = s.nPairs === 0 ? 0 : (s.nEvents / s.nPairs) * 100;
+    console.log(
+      `  ${s.id}: ${s.nPairs.toString().padStart(4)} pairs, ` +
+        `${s.nEvents.toString().padStart(3)} events (${rate.toFixed(1)}%)`,
+    );
+  }
+  console.log("");
+  console.log("Reliability diagram:");
+  for (const b of cal.reliabilityBins) {
+    if (b.count === 0) {
+      console.log(
+        `  [${b.binLow.toFixed(1)}-${b.binHigh.toFixed(1)})  empty`,
+      );
+      continue;
+    }
+    console.log(
+      `  [${b.binLow.toFixed(1)}-${b.binHigh.toFixed(1)})  ` +
+        `pred=${b.predictedMean.toFixed(3)}  obs=${b.observedRate.toFixed(3)}  ` +
+        `n=${b.count}`,
+    );
+  }
+
+  // Wrap as a DiscoveryRun-shaped record so the existing UI / API
+  // surfaces can render it without schema gymnastics.
+  const run = buildDiscoveryRun({
+    id: randomUUID(),
+    cohort,
+    algorithm: { id: "bocpd-hypo-calibration", version: "0.1.0" },
+    params: { ...DEFAULT_PARAMS } as Record<string, unknown>,
+    startedAt,
+    completedAt,
+    result: {
+      variables: [DEFAULT_PARAMS.cgmVariableId],
+      edges: [], // calibration is not a structure-discovery output
+      diagnostics: {
+        auroc: cal.auroc,
+        brierScore: cal.brierScore,
+        ece: cal.ece,
+        baseRate: cal.baseRate,
+        nPairs: cal.nPairs,
+        nSubjects: cal.nSubjects,
+        reliabilityBins: cal.reliabilityBins,
+        perSubject: cal.perSubject,
+      },
+    },
+  });
+
+  const outDir = path.join(repoRoot, "research", "runs");
+  await fs.mkdir(outDir, { recursive: true });
+  const ts = startedAt.replace(/[:.]/g, "-");
+  const outPath = path.join(
+    outDir,
+    `d1namo-bocpd-hypo-calibration-${ts}.json`,
+  );
+  await fs.writeFile(outPath, JSON.stringify(run, null, 2));
+  console.log("");
+  console.log(`[d1namo-cal] wrote ${path.relative(repoRoot, outPath)}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/components/DiscoveryRunsPanel.tsx
+++ b/src/components/DiscoveryRunsPanel.tsx
@@ -21,6 +21,7 @@ import type { DiscoveryRun } from "@/lib/discovery";
 const SAMPLE_RUN_URLS = [
   "/discovery-runs/d1namo-lag-correlation-v0-1-0.json",
   "/discovery-runs/d1namo-pcmci-linear-v0-1-0.json",
+  "/discovery-runs/d1namo-bocpd-hypo-calibration-v0-1-0.json",
 ];
 
 type LoadState =
@@ -118,6 +119,7 @@ function ErrorTile({ message }: { message: string }) {
 
 function RunTile({ run }: { run: DiscoveryRun }) {
   const r = run.result;
+  const isCalibration = run.algorithm.id === "bocpd-hypo-calibration";
   const sortedEdges = useMemo(
     () =>
       [...r.edges].sort(
@@ -131,7 +133,7 @@ function RunTile({ run }: { run: DiscoveryRun }) {
       {/* Header */}
       <div className="flex items-center justify-between">
         <span className="text-[9px] font-[family-name:var(--font-michroma)] tracking-wider text-[#40c4ff]">
-          DISCOVERY RUN
+          {isCalibration ? "CALIBRATION RUN" : "DISCOVERY RUN"}
         </span>
         <span
           className={`text-[7px] font-mono ${
@@ -148,15 +150,30 @@ function RunTile({ run }: { run: DiscoveryRun }) {
       <div className="grid grid-cols-2 gap-1.5">
         <Stat label="ALGORITHM" value={`${run.algorithm.id} v${run.algorithm.version}`} />
         <Stat label="COHORT" value={run.cohortId} />
-        <Stat label="EDGES" value={String(r.edges.length)} />
-        <Stat
-          label="VARIABLES"
-          value={String(r.variables.length)}
-        />
+        {isCalibration ? (
+          <>
+            <Stat
+              label="N PAIRS"
+              value={String(r.diagnostics?.nPairs ?? 0)}
+            />
+            <Stat
+              label="SUBJECTS"
+              value={String(r.diagnostics?.nSubjects ?? 0)}
+            />
+          </>
+        ) : (
+          <>
+            <Stat label="EDGES" value={String(r.edges.length)} />
+            <Stat
+              label="VARIABLES"
+              value={String(r.variables.length)}
+            />
+          </>
+        )}
       </div>
 
-      {/* Diagnostics */}
-      {r.diagnostics && (
+      {/* Diagnostics — discovery flavour */}
+      {!isCalibration && r.diagnostics && (
         <div className="text-[7px] font-mono text-text-muted leading-relaxed border-l-2 border-[#40c4ff]/30 pl-2">
           {typeof r.diagnostics.nSubjectsUsed === "number" && (
             <>
@@ -174,49 +191,56 @@ function RunTile({ run }: { run: DiscoveryRun }) {
         </div>
       )}
 
-      {/* Edges */}
-      <div className="space-y-1.5">
-        <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-foreground pt-1">
-          DISCOVERED EDGES
-        </div>
-        {sortedEdges.length === 0 ? (
-          <div className="text-[8px] font-mono text-text-muted">
-            No edges passed the FDR threshold.
+      {/* Calibration metrics — only when this run is a calibration */}
+      {isCalibration && r.diagnostics && (
+        <CalibrationBlock diagnostics={r.diagnostics} />
+      )}
+
+      {/* Edges — only for discovery runs */}
+      {!isCalibration && (
+        <div className="space-y-1.5">
+          <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-foreground pt-1">
+            DISCOVERED EDGES
           </div>
-        ) : (
-          <ul className="space-y-1">
-            {sortedEdges.map((edge, i) => (
-              <li
-                key={i}
-                className="text-[8px] font-mono text-foreground p-1.5 rounded border border-border bg-surface-elevated"
-                title={edge.evidence}
-              >
-                <div className="flex items-center justify-between gap-2">
-                  <span className="truncate">
-                    <span className="text-accent-cyan">{edge.source}</span>
-                    <span className="text-text-muted mx-1">{"→"}</span>
-                    <span className="text-accent-amber">{edge.target}</span>
-                    {typeof edge.lag === "number" && edge.lag > 0 && (
-                      <span className="text-text-muted ml-2">
-                        (+{edge.lag}s)
-                      </span>
-                    )}
-                  </span>
-                  <span className="text-[7px] text-text-muted shrink-0">
-                    r={edge.strength.toFixed(3)}
-                    {typeof edge.pValue === "number" && (
-                      <>
-                        {" "}
-                        · p={edge.pValue.toExponential(1)}
-                      </>
-                    )}
-                  </span>
-                </div>
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
+          {sortedEdges.length === 0 ? (
+            <div className="text-[8px] font-mono text-text-muted">
+              No edges passed the FDR threshold.
+            </div>
+          ) : (
+            <ul className="space-y-1">
+              {sortedEdges.map((edge, i) => (
+                <li
+                  key={i}
+                  className="text-[8px] font-mono text-foreground p-1.5 rounded border border-border bg-surface-elevated"
+                  title={edge.evidence}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="truncate">
+                      <span className="text-accent-cyan">{edge.source}</span>
+                      <span className="text-text-muted mx-1">{"→"}</span>
+                      <span className="text-accent-amber">{edge.target}</span>
+                      {typeof edge.lag === "number" && edge.lag > 0 && (
+                        <span className="text-text-muted ml-2">
+                          (+{edge.lag}s)
+                        </span>
+                      )}
+                    </span>
+                    <span className="text-[7px] text-text-muted shrink-0">
+                      r={edge.strength.toFixed(3)}
+                      {typeof edge.pValue === "number" && (
+                        <>
+                          {" "}
+                          · p={edge.pValue.toExponential(1)}
+                        </>
+                      )}
+                    </span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
 
       {/* Algorithm caveat — honest framing carries through to the UI */}
       {run.algorithm.id === "lag-correlation" && (
@@ -240,6 +264,18 @@ function RunTile({ run }: { run: DiscoveryRun }) {
           residual signal.
         </div>
       )}
+      {run.algorithm.id === "bocpd-hypo-calibration" && (
+        <div className="text-[7px] font-mono text-accent-amber/80 leading-relaxed border border-accent-amber/20 bg-accent-amber/5 rounded px-1.5 py-1">
+          <strong>BOCPD vs hypoglycemia, 30-min horizon.</strong> The
+          methodology the Joslin proposal commits to, executed on the
+          public D1NAMO cohort. AUROC measures discrimination; ECE
+          measures calibration loss. A platform whose discrimination is
+          high but calibration poor needs post-hoc re-calibration
+          (Platt / isotonic) before the raw scores can drive clinical
+          interpretation — exactly the question the Phase-1 deliverable
+          on Joslin data is meant to answer at scale.
+        </div>
+      )}
     </div>
   );
 }
@@ -250,6 +286,92 @@ function Stat({ label, value }: { label: string; value: string }) {
       <div className="text-[7px] font-mono text-text-muted">{label}</div>
       <div className="text-[9px] font-mono text-foreground truncate" title={value}>
         {value}
+      </div>
+    </div>
+  );
+}
+
+// ─── Calibration metrics + reliability diagram ───────────────────────
+
+interface ReliabilityBin {
+  binLow: number;
+  binHigh: number;
+  predictedMean: number;
+  observedRate: number;
+  count: number;
+}
+
+function CalibrationBlock({
+  diagnostics,
+}: {
+  diagnostics: Record<string, unknown>;
+}) {
+  const auroc = typeof diagnostics.auroc === "number" ? diagnostics.auroc : null;
+  const brier =
+    typeof diagnostics.brierScore === "number" ? diagnostics.brierScore : null;
+  const ece = typeof diagnostics.ece === "number" ? diagnostics.ece : null;
+  const baseRate =
+    typeof diagnostics.baseRate === "number" ? diagnostics.baseRate : null;
+  const bins = Array.isArray(diagnostics.reliabilityBins)
+    ? (diagnostics.reliabilityBins as ReliabilityBin[])
+    : [];
+  const maxCount = bins.reduce((m, b) => Math.max(m, b.count), 0);
+
+  return (
+    <div className="space-y-2">
+      <div className="grid grid-cols-4 gap-1.5">
+        <Stat label="AUROC" value={auroc !== null ? auroc.toFixed(3) : "—"} />
+        <Stat label="BRIER" value={brier !== null ? brier.toFixed(3) : "—"} />
+        <Stat label="ECE" value={ece !== null ? ece.toFixed(3) : "—"} />
+        <Stat
+          label="BASE RATE"
+          value={baseRate !== null ? `${(baseRate * 100).toFixed(1)}%` : "—"}
+        />
+      </div>
+
+      {/* Reliability diagram */}
+      <div className="space-y-1">
+        <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-foreground pt-1">
+          RELIABILITY DIAGRAM
+        </div>
+        <div className="text-[7px] font-mono text-text-muted">
+          Each row: predicted bin (left) → observed event rate (cyan bar)
+          vs predicted mean (amber tick). Perfect calibration would put
+          the tick exactly on the bar's right edge.
+        </div>
+        <ul className="space-y-0.5">
+          {bins.map((b, i) => (
+            <li
+              key={i}
+              className="text-[7px] font-mono text-foreground flex items-center gap-2"
+            >
+              <span className="text-text-muted shrink-0 w-12">
+                [{b.binLow.toFixed(1)}–{b.binHigh.toFixed(1)})
+              </span>
+              <span className="text-text-muted shrink-0 w-10">
+                n={b.count}
+              </span>
+              <div className="flex-1 relative h-3 bg-surface-elevated rounded">
+                <div
+                  className="absolute left-0 top-0 bottom-0 bg-accent-cyan/40 rounded-l"
+                  style={{
+                    width: `${Math.min(100, b.observedRate * 100)}%`,
+                  }}
+                />
+                <div
+                  className="absolute top-0 bottom-0 w-px bg-accent-amber"
+                  style={{
+                    left: `${Math.min(100, b.predictedMean * 100)}%`,
+                  }}
+                />
+              </div>
+              <span className="text-text-muted shrink-0 w-16 text-right">
+                obs={b.observedRate.toFixed(2)}
+                {maxCount > 0 && b.count === 0 && " (empty)"}
+              </span>
+            </li>
+          ))}
+        </ul>
       </div>
     </div>
   );

--- a/src/lib/discovery/calibration/__tests__/bocpd-hypo-calibrator.test.ts
+++ b/src/lib/discovery/calibration/__tests__/bocpd-hypo-calibrator.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from "vitest";
+import { calibrateBocpdHypo } from "../bocpd-hypo-calibrator";
+import type { Cohort } from "../../cohort-types";
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+function lcg(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return ((s >>> 8) / 0xffffff) * 2 - 1;
+  };
+}
+
+/**
+ * Build a synthetic CGM-shaped cohort with known regime shifts that
+ * always end in a hypo dip. BOCPD should detect the regime shift; the
+ * label (hypo within next K steps) is true after the shift; AUROC > 0.5.
+ */
+function syntheticCgmCohort(opts: {
+  nSubjects: number;
+  nSteps: number;
+  hypoStartStep: number;
+  seed: number;
+}): Cohort {
+  const { nSubjects, nSteps, hypoStartStep, seed } = opts;
+  const rand = lcg(seed);
+  const subjects = Array.from({ length: nSubjects }, (_, si) => {
+    const cgm = new Array<number>(nSteps);
+    for (let i = 0; i < nSteps; i++) {
+      // Stable in-range until hypoStartStep; rapid drop after.
+      const baseline = i < hypoStartStep ? 130 : 130 - (i - hypoStartStep) * 8;
+      cgm[i] = Math.max(40, baseline + 4 * rand());
+    }
+    return {
+      id: `s-${si}`,
+      measurements: cgm.map((v, i) => ({
+        variableId: "cgm_glucose_mgdl",
+        t: i * 300,
+        value: v,
+      })),
+    };
+  });
+
+  return {
+    id: "synthetic-cgm",
+    label: "synthetic CGM with hypo regime shift",
+    source: {
+      adapter: "test",
+      adapterVersion: "0",
+      ingestedAt: "2026-04-30T00:00:00Z",
+      containsPHI: false,
+    },
+    variables: [
+      {
+        id: "cgm_glucose_mgdl",
+        label: "CGM glucose",
+        kind: "continuous",
+        cadenceSeconds: 300,
+      },
+    ],
+    subjects,
+    timeAxis: { zeroConvention: "session-start", displayUnit: "seconds" },
+    metadata: { description: "test", accessTier: "public" },
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────
+
+describe("calibrateBocpdHypo", () => {
+  it("returns the expected result shape on a valid cohort", () => {
+    const cohort = syntheticCgmCohort({
+      nSubjects: 4,
+      nSteps: 200,
+      hypoStartStep: 120,
+      seed: 11,
+    });
+    const r = calibrateBocpdHypo(cohort);
+    expect(typeof r.auroc).toBe("number");
+    expect(typeof r.brierScore).toBe("number");
+    expect(typeof r.ece).toBe("number");
+    expect(r.nPairs).toBeGreaterThan(0);
+    expect(r.nSubjects).toBe(4);
+    expect(r.reliabilityBins).toHaveLength(10);
+    expect(r.perSubject).toHaveLength(4);
+  });
+
+  it("AUROC and Brier are in valid ranges", () => {
+    const cohort = syntheticCgmCohort({
+      nSubjects: 3,
+      nSteps: 200,
+      hypoStartStep: 120,
+      seed: 7,
+    });
+    const r = calibrateBocpdHypo(cohort);
+    expect(r.auroc).toBeGreaterThanOrEqual(0);
+    expect(r.auroc).toBeLessThanOrEqual(1);
+    expect(r.brierScore).toBeGreaterThanOrEqual(0);
+    expect(r.brierScore).toBeLessThanOrEqual(1);
+    expect(r.ece).toBeGreaterThanOrEqual(0);
+    expect(r.ece).toBeLessThanOrEqual(1);
+  });
+
+  it("base rate matches the empirical event prevalence", () => {
+    const cohort = syntheticCgmCohort({
+      nSubjects: 3,
+      nSteps: 150,
+      hypoStartStep: 80,
+      seed: 19,
+    });
+    const r = calibrateBocpdHypo(cohort);
+    expect(r.baseRate).toBeGreaterThanOrEqual(0);
+    expect(r.baseRate).toBeLessThanOrEqual(1);
+    // With a forced hypo around step 80, we expect a non-trivial base rate.
+    expect(r.baseRate).toBeGreaterThan(0);
+  });
+
+  it("reliability bins partition the score range and counts sum to N", () => {
+    const cohort = syntheticCgmCohort({
+      nSubjects: 3,
+      nSteps: 150,
+      hypoStartStep: 80,
+      seed: 23,
+    });
+    const r = calibrateBocpdHypo(cohort);
+    const totalCount = r.reliabilityBins.reduce((a, b) => a + b.count, 0);
+    expect(totalCount).toBe(r.nPairs);
+    // Bins should be monotonically increasing in [0, 1].
+    for (let i = 1; i < r.reliabilityBins.length; i++) {
+      expect(r.reliabilityBins[i].binLow).toBeGreaterThanOrEqual(
+        r.reliabilityBins[i - 1].binLow,
+      );
+    }
+  });
+
+  it("returns 0.5 AUROC when the cohort has no events at all", () => {
+    // All glucose stays well above hypo threshold → no events → AUROC undefined → 0.5.
+    const cohort = syntheticCgmCohort({
+      nSubjects: 3,
+      nSteps: 200,
+      hypoStartStep: 10000, // never triggers
+      seed: 31,
+    });
+    const r = calibrateBocpdHypo(cohort);
+    expect(r.auroc).toBe(0.5);
+    expect(r.baseRate).toBe(0);
+  });
+
+  it("respects custom prediction horizon and threshold params", () => {
+    const cohort = syntheticCgmCohort({
+      nSubjects: 3,
+      nSteps: 200,
+      hypoStartStep: 120,
+      seed: 41,
+    });
+    const tight = calibrateBocpdHypo(cohort, {
+      predictionHorizonMin: 5,
+    });
+    const loose = calibrateBocpdHypo(cohort, {
+      predictionHorizonMin: 60,
+    });
+    // Looser horizon → more positive labels → higher base rate.
+    expect(loose.baseRate).toBeGreaterThanOrEqual(tight.baseRate);
+  });
+});

--- a/src/lib/discovery/calibration/bocpd-hypo-calibrator.ts
+++ b/src/lib/discovery/calibration/bocpd-hypo-calibrator.ts
@@ -1,0 +1,305 @@
+// ─── BOCPD Hypoglycemia-Event Calibration ────────────────────────────
+//
+// HONEST FRAMING — READ FIRST
+// ----------------------------
+// This is the validation methodology the Joslin proposal commits to,
+// executed end-to-end on a public T1D cohort (D1NAMO). It answers the
+// question: does BOCPD's per-step "P(new run started)" actually
+// correlate with imminent hypoglycemic events?
+//
+// What it does:
+//   1. For each subject, runs BOCPD on the CGM trace and gets the
+//      per-step new-run probability `newRunProb[t]` (0..1).
+//   2. For each timestep, defines a binary label: did glucose fall
+//      below `hypoThresholdMgdl` within the next `predictionHorizonMin`
+//      minutes?
+//   3. Pools (score, label) pairs across all subjects.
+//   4. Computes AUROC (discrimination), Brier score (calibration loss),
+//      Expected Calibration Error (ECE), and a 10-bin reliability
+//      diagram.
+//
+// This is the "calibration of each estimator's relevance score against
+// trial-CRF event labels" deliverable in PR #121's reframed Joslin
+// proposal — but on a public substrate so the methodology can be shown
+// without waiting on a DUA.
+
+import type { Cohort } from "../cohort-types";
+import { bocpd } from "@/lib/estimators/bocpd";
+
+export interface BocpdHypoCalibrationParams {
+  /** CGM variable id in the cohort. */
+  cgmVariableId: string;
+  /** Hypoglycemia threshold (mg/dL). Default 70 (ADA standard). */
+  hypoThresholdMgdl: number;
+  /**
+   * How far ahead we predict (minutes). Default 30 — the clinically
+   * actionable window for a CGM-based hypo alert.
+   */
+  predictionHorizonMin: number;
+  /**
+   * Grid cadence in seconds — should match the CGM sample rate.
+   * D1NAMO is 5 min = 300 s.
+   */
+  gridSeconds: number;
+  /** BOCPD hazard rate. Default 0.01 — slow regime shifts. */
+  bocpdHazard: number;
+  /** Minimum subject CGM length to include. */
+  minPointsPerSubject: number;
+  /** Number of reliability bins. Default 10. */
+  nReliabilityBins: number;
+}
+
+export const DEFAULT_PARAMS: BocpdHypoCalibrationParams = {
+  cgmVariableId: "cgm_glucose_mgdl",
+  hypoThresholdMgdl: 70,
+  predictionHorizonMin: 30,
+  gridSeconds: 300,
+  bocpdHazard: 0.01,
+  minPointsPerSubject: 50,
+  nReliabilityBins: 10,
+};
+
+export interface ReliabilityBin {
+  /** Bin lower bound (inclusive). */
+  binLow: number;
+  /** Bin upper bound (exclusive, except top bin). */
+  binHigh: number;
+  /** Mean predicted score in this bin. */
+  predictedMean: number;
+  /** Empirical event rate in this bin (0..1). */
+  observedRate: number;
+  /** Number of (score, label) pairs in this bin. */
+  count: number;
+}
+
+export interface BocpdHypoCalibrationResult {
+  auroc: number;
+  brierScore: number;
+  /** Expected calibration error — Σ (|predicted − observed| · bin_count) / N. */
+  ece: number;
+  reliabilityBins: ReliabilityBin[];
+  /** Total (score, label) pairs across all subjects. */
+  nPairs: number;
+  /** Subjects that contributed at least one valid pair. */
+  nSubjects: number;
+  /** Empirical hypo-event prevalence in the labeled window. */
+  baseRate: number;
+  /** Diagnostic params + per-subject summary. */
+  perSubject: { id: string; nPairs: number; nEvents: number }[];
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+/** Build per-subject CGM grid (sample-and-hold to uniform `gridSeconds`). */
+function buildCgmGrid(
+  measurements: { variableId: string; t: number; value: number | string }[],
+  variableId: string,
+  gridSeconds: number,
+): Float64Array | null {
+  const events: { t: number; value: number }[] = [];
+  for (const m of measurements) {
+    if (m.variableId !== variableId) continue;
+    const v = typeof m.value === "number" ? m.value : Number(m.value);
+    if (!Number.isFinite(v)) continue;
+    events.push({ t: m.t, value: v });
+  }
+  if (events.length < 2) return null;
+  events.sort((a, b) => a.t - b.t);
+  const tMin = events[0].t;
+  const tMax = events[events.length - 1].t;
+  const span = tMax - tMin;
+  const nGrid = Math.floor(span / gridSeconds);
+  if (nGrid < 2) return null;
+
+  const out = new Float64Array(nGrid);
+  let cursor = 0;
+  let lastVal = NaN;
+  for (let i = 0; i < nGrid; i++) {
+    const tCenter = tMin + (i + 0.5) * gridSeconds;
+    while (cursor < events.length && events[cursor].t <= tCenter) {
+      lastVal = events[cursor].value;
+      cursor += 1;
+    }
+    out[i] = lastVal;
+  }
+  return out;
+}
+
+/**
+ * Compute AUROC via the rank-based formula:
+ *   AUROC = (sum of ranks of positive class − n_pos·(n_pos+1)/2) / (n_pos · n_neg)
+ * Handles ties by averaging ranks. O(n log n).
+ */
+function auroc(scores: number[], labels: number[]): number {
+  const n = scores.length;
+  if (n === 0) return 0.5;
+  const idx = Array.from({ length: n }, (_, i) => i).sort(
+    (a, b) => scores[a] - scores[b],
+  );
+  // Average ranks for ties.
+  const ranks = new Array<number>(n);
+  let i = 0;
+  while (i < n) {
+    let j = i;
+    while (j + 1 < n && scores[idx[j + 1]] === scores[idx[i]]) j += 1;
+    const avgRank = (i + j) / 2 + 1; // 1-based
+    for (let k = i; k <= j; k++) ranks[idx[k]] = avgRank;
+    i = j + 1;
+  }
+  let sumPos = 0;
+  let nPos = 0;
+  let nNeg = 0;
+  for (let k = 0; k < n; k++) {
+    if (labels[k] === 1) {
+      sumPos += ranks[k];
+      nPos += 1;
+    } else {
+      nNeg += 1;
+    }
+  }
+  if (nPos === 0 || nNeg === 0) return 0.5; // undefined, return uninformative
+  return (sumPos - (nPos * (nPos + 1)) / 2) / (nPos * nNeg);
+}
+
+function brier(scores: number[], labels: number[]): number {
+  if (scores.length === 0) return 0;
+  let s = 0;
+  for (let i = 0; i < scores.length; i++) {
+    const d = scores[i] - labels[i];
+    s += d * d;
+  }
+  return s / scores.length;
+}
+
+function reliabilityDiagram(
+  scores: number[],
+  labels: number[],
+  nBins: number,
+): { bins: ReliabilityBin[]; ece: number } {
+  const bins: ReliabilityBin[] = [];
+  for (let b = 0; b < nBins; b++) {
+    const lo = b / nBins;
+    const hi = (b + 1) / nBins;
+    let predSum = 0;
+    let obsSum = 0;
+    let count = 0;
+    for (let i = 0; i < scores.length; i++) {
+      const s = scores[i];
+      const inBin = b === nBins - 1
+        ? s >= lo && s <= hi
+        : s >= lo && s < hi;
+      if (!inBin) continue;
+      predSum += s;
+      obsSum += labels[i];
+      count += 1;
+    }
+    bins.push({
+      binLow: lo,
+      binHigh: hi,
+      predictedMean: count === 0 ? (lo + hi) / 2 : predSum / count,
+      observedRate: count === 0 ? 0 : obsSum / count,
+      count,
+    });
+  }
+  const N = scores.length;
+  let ece = 0;
+  for (const b of bins) {
+    if (b.count === 0 || N === 0) continue;
+    ece += (b.count / N) * Math.abs(b.predictedMean - b.observedRate);
+  }
+  return { bins, ece };
+}
+
+// ─── Calibrator entry point ──────────────────────────────────────────
+
+export function calibrateBocpdHypo(
+  cohort: Cohort,
+  params: Partial<BocpdHypoCalibrationParams> = {},
+): BocpdHypoCalibrationResult {
+  const p = { ...DEFAULT_PARAMS, ...params };
+  const horizonSteps = Math.max(
+    1,
+    Math.round((p.predictionHorizonMin * 60) / p.gridSeconds),
+  );
+
+  const allScores: number[] = [];
+  const allLabels: number[] = [];
+  const perSubject: { id: string; nPairs: number; nEvents: number }[] = [];
+  let nSubjectsUsed = 0;
+
+  for (const subj of cohort.subjects) {
+    const grid = buildCgmGrid(
+      subj.measurements,
+      p.cgmVariableId,
+      p.gridSeconds,
+    );
+    if (!grid || grid.length < p.minPointsPerSubject) {
+      perSubject.push({ id: subj.id, nPairs: 0, nEvents: 0 });
+      continue;
+    }
+
+    // Drop NaN tail (sample-and-hold may have a leading NaN before the
+    // first reading); BOCPD requires finite values.
+    const cleaned: number[] = [];
+    const cleanIdxToOrig: number[] = [];
+    for (let i = 0; i < grid.length; i++) {
+      if (Number.isFinite(grid[i])) {
+        cleaned.push(grid[i]);
+        cleanIdxToOrig.push(i);
+      }
+    }
+    if (cleaned.length < p.minPointsPerSubject) {
+      perSubject.push({ id: subj.id, nPairs: 0, nEvents: 0 });
+      continue;
+    }
+
+    // Run BOCPD on the cleaned series.
+    const result = bocpd(cleaned, { hazard: p.bocpdHazard });
+    const newRunProb = result.newRunProb;
+
+    // For each cleaned-index t, label = 1 if any glucose value in the
+    // next `horizonSteps` (also in cleaned coords) falls below threshold.
+    let nPairs = 0;
+    let nEvents = 0;
+    for (let t = 0; t < cleaned.length - horizonSteps; t++) {
+      const score = newRunProb[t];
+      if (!Number.isFinite(score)) continue;
+      let event = 0;
+      for (let h = 1; h <= horizonSteps; h++) {
+        if (cleaned[t + h] < p.hypoThresholdMgdl) {
+          event = 1;
+          break;
+        }
+      }
+      allScores.push(Math.max(0, Math.min(1, score)));
+      allLabels.push(event);
+      nPairs += 1;
+      nEvents += event;
+    }
+
+    perSubject.push({ id: subj.id, nPairs, nEvents });
+    if (nPairs > 0) nSubjectsUsed += 1;
+  }
+
+  const N = allScores.length;
+  const baseRate =
+    N === 0 ? 0 : allLabels.reduce((a, b) => a + b, 0) / N;
+  const auc = auroc(allScores, allLabels);
+  const bs = brier(allScores, allLabels);
+  const { bins, ece } = reliabilityDiagram(
+    allScores,
+    allLabels,
+    p.nReliabilityBins,
+  );
+
+  return {
+    auroc: auc,
+    brierScore: bs,
+    ece,
+    reliabilityBins: bins,
+    nPairs: N,
+    nSubjects: nSubjectsUsed,
+    baseRate,
+    perSubject,
+  };
+}


### PR DESCRIPTION
## Summary

Executes the calibration methodology the Joslin proposal commits to — but on a public T1D cohort so the methodology is demonstrable without waiting on a DUA. Produces the first concrete validation artifact in the platform: AUROC, Brier score, ECE, and a 10-bin reliability diagram for BOCPD's per-step new-run probability against ground-truth hypo events.

## Real result on D1NAMO

| Metric | Value | Interpretation |
|---|---|---|
| AUROC | **0.679** | BOCPD has meaningful discrimination for hypo at 30-min horizon |
| Brier | 0.183 | calibration loss |
| ECE | 0.175 | substantial miscalibration — raw scores not directly usable as probabilities |
| Base rate | 11.99% | hypo-event prevalence in the labeled window |
| N pairs | 8,309 across 9 subjects | |

Top decile predicts 99% confidence but observes only 20% events. Practical implication: a deployed platform would need post-hoc re-calibration (Platt / isotonic) before raw scores drive clinical interpretation. **This is exactly the kind of finding the Joslin proposal's Phase-1 deliverable is designed to surface at scale.**

## Files

- `src/lib/discovery/calibration/bocpd-hypo-calibrator.ts` — calibrator library, AUROC + Brier + ECE + reliability bins
- `src/lib/discovery/calibration/__tests__/bocpd-hypo-calibrator.test.ts` — 6 cases on synthetic CGM cohorts
- `scripts/run-d1namo-bocpd-calibration.ts` — end-to-end runner
- `public/discovery-runs/` and `research/sample-runs/` — committed sample run record
- `src/components/DiscoveryRunsPanel.tsx` — SPIRTES module now shows three side-by-side tabs (lag-correlation, pcmci-linear, bocpd-hypo-calibration). Calibration tile renders the metric grid + reliability-diagram bar chart instead of the discovery edges list.

## Test plan

- [x] 394 vitest tests pass (6 new in calibration)
- [x] `tsc --noEmit` clean
- [x] End-to-end run on real D1NAMO bytes produces the artifact
- [ ] Vercel preview: open SPIRTES module, click third tab → AUROC 0.679 / ECE 0.175 / reliability bars render
- [ ] Per-subject breakdown shows 9 entries with varying event counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)