### PR TITLE
feat(admin): trusted-access invite card on /admin

### DIFF
--- a/src/app/admin/TrustedInviteCard.tsx
+++ b/src/app/admin/TrustedInviteCard.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState } from "react";
+
+export default function TrustedInviteCard({
+  signupUrl,
+  inviteCode,
+}: {
+  signupUrl: string;
+  inviteCode: string | null;
+}) {
+  const [revealed, setRevealed] = useState(false);
+  const [urlCopied, setUrlCopied] = useState(false);
+  const [codeCopied, setCodeCopied] = useState(false);
+
+  async function copy(text: string, kind: "url" | "code") {
+    try {
+      await navigator.clipboard.writeText(text);
+      if (kind === "url") {
+        setUrlCopied(true);
+        setTimeout(() => setUrlCopied(false), 1500);
+      } else {
+        setCodeCopied(true);
+        setTimeout(() => setCodeCopied(false), 1500);
+      }
+    } catch {
+      // Clipboard blocked (e.g., insecure origin). Fall back silently.
+    }
+  }
+
+  return (
+    <div className="border border-border rounded p-5 bg-surface space-y-4">
+      <div>
+        <div className="text-[11px] font-[family-name:var(--font-michroma)] tracking-[0.2em] text-foreground">
+          TRUSTED ACCESS
+        </div>
+        <p className="text-[10px] text-text-muted leading-relaxed mt-2">
+          Send the URL and the invite code to someone you trust (internal
+          team, due-diligence reviewers, partners). They&apos;ll create
+          their account on the signup page and land directly with{" "}
+          <code className="text-text-muted">tier=&apos;trusted&apos;</code>{" "}
+          — no Mercury invoice needed, no expiry. Treat the code like a
+          password; rotate via the{" "}
+          <code className="text-text-muted">TRUSTED_INVITE_CODE</code> env
+          var on Vercel.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <Field label="SIGNUP URL">
+          <div className="flex items-stretch gap-2">
+            <input
+              readOnly
+              value={signupUrl}
+              className="flex-1 bg-background border border-border rounded px-3 py-2 text-[11px] font-mono text-foreground"
+              onFocus={(e) => e.currentTarget.select()}
+            />
+            <button
+              onClick={() => copy(signupUrl, "url")}
+              className="px-3 py-2 text-[9px] tracking-wider border border-border rounded text-text-muted hover:text-foreground hover:border-foreground transition-colors"
+            >
+              {urlCopied ? "COPIED" : "COPY"}
+            </button>
+          </div>
+        </Field>
+
+        <Field label="INVITE CODE">
+          {inviteCode == null ? (
+            <div className="text-[11px] font-mono text-accent-red">
+              TRUSTED_INVITE_CODE env var is not set on this environment.
+              The signup page will reject all attempts. Set it in Vercel
+              and redeploy.
+            </div>
+          ) : (
+            <div className="flex items-stretch gap-2">
+              <input
+                readOnly
+                type={revealed ? "text" : "password"}
+                value={inviteCode}
+                className="flex-1 bg-background border border-border rounded px-3 py-2 text-[11px] font-mono text-foreground"
+                onFocus={(e) => e.currentTarget.select()}
+              />
+              <button
+                onClick={() => setRevealed((r) => !r)}
+                className="px-3 py-2 text-[9px] tracking-wider border border-border rounded text-text-muted hover:text-foreground hover:border-foreground transition-colors"
+              >
+                {revealed ? "HIDE" : "REVEAL"}
+              </button>
+              <button
+                onClick={() => copy(inviteCode, "code")}
+                className="px-3 py-2 text-[9px] tracking-wider border border-border rounded text-text-muted hover:text-foreground hover:border-foreground transition-colors"
+              >
+                {codeCopied ? "COPIED" : "COPY"}
+              </button>
+            </div>
+          )}
+        </Field>
+      </div>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label className="text-[8px] tracking-wider text-text-muted uppercase block mb-1">
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
+import { headers } from "next/headers";
 import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+import TrustedInviteCard from "./TrustedInviteCard";
 
 export const dynamic = "force-dynamic";
 
@@ -84,6 +86,17 @@ export default async function AdminLandingPage() {
     },
   ];
 
+  // Build the absolute signup URL from the incoming request so it
+  // works on prod, preview deploys, and localhost without hardcoding.
+  const headersList = await headers();
+  const host =
+    headersList.get("host") ?? "manifold.apexanalytica.co";
+  const proto =
+    headersList.get("x-forwarded-proto") ??
+    (host.startsWith("localhost") ? "http" : "https");
+  const signupUrl = `${proto}://${host}/trusted-signup`;
+  const inviteCode = process.env.TRUSTED_INVITE_CODE ?? null;
+
   return (
     <div className="min-h-screen bg-background text-foreground p-6 font-mono">
       <div className="max-w-5xl mx-auto">
@@ -144,6 +157,13 @@ export default async function AdminLandingPage() {
               </div>
             </Link>
           ))}
+        </div>
+
+        <div className="mt-6">
+          <TrustedInviteCard
+            signupUrl={signupUrl}
+            inviteCode={inviteCode}
+          />
         </div>
 
         <div className="mt-10 text-[9px] text-text-muted/70 leading-relaxed border-t border-border/60 pt-4">


### PR DESCRIPTION
## Summary

Adds a trusted-access invite card to `/admin` so the operator can grant trusted access without digging into Vercel env vars or the Supabase dashboard.

The card shows:

- **Signup URL** — derived from request headers so it works on prod, preview deploys, and localhost. Copy-to-clipboard button.
- **`TRUSTED_INVITE_CODE`** — password-masked by default, with a REVEAL toggle and a COPY button. If the env var is missing, the card shows a clear "set it in Vercel" warning instead of rendering empty.

Code is SSR'd into the HTML but only admins (`ADMIN_EMAILS` allowlist) can reach `/admin` — same trust boundary that protects every other secret in the admin console.

Workflow this enables:

1. Open `/admin`
2. REVEAL the code, COPY the URL, COPY the code
3. Paste both into an email/Slack to the person you want to comp
4. They self-onboard at the URL using the code
5. Their account lands as `tier='trusted'` immediately

## Test plan
- [ ] After merge: `/admin` shows the new TRUSTED ACCESS card below the three cards
- [ ] URL renders correctly (matches the deployed origin)
- [ ] Code is masked initially; REVEAL toggle works; COPY puts the value on the clipboard
- [ ] If `TRUSTED_INVITE_CODE` is unset, the card shows the red warning instead of an empty input

https://claude.ai/code/session_01Bk4PoJxdEhTNGrKbN5MHE3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bk4PoJxdEhTNGrKbN5MHE3)_