### PR TITLE
feat(billing): institutional billing + tier gating + admin console

### DIFF
--- a/BILLING_BLOCKERS.md
+++ b/BILLING_BLOCKERS.md
@@ -1,0 +1,70 @@
+# Billing — deferred items / blockers
+
+Tracking decisions that were deferred during the institutional-billing
+build (branch: `claude/billing-tier-gating-zOcFJ`). Each item is either
+unblocked by a small, well-defined external action or genuinely waiting
+on product input.
+
+## 1. Mercury invoice webhooks — DEFERRED (no path forward today)
+
+**Status:** Mercury's webhook event surface as of 2026-04-30 only
+exposes treasury-level events. Confirmed via the Create-webhook UI on
+the Apex Analytica workspace:
+
+- `transaction.created`, `transaction.updated`
+- `checkingAccount.balance.updated`, `savingsAccount.balance.updated`,
+  `treasuryAccount.balance.updated`, `investmentAccount.balance.updated`,
+  `creditAccount.balance.updated`
+
+There are **no `invoice.*` events**. The auto-flip-on-payment flow is
+not viable on Mercury's current API.
+
+**Workarounds considered and rejected for v1:**
+
+- *Inferring invoice payment from `transaction.created` payloads by
+  matching ACH/wire memo strings against invoice IDs.* Brittle: wire
+  memos get truncated by intermediary banks, customer references are
+  unreliable, and false positives are real on multi-invoice customers.
+
+**Recommended posture:** stay on Path A (manual mark-paid via
+`/admin/billing`). The `profiles.mercury_invoice_id` column is a
+tracking field — admin pastes the Mercury invoice ID there for record
+keeping. When Mercury ships invoice webhooks, layer them on top
+without changing the schema.
+
+**To revisit when:** Mercury announces invoice webhooks (track their
+[changelog](https://docs.mercury.com/changelog)).
+
+## 2. Renewal email transport — DEFERRED (scope decision)
+
+The handoff plan included T-30d renewal reminder emails. No
+transactional email transport (Resend / Postmark / SES) was selected,
+so v1 surfaces upcoming renewals in the admin console (the "DUE SOON"
+view filters customers whose `current_period_end` is ≤ 30d away) and
+admins email customers manually from their own inbox.
+
+**Unblock with:** pick a transport, add an env var
+(`RESEND_API_KEY` or equivalent), build a simple
+`renewalReminderEmail(customer)` and a `pg_cron` daily that selects
+customers expiring in 30/14/7 days and dispatches.
+
+## 3. Scheduler URL (Cal.com / Savvycal) — PLACEHOLDER (Phase 4)
+
+Phase 4's upgrade-wall and `/pricing` CTAs need a real "book a call"
+URL. v1 will use `NEXT_PUBLIC_SCHEDULER_URL` with a fallback so a
+single env-var change swaps the link. Pick one when ready.
+
+## 4. Server-enforced domain gating on engine routes — DEFERRED
+
+The compute, copilot, enrich, news, and structure routes accept
+opaque graph-context strings without explicit domain IDs.
+`requireDomainAccess()` is wired and ready, but those routes can't
+truly enforce gating without a deeper refactor that moves graph
+construction server-side. v1 relies on the UI lock in
+`DomainSelector.tsx` (a user can't select a locked domain to begin
+with). A determined caller hand-crafting requests is a v2 concern.
+
+**Unblock with:** refactor the client→server contract so the client
+sends `{ domainIds, ... }` and the server reconstructs the graph
+after `requireDomainAccess()`. Out of scope per the
+"don't-touch-engine-code" guardrail.

--- a/src/app/admin/billing/BillingAdminList.tsx
+++ b/src/app/admin/billing/BillingAdminList.tsx
@@ -1,0 +1,497 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import type { AdminCustomerRow } from "@/app/api/admin/billing/customers/route";
+import type { SubscriptionStatus, Tier } from "@/lib/billing";
+
+const TIERS: Tier[] = [
+  "trial",
+  "analyst",
+  "multi_domain",
+  "enterprise",
+  "trusted",
+  "expired",
+];
+
+const STATUSES: SubscriptionStatus[] = [
+  "active",
+  "past_due",
+  "canceled",
+  "pending",
+  "none",
+];
+
+const TIER_COLORS: Record<Tier, string> = {
+  trial:        "text-accent-cyan border-accent-cyan/40 bg-accent-cyan/5",
+  analyst:      "text-accent-amber border-accent-amber/40 bg-accent-amber/5",
+  multi_domain: "text-accent-violet border-accent-violet/40 bg-accent-violet/5",
+  enterprise:   "text-accent-green border-accent-green/40 bg-accent-green/5",
+  trusted:      "text-accent-blue border-accent-blue/40 bg-accent-blue/5",
+  expired:      "text-text-muted border-border bg-surface/30",
+};
+
+const TIER_FILTERS: Array<Tier | "all" | "due_soon"> = [
+  "all",
+  "due_soon",
+  ...TIERS,
+];
+
+function fmtDate(s: string | null): string {
+  if (!s) return "—";
+  const d = new Date(s);
+  if (isNaN(d.getTime())) return "—";
+  return d.toISOString().slice(0, 10);
+}
+
+function daysUntil(s: string | null): number | null {
+  if (!s) return null;
+  const d = new Date(s);
+  if (isNaN(d.getTime())) return null;
+  const ms = d.getTime() - Date.now();
+  return Math.ceil(ms / (24 * 60 * 60 * 1000));
+}
+
+// Convert an ISO timestamp to the value format that <input type="datetime-local">
+// expects: YYYY-MM-DDTHH:MM (no seconds, no tz). Returns "" for null.
+function toLocalInput(s: string | null | undefined): string {
+  if (!s) return "";
+  const d = new Date(s);
+  if (isNaN(d.getTime())) return "";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+// Convert a datetime-local input value back to ISO. Treats input as
+// local time (matches what the user sees). Empty string => null.
+function fromLocalInput(s: string): string | null {
+  if (!s) return null;
+  const d = new Date(s);
+  if (isNaN(d.getTime())) return null;
+  return d.toISOString();
+}
+
+export default function BillingAdminList({ rows }: { rows: AdminCustomerRow[] }) {
+  const router = useRouter();
+  const [filter, setFilter] = useState<Tier | "all" | "due_soon">("all");
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const visibleRows = useMemo(() => {
+    if (filter === "all") return rows;
+    if (filter === "due_soon") {
+      return rows.filter((r) => {
+        const d = daysUntil(r.current_period_end);
+        return d !== null && d <= 30 && r.tier !== "expired";
+      });
+    }
+    return rows.filter((r) => r.tier === filter);
+  }, [rows, filter]);
+
+  const editingRow = rows.find((r) => r.id === editingId) ?? null;
+
+  async function expireNow(id: string, email: string) {
+    if (!confirm(`Flip ${email} to tier='expired' immediately?`)) return;
+    setActionError(null);
+    try {
+      const res = await fetch("/api/admin/billing/expire", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId: id }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setActionError(body.error ?? `HTTP ${res.status}`);
+        return;
+      }
+      startTransition(() => router.refresh());
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-background text-foreground p-6 font-mono">
+      <div className="max-w-7xl mx-auto">
+        <div className="flex items-center justify-between mb-6">
+          <h1 className="text-[14px] font-[family-name:var(--font-michroma)] tracking-wider">
+            BILLING CONSOLE
+          </h1>
+          <div className="text-[10px] text-text-muted">
+            {rows.length} total ·{" "}
+            {
+              rows.filter((r) => {
+                const d = daysUntil(r.current_period_end);
+                return d !== null && d <= 30 && r.tier !== "expired";
+              }).length
+            }{" "}
+            renewing within 30d
+          </div>
+        </div>
+
+        {/* Filter tabs */}
+        <div className="flex flex-wrap gap-2 mb-4">
+          {TIER_FILTERS.map((s) => (
+            <button
+              key={s}
+              onClick={() => setFilter(s)}
+              className={`px-3 py-1 text-[9px] font-[family-name:var(--font-michroma)] tracking-wider rounded border transition-colors ${
+                filter === s
+                  ? "border-foreground text-foreground"
+                  : "border-border text-text-muted hover:text-foreground"
+              }`}
+            >
+              {s.toUpperCase().replace("_", " ")}
+              {s !== "all" && (
+                <span className="ml-2 opacity-60">
+                  {s === "due_soon"
+                    ? rows.filter((r) => {
+                        const d = daysUntil(r.current_period_end);
+                        return (
+                          d !== null && d <= 30 && r.tier !== "expired"
+                        );
+                      }).length
+                    : rows.filter((r) => r.tier === s).length}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+
+        {actionError && (
+          <div className="mb-4 text-[11px] text-accent-red bg-accent-red/10 border border-accent-red/30 rounded px-3 py-2">
+            {actionError}
+          </div>
+        )}
+
+        {/* Table */}
+        <div className="border border-border rounded overflow-hidden">
+          <table className="w-full text-[10px]">
+            <thead className="bg-surface/50 text-text-muted">
+              <tr>
+                <th className="text-left px-3 py-2 tracking-wider">EMAIL</th>
+                <th className="text-left px-3 py-2 tracking-wider">ORG</th>
+                <th className="text-left px-3 py-2 tracking-wider">TIER</th>
+                <th className="text-left px-3 py-2 tracking-wider">STATUS</th>
+                <th className="text-left px-3 py-2 tracking-wider">PERIOD END</th>
+                <th className="text-left px-3 py-2 tracking-wider">DAYS</th>
+                <th className="text-left px-3 py-2 tracking-wider">SEATS</th>
+                <th className="text-left px-3 py-2 tracking-wider">INVOICE</th>
+                <th className="text-right px-3 py-2 tracking-wider">ACTIONS</th>
+              </tr>
+            </thead>
+            <tbody>
+              {visibleRows.length === 0 && (
+                <tr>
+                  <td
+                    colSpan={9}
+                    className="px-3 py-8 text-center text-text-muted"
+                  >
+                    No customers in this view.
+                  </td>
+                </tr>
+              )}
+              {visibleRows.map((r) => {
+                const days = daysUntil(r.current_period_end);
+                const dueSoon =
+                  days !== null && days <= 30 && r.tier !== "expired";
+                return (
+                  <tr key={r.id} className="border-t border-border hover:bg-surface/30">
+                    <td className="px-3 py-2 font-mono">{r.email}</td>
+                    <td className="px-3 py-2 text-text-muted">
+                      {r.org_name ?? "—"}
+                    </td>
+                    <td className="px-3 py-2">
+                      <span
+                        className={`inline-block px-2 py-0.5 rounded border text-[9px] tracking-wider ${TIER_COLORS[r.tier]}`}
+                      >
+                        {r.tier.replace("_", " ").toUpperCase()}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 text-text-muted">
+                      {r.subscription_status ?? "—"}
+                    </td>
+                    <td className="px-3 py-2 font-mono text-text-muted">
+                      {fmtDate(r.current_period_end)}
+                    </td>
+                    <td className="px-3 py-2 font-mono">
+                      {days === null ? (
+                        <span className="text-text-muted">—</span>
+                      ) : days < 0 ? (
+                        <span className="text-accent-red">{days}d</span>
+                      ) : dueSoon ? (
+                        <span className="text-accent-amber">{days}d</span>
+                      ) : (
+                        <span className="text-text-muted">{days}d</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 font-mono text-text-muted">
+                      {r.seats}
+                    </td>
+                    <td className="px-3 py-2 font-mono text-text-muted truncate max-w-[120px]">
+                      {r.mercury_invoice_id ?? "—"}
+                    </td>
+                    <td className="px-3 py-2 text-right whitespace-nowrap">
+                      <button
+                        onClick={() => setEditingId(r.id)}
+                        className="px-2 py-1 mr-1 text-[9px] tracking-wider border border-border rounded text-text-muted hover:text-foreground hover:border-foreground transition-colors"
+                      >
+                        EDIT
+                      </button>
+                      {r.tier !== "expired" && (
+                        <button
+                          onClick={() => expireNow(r.id, r.email)}
+                          disabled={pending}
+                          className="px-2 py-1 text-[9px] tracking-wider border border-accent-red/40 text-accent-red rounded hover:bg-accent-red/10 transition-colors disabled:opacity-50"
+                        >
+                          EXPIRE
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        {editingRow && (
+          <EditModal
+            row={editingRow}
+            onClose={() => setEditingId(null)}
+            onSaved={() => {
+              setEditingId(null);
+              startTransition(() => router.refresh());
+            }}
+            onError={(msg) => setActionError(msg)}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EditModal({
+  row,
+  onClose,
+  onSaved,
+  onError,
+}: {
+  row: AdminCustomerRow;
+  onClose: () => void;
+  onSaved: () => void;
+  onError: (msg: string) => void;
+}) {
+  const [tier, setTier] = useState<Tier>(row.tier);
+  const [periodStart, setPeriodStart] = useState(toLocalInput(row.current_period_start));
+  const [periodEnd, setPeriodEnd] = useState(toLocalInput(row.current_period_end));
+  const [invoiceId, setInvoiceId] = useState(row.mercury_invoice_id ?? "");
+  const [seats, setSeats] = useState(String(row.seats));
+  const [domainAccess, setDomainAccess] = useState(
+    row.domain_access ? row.domain_access.join(",") : ""
+  );
+  const [status, setStatus] = useState<SubscriptionStatus | "">(
+    row.subscription_status ?? ""
+  );
+  const [saving, setSaving] = useState(false);
+
+  function bumpOneYear() {
+    const base = periodEnd ? new Date(periodEnd) : new Date();
+    if (isNaN(base.getTime())) return;
+    base.setFullYear(base.getFullYear() + 1);
+    setPeriodEnd(toLocalInput(base.toISOString()));
+  }
+
+  async function save() {
+    setSaving(true);
+    try {
+      const seatsNum = seats.trim() === "" ? null : Number(seats);
+      if (seatsNum !== null && (!Number.isInteger(seatsNum) || seatsNum < 1)) {
+        onError("Seats must be an integer >= 1.");
+        setSaving(false);
+        return;
+      }
+
+      const body = {
+        userId: row.id,
+        tier,
+        currentPeriodStart: fromLocalInput(periodStart),
+        currentPeriodEnd: fromLocalInput(periodEnd),
+        mercuryInvoiceId: invoiceId.trim() || null,
+        seats: seatsNum,
+        domainAccess:
+          domainAccess.trim() === ""
+            ? null
+            : domainAccess
+                .split(",")
+                .map((s) => s.trim())
+                .filter(Boolean),
+        subscriptionStatus: status === "" ? null : status,
+      };
+
+      const res = await fetch("/api/admin/billing/grant-tier", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        onError(j.error ?? `HTTP ${res.status}`);
+        return;
+      }
+      onSaved();
+    } catch (err) {
+      onError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm p-4">
+      <div className="w-full max-w-lg bg-background border border-border rounded-lg shadow-2xl overflow-hidden">
+        <div className="px-5 py-3 border-b border-border flex items-center justify-between">
+          <div>
+            <h2 className="text-[12px] font-[family-name:var(--font-michroma)] tracking-wider">
+              EDIT CUSTOMER
+            </h2>
+            <div className="text-[10px] text-text-muted mt-0.5 truncate">{row.email}</div>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-text-muted hover:text-foreground text-[12px]"
+          >
+            CLOSE
+          </button>
+        </div>
+
+        <div className="px-5 py-4 space-y-3 text-[11px]">
+          <Field label="TIER">
+            <select
+              value={tier}
+              onChange={(e) => setTier(e.target.value as Tier)}
+              className="w-full bg-surface border border-border rounded px-2 py-1 text-foreground"
+            >
+              {TIERS.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+          </Field>
+
+          <Field label="STATUS (auto if blank)">
+            <select
+              value={status}
+              onChange={(e) => setStatus(e.target.value as SubscriptionStatus | "")}
+              className="w-full bg-surface border border-border rounded px-2 py-1 text-foreground"
+            >
+              <option value="">— auto —</option>
+              {STATUSES.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+          </Field>
+
+          <Field label="PERIOD START">
+            <input
+              type="datetime-local"
+              value={periodStart}
+              onChange={(e) => setPeriodStart(e.target.value)}
+              className="w-full bg-surface border border-border rounded px-2 py-1 text-foreground"
+            />
+          </Field>
+
+          <Field
+            label="PERIOD END"
+            extra={
+              <button
+                type="button"
+                onClick={bumpOneYear}
+                className="text-[9px] text-accent-cyan/70 hover:text-accent-cyan"
+              >
+                +1 YEAR
+              </button>
+            }
+          >
+            <input
+              type="datetime-local"
+              value={periodEnd}
+              onChange={(e) => setPeriodEnd(e.target.value)}
+              className="w-full bg-surface border border-border rounded px-2 py-1 text-foreground"
+            />
+          </Field>
+
+          <Field label="MERCURY INVOICE ID">
+            <input
+              type="text"
+              value={invoiceId}
+              onChange={(e) => setInvoiceId(e.target.value)}
+              placeholder="e.g. INV-001"
+              className="w-full bg-surface border border-border rounded px-2 py-1 text-foreground placeholder:text-text-muted/50"
+            />
+          </Field>
+
+          <Field label="SEATS">
+            <input
+              type="number"
+              min={1}
+              value={seats}
+              onChange={(e) => setSeats(e.target.value)}
+              className="w-full bg-surface border border-border rounded px-2 py-1 text-foreground"
+            />
+          </Field>
+
+          <Field label="DOMAIN ACCESS (csv, blank = tier default)">
+            <input
+              type="text"
+              value={domainAccess}
+              onChange={(e) => setDomainAccess(e.target.value)}
+              placeholder="energy-systems,t1d-beta-cell"
+              className="w-full bg-surface border border-border rounded px-2 py-1 text-foreground placeholder:text-text-muted/50"
+            />
+          </Field>
+        </div>
+
+        <div className="px-5 py-3 border-t border-border flex items-center justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="px-3 py-1.5 text-[10px] tracking-wider border border-border rounded text-text-muted hover:text-foreground"
+          >
+            CANCEL
+          </button>
+          <button
+            onClick={save}
+            disabled={saving}
+            className="px-4 py-1.5 text-[10px] tracking-wider border border-accent-cyan/40 rounded text-accent-cyan bg-accent-cyan/10 hover:bg-accent-cyan/20 disabled:opacity-50"
+          >
+            {saving ? "SAVING..." : "SAVE"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  extra,
+  children,
+}: {
+  label: string;
+  extra?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1">
+        <label className="text-[9px] text-text-muted tracking-wider">{label}</label>
+        {extra}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/app/admin/billing/page.tsx
+++ b/src/app/admin/billing/page.tsx
@@ -1,0 +1,32 @@
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+import BillingAdminList from "./BillingAdminList";
+import type { AdminCustomerRow } from "@/app/api/admin/billing/customers/route";
+
+export const dynamic = "force-dynamic";
+
+export default async function BillingAdminPage() {
+  // Middleware gates /admin/* to ADMIN_EMAILS allowlist, so it's safe to
+  // bypass RLS here with the service-role client.
+  const supabase = createSupabaseClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+  const { data, error } = await supabase
+    .from("profiles")
+    .select(
+      "id, email, org_name, tier, subscription_status, current_period_start, current_period_end, mercury_invoice_id, seats, domain_access, trial_expires_at, created_at"
+    )
+    .order("current_period_end", { ascending: true, nullsFirst: false })
+    .limit(500);
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-background text-foreground p-8 font-mono">
+        <div className="text-accent-red">Failed to load customers: {error.message}</div>
+      </div>
+    );
+  }
+
+  const rows = (data ?? []) as AdminCustomerRow[];
+  return <BillingAdminList rows={rows} />;
+}

--- a/src/app/admin/leads/LeadsAdminList.tsx
+++ b/src/app/admin/leads/LeadsAdminList.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import type { LeadRow, LeadStatus } from "./page";
+
+const STATUSES: LeadStatus[] = [
+  "new",
+  "contacted",
+  "trial-issued",
+  "closed-won",
+  "closed-lost",
+];
+
+const STATUS_COLORS: Record<LeadStatus, string> = {
+  new: "text-accent-cyan border-accent-cyan/40 bg-accent-cyan/5",
+  contacted: "text-accent-amber border-accent-amber/40 bg-accent-amber/5",
+  "trial-issued": "text-accent-purple border-accent-purple/40 bg-accent-purple/5",
+  "closed-won": "text-accent-green border-accent-green/40 bg-accent-green/5",
+  "closed-lost": "text-text-muted border-border bg-surface/30",
+};
+
+const FILTERS: Array<LeadStatus | "all"> = ["all", ...STATUSES];
+
+function fmtDate(s: string | null): string {
+  if (!s) return "—";
+  const d = new Date(s);
+  if (isNaN(d.getTime())) return "—";
+  return d.toISOString().slice(0, 10);
+}
+
+export default function LeadsAdminList({ rows }: { rows: LeadRow[] }) {
+  const router = useRouter();
+  const [filter, setFilter] = useState<LeadStatus | "all">("all");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const visibleRows = useMemo(() => {
+    if (filter === "all") return rows;
+    return rows.filter((r) => r.status === filter);
+  }, [rows, filter]);
+
+  const selected = rows.find((r) => r.id === selectedId) ?? null;
+
+  async function updateLead(
+    id: string,
+    payload: { status?: LeadStatus; admin_notes?: string | null }
+  ) {
+    setActionError(null);
+    try {
+      const res = await fetch(`/api/admin/leads/${id}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        setActionError(j.error ?? `HTTP ${res.status}`);
+        return;
+      }
+      startTransition(() => router.refresh());
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-background text-foreground p-6 font-mono">
+      <div className="max-w-7xl mx-auto">
+        <div className="flex items-center justify-between mb-6">
+          <h1 className="text-[14px] font-[family-name:var(--font-michroma)] tracking-wider">
+            ACCESS REQUESTS
+          </h1>
+          <div className="text-[10px] text-text-muted">
+            {rows.length} total ·{" "}
+            {rows.filter((r) => r.status === "new").length} new
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2 mb-4">
+          {FILTERS.map((s) => (
+            <button
+              key={s}
+              onClick={() => setFilter(s)}
+              className={`px-3 py-1 text-[9px] font-[family-name:var(--font-michroma)] tracking-wider rounded border transition-colors ${
+                filter === s
+                  ? "border-foreground text-foreground"
+                  : "border-border text-text-muted hover:text-foreground"
+              }`}
+            >
+              {s.toUpperCase().replace(/-/g, " ")}
+              {s !== "all" && (
+                <span className="ml-2 opacity-60">
+                  {rows.filter((r) => r.status === s).length}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+
+        {actionError && (
+          <div className="mb-4 text-[11px] text-accent-red bg-accent-red/10 border border-accent-red/30 rounded px-3 py-2">
+            {actionError}
+          </div>
+        )}
+
+        <div className="grid md:grid-cols-2 gap-4">
+          <div className="border border-border rounded overflow-hidden">
+            <table className="w-full text-[10px]">
+              <thead className="bg-surface/50 text-text-muted">
+                <tr>
+                  <th className="text-left px-3 py-2 tracking-wider">RECEIVED</th>
+                  <th className="text-left px-3 py-2 tracking-wider">NAME</th>
+                  <th className="text-left px-3 py-2 tracking-wider">ORG</th>
+                  <th className="text-left px-3 py-2 tracking-wider">STATUS</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visibleRows.length === 0 && (
+                  <tr>
+                    <td colSpan={4} className="px-3 py-8 text-center text-text-muted">
+                      No leads in this view.
+                    </td>
+                  </tr>
+                )}
+                {visibleRows.map((r) => (
+                  <tr
+                    key={r.id}
+                    onClick={() => setSelectedId(r.id)}
+                    className={`border-t border-border cursor-pointer hover:bg-surface/30 ${
+                      selectedId === r.id ? "bg-surface/40" : ""
+                    }`}
+                  >
+                    <td className="px-3 py-2 font-mono text-text-muted">
+                      {fmtDate(r.created_at)}
+                    </td>
+                    <td className="px-3 py-2">{r.name}</td>
+                    <td className="px-3 py-2 text-text-muted">{r.organization}</td>
+                    <td className="px-3 py-2">
+                      <span
+                        className={`inline-block px-2 py-0.5 rounded border text-[9px] tracking-wider ${STATUS_COLORS[r.status]}`}
+                      >
+                        {r.status.toUpperCase().replace(/-/g, " ")}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {selected ? (
+            <LeadDetail
+              row={selected}
+              pending={pending}
+              onUpdate={(payload) => updateLead(selected.id, payload)}
+            />
+          ) : (
+            <div className="border border-border rounded p-6 text-[11px] text-text-muted text-center">
+              Select a lead to view details and update status.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function LeadDetail({
+  row,
+  pending,
+  onUpdate,
+}: {
+  row: LeadRow;
+  pending: boolean;
+  onUpdate: (payload: { status?: LeadStatus; admin_notes?: string | null }) => void;
+}) {
+  const [notes, setNotes] = useState(row.admin_notes ?? "");
+
+  return (
+    <div className="border border-border rounded p-5 space-y-4 text-[11px]">
+      <div>
+        <div className="text-[9px] tracking-wider text-text-muted">NAME</div>
+        <div className="text-foreground">{row.name}</div>
+      </div>
+      <div>
+        <div className="text-[9px] tracking-wider text-text-muted">EMAIL</div>
+        <a
+          href={`mailto:${row.email}`}
+          className="text-accent-cyan/80 hover:text-accent-cyan break-all"
+        >
+          {row.email}
+        </a>
+      </div>
+      <div>
+        <div className="text-[9px] tracking-wider text-text-muted">ORG</div>
+        <div className="text-foreground">{row.organization}</div>
+      </div>
+      <div>
+        <div className="text-[9px] tracking-wider text-text-muted">SOURCE</div>
+        <div className="text-text-muted">{row.source}</div>
+      </div>
+      {row.use_case && (
+        <div>
+          <div className="text-[9px] tracking-wider text-text-muted">USE CASE</div>
+          <div className="text-foreground/90 whitespace-pre-wrap leading-relaxed">
+            {row.use_case}
+          </div>
+        </div>
+      )}
+
+      <div className="border-t border-border pt-3">
+        <div className="text-[9px] tracking-wider text-text-muted mb-1">
+          ADMIN NOTES
+        </div>
+        <textarea
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          rows={3}
+          className="w-full bg-surface border border-border rounded px-2 py-1.5 text-foreground text-[11px]"
+          placeholder="Internal notes — context for sales follow-up."
+        />
+        <button
+          onClick={() => onUpdate({ admin_notes: notes.trim() || null })}
+          disabled={pending}
+          className="mt-2 px-3 py-1 text-[9px] tracking-wider border border-border rounded text-text-muted hover:text-foreground hover:border-foreground transition-colors disabled:opacity-50"
+        >
+          SAVE NOTES
+        </button>
+      </div>
+
+      <div className="border-t border-border pt-3">
+        <div className="text-[9px] tracking-wider text-text-muted mb-2">
+          UPDATE STATUS
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {STATUSES.map((s) => (
+            <button
+              key={s}
+              onClick={() => onUpdate({ status: s })}
+              disabled={pending || s === row.status}
+              className={`px-2 py-1 text-[9px] tracking-wider rounded border transition-colors disabled:opacity-50 ${
+                s === row.status
+                  ? "border-foreground text-foreground"
+                  : "border-border text-text-muted hover:text-foreground hover:border-foreground"
+              }`}
+            >
+              {s.toUpperCase().replace(/-/g, " ")}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/leads/page.tsx
+++ b/src/app/admin/leads/page.tsx
@@ -1,0 +1,51 @@
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+import LeadsAdminList from "./LeadsAdminList";
+
+export const dynamic = "force-dynamic";
+
+export type LeadStatus =
+  | "new"
+  | "contacted"
+  | "trial-issued"
+  | "closed-won"
+  | "closed-lost";
+
+export interface LeadRow {
+  id: string;
+  name: string;
+  email: string;
+  organization: string;
+  use_case: string | null;
+  source: string;
+  status: LeadStatus;
+  admin_notes: string | null;
+  contacted_at: string | null;
+  created_at: string;
+}
+
+export default async function LeadsAdminPage() {
+  const supabase = createSupabaseClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+  const { data, error } = await supabase
+    .from("leads")
+    .select(
+      "id, name, email, organization, use_case, source, status, admin_notes, contacted_at, created_at"
+    )
+    .order("created_at", { ascending: false })
+    .limit(500);
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-background text-foreground p-8 font-mono">
+        <div className="text-accent-red">
+          Failed to load leads: {error.message}
+        </div>
+      </div>
+    );
+  }
+
+  const rows = (data ?? []) as LeadRow[];
+  return <LeadsAdminList rows={rows} />;
+}

--- a/src/app/api/admin/billing/customers/route.ts
+++ b/src/app/api/admin/billing/customers/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { createClient as createServiceClient } from "@supabase/supabase-js";
+import { requireAdmin } from "@/lib/admin-auth";
+import type { Tier, SubscriptionStatus } from "@/lib/billing";
+
+const service = createServiceClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+export interface AdminCustomerRow {
+  id: string;
+  email: string;
+  org_name: string | null;
+  tier: Tier;
+  subscription_status: SubscriptionStatus | null;
+  current_period_start: string | null;
+  current_period_end: string | null;
+  mercury_invoice_id: string | null;
+  seats: number;
+  domain_access: string[] | null;
+  trial_expires_at: string | null;
+  created_at: string;
+}
+
+// Lists all profiles for the admin billing console. Sorted with
+// soonest current_period_end first so renewals coming due naturally
+// surface to the top; rows with no period_end fall to the bottom.
+export async function GET() {
+  const auth = await requireAdmin();
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status });
+  }
+
+  const { data, error } = await service
+    .from("profiles")
+    .select(
+      "id, email, org_name, tier, subscription_status, current_period_start, current_period_end, mercury_invoice_id, seats, domain_access, trial_expires_at, created_at"
+    )
+    .order("current_period_end", { ascending: true, nullsFirst: false })
+    .limit(500);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json(
+    { customers: (data ?? []) as AdminCustomerRow[] },
+    { headers: { "Cache-Control": "private, no-store" } }
+  );
+}

--- a/src/app/api/admin/billing/expire/route.ts
+++ b/src/app/api/admin/billing/expire/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient as createServiceClient } from "@supabase/supabase-js";
+import { requireAdmin } from "@/lib/admin-auth";
+
+const service = createServiceClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Fast-path mutation to flip a customer to tier='expired' immediately.
+// Equivalent to grant-tier { tier: 'expired' } but easier to use from
+// the admin UI (single button, no form fill).
+export async function POST(req: NextRequest) {
+  const auth = await requireAdmin();
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status });
+  }
+
+  const body = (await req.json().catch(() => ({}))) as { userId?: string };
+  if (!body.userId || !UUID_RE.test(body.userId)) {
+    return NextResponse.json(
+      { error: "userId (uuid) is required" },
+      { status: 400 }
+    );
+  }
+
+  const { error } = await service
+    .from("profiles")
+    .update({
+      tier: "expired",
+      subscription_status: "none",
+    })
+    .eq("id", body.userId);
+
+  if (error) {
+    console.error("admin/billing/expire:", error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/admin/billing/grant-tier/route.ts
+++ b/src/app/api/admin/billing/grant-tier/route.ts
@@ -1,0 +1,141 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient as createServiceClient } from "@supabase/supabase-js";
+import { requireAdmin } from "@/lib/admin-auth";
+import type { SubscriptionStatus, Tier } from "@/lib/billing";
+
+const service = createServiceClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+const VALID_TIERS = new Set<Tier>([
+  "trial",
+  "analyst",
+  "multi_domain",
+  "enterprise",
+  "trusted",
+  "expired",
+]);
+
+const VALID_STATUSES = new Set<SubscriptionStatus>([
+  "active",
+  "past_due",
+  "canceled",
+  "pending",
+  "none",
+]);
+
+const PAID_TIERS = new Set<Tier>(["analyst", "multi_domain", "enterprise"]);
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+interface GrantBody {
+  userId?: string;
+  tier?: Tier;
+  currentPeriodStart?: string | null;
+  currentPeriodEnd?: string | null;
+  mercuryInvoiceId?: string | null;
+  seats?: number | null;
+  domainAccess?: string[] | null;
+  subscriptionStatus?: SubscriptionStatus | null;
+}
+
+// Sets tier + billing fields on a profile. Used for: closing a sale
+// (grant analyst/multi_domain/enterprise + period dates + invoice
+// id), renewing (extend currentPeriodEnd), comping a user (set
+// trusted), or extending a trial (set tier=trial + new period_end).
+//
+// All fields except userId and tier are optional — anything omitted
+// from the body is left untouched on the row. Sensible defaults for
+// subscription_status are applied when omitted.
+export async function POST(req: NextRequest) {
+  const auth = await requireAdmin();
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status });
+  }
+
+  let body: GrantBody;
+  try {
+    body = (await req.json()) as GrantBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body.userId || !UUID_RE.test(body.userId)) {
+    return NextResponse.json(
+      { error: "userId (uuid) is required" },
+      { status: 400 }
+    );
+  }
+  if (!body.tier || !VALID_TIERS.has(body.tier)) {
+    return NextResponse.json(
+      { error: `tier must be one of ${[...VALID_TIERS].join(", ")}` },
+      { status: 400 }
+    );
+  }
+  if (
+    body.subscriptionStatus !== undefined &&
+    body.subscriptionStatus !== null &&
+    !VALID_STATUSES.has(body.subscriptionStatus)
+  ) {
+    return NextResponse.json(
+      {
+        error: `subscriptionStatus must be one of ${[...VALID_STATUSES].join(", ")}`,
+      },
+      { status: 400 }
+    );
+  }
+  if (body.seats !== undefined && body.seats !== null) {
+    if (!Number.isInteger(body.seats) || body.seats < 1) {
+      return NextResponse.json(
+        { error: "seats must be an integer >= 1" },
+        { status: 400 }
+      );
+    }
+  }
+  if (body.domainAccess !== undefined && body.domainAccess !== null) {
+    if (
+      !Array.isArray(body.domainAccess) ||
+      body.domainAccess.some((d) => typeof d !== "string")
+    ) {
+      return NextResponse.json(
+        { error: "domainAccess must be a string[] or null" },
+        { status: 400 }
+      );
+    }
+  }
+
+  const update: Record<string, unknown> = { tier: body.tier };
+  if (body.currentPeriodStart !== undefined)
+    update.current_period_start = body.currentPeriodStart;
+  if (body.currentPeriodEnd !== undefined)
+    update.current_period_end = body.currentPeriodEnd;
+  if (body.mercuryInvoiceId !== undefined)
+    update.mercury_invoice_id = body.mercuryInvoiceId;
+  if (body.seats !== undefined && body.seats !== null) update.seats = body.seats;
+  if (body.domainAccess !== undefined) update.domain_access = body.domainAccess;
+
+  // Apply default subscription_status when admin didn't specify one.
+  if (body.subscriptionStatus !== undefined) {
+    update.subscription_status = body.subscriptionStatus;
+  } else {
+    if (body.tier === "expired") update.subscription_status = "none";
+    else if (body.tier === "trusted") update.subscription_status = "active";
+    else if (body.tier === "trial") update.subscription_status = "active";
+    else if (PAID_TIERS.has(body.tier) && body.currentPeriodEnd) {
+      update.subscription_status = "active";
+    }
+  }
+
+  const { error } = await service
+    .from("profiles")
+    .update(update)
+    .eq("id", body.userId);
+
+  if (error) {
+    console.error("admin/billing/grant-tier:", error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/admin/leads/[id]/route.ts
+++ b/src/app/api/admin/leads/[id]/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient as createServiceClient } from "@supabase/supabase-js";
+import { requireAdmin } from "@/lib/admin-auth";
+
+const service = createServiceClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const VALID_STATUSES = new Set([
+  "new",
+  "contacted",
+  "trial-issued",
+  "closed-won",
+  "closed-lost",
+]);
+
+interface UpdateBody {
+  status?: string;
+  admin_notes?: string | null;
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await requireAdmin();
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status });
+  }
+
+  const { id } = await params;
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json({ error: "Invalid lead id" }, { status: 400 });
+  }
+
+  let body: UpdateBody;
+  try {
+    body = (await req.json()) as UpdateBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const update: Record<string, unknown> = {};
+
+  if (body.status !== undefined) {
+    if (typeof body.status !== "string" || !VALID_STATUSES.has(body.status)) {
+      return NextResponse.json(
+        { error: `status must be one of ${[...VALID_STATUSES].join(", ")}` },
+        { status: 400 }
+      );
+    }
+    update.status = body.status;
+    // Stamp contacted_at the first time a lead moves out of 'new'.
+    if (body.status !== "new") {
+      update.contacted_at = new Date().toISOString();
+    }
+  }
+
+  if (body.admin_notes !== undefined) {
+    if (body.admin_notes !== null && typeof body.admin_notes !== "string") {
+      return NextResponse.json(
+        { error: "admin_notes must be a string or null" },
+        { status: 400 }
+      );
+    }
+    update.admin_notes = body.admin_notes;
+  }
+
+  if (Object.keys(update).length === 0) {
+    return NextResponse.json(
+      { error: "No fields to update (status or admin_notes)" },
+      { status: 400 }
+    );
+  }
+
+  const { error } = await service.from("leads").update(update).eq("id", id);
+  if (error) {
+    console.error("admin/leads update:", error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/me/access/route.ts
+++ b/src/app/api/me/access/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { getUserAccess } from "@/lib/billing-server";
+
+// Returns the authed user's resolved tier + effective domain access.
+// Used by the client (DomainSelector, upgrade CTAs) to gate UI.
+// Middleware enforces auth on this route; if it leaks through to an
+// unauthed request we still 401 explicitly.
+export async function GET() {
+  const access = await getUserAccess();
+  if (!access) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+  return NextResponse.json(access, {
+    // Per-user data, never cache.
+    headers: { "Cache-Control": "private, no-store" },
+  });
+}

--- a/src/app/api/request-access/route.ts
+++ b/src/app/api/request-access/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient as createServiceClient } from "@supabase/supabase-js";
+
+// Public lead-capture endpoint. Anonymous; rate-limiting and bot
+// protection are out of scope here — Vercel/middleware can layer on
+// later if abuse becomes real. Insert via service-role to bypass
+// RLS predictably (the policy already allows anon inserts, this is
+// belt-and-suspenders).
+
+const service = createServiceClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_FIELD = 500;
+const MAX_USE_CASE = 4000;
+
+interface LeadBody {
+  name?: unknown;
+  email?: unknown;
+  organization?: unknown;
+  useCase?: unknown;
+  source?: unknown;
+}
+
+function asBoundedString(v: unknown, max: number): string | null {
+  if (typeof v !== "string") return null;
+  const trimmed = v.trim();
+  if (!trimmed || trimmed.length > max) return null;
+  return trimmed;
+}
+
+export async function POST(req: NextRequest) {
+  let body: LeadBody;
+  try {
+    body = (await req.json()) as LeadBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const name = asBoundedString(body.name, MAX_FIELD);
+  const email = asBoundedString(body.email, MAX_FIELD);
+  const organization = asBoundedString(body.organization, MAX_FIELD);
+  const useCase =
+    body.useCase == null ? null : asBoundedString(body.useCase, MAX_USE_CASE);
+  const source =
+    asBoundedString(body.source, MAX_FIELD) ?? "request-access";
+
+  if (!name) {
+    return NextResponse.json(
+      { error: "name is required (1-500 chars)" },
+      { status: 400 }
+    );
+  }
+  if (!email || !EMAIL_RE.test(email)) {
+    return NextResponse.json(
+      { error: "valid email is required" },
+      { status: 400 }
+    );
+  }
+  if (!organization) {
+    return NextResponse.json(
+      { error: "organization is required (1-500 chars)" },
+      { status: 400 }
+    );
+  }
+
+  const { error } = await service.from("leads").insert({
+    name,
+    email: email.toLowerCase(),
+    organization,
+    use_case: useCase,
+    source,
+  });
+
+  if (error) {
+    console.error("request-access insert error:", error);
+    return NextResponse.json(
+      { error: "Could not record request. Please email us instead." },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/trusted-signup/route.ts
+++ b/src/app/api/trusted-signup/route.ts
@@ -45,17 +45,16 @@ export async function POST(request: NextRequest) {
     }
 
     // ── Create user via admin API (service-role) ─────────────────
-    // The handle_new_user trigger will fire and create the profiles
-    // row with access_type from raw_user_meta_data. Because this
-    // call comes from the service-role (not the browser), the
-    // metadata is trustworthy.
+    // The handle_new_user trigger reads `tier` from raw_user_meta_data
+    // when invoked under service-role. Browser callers cannot reach
+    // this path, so the metadata is trustworthy.
     const { data, error: createError } =
       await supabase.auth.admin.createUser({
         email,
         password,
         email_confirm: true, // skip email verification for trusted users
         user_metadata: {
-          access_type: "trusted",
+          tier: "trusted",
           org_name: orgName || null,
         },
       });
@@ -82,7 +81,13 @@ export async function POST(request: NextRequest) {
     if (data.user) {
       const { error: updateError } = await supabase
         .from("profiles")
-        .update({ access_type: "trusted", trial_expires_at: null })
+        .update({
+          tier: "trusted",
+          subscription_status: "active",
+          trial_expires_at: null,
+          current_period_end: null,
+          access_type: "trusted",
+        })
         .eq("id", data.user.id);
 
       if (updateError) {

--- a/src/app/expired/SignOutButton.tsx
+++ b/src/app/expired/SignOutButton.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+
+export default function SignOutButton() {
+  const router = useRouter();
+  const supabase = createClient();
+
+  async function handleSignOut() {
+    await supabase.auth.signOut();
+    router.push("/login");
+    router.refresh();
+  }
+
+  return (
+    <button
+      onClick={handleSignOut}
+      className="hover:text-foreground transition-colors"
+    >
+      Sign out
+    </button>
+  );
+}

--- a/src/app/expired/page.tsx
+++ b/src/app/expired/page.tsx
@@ -1,29 +1,60 @@
-"use client";
-
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 import Image from "next/image";
-import { createClient } from "@/lib/supabase/client";
+import { createClient } from "@/lib/supabase/server";
+import { TIER_LABELS, type Tier } from "@/lib/billing";
+import UpgradeCTA from "@/components/UpgradeCTA";
+import SignOutButton from "./SignOutButton";
 
-export default function ExpiredPage() {
-  const router = useRouter();
-  const supabase = createClient();
+export const dynamic = "force-dynamic";
 
-  async function handleSignOut() {
-    await supabase.auth.signOut();
-    router.push("/login");
-    router.refresh();
+export default async function ExpiredPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  let tier: Tier | null = null;
+  let orgName: string | null = null;
+  let periodEnd: string | null = null;
+
+  if (user) {
+    const { data } = await supabase
+      .from("profiles")
+      .select("tier, org_name, current_period_end")
+      .eq("id", user.id)
+      .single<{ tier: Tier; org_name: string | null; current_period_end: string | null }>();
+    if (data) {
+      tier = data.tier;
+      orgName = data.org_name;
+      periodEnd = data.current_period_end;
+    }
   }
 
+  // Headline copy depends on which state the user is in: trial that
+  // ran out, paid tier whose period lapsed, or admin-flipped expired.
+  const headline =
+    tier === "trial"
+      ? "TRIAL ACCESS EXPIRED"
+      : tier === "expired"
+        ? "ACCESS EXPIRED"
+        : "ACCESS EXPIRED";
+
+  const blurb =
+    tier === "trial"
+      ? "Your 48-hour pilot has ended. Speak with us about an Analyst, Multi-Domain, or Enterprise seat."
+      : tier === "expired"
+        ? "Your subscription has lapsed. Schedule a call to renew, or email us to discuss an upgrade."
+        : "Your access window has closed. Reach out to renew or upgrade.";
+
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background px-4">
-      <div className="w-full max-w-md space-y-8 text-center">
-        {/* Logo */}
+    <div className="min-h-screen flex items-center justify-center bg-background px-4 py-12">
+      <div className="w-full max-w-md space-y-7 text-center">
         <div className="space-y-2">
           <Image
             src="/logo.png"
-            alt="Manifold Logo"
-            width={160}
-            height={160}
+            alt="Manifold"
+            width={140}
+            height={140}
             className="mx-auto object-contain"
             priority
           />
@@ -33,33 +64,45 @@ export default function ExpiredPage() {
           <span className="font-[family-name:var(--font-michroma)] text-[8px] tracking-[0.25em] text-text-muted">
             by APEX ANALYTICA
           </span>
-          <div className="w-16 h-px bg-accent-red/40 mx-auto mt-4" />
+          <div className="w-16 h-px bg-accent-red/40 mx-auto mt-3" />
         </div>
 
-        {/* Expired notice */}
         <div className="bg-surface border border-accent-red/20 rounded p-6 space-y-4">
           <div className="text-[11px] font-[family-name:var(--font-michroma)] tracking-wider text-accent-red">
-            TRIAL ACCESS EXPIRED
+            {headline}
           </div>
           <p className="text-[12px] font-mono text-text-muted leading-relaxed">
-            Your 48-hour trial access has ended. To continue using
-            Manifold, contact us for extended or permanent access.
+            {blurb}
           </p>
-          <a
-            href="mailto:info@apexanalytica.co"
-            className="inline-block px-5 py-2.5 bg-accent-cyan/10 border border-accent-cyan/40 rounded text-[11px] font-[family-name:var(--font-michroma)] tracking-wider text-accent-cyan hover:bg-accent-cyan/20 hover:border-accent-cyan/60 transition-all"
-          >
-            CONTACT info@apexanalytica.co
-          </a>
+
+          {(orgName || tier) && (
+            <div className="text-[10px] font-mono text-text-muted/80 border-t border-border pt-3 space-y-0.5">
+              {orgName && <div>Org · {orgName}</div>}
+              {tier && <div>Last tier · {TIER_LABELS[tier]}</div>}
+              {periodEnd && (
+                <div>
+                  Period ended ·{" "}
+                  {new Date(periodEnd).toISOString().slice(0, 10)}
+                </div>
+              )}
+            </div>
+          )}
+
+          <div className="pt-2">
+            <UpgradeCTA
+              primaryLabel="Schedule a renewal call"
+              subjectHint="Manifold renewal / upgrade"
+            />
+          </div>
         </div>
 
-        {/* Sign out */}
-        <button
-          onClick={handleSignOut}
-          className="text-[10px] font-mono text-text-muted hover:text-foreground transition-colors"
-        >
-          Sign out
-        </button>
+        <div className="flex items-center justify-center gap-4 text-[10px] font-mono text-text-muted">
+          <Link href="/pricing" className="hover:text-foreground">
+            View pricing
+          </Link>
+          <span className="text-border">·</span>
+          <SignOutButton />
+        </div>
       </div>
     </div>
   );

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,0 +1,133 @@
+import Link from "next/link";
+import Image from "next/image";
+import { PRICING_PLANS } from "@/lib/billing";
+
+export const metadata = {
+  title: "Pricing — Manifold by Apex Analytica",
+  description:
+    "Institutional pricing for Manifold, the causal-inference terminal for cross-domain risk.",
+};
+
+export default function PricingPage() {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <header className="border-b border-border">
+        <div className="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
+          <Link href="/" className="flex items-center gap-3">
+            <Image src="/logo.png" alt="Manifold" width={36} height={36} />
+            <div className="leading-tight">
+              <div className="text-[12px] font-[family-name:var(--font-michroma)] tracking-[0.25em] text-accent-cyan">
+                MANIFOLD
+              </div>
+              <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-[0.25em] text-text-muted">
+                by APEX ANALYTICA
+              </div>
+            </div>
+          </Link>
+          <nav className="flex items-center gap-5 text-[10px] font-mono text-text-muted">
+            <Link href="/login" className="hover:text-foreground">
+              SIGN IN
+            </Link>
+            <Link
+              href="/request-access"
+              className="px-3 py-1.5 border border-accent-cyan/40 rounded text-accent-cyan hover:bg-accent-cyan/10 tracking-wider"
+            >
+              REQUEST ACCESS
+            </Link>
+          </nav>
+        </div>
+      </header>
+
+      <main className="max-w-6xl mx-auto px-6 py-16">
+        <div className="text-center mb-14 space-y-3">
+          <div className="text-[10px] font-[family-name:var(--font-michroma)] tracking-[0.3em] text-text-muted">
+            INSTITUTIONAL ACCESS
+          </div>
+          <h1 className="text-3xl md:text-4xl font-[family-name:var(--font-michroma)] tracking-wider">
+            Pricing
+          </h1>
+          <p className="text-[12px] font-mono text-text-muted max-w-xl mx-auto leading-relaxed">
+            Manifold is sold per-seat, annual. No self-serve checkout.
+            Every deployment starts with a sales conversation and a
+            48-hour pilot scoped to your evaluation use case.
+          </p>
+        </div>
+
+        <div className="grid md:grid-cols-3 gap-5">
+          {PRICING_PLANS.map((plan) => (
+            <div
+              key={plan.tier}
+              className={`flex flex-col rounded border p-6 transition-colors ${
+                plan.highlight
+                  ? "border-accent-cyan/60 bg-accent-cyan/5"
+                  : "border-border bg-surface"
+              }`}
+            >
+              <div className="text-[9px] font-[family-name:var(--font-michroma)] tracking-[0.25em] text-text-muted">
+                {plan.name.toUpperCase()}
+              </div>
+              <div className="mt-3 flex items-baseline gap-2">
+                <div className="text-2xl font-[family-name:var(--font-michroma)] text-foreground">
+                  {plan.priceLabel}
+                </div>
+                <div className="text-[9px] font-mono text-text-muted">
+                  {plan.cadence}
+                </div>
+              </div>
+              <p className="mt-3 text-[11px] font-mono text-text-muted leading-relaxed">
+                {plan.blurb}
+              </p>
+
+              <ul className="mt-5 space-y-2 flex-1">
+                {plan.features.map((f) => (
+                  <li
+                    key={f}
+                    className="flex gap-2 text-[11px] font-mono text-foreground/90 leading-relaxed"
+                  >
+                    <span className="text-accent-cyan/70 mt-0.5">·</span>
+                    <span>{f}</span>
+                  </li>
+                ))}
+              </ul>
+
+              <Link
+                href={`/request-access?tier=${plan.tier}`}
+                className={`mt-6 inline-block text-center px-4 py-2.5 rounded text-[10px] font-[family-name:var(--font-michroma)] tracking-wider border transition-colors ${
+                  plan.highlight
+                    ? "bg-accent-cyan/15 border-accent-cyan/60 text-accent-cyan hover:bg-accent-cyan/25"
+                    : "border-border text-foreground hover:border-accent-cyan/60 hover:text-accent-cyan"
+                }`}
+              >
+                {plan.ctaLabel.toUpperCase()}
+              </Link>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-16 border-t border-border pt-10 text-center space-y-3">
+          <div className="text-[10px] font-[family-name:var(--font-michroma)] tracking-[0.25em] text-text-muted">
+            EVALUATING MANIFOLD
+          </div>
+          <p className="text-[12px] font-mono text-text-muted max-w-2xl mx-auto leading-relaxed">
+            We provision a 48-hour pilot for qualified institutional
+            buyers — funds, banks, defense primes, sovereign offices,
+            and research institutions. Tell us who you are and what
+            you&apos;re evaluating; we&apos;ll respond within one business day.
+          </p>
+          <div className="pt-2">
+            <Link
+              href="/request-access"
+              className="inline-block px-5 py-2.5 bg-accent-cyan/10 border border-accent-cyan/40 rounded text-[11px] font-[family-name:var(--font-michroma)] tracking-wider text-accent-cyan hover:bg-accent-cyan/20"
+            >
+              REQUEST ACCESS
+            </Link>
+          </div>
+        </div>
+      </main>
+
+      <footer className="border-t border-border mt-16 py-8 text-center text-[9px] font-mono text-text-muted">
+        © Apex Analytica · Manifold is an institutional research terminal
+      </footer>
+    </div>
+  );
+}

--- a/src/app/request-access/RequestAccessForm.tsx
+++ b/src/app/request-access/RequestAccessForm.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { TIER_LABELS, type Tier } from "@/lib/billing";
+
+const VALID_TIER_HINTS: ReadonlyArray<Tier> = [
+  "analyst",
+  "multi_domain",
+  "enterprise",
+];
+
+export default function RequestAccessForm() {
+  const sp = useSearchParams();
+  const tierHintRaw = sp.get("tier");
+  const tierHint = (VALID_TIER_HINTS as ReadonlyArray<string>).includes(
+    tierHintRaw ?? ""
+  )
+    ? (tierHintRaw as Tier)
+    : null;
+
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [org, setOrg] = useState("");
+  const [useCase, setUseCase] = useState(
+    tierHint ? `Interested in the ${TIER_LABELS[tierHint]} tier. ` : ""
+  );
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/request-access", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          email: email.trim(),
+          organization: org.trim(),
+          useCase: useCase.trim() || null,
+          source: tierHint ? `pricing-${tierHint}` : "request-access",
+        }),
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        setError(j.error ?? `HTTP ${res.status}`);
+        return;
+      }
+      setSubmitted(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (submitted) {
+    return (
+      <div className="bg-surface border border-accent-cyan/30 rounded p-6 space-y-4 text-center">
+        <div className="text-[11px] font-[family-name:var(--font-michroma)] tracking-wider text-accent-cyan">
+          REQUEST RECEIVED
+        </div>
+        <p className="text-[11px] font-mono text-text-muted leading-relaxed">
+          Thanks for reaching out. A member of the Apex Analytica team
+          will respond within one business day to scope a 48-hour pilot.
+        </p>
+        <Link
+          href="/pricing"
+          className="inline-block text-[10px] font-mono text-accent-cyan/70 hover:text-accent-cyan"
+        >
+          ← BACK TO PRICING
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="bg-surface border border-border rounded p-4 space-y-2">
+        <div className="text-[10px] font-[family-name:var(--font-michroma)] tracking-wider text-accent-cyan">
+          INSTITUTIONAL EVALUATION
+        </div>
+        <div className="text-[11px] font-mono text-text-muted leading-relaxed">
+          Manifold is provisioned per-seat, per institution. Tell us
+          who you are and what you&apos;re evaluating. A 48-hour pilot
+          follows the introductory call.
+          {tierHint && (
+            <>
+              {" "}
+              Inquiry tier:{" "}
+              <span className="text-accent-cyan">{TIER_LABELS[tierHint]}</span>.
+            </>
+          )}
+        </div>
+      </div>
+
+      <form onSubmit={onSubmit} className="space-y-4">
+        <Field label="Name">
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            placeholder="Jane Doe"
+            className="w-full px-3 py-2.5 bg-surface border border-border rounded text-sm font-mono text-foreground placeholder:text-text-muted/50 focus:outline-none focus:border-accent-cyan/60 transition-colors"
+          />
+        </Field>
+        <Field label="Work email">
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            placeholder="jane@institution.com"
+            className="w-full px-3 py-2.5 bg-surface border border-border rounded text-sm font-mono text-foreground placeholder:text-text-muted/50 focus:outline-none focus:border-accent-cyan/60 transition-colors"
+          />
+        </Field>
+        <Field label="Organization">
+          <input
+            type="text"
+            value={org}
+            onChange={(e) => setOrg(e.target.value)}
+            required
+            placeholder="Fund · Bank · Sovereign · Defense · Research"
+            className="w-full px-3 py-2.5 bg-surface border border-border rounded text-sm font-mono text-foreground placeholder:text-text-muted/50 focus:outline-none focus:border-accent-cyan/60 transition-colors"
+          />
+        </Field>
+        <Field label="What are you evaluating?">
+          <textarea
+            value={useCase}
+            onChange={(e) => setUseCase(e.target.value)}
+            rows={4}
+            placeholder="Briefly: which risk domain, which decision, which timescale."
+            className="w-full px-3 py-2.5 bg-surface border border-border rounded text-sm font-mono text-foreground placeholder:text-text-muted/50 focus:outline-none focus:border-accent-cyan/60 transition-colors resize-none"
+          />
+        </Field>
+
+        {error && (
+          <div className="text-[11px] font-mono text-accent-red bg-accent-red/10 border border-accent-red/20 rounded px-3 py-2">
+            {error}
+          </div>
+        )}
+
+        <button
+          type="submit"
+          disabled={submitting}
+          className="w-full py-2.5 bg-accent-cyan/10 border border-accent-cyan/40 rounded text-[11px] font-[family-name:var(--font-michroma)] tracking-wider text-accent-cyan hover:bg-accent-cyan/20 hover:border-accent-cyan/60 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {submitting ? "SUBMITTING..." : "REQUEST ACCESS"}
+        </button>
+      </form>
+
+      <p className="text-center text-[10px] font-mono text-text-muted">
+        Already have access?{" "}
+        <Link
+          href="/login"
+          className="text-accent-cyan/70 hover:text-accent-cyan"
+        >
+          Sign in
+        </Link>
+      </p>
+    </>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1">
+      <label className="text-[10px] font-mono text-text-muted tracking-wider uppercase">
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}

--- a/src/app/request-access/page.tsx
+++ b/src/app/request-access/page.tsx
@@ -1,0 +1,46 @@
+import { Suspense } from "react";
+import Image from "next/image";
+import RequestAccessForm from "./RequestAccessForm";
+
+export const metadata = {
+  title: "Request access — Manifold by Apex Analytica",
+};
+
+export default function RequestAccessPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background px-4 py-12">
+      <div className="w-full max-w-md space-y-7">
+        <div className="text-center space-y-2">
+          <Image
+            src="/logo.png"
+            alt="Manifold"
+            width={120}
+            height={120}
+            className="mx-auto object-contain"
+            priority
+          />
+          <h1 className="text-xl font-[family-name:var(--font-michroma)] tracking-[0.3em] text-accent-cyan">
+            MANIFOLD
+          </h1>
+          <span className="font-[family-name:var(--font-michroma)] text-[8px] tracking-[0.25em] text-text-muted">
+            by APEX ANALYTICA
+          </span>
+          <div className="text-[10px] font-mono text-text-muted tracking-wider mt-1">
+            REQUEST ACCESS
+          </div>
+          <div className="w-16 h-px bg-accent-cyan/40 mx-auto mt-3" />
+        </div>
+
+        <Suspense
+          fallback={
+            <div className="text-center text-[10px] font-mono text-text-muted">
+              Loading…
+            </div>
+          }
+        >
+          <RequestAccessForm />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/src/app/trial-signup/page.tsx
+++ b/src/app/trial-signup/page.tsx
@@ -26,7 +26,10 @@ export default function TrialSignupPage() {
       options: {
         data: {
           org_name: orgName || null,
-          access_type: "trial",
+          // Browser-supplied tier is intentionally ignored by the
+          // handle_new_user trigger (forced to 'trial'). Sent for
+          // forward-compat / observability only.
+          tier: "trial",
         },
       },
     });

--- a/src/components/DomainSelector.tsx
+++ b/src/components/DomainSelector.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useApexStore } from "@/stores/useApexStore";
+import { useUserAccess } from "@/hooks/useUserAccess";
 import { MAIN_GRAPH, EMPTY_GRAPH } from "@/lib/graph-data";
 import { ATHENA_GRAPH, BRIDGE_EDGES } from "@/lib/athena-graph-data";
 import { T1D_GRAPH } from "@/lib/t1d-graph-data";
@@ -314,6 +315,20 @@ export default function DomainSelector() {
   const [localSources, setLocalSources] = useState<Set<string>>(new Set());
   const [showDataLayers, setShowDataLayers] = useState(false);
 
+  // Tier-based domain access. While `access` is loading we leave
+  // everything unlocked to avoid a visual flash; the API-level gate
+  // is the authoritative check. Once loaded, any domain not in the
+  // user's effective access is rendered locked + non-clickable.
+  const { access } = useUserAccess();
+  const lockedIds = useMemo(() => {
+    if (!access) return new Set<string>();
+    return new Set(
+      DOMAIN_CARDS
+        .filter((d) => !access.domains.includes(d.id))
+        .map((d) => d.id)
+    );
+  }, [access]);
+
   // Cards visible for the active persona (filtered by domain group)
   const allowedGroups = PERSONA_GROUPS[activePersona];
   const visibleGroups = DOMAIN_GROUPS
@@ -336,6 +351,8 @@ export default function DomainSelector() {
 
   const toggleDomain = useCallback(
     (id: string) => {
+      // Defense-in-depth — UI also disables onClick for locked cards.
+      if (lockedIds.has(id)) return;
       setLocalSelected((prev) => {
         if (prev.includes(id)) return prev.filter((d) => d !== id);
         if (!localMulti) return [id];
@@ -354,7 +371,7 @@ export default function DomainSelector() {
         return [...prev, id];
       });
     },
-    [localMulti, activePersona]
+    [localMulti, activePersona, lockedIds]
   );
 
   const switchMode = useCallback(
@@ -516,12 +533,19 @@ export default function DomainSelector() {
                   <div className="grid gap-1.5">
                     {group.domains.map((domain) => {
                       const isSelected = localSelected.includes(domain.id);
-                      const isDisabled = !domain.hasData;
+                      const isComingSoon = !domain.hasData;
+                      const isLocked = lockedIds.has(domain.id);
+                      const isDisabled = isComingSoon || isLocked;
 
                       return (
                         <button
                           key={domain.id}
                           onClick={() => !isDisabled && toggleDomain(domain.id)}
+                          title={
+                            isLocked
+                              ? `Not included in your ${access?.tier ?? ""} tier — contact sales to upgrade`
+                              : undefined
+                          }
                           className="flex items-center gap-3 px-4 py-2.5 rounded border transition-all text-left"
                           style={{
                             borderColor: isSelected ? domain.color : "var(--border)",
@@ -542,9 +566,14 @@ export default function DomainSelector() {
                               style={{ color: isSelected ? domain.color : domain.hasData ? "var(--foreground)" : "var(--text-muted)" }}
                             >
                               {domain.label.toUpperCase()}
-                              {!domain.hasData && (
+                              {isComingSoon && (
                                 <span className="text-[7px] px-1.5 py-0.5 rounded border border-border text-text-muted bg-surface/50">
                                   COMING SOON
+                                </span>
+                              )}
+                              {isLocked && !isComingSoon && (
+                                <span className="text-[7px] px-1.5 py-0.5 rounded border border-accent-amber/40 text-accent-amber bg-accent-amber/10 tracking-wider">
+                                  UPGRADE
                                 </span>
                               )}
                             </div>

--- a/src/components/UpgradeCTA.tsx
+++ b/src/components/UpgradeCTA.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+// Reusable "Contact sales" affordance — primary CTA opens the
+// scheduler if NEXT_PUBLIC_SCHEDULER_URL is configured, secondary
+// opens a mailto: to NEXT_PUBLIC_SALES_EMAIL (default
+// info@apexanalytica.co — the address already used on /expired).
+
+const SCHEDULER_URL = process.env.NEXT_PUBLIC_SCHEDULER_URL ?? "";
+const SALES_EMAIL =
+  process.env.NEXT_PUBLIC_SALES_EMAIL ?? "info@apexanalytica.co";
+
+export interface UpgradeCTAProps {
+  primaryLabel?: string;
+  secondaryLabel?: string;
+  subjectHint?: string;
+  variant?: "stacked" | "inline";
+}
+
+export default function UpgradeCTA({
+  primaryLabel = "Schedule a call",
+  secondaryLabel,
+  subjectHint = "Apex Analytica — Manifold inquiry",
+  variant = "stacked",
+}: UpgradeCTAProps) {
+  const mailto = `mailto:${SALES_EMAIL}?subject=${encodeURIComponent(subjectHint)}`;
+  const hasScheduler = SCHEDULER_URL.length > 0;
+  const secondary = secondaryLabel ?? `Email ${SALES_EMAIL}`;
+
+  const containerCls =
+    variant === "inline"
+      ? "flex flex-wrap gap-3 items-center"
+      : "flex flex-col gap-2 items-center";
+
+  return (
+    <div className={containerCls}>
+      <a
+        href={hasScheduler ? SCHEDULER_URL : mailto}
+        target={hasScheduler ? "_blank" : undefined}
+        rel={hasScheduler ? "noopener noreferrer" : undefined}
+        className="inline-block px-5 py-2.5 bg-accent-cyan/10 border border-accent-cyan/40 rounded text-[11px] font-[family-name:var(--font-michroma)] tracking-wider text-accent-cyan hover:bg-accent-cyan/20 hover:border-accent-cyan/60 transition-all"
+      >
+        {primaryLabel}
+      </a>
+      {hasScheduler && (
+        <a
+          href={mailto}
+          className="text-[10px] font-mono text-text-muted hover:text-foreground transition-colors"
+        >
+          {secondary}
+        </a>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useUserAccess.ts
+++ b/src/hooks/useUserAccess.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { Tier } from "@/lib/billing";
+
+export interface UserAccess {
+  tier: Tier;
+  domains: string[];
+  isExpired: boolean;
+  current_period_end: string | null;
+}
+
+// Module-level cache so multiple components mounting simultaneously
+// share one in-flight fetch.
+let cached: Promise<UserAccess | null> | null = null;
+
+async function fetchAccess(): Promise<UserAccess | null> {
+  try {
+    const res = await fetch("/api/me/access", { credentials: "include" });
+    if (!res.ok) return null;
+    return (await res.json()) as UserAccess;
+  } catch {
+    return null;
+  }
+}
+
+export function useUserAccess(): {
+  loading: boolean;
+  access: UserAccess | null;
+} {
+  const [access, setAccess] = useState<UserAccess | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!cached) cached = fetchAccess();
+    let mounted = true;
+    cached.then((a) => {
+      if (!mounted) return;
+      setAccess(a);
+      setLoading(false);
+    });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return { loading, access };
+}

--- a/src/lib/__tests__/billing.test.ts
+++ b/src/lib/__tests__/billing.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { isExpired } from "@/lib/billing";
+
+describe("isExpired", () => {
+  const now = new Date("2026-04-29T12:00:00Z");
+
+  it("returns true for tier='expired' regardless of period", () => {
+    expect(isExpired({ tier: "expired", current_period_end: null }, now)).toBe(true);
+    expect(
+      isExpired(
+        { tier: "expired", current_period_end: "2099-01-01T00:00:00Z" },
+        now
+      )
+    ).toBe(true);
+  });
+
+  it("returns false for tier='trusted' regardless of period", () => {
+    expect(isExpired({ tier: "trusted", current_period_end: null }, now)).toBe(false);
+    expect(
+      isExpired(
+        { tier: "trusted", current_period_end: "1999-01-01T00:00:00Z" },
+        now
+      )
+    ).toBe(false);
+  });
+
+  it("respects current_period_end for paid tiers", () => {
+    expect(
+      isExpired(
+        { tier: "analyst", current_period_end: "2026-04-30T00:00:00Z" },
+        now
+      )
+    ).toBe(false);
+    expect(
+      isExpired(
+        { tier: "analyst", current_period_end: "2026-04-29T11:59:59Z" },
+        now
+      )
+    ).toBe(true);
+  });
+
+  it("trial without period_end is treated as expired (malformed)", () => {
+    expect(isExpired({ tier: "trial", current_period_end: null }, now)).toBe(true);
+  });
+
+  it("paid tier without period_end is fail-open (admin onboarding window)", () => {
+    expect(
+      isExpired({ tier: "multi_domain", current_period_end: null }, now)
+    ).toBe(false);
+    expect(
+      isExpired({ tier: "enterprise", current_period_end: null }, now)
+    ).toBe(false);
+  });
+
+  it("trial with future period_end is active", () => {
+    expect(
+      isExpired(
+        { tier: "trial", current_period_end: "2026-04-30T00:00:00Z" },
+        now
+      )
+    ).toBe(false);
+  });
+});

--- a/src/lib/__tests__/billing.test.ts
+++ b/src/lib/__tests__/billing.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { isExpired } from "@/lib/billing";
+import {
+  canAccessDomain,
+  effectiveDomainAccess,
+  isExpired,
+} from "@/lib/billing";
 
 describe("isExpired", () => {
   const now = new Date("2026-04-29T12:00:00Z");
@@ -59,5 +63,76 @@ describe("isExpired", () => {
         now
       )
     ).toBe(false);
+  });
+});
+
+describe("effectiveDomainAccess", () => {
+  const features = new Map<
+    "trial" | "analyst" | "multi_domain" | "enterprise" | "trusted" | "expired",
+    string[]
+  >([
+    ["trial", ["a", "b", "c"]],
+    ["analyst", []],
+    ["multi_domain", ["a", "b", "c"]],
+    ["enterprise", ["a", "b", "c"]],
+    ["trusted", ["a", "b", "c"]],
+    ["expired", []],
+  ]);
+
+  it("returns tier default when domain_access is null", () => {
+    expect(
+      effectiveDomainAccess({ tier: "multi_domain", domain_access: null }, features)
+    ).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns the override when domain_access is set (even if empty)", () => {
+    expect(
+      effectiveDomainAccess({ tier: "analyst", domain_access: ["a"] }, features)
+    ).toEqual(["a"]);
+    // Empty override is honored — admin assigned no domain yet.
+    expect(
+      effectiveDomainAccess({ tier: "analyst", domain_access: [] }, features)
+    ).toEqual([]);
+  });
+
+  it("expired tier always returns empty regardless of override", () => {
+    expect(
+      effectiveDomainAccess(
+        { tier: "expired", domain_access: ["a", "b"] },
+        features
+      )
+    ).toEqual([]);
+  });
+
+  it("falls back to [] when tier has no feature row", () => {
+    const empty = new Map<typeof features extends Map<infer K, unknown> ? K : never, string[]>();
+    expect(
+      effectiveDomainAccess({ tier: "trusted", domain_access: null }, empty)
+    ).toEqual([]);
+  });
+
+  it("accepts a Record in addition to a Map", () => {
+    const record: Record<
+      "trial" | "analyst" | "multi_domain" | "enterprise" | "trusted" | "expired",
+      string[] | undefined
+    > = {
+      trial: ["x"],
+      analyst: undefined,
+      multi_domain: undefined,
+      enterprise: undefined,
+      trusted: undefined,
+      expired: undefined,
+    };
+    expect(
+      effectiveDomainAccess({ tier: "trial", domain_access: null }, record)
+    ).toEqual(["x"]);
+  });
+});
+
+describe("canAccessDomain", () => {
+  it("matches by exact id", () => {
+    expect(canAccessDomain(["a", "b"], "a")).toBe(true);
+    expect(canAccessDomain(["a", "b"], "c")).toBe(false);
+    expect(canAccessDomain([], "a")).toBe(false);
   });
 });

--- a/src/lib/billing-server.ts
+++ b/src/lib/billing-server.ts
@@ -1,0 +1,88 @@
+// Server-only billing helpers. Loads the user's profile + tier_features
+// from Supabase and resolves effective domain access. Use these in
+// route handlers and server components — never import from the client.
+
+import { createClient } from "@/lib/supabase/server";
+import {
+  effectiveDomainAccess,
+  isExpired,
+  type Tier,
+} from "@/lib/billing";
+
+export interface UserAccess {
+  tier: Tier;
+  domains: string[];      // resolved effective domain IDs
+  isExpired: boolean;
+  current_period_end: string | null;
+}
+
+export async function getUserAccess(): Promise<UserAccess | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const [profileRes, featuresRes] = await Promise.all([
+    supabase
+      .from("profiles")
+      .select("tier, current_period_end, domain_access")
+      .eq("id", user.id)
+      .single<{
+        tier: Tier;
+        current_period_end: string | null;
+        domain_access: string[] | null;
+      }>(),
+    supabase.from("tier_features").select("tier, domain_ids"),
+  ]);
+
+  const profile = profileRes.data;
+  if (!profile) return null;
+
+  const featureMap = new Map<Tier, string[]>(
+    (featuresRes.data ?? []).map((f) => [
+      f.tier as Tier,
+      (f.domain_ids ?? []) as string[],
+    ])
+  );
+
+  const expired = isExpired(profile);
+  const domains = expired ? [] : effectiveDomainAccess(profile, featureMap);
+
+  return {
+    tier: profile.tier,
+    domains,
+    isExpired: expired,
+    current_period_end: profile.current_period_end,
+  };
+}
+
+// Defense-in-depth gate for API routes that accept an explicit list
+// of domain IDs in the request body. Returns 401 if not authed,
+// 403 if expired or any claimed ID is outside the user's effective
+// access. The caller should branch on `result.ok` and surface
+// `result.error` / `result.status` as the response.
+export async function requireDomainAccess(
+  claimedDomainIds: readonly string[]
+): Promise<
+  | { ok: true; access: UserAccess }
+  | { ok: false; status: number; error: string }
+> {
+  const access = await getUserAccess();
+  if (!access) return { ok: false, status: 401, error: "Not authenticated" };
+  if (access.isExpired)
+    return { ok: false, status: 403, error: "Subscription expired" };
+
+  const denied = claimedDomainIds.filter(
+    (id) => !access.domains.includes(id)
+  );
+  if (denied.length > 0) {
+    return {
+      ok: false,
+      status: 403,
+      error: `Tier '${access.tier}' does not include: ${denied.join(", ")}`,
+    };
+  }
+
+  return { ok: true, access };
+}

--- a/src/lib/billing.ts
+++ b/src/lib/billing.ts
@@ -75,3 +75,24 @@ export function isExpired(
   if (profile.tier === "trial") return true;
   return false;
 }
+
+// Resolve a user's effective set of accessible domain IDs.
+// Per-profile `domain_access` is the override; otherwise fall back
+// to the tier's default in `tier_features`. Expired users always
+// have empty access (caller should short-circuit before calling
+// this, but we defend in depth).
+export function effectiveDomainAccess(
+  profile: Pick<BillingProfile, "tier" | "domain_access">,
+  tierFeatures: Map<Tier, string[]> | Record<Tier, string[] | undefined>
+): string[] {
+  if (profile.tier === "expired") return [];
+  if (profile.domain_access != null) return profile.domain_access;
+  if (tierFeatures instanceof Map) {
+    return tierFeatures.get(profile.tier) ?? [];
+  }
+  return tierFeatures[profile.tier] ?? [];
+}
+
+export function canAccessDomain(domains: string[], domainId: string): boolean {
+  return domains.includes(domainId);
+}

--- a/src/lib/billing.ts
+++ b/src/lib/billing.ts
@@ -96,3 +96,66 @@ export function effectiveDomainAccess(
 export function canAccessDomain(domains: string[], domainId: string): boolean {
   return domains.includes(domainId);
 }
+
+// Marketing copy for the public /pricing page and the upgrade-wall.
+// Single source of truth so /pricing, /expired, and any future
+// upsell surfaces stay in sync. Prices are annual per-seat USD.
+export interface PricingPlan {
+  tier: Tier;
+  name: string;
+  priceLabel: string;
+  cadence: string;
+  blurb: string;
+  features: string[];
+  ctaLabel: string;
+  highlight?: boolean;
+}
+
+export const PRICING_PLANS: PricingPlan[] = [
+  {
+    tier: "analyst",
+    name: "Analyst",
+    priceLabel: "$24,000",
+    cadence: "per seat / year",
+    blurb: "One domain. Full criticality readouts.",
+    features: [
+      "Single domain workspace",
+      "Full Ω-fragility scoring",
+      "Pearl intervention engine",
+      "Tarski formal verification",
+      "Email support",
+    ],
+    ctaLabel: "Contact sales",
+  },
+  {
+    tier: "multi_domain",
+    name: "Multi-Domain",
+    priceLabel: "$48,000",
+    cadence: "per seat / year",
+    blurb: "All public domains. Live feeds. Estimator outputs.",
+    features: [
+      "All public risk domains",
+      "Cross-domain causal bridges",
+      "Estimator outputs (BOCPD, Cox, NLME, transfer entropy)",
+      "Live data feeds",
+      "Priority support",
+    ],
+    ctaLabel: "Contact sales",
+    highlight: true,
+  },
+  {
+    tier: "enterprise",
+    name: "Enterprise",
+    priceLabel: "$150,000+",
+    cadence: "custom / year",
+    blurb: "Custom subgraphs. On-demand estimator runs. SLA.",
+    features: [
+      "Everything in Multi-Domain",
+      "Custom subgraphs and domain models",
+      "On-demand estimator runs",
+      "Dedicated solutions engineer",
+      "Contractual SLA",
+    ],
+    ctaLabel: "Talk to founders",
+  },
+];

--- a/src/lib/billing.ts
+++ b/src/lib/billing.ts
@@ -1,0 +1,77 @@
+// Billing / tier types and helpers shared by middleware, API routes,
+// and UI. This module deliberately has no React or Supabase imports
+// so it is safe to use in edge middleware.
+
+export type Tier =
+  | "trial"
+  | "analyst"
+  | "multi_domain"
+  | "enterprise"
+  | "trusted"
+  | "expired";
+
+export type SubscriptionStatus =
+  | "active"
+  | "past_due"
+  | "canceled"
+  | "pending"
+  | "none";
+
+export interface BillingProfile {
+  tier: Tier;
+  subscription_status: SubscriptionStatus | null;
+  current_period_start: string | null;
+  current_period_end: string | null;
+  mercury_invoice_id: string | null;
+  seats: number | null;
+  domain_access: string[] | null;
+}
+
+export const TIER_LABELS: Record<Tier, string> = {
+  trial: "Trial",
+  analyst: "Analyst",
+  multi_domain: "Multi-Domain",
+  enterprise: "Enterprise",
+  trusted: "Trusted",
+  expired: "Expired",
+};
+
+// Tiers that are billed (i.e. require Mercury invoice + period dates).
+export const PAID_TIERS: ReadonlyArray<Tier> = [
+  "analyst",
+  "multi_domain",
+  "enterprise",
+];
+
+// Tiers that always have access regardless of period dates.
+export const UNCAPPED_TIERS: ReadonlyArray<Tier> = ["trusted"];
+
+// Decide whether a profile's access window has lapsed. Returns true
+// if the user should be redirected to the upgrade wall.
+//
+// Rules:
+//   - tier === 'expired'                    => expired
+//   - tier === 'trusted'                    => never expired
+//   - current_period_end set and in past    => expired
+//   - paid tier with no period_end set      => not yet expired (admin
+//                                              hasn't finished onboarding;
+//                                              fail-open for that brief
+//                                              window — Phase 3 closes it)
+//   - trial with no period_end set          => expired (defensive: a
+//                                              trial without an end date
+//                                              is malformed)
+export function isExpired(
+  profile: Pick<BillingProfile, "tier" | "current_period_end">,
+  now: Date = new Date()
+): boolean {
+  if (profile.tier === "expired") return true;
+  if (profile.tier === "trusted") return false;
+
+  if (profile.current_period_end) {
+    return new Date(profile.current_period_end) <= now;
+  }
+
+  // No period end recorded.
+  if (profile.tier === "trial") return true;
+  return false;
+}

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -33,7 +33,7 @@ export async function updateSession(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
 
   // Public routes — no auth required
-  const publicRoutes = ["/login", "/trial-signup", "/trusted-signup", "/api/trusted-signup", "/api/webhooks", "/expired", "/forgot-password", "/reset-password", "/auth"];
+  const publicRoutes = ["/login", "/trial-signup", "/trusted-signup", "/api/trusted-signup", "/api/webhooks", "/expired", "/forgot-password", "/reset-password", "/auth", "/pricing", "/request-access", "/api/request-access"];
   const isPublic =
     publicRoutes.some((r) => pathname.startsWith(r)) ||
     pathname.startsWith("/_next") ||

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -1,5 +1,6 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
+import { isExpired, type Tier } from "@/lib/billing";
 
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({ request });
@@ -52,12 +53,12 @@ export async function updateSession(request: NextRequest) {
     return NextResponse.redirect(url);
   }
 
-  // Check access type and trial expiry
+  // Load tier + period bounds from profile
   const { data: profile } = await supabase
     .from("profiles")
-    .select("access_type, trial_expires_at")
+    .select("tier, current_period_end")
     .eq("id", user.id)
-    .single();
+    .single<{ tier: Tier; current_period_end: string | null }>();
 
   if (!profile) {
     // No profile row — redirect to login
@@ -80,19 +81,10 @@ export async function updateSession(request: NextRequest) {
     }
   }
 
-  // Trusted users — always allowed
-  if (profile.access_type === "trusted") {
-    return supabaseResponse;
-  }
-
-  // Trial users — check expiry
-  if (profile.access_type === "trial") {
-    const expiresAt = new Date(profile.trial_expires_at);
-    if (expiresAt <= new Date()) {
-      const url = request.nextUrl.clone();
-      url.pathname = "/expired";
-      return NextResponse.redirect(url);
-    }
+  if (isExpired(profile)) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/expired";
+    return NextResponse.redirect(url);
   }
 
   return supabaseResponse;

--- a/supabase-billing-cron.sql
+++ b/supabase-billing-cron.sql
@@ -1,0 +1,34 @@
+-- =============================================================
+-- APEX Terminal — Billing cron schedule (Phase 3)
+-- =============================================================
+-- Schedules the trial-expiry helper from supabase-billing-migration.sql
+-- to run daily at 00:00 UTC. Idempotent: re-running unschedules the
+-- existing job (if any) before re-creating it.
+--
+-- PREREQUISITES (run once via the Supabase dashboard if not already on):
+--   1. Enable the pg_cron extension:
+--      Database → Extensions → search "pg_cron" → Enable.
+--   2. Re-run supabase-billing-migration.sql first so
+--      public.expire_trial_users() exists.
+--
+-- Verify the job after applying:
+--   select * from cron.job where jobname = 'expire-trial-users-daily';
+--
+-- See logs:
+--   select * from cron.job_run_details
+--    where jobid = (select jobid from cron.job
+--                    where jobname = 'expire-trial-users-daily')
+--    order by start_time desc limit 20;
+-- =============================================================
+
+-- 1. Remove any prior scheduling under this name (no-op safe).
+do $$ begin
+  perform cron.unschedule('expire-trial-users-daily');
+exception when others then null; end $$;
+
+-- 2. Schedule daily expiry sweep at 00:00 UTC.
+select cron.schedule(
+  'expire-trial-users-daily',
+  '0 0 * * *',
+  $$select public.expire_trial_users()$$
+);

--- a/supabase-billing-leads.sql
+++ b/supabase-billing-leads.sql
@@ -1,0 +1,41 @@
+-- =============================================================
+-- APEX Terminal — Leads table (Phase 4)
+-- Run in the Supabase SQL Editor. Idempotent.
+--
+-- The /request-access form is public (no auth) and posts here.
+-- Anonymous INSERT is allowed; reads/updates require service-role,
+-- which is what the admin console (/admin/leads) uses.
+-- =============================================================
+
+begin;
+
+create table if not exists public.leads (
+  id            uuid primary key default gen_random_uuid(),
+  name          text not null,
+  email         text not null,
+  organization  text not null,
+  use_case      text,
+  source        text not null default 'request-access',
+  status        text not null default 'new'
+                  check (status in ('new','contacted','trial-issued','closed-won','closed-lost')),
+  admin_notes   text,
+  contacted_at  timestamptz,
+  created_at    timestamptz default now()
+);
+
+create index if not exists leads_status_created_at_idx
+  on public.leads (status, created_at desc);
+
+alter table public.leads enable row level security;
+
+-- Anonymous + authenticated callers can INSERT new leads (the public
+-- /request-access form). They cannot SELECT or UPDATE — only the
+-- service-role key (used by /admin/leads) can read or mutate.
+do $$ begin
+  create policy "anon and auth can insert leads"
+    on public.leads for insert
+    to anon, authenticated
+    with check (true);
+exception when duplicate_object then null; end $$;
+
+commit;

--- a/supabase-billing-migration.sql
+++ b/supabase-billing-migration.sql
@@ -41,9 +41,17 @@ alter table public.profiles
   add column if not exists current_period_start timestamptz,
   add column if not exists current_period_end   timestamptz,
   add column if not exists mercury_invoice_id   text,
-  add column if not exists seats                integer default 1
-    check (seats is null or seats >= 1),
+  add column if not exists seats                integer not null default 1,
   add column if not exists domain_access        text[];   -- NULL => use tier default
+
+-- 2a. Tighten `seats` constraints on already-applied databases.
+-- (No-op on a fresh apply; a re-run from v1 brings the column to spec.)
+update public.profiles set seats = 1 where seats is null;
+alter table public.profiles
+  alter column seats set default 1,
+  alter column seats set not null;
+alter table public.profiles drop constraint if exists profiles_seats_check;
+alter table public.profiles add constraint profiles_seats_check check (seats >= 1);
 
 -- 3. Backfill `tier` from legacy access_type ------------------
 update public.profiles
@@ -169,5 +177,27 @@ insert into public.tier_features (tier, domain_ids, description) values
   ('trusted',      '{}', 'Internal/comp accounts — all public domains'),
   ('expired',      '{}', 'No access — upgrade wall')
 on conflict (tier) do nothing;
+
+-- 9. Phase 3 cron helper: flip lapsed trials to 'expired'. -----
+-- Idempotent. Safe to invoke on a schedule. Returns the number of
+-- rows transitioned so cron logs are useful. Uses current_period_end
+-- as the source of truth (matches middleware's isExpired()), with a
+-- legacy fallback to trial_expires_at for any rows the backfill
+-- missed.
+create or replace function public.expire_trial_users()
+returns integer as $$
+declare
+  _count integer;
+begin
+  update public.profiles
+  set tier = 'expired'::public.tier,
+      subscription_status = 'none'
+  where tier = 'trial'::public.tier
+    and coalesce(current_period_end, trial_expires_at) is not null
+    and coalesce(current_period_end, trial_expires_at) <= now();
+  get diagnostics _count = row_count;
+  return _count;
+end;
+$$ language plpgsql security definer;
 
 commit;

--- a/supabase-billing-migration.sql
+++ b/supabase-billing-migration.sql
@@ -178,6 +178,29 @@ insert into public.tier_features (tier, domain_ids, description) values
   ('expired',      '{}', 'No access — upgrade wall')
 on conflict (tier) do nothing;
 
+-- 8a. Phase 2 seed: populate tier_features.domain_ids with the
+-- current public domain set. Only updates rows still at the empty
+-- default ('{}') so admin overrides are preserved on re-run. The
+-- canonical list lives in src/components/DomainSelector.tsx —
+-- update both when a new public domain ships.
+update public.tier_features
+set domain_ids = array[
+      'energy-systems',
+      'manufacturing',
+      'supply-chain',
+      'financial-contagion',
+      'sovereign-risk',
+      'infrastructure',
+      'defense-isr',
+      'macro-labor',
+      'macro-inflation',
+      't1d-beta-cell',
+      't1d-vx880'
+    ],
+    updated_at = now()
+where tier in ('trial','multi_domain','enterprise','trusted')
+  and (domain_ids = '{}' or domain_ids is null);
+
 -- 9. Phase 3 cron helper: flip lapsed trials to 'expired'. -----
 -- Idempotent. Safe to invoke on a schedule. Returns the number of
 -- rows transitioned so cron logs are useful. Uses current_period_end

--- a/supabase-billing-migration.sql
+++ b/supabase-billing-migration.sql
@@ -1,0 +1,173 @@
+-- =============================================================
+-- APEX Terminal — Billing / Tier Migration (Phase 1)
+-- Idempotent. Safe to re-run.
+-- Run AFTER supabase-setup.sql in the Supabase SQL Editor.
+--
+-- This migration:
+--   1. Introduces a `tier` enum (replacing the binary access_type
+--      check) with the institutional plan set.
+--   2. Adds billing-state columns (subscription_status, period
+--      bounds, mercury_invoice_id, seats, domain_access).
+--   3. Backfills existing rows from `access_type`/`trial_expires_at`.
+--   4. Updates the handle_new_user() trigger to write `tier` and
+--      `current_period_end`.
+--   5. Creates a `tier_features` reference table used by Phase 2
+--      domain-level gating.
+--
+-- The legacy `access_type` column is RETAINED for one deprecation
+-- release. Application code reads `tier` exclusively after this
+-- migration; a later migration drops the column.
+-- =============================================================
+
+begin;
+
+-- 1. Tier enum -------------------------------------------------
+do $$ begin
+  create type public.tier as enum (
+    'trial',
+    'analyst',
+    'multi_domain',
+    'enterprise',
+    'trusted',
+    'expired'
+  );
+exception when duplicate_object then null; end $$;
+
+-- 2. New columns on profiles ----------------------------------
+alter table public.profiles
+  add column if not exists tier                 public.tier,
+  add column if not exists subscription_status  text
+    check (subscription_status in ('active','past_due','canceled','pending','none')),
+  add column if not exists current_period_start timestamptz,
+  add column if not exists current_period_end   timestamptz,
+  add column if not exists mercury_invoice_id   text,
+  add column if not exists seats                integer default 1
+    check (seats is null or seats >= 1),
+  add column if not exists domain_access        text[];   -- NULL => use tier default
+
+-- 3. Backfill `tier` from legacy access_type ------------------
+update public.profiles
+set tier = case access_type
+             when 'trusted' then 'trusted'::public.tier
+             when 'trial'   then 'trial'::public.tier
+             else 'trial'::public.tier
+           end
+where tier is null;
+
+-- 4. Backfill current_period_end for trial rows ---------------
+update public.profiles
+set current_period_end = trial_expires_at
+where tier = 'trial'
+  and current_period_end is null
+  and trial_expires_at is not null;
+
+update public.profiles
+set current_period_start = created_at
+where tier = 'trial'
+  and current_period_start is null;
+
+-- 5. Backfill subscription_status -----------------------------
+update public.profiles
+set subscription_status = case
+  when tier in ('trial','trusted') then 'active'
+  else 'none'
+end
+where subscription_status is null;
+
+-- 6. Constrain `tier` and relax legacy access_type ------------
+alter table public.profiles
+  alter column tier set not null,
+  alter column tier set default 'trial'::public.tier;
+
+alter table public.profiles
+  drop constraint if exists profiles_access_type_check;
+
+alter table public.profiles
+  alter column access_type drop not null;
+
+-- 7. handle_new_user — write `tier` + `current_period_end` ----
+create or replace function public.handle_new_user()
+returns trigger as $$
+declare
+  _tier        public.tier;
+  _caller_role text;
+  _period_end  timestamptz;
+  _meta_tier   text;
+begin
+  _caller_role := coalesce(current_setting('request.jwt.claim.role', true), 'anon');
+
+  if _caller_role = 'service_role' then
+    -- Prefer explicit `tier` metadata; fall back to legacy `access_type`.
+    _meta_tier := coalesce(
+      nullif(new.raw_user_meta_data->>'tier', ''),
+      nullif(new.raw_user_meta_data->>'access_type', '')
+    );
+    begin
+      _tier := coalesce(_meta_tier::public.tier, 'trial'::public.tier);
+    exception when invalid_text_representation then
+      _tier := 'trial'::public.tier;   -- bad metadata => fail-closed to trial
+    end;
+  else
+    _tier := 'trial'::public.tier;     -- never trust browser metadata
+  end if;
+
+  _period_end := case
+    when _tier = 'trial' then now() + interval '48 hours'
+    else null   -- paid tiers: admin sets period explicitly post-Mercury
+  end;
+
+  insert into public.profiles (
+    id, email,
+    access_type,
+    tier,
+    trial_expires_at,
+    current_period_start,
+    current_period_end,
+    subscription_status,
+    org_name
+  ) values (
+    new.id,
+    new.email,
+    -- Legacy column: keep populated with 'trial' or 'trusted' for
+    -- back-compat with anything that still reads it; new tiers
+    -- write NULL (column NOT NULL was relaxed in step 6).
+    case when _tier in ('trial','trusted') then _tier::text else null end,
+    _tier,
+    case when _tier = 'trial' then _period_end else null end,
+    case when _tier in ('trial','trusted') then now() else null end,
+    _period_end,
+    case when _tier in ('trial','trusted') then 'active' else 'none' end,
+    new.raw_user_meta_data->>'org_name'
+  );
+  return new;
+end;
+$$ language plpgsql security definer;
+
+-- 8. Tier features reference table (Phase 2 reads this) -------
+create table if not exists public.tier_features (
+  tier        public.tier primary key,
+  domain_ids  text[] not null default '{}',
+  description text,
+  updated_at  timestamptz default now()
+);
+
+alter table public.tier_features enable row level security;
+
+do $$ begin
+  create policy "tier_features readable by authed"
+    on public.tier_features for select
+    using (auth.role() = 'authenticated');
+exception when duplicate_object then null; end $$;
+-- writes are service-role only (no policy => RLS denies)
+
+-- Seed defaults. Phase 2 will refine the public-domain list.
+insert into public.tier_features (tier, domain_ids, description) values
+  ('trial',        '{}', 'All public domains during 48hr eval (resolved at runtime)'),
+  ('analyst',      '{}', 'Single domain, set per-customer via profiles.domain_access'),
+  ('multi_domain', '{}', 'All public domains (resolved at runtime)'),
+  ('enterprise',   '{}', 'All public domains + custom subgraphs (per-customer overrides)'),
+  ('trusted',      '{}', 'Internal/comp accounts — all public domains'),
+  ('expired',      '{}', 'No access — upgrade wall')
+on conflict (tier) do nothing;
+
+commit;


### PR DESCRIPTION
## Summary

Replaces the binary `access_type` (trial / trusted) with an institutional tier model and the operational tooling around it. No payment SDK is added — Mercury is the rail, manual-flip via the admin console is the v1 motion, auto-flip is documented as a future enhancement when Mercury ships invoice webhooks.

Four phases, layered from schema upward:

- **Phase 1 — Schema.** `tier` enum (`trial | analyst | multi_domain | enterprise | trusted | expired`), billing columns on `profiles` (`subscription_status`, `current_period_start/end`, `mercury_invoice_id`, `seats`, `domain_access[]`). Middleware now reads `tier + current_period_end` via `isExpired()`. Legacy `access_type` retained one release (NOT NULL relaxed).
- **Phase 2 — Domain gating.** `tier_features` reference table seeded with the public domain set + `profiles.domain_access` per-customer override. `effectiveDomainAccess()` resolves with override-beats-default. `/api/me/access` GET. UI lock in `DomainSelector.tsx` (locked domains render with an UPGRADE badge and aren't clickable).
- **Phase 3 — Admin tooling.** `/admin/billing` console (filterable customer table, EDIT modal, EXPIRE button, "DUE SOON" filter for renewals ≤30d). Mutation routes `POST /api/admin/billing/{customers,grant-tier,expire}`. Daily `pg_cron` job calling `expire_trial_users()` at 00:00 UTC.
- **Phase 4 — Public surfaces.** `/pricing` (3 tier cards, "Contact sales" CTAs), `/request-access` (lead capture into a new `leads` table with anon-INSERT-only RLS), rebuilt `/expired` (auth-aware upgrade wall), `/admin/leads` (lead pipeline, status transitions, notes). Reusable `UpgradeCTA` reads `NEXT_PUBLIC_SCHEDULER_URL` / `NEXT_PUBLIC_SALES_EMAIL`.

## Rollout state at the time of this PR

- Supabase migrations applied to production project: ✅ `supabase-billing-migration.sql`, `supabase-billing-leads.sql`, `supabase-billing-cron.sql`.
- `pg_cron` enabled, daily expiry job verified: ✅ `jobid=2, schedule='0 0 * * *', active=true`.
- Vercel env vars audited: existing `SUPABASE_*`, `ADMIN_EMAILS`, `TRUSTED_INVITE_CODE` are present in Production. New optional `NEXT_PUBLIC_SCHEDULER_URL` left unset for v1 — `UpgradeCTA` falls back to `mailto:info@apexanalytica.co`.
- Tests: 295/295 green. Typecheck clean. Vercel `prebuild` runs vitest, so this is gated on the build too.

## Deferred — see [`BILLING_BLOCKERS.md`](./BILLING_BLOCKERS.md)

1. **Mercury invoice webhooks** — Mercury's webhook surface is treasury-only as of 2026-04-30 (verified via the Create-webhook UI on workspace "Apex Analytica" — only `transaction.{created,updated}` and `*Account.balance.updated` events). No `invoice.*` events. The `mercury_invoice_id` column is a manual tracking field.
2. **Renewal email transport** — admin emails customers manually for v1; surface "DUE SOON" view in `/admin/billing` covers the workflow.
3. **Server-enforced gating on engine routes** (`/api/{compute,copilot,enrich,news,structure}`) — UI lock is the v1 gate. `requireDomainAccess()` is wired and ready for routes that take explicit domain ids in the future.
4. **`/trial-signup`** is left functional but soft-deprecated; future cleanup.

## Test plan

After merge, Vercel auto-deploys to production and re-aliases `manifold.apexanalytica.co`. Smoke checklist:

- [ ] `https://manifold.apexanalytica.co/pricing` renders 3 tier cards (Multi-Domain highlighted)
- [ ] `https://manifold.apexanalytica.co/request-access` form submits → row in `public.leads`
- [ ] Sign in as admin → `/admin/billing` lists customers (sorted by `current_period_end` ASC NULLS LAST)
- [ ] `/admin/leads` shows the smoke-test row from the previous step
- [ ] Domain selector still works for the admin user (no regressions)
- [ ] Briefly flip own tier to `'expired'` → reload → redirect to `/expired` upgrade wall renders correctly → flip back to `'trusted'`
- [ ] Confirm `cron.job` still active after deploy (no Supabase changes expected, but worth eyeballing)

Rollback if needed: Vercel → Deployments → previous Production build → "Promote to Production". DB schema is additive; legacy `access_type` is still present, so the old code path keeps working.

https://claude.ai/code/session_01Bk4PoJxdEhTNGrKbN5MHE3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bk4PoJxdEhTNGrKbN5MHE3)_