### PR TITLE
feat(2d): Obsidian-style force layout, hover emphasis, drag perturb, focus

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -1,0 +1,71 @@
+# Session — Rendering & Perf (Manifold)
+
+**Branch:** `claude/rendering-perf-manifold-UblqD`
+**Scope:** layout algorithms, viewport behavior, selection mechanics, animations, render perf, bundle perf, visual regressions, time-series rendering on the canvas. Out of scope: domain data, engines (Spirtes / Tarski / Pearl / Pareto), UX/onboarding, auth/platform, payments — each has its own session.
+
+This is the running log for the Rendering & Perf session. Every change pushed from this session also lands an entry here so the work survives a system crash and a fresh session can resume from the bottom of the file.
+
+---
+
+## Surfaces under this session
+
+- `src/components/CausalDAG2D.tsx` — React Flow 11 (`reactflow`).
+- `src/components/CausalDAG3D.tsx` — react-three-fiber + drei + postprocessing on `three@0.183`.
+- `src/components/CausalDAGMap.tsx` — MapLibre GL, dynamically imported (`next/dynamic`, `ssr: false`).
+- Shared: viewport refit, selection state, timeline scrubbing, shock cascade animations, status banner.
+- Layout seam: `src/lib/graph-layout.ts` (3D force-directed + `DOMAIN_Z_OFFSETS`).
+- Store seam: `src/stores/useApexStore.ts` (Zustand, fine-grained selectors).
+
+---
+
+## Open work tracked
+
+- **Issue #1 — 3D layout fix (Sugiyama + bounds scaled to node count).** Highest-leverage rendering item still open. Pending greenlight. Plan-agent recommendation: Sugiyama-style rank layout, bounds scaled to node count.
+- **Issue #2 — ΩF SERIES "NO DATA" cards.** _Shipped_ — see entry 2026-05-02 below.
+- **Diagnostic — canvas-vs-screenshot mismatch.** Last poked 2026-04-24 via Claude_in_Chrome; DOM showed correctly-positioned nodes but the screenshot was an empty dark rectangle. Treated as a Claude_in_Chrome compositor artifact, not a real prod bug, until reproduced in a real browser.
+
+---
+
+## Session log
+
+### 2026-05-02 — Issue #2 fix shipped: temporalData invariant on graph swap
+
+**PR:** [#156 — fix(timeseries): refresh temporalData + prune ghost pins on graph swap](https://github.com/ApexAnalytica/apex-terminal/pull/156) — merged `20c3389`.
+
+**Problem.** `TimeSeriesOverlay`'s "NO DATA" badge fires when a pinned node id exists in `graphData.nodes` but is missing from `temporalData.nodes`. `setGraphData` already cleared `temporalData` and re-fired `initTemporalData()` on swap, but `mergeGraphData`, `addSandboxGraph`, `switchSandboxGraph`, `deleteSandboxGraph`, and `removeImportedDataset` all changed the graph node id set without honoring that invariant. Imports and sandbox swaps left stale temporal data and ghost pins around.
+
+**Fix.** Added `prunePinsToGraph` helper in `useApexStore.ts` and routed every graph-mutating action through the same `temporalData: null` + pin-prune + `initTemporalData()` path. Helper returns the same array reference when nothing changes so subscribers don't re-render.
+
+**Verification.** `tsc --noEmit` clean; vitest 330/330 pass. Visual verification deferred to prod (manifold.apexanalytica.co) since the change is a store-level invariant with no canvas surface change.
+
+**Out of scope.** Diagnosing whether the original "NO DATA" reports were also driven by the engine-side `loadRealTemporalData` producer (Pass 2 1-point fallback) was punted — the Explore agent's earlier read of `real-timeseries.ts:317–318` was misled by a stale comment; current rendering at `TimeSeriesOverlay.tsx:151–154` does render 1-point histories as flat lines with a "STATIC" badge. So "STATIC" is working as designed; only the "NO DATA" path was the bug, and it's mine.
+
+### 2026-05-02 — In progress: 2D Obsidian-style layout v1
+
+**Branch state:** unpushed local changes on `claude/rendering-perf-manifold-UblqD`.
+
+**Goal.** Make `CausalDAG2D.tsx` feel like Obsidian's graph view — force-directed positions, hover-emphasize-1-hop dim-rest, click-to-focus, drag-to-perturb. The deterministic id-hash grid is replaced.
+
+**Decisions.**
+- **Force engine:** 2D-tuned `d3-force-3d` with `nDim=2` (existing dep, no new package).
+- **Surface:** `CausalDAG2D.tsx` only — `CausalDAGMap.tsx` keeps real geographic lat/lng.
+- **Caching:** layout computed once per graph signature (sorted node-id ∪ edge-id join). Filter / isolation / replay never trigger a re-layout.
+- **Live perturb:** drag pins the node (`fx`/`fy`), reheats alpha, ticks via rAF, releases on drop, alpha decays naturally.
+
+**Files touched (uncommitted):**
+- `src/lib/graph-layout-2d.ts` (new) — `compute2DForceLayout` (one-shot offline) + `create2DLiveSimulation` (live handle: `tick`, `pin`, `unpin`, `reheat`, `cool`, `positions`) + `graphSignature`.
+- `src/components/CausalDAG2D.tsx` — replaced id-hash grid with force-layout positions; added hover/focus state; rAF loop pushes live positions during drag; emphasis flows through `node.data.emphasis` → opacity in `CausalNode2D`; edges dim when out of emphasis scope; preserved marquee selection, isolation filter, refit-on-visible-set, and replay contraction (now applied as offset over dynamic positions).
+
+**Verified locally:** `tsc --noEmit` clean; lint clean on changed files; vitest 330/330 pass. Visual smoke test in dev server: pending.
+
+**Next:** dev-server smoke test (golden path + edge cases: empty graph, single domain, large graph, replay-while-dragging, isolate-then-drag), then commit + push + PR. Will not auto-merge until visual sign-off.
+
+---
+
+## How a fresh session resumes
+
+1. Read this file bottom-up — the most recent entry is the live state.
+2. Check the session brief in scrollback or in `~/.claude/projects/-Users-Junaid-Documents-apex-terminal/memory/` for the canonical scope.
+3. Confirm branch: `git branch --show-current` should be `claude/rendering-perf-manifold-UblqD`. Check `git status` and `git log --oneline -5` to see what's landed locally vs pushed vs merged.
+4. Check open PRs in `ApexAnalytica/apex-terminal` filtered to this branch / session label.
+5. Resume from the most recent "In progress" or "Next" line above.

--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -27,16 +27,28 @@ import DAGOverlay from "./dag3d/DAGOverlay";
 import CanvasWatermark from "./CanvasWatermark";
 import { useReplayTickDOM } from "@/lib/useReplayTick";
 import type { CausalEdge, EpochSnapshot } from "@/lib/types";
+import {
+  compute2DForceLayout,
+  create2DLiveSimulation,
+  graphSignature,
+  type LiveSimulation,
+  type Position2D,
+} from "@/lib/graph-layout-2d";
 import { AnimatePresence } from "framer-motion";
 
+type NodeEmphasis = "focus" | "neighbor" | "dim" | "none";
+
 function CausalNode2D({ data, selected }: NodeProps) {
-  const { label, category, omegaComposite, isRestricted, domain, datasetColor, shockIntensity } = data;
+  const { label, category, omegaComposite, isRestricted, domain, datasetColor, shockIntensity, emphasis } = data;
   const color = datasetColor ?? getCategoryColor(category);
   const isFractured = omegaComposite > 9;
   const isStressed = omegaComposite > 7;
   const shockGlow = shockIntensity ?? 0;
+  const nodeEmphasis: NodeEmphasis = emphasis ?? "none";
+  const isDim = nodeEmphasis === "dim";
+  const isFocus = nodeEmphasis === "focus";
 
-  const selectionGlow = selected
+  const selectionGlow = selected || isFocus
     ? "0 0 12px #00e5ff80, 0 0 24px #00e5ff40"
     : "";
 
@@ -44,9 +56,11 @@ function CausalNode2D({ data, selected }: NodeProps) {
     <motion.div
       className="relative px-5 py-3 rounded border font-mono text-[11px] tracking-wider text-center min-w-[120px]"
       style={{
-        borderColor: selected ? "#00e5ff" : isRestricted ? "#ff1744" : color,
+        borderColor: selected || isFocus ? "#00e5ff" : isRestricted ? "#ff1744" : color,
         backgroundColor: `color-mix(in srgb, ${color} ${Math.round(5 + (omegaComposite / 10) * 15)}%, #0a0b10)`,
         color,
+        opacity: isDim ? 0.18 : 1,
+        transition: "opacity 180ms ease-out",
         boxShadow: [
           selectionGlow,
           shockGlow > 0
@@ -286,61 +300,100 @@ function CausalDAG2DInner() {
 
   const CONTRACTION = 0.18;
 
-  // Stable hash: deterministic position per node ID (won't jump when nodes are filtered)
-  const idHash = useCallback((id: string): number => {
-    let h = 0;
-    for (let i = 0; i < id.length; i++) {
-      h = ((h << 5) - h + id.charCodeAt(i)) | 0;
+  // Force-directed layout. Cached positions come from a one-shot offline
+  // simulation per graph signature; live positions are written by the rAF
+  // loop while a node is being dragged. Display falls back to cached when
+  // no live perturbation is in flight. Filter / isolation / replay never
+  // trigger a re-layout.
+  const liveSimRef = useRef<LiveSimulation | null>(null);
+  const rafRef = useRef<number | null>(null);
+
+  const selectedNode = useApexStore((s) => s.selectedNode);
+  const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
+
+  const sig = graphSignature(graphData.nodes, graphData.edges);
+  const [prevSig, setPrevSig] = useState<string>("");
+  const [cachedLayout, setCachedLayout] = useState<Map<string, Position2D>>(
+    () => new Map(),
+  );
+  const [livePositions, setLivePositions] = useState<Map<string, Position2D> | null>(
+    null,
+  );
+  if (sig !== prevSig) {
+    setPrevSig(sig);
+    setCachedLayout(compute2DForceLayout(graphData.nodes, graphData.edges));
+    setLivePositions(null);
+  }
+  const nodePositions = livePositions ?? cachedLayout;
+
+  // Build the live (perturbable) simulation whenever the cached layout swaps.
+  // No setState here — only ref + rAF management.
+  useEffect(() => {
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
     }
-    return Math.abs(h);
+    liveSimRef.current = create2DLiveSimulation(
+      graphData.nodes,
+      graphData.edges,
+      cachedLayout,
+    );
+  }, [graphData.nodes, graphData.edges, cachedLayout]);
+
+  // Cleanup any in-flight rAF on unmount.
+  useEffect(() => {
+    return () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    };
   }, []);
 
-  const nodes: Node[] = useMemo(() => {
-    // Vertical layout: 5 columns, nodes flow top-to-bottom
-    // Stable positions based on node ID hash — won't jump when filtered
-    const COLS = 5;
-    const COL_W = 220;
-    const ROW_H = 130;
-
-    // Sort nodes by domain then by ID hash for consistent vertical ordering
-    const domainOrder: Record<string, number> = {
-      "Saudi Aramco Energy": 0,
-      "QatarEnergy LNG": 1,
-      "QAFCO Fertilizer": 2,
-      "Ma'aden Phosphate": 3,
+  const startSimLoop = useCallback(() => {
+    if (rafRef.current !== null) return;
+    const tick = () => {
+      const sim = liveSimRef.current;
+      if (!sim) {
+        rafRef.current = null;
+        return;
+      }
+      sim.tick();
+      setLivePositions(sim.positions());
+      if (sim.alpha() > 0.005) {
+        rafRef.current = requestAnimationFrame(tick);
+      } else {
+        rafRef.current = null;
+      }
     };
-    const sorted = [...graphData.nodes].sort((a, b) => {
-      const da = domainOrder[a.domain] ?? 4;
-      const db = domainOrder[b.domain] ?? 4;
-      if (da !== db) return da - db;
-      return idHash(a.id) - idHash(b.id);
-    });
+    rafRef.current = requestAnimationFrame(tick);
+  }, []);
 
-    // Assign stable column/row positions
-    const positions = new Map<string, { x: number; y: number }>();
-    sorted.forEach((n, i) => {
-      const col = i % COLS;
-      const row = Math.floor(i / COLS);
-      // Slight jitter from ID hash for organic feel, but small (±20px)
-      const h = idHash(n.id);
-      const jitterX = ((h % 41) - 20);
-      const jitterY = ((h % 37) - 18);
-      positions.set(n.id, {
-        x: col * COL_W + 50 + jitterX,
-        y: row * ROW_H + 30 + jitterY,
-      });
-    });
+  // Emphasis target: hover wins over selection. Empty when nothing is hovered
+  // or selected — that's the default "no dimming" state.
+  const emphasisTarget = hoveredNodeId ?? selectedNode ?? null;
 
+  const emphasisMap = useMemo(() => {
+    const map = new Map<string, NodeEmphasis>();
+    if (!emphasisTarget) return map;
+    const neighbors = new Set<string>();
+    for (const e of graphData.edges) {
+      if (e.source === emphasisTarget) neighbors.add(e.target);
+      if (e.target === emphasisTarget) neighbors.add(e.source);
+    }
+    for (const n of graphData.nodes) {
+      if (n.id === emphasisTarget) map.set(n.id, "focus");
+      else if (neighbors.has(n.id)) map.set(n.id, "neighbor");
+      else map.set(n.id, "dim");
+    }
+    return map;
+  }, [emphasisTarget, graphData.nodes, graphData.edges]);
+
+  const nodes: Node[] = useMemo(() => {
     return graphData.nodes.map((n) => {
-      const base = positions.get(n.id) ?? { x: 0, y: 0 };
-      const omega = n.omegaFragility.composite;
-
-      // Positions are purely structural — no omega-dependent drift.
-      // This prevents position shifts during temporal scrubbing.
+      const base = nodePositions.get(n.id) ?? { id: n.id, x: 0, y: 0 };
       let posX = base.x;
       let posY = base.y;
 
-      // Apply contraction during replay
+      // Replay contraction: pull stressed nodes toward stressed neighbors.
+      // Applied as an offset over the dynamic layout so it doesn't fight drag.
       if (currentSnapshot) {
         const state = currentSnapshot.nodeStates[n.id];
         if (state && state.shockIntensity > 0.01) {
@@ -348,7 +401,7 @@ function CausalDAG2DInner() {
           for (const edge of graphData.edges) {
             const nbId = edge.source === n.id ? edge.target : edge.target === n.id ? edge.source : null;
             if (!nbId) continue;
-            const nbPos = positions.get(nbId);
+            const nbPos = nodePositions.get(nbId);
             const nbState = currentSnapshot.nodeStates[nbId];
             if (!nbPos) continue;
             const w = nbState ? 0.3 + nbState.shockIntensity * 0.7 : 0.1;
@@ -366,6 +419,7 @@ function CausalDAG2DInner() {
         }
       }
 
+      const omega = n.omegaFragility.composite;
       const epochOmega = currentSnapshot?.nodeStates[n.id]?.omegaComposite ?? omega;
       const epochShock = currentSnapshot?.nodeStates[n.id]?.shockIntensity ?? 0;
 
@@ -381,10 +435,11 @@ function CausalDAG2DInner() {
           isRestricted: truthFilter === "verified" && n.isRestricted,
           datasetColor: n.datasetColor,
           shockIntensity: epochShock,
+          emphasis: emphasisMap.get(n.id) ?? "none",
         },
       };
     });
-  }, [graphData, truthFilter, currentSnapshot, idHash]);
+  }, [graphData, nodePositions, truthFilter, currentSnapshot, emphasisMap]);
 
   // Filter nodes for isolation mode
   const visibleNodes = useMemo(() => {
@@ -399,6 +454,8 @@ function CausalDAG2DInner() {
         const isInconsistent = truthFilter === "verified" && e.isInconsistent;
         const propagationSignal = currentSnapshot?.edgeStates[e.id]?.propagationSignal ?? 0;
         const isSelected = selectedEdge?.id === e.id;
+        const inEmphasisScope =
+          !emphasisTarget || e.source === emphasisTarget || e.target === emphasisTarget;
 
         const baseColor = isInconsistent
           ? "#ff1744"
@@ -414,9 +471,10 @@ function CausalDAG2DInner() {
           : baseColor;
 
         const baseOpacity = isSelected ? 1 : isInconsistent ? 0.6 : 0.7;
-        const opacity = propagationSignal > 0
+        let opacity = propagationSignal > 0
           ? Math.min(1, baseOpacity + propagationSignal * 0.3)
           : selectedEdge && !isSelected ? 0.15 : baseOpacity;
+        if (!inEmphasisScope) opacity = Math.min(opacity, 0.1);
 
         const baseWidth = 0.5 + e.weight * 1.5;
         const strokeWidth = isSelected
@@ -439,6 +497,7 @@ function CausalDAG2DInner() {
             strokeWidth,
             strokeDasharray: e.type === "confounded" || isInconsistent ? "5,5" : undefined,
             opacity,
+            transition: "opacity 180ms ease-out",
           },
           labelStyle: {
             fill: "#5a5e72",
@@ -451,7 +510,7 @@ function CausalDAG2DInner() {
           },
         };
       }),
-    [graphData, truthFilter, currentSnapshot, selectedEdge]
+    [graphData, truthFilter, currentSnapshot, selectedEdge, emphasisTarget]
   );
 
   // Filter edges for isolation mode
@@ -587,7 +646,40 @@ function CausalDAG2DInner() {
   const onPaneClick = useCallback(() => {
     setSelectedEdge(null);
     setSelectedNode(null);
+    setHoveredNodeId(null);
   }, [setSelectedNode]);
+
+  const onNodeMouseEnter: NodeMouseHandler = useCallback((_event, rfNode) => {
+    setHoveredNodeId(rfNode.id);
+  }, []);
+
+  const onNodeMouseLeave: NodeMouseHandler = useCallback(() => {
+    setHoveredNodeId(null);
+  }, []);
+
+  const onNodeDragStart: NodeMouseHandler = useCallback(
+    (_event, rfNode) => {
+      const sim = liveSimRef.current;
+      if (!sim) return;
+      sim.pin(rfNode.id, rfNode.position.x, rfNode.position.y);
+      sim.reheat(0.5);
+      startSimLoop();
+    },
+    [startSimLoop],
+  );
+
+  const onNodeDrag: NodeMouseHandler = useCallback((_event, rfNode) => {
+    const sim = liveSimRef.current;
+    if (!sim) return;
+    sim.pin(rfNode.id, rfNode.position.x, rfNode.position.y);
+  }, []);
+
+  const onNodeDragStop: NodeMouseHandler = useCallback((_event, rfNode) => {
+    const sim = liveSimRef.current;
+    if (!sim) return;
+    sim.unpin(rfNode.id);
+    sim.cool();
+  }, []);
 
   // Resolve labels for edge inspector
   const selectedSourceLabel = selectedEdge
@@ -608,6 +700,11 @@ function CausalDAG2DInner() {
           nodeTypes={nodeTypes}
           onInit={onInit}
           onNodeClick={onNodeClick}
+          onNodeMouseEnter={onNodeMouseEnter}
+          onNodeMouseLeave={onNodeMouseLeave}
+          onNodeDragStart={onNodeDragStart}
+          onNodeDrag={onNodeDrag}
+          onNodeDragStop={onNodeDragStop}
           onEdgeClick={onEdgeClick}
           onPaneClick={onPaneClick}
           onSelectionChange={onSelectionChange}

--- a/src/lib/graph-layout-2d.ts
+++ b/src/lib/graph-layout-2d.ts
@@ -1,0 +1,189 @@
+import {
+  forceSimulation,
+  forceLink,
+  forceManyBody,
+  forceCenter,
+  // @ts-expect-error d3-force-3d types omit forceCollide; runtime export exists
+  forceCollide,
+} from "d3-force-3d";
+import type { CausalNode, CausalEdge } from "./types";
+
+export interface Position2D {
+  id: string;
+  x: number;
+  y: number;
+}
+
+interface LayoutNode2D {
+  id: string;
+  x: number;
+  y: number;
+  vx?: number;
+  vy?: number;
+  fx?: number | null;
+  fy?: number | null;
+}
+
+interface LayoutLink2D {
+  source: string | LayoutNode2D;
+  target: string | LayoutNode2D;
+  weight: number;
+}
+
+// Matches CausalNode2D's rendered footprint (~120px wide × ~70px tall).
+// Collision radius needs to clear the diagonal so dense clusters don't overlap.
+const NODE_COLLISION_R = 78;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnySim = any;
+
+function buildSim(
+  nodes: CausalNode[],
+  edges: CausalEdge[],
+): { sim: AnySim; simNodes: LayoutNode2D[] } {
+  // Seed on a circle so the initial step doesn't explode from collinear positions.
+  const R = Math.max(120, nodes.length * 14);
+  const simNodes: LayoutNode2D[] = nodes.map((n, i) => {
+    const a = (i / Math.max(1, nodes.length)) * Math.PI * 2;
+    return {
+      id: n.id,
+      x: Math.cos(a) * R + (Math.random() - 0.5) * 30,
+      y: Math.sin(a) * R + (Math.random() - 0.5) * 30,
+    };
+  });
+
+  const simLinks: LayoutLink2D[] = edges.map((e) => ({
+    source: e.source,
+    target: e.target,
+    weight: e.weight,
+  }));
+
+  const connected = new Set<string>();
+  for (const e of edges) {
+    connected.add(e.source);
+    connected.add(e.target);
+  }
+
+  // d3-force-3d types are incomplete — pass nDim=2 at runtime.
+  const sim = (forceSimulation as AnySim)(simNodes, 2)
+    .force(
+      "link",
+      (forceLink as AnySim)(simLinks)
+        .id((d: AnySim) => d.id)
+        // Strong correlation → shorter spring. Range tuned for ~120px nodes.
+        .distance((d: AnySim) => 110 + (1 - d.weight) * 140)
+        .strength((d: AnySim) => 0.45 + d.weight * 0.35),
+    )
+    .force(
+      "charge",
+      (forceManyBody as AnySim)().strength((d: AnySim) =>
+        connected.has(d.id) ? -900 : -250,
+      ),
+    )
+    .force("center", forceCenter(0, 0))
+    .force("collide", (forceCollide as AnySim)(NODE_COLLISION_R).strength(0.9))
+    .velocityDecay(0.45);
+
+  return { sim, simNodes };
+}
+
+/**
+ * One-shot offline 2D force-directed layout. Cache the result keyed on the
+ * graph signature so filter / isolation / replay changes don't reshuffle.
+ */
+export function compute2DForceLayout(
+  nodes: CausalNode[],
+  edges: CausalEdge[],
+): Map<string, Position2D> {
+  const out = new Map<string, Position2D>();
+  if (nodes.length === 0) return out;
+  const { sim, simNodes } = buildSim(nodes, edges);
+  sim.stop();
+  const iters = nodes.length < 30 ? 220 : 320;
+  for (let i = 0; i < iters; i++) sim.tick();
+  for (const n of simNodes) {
+    out.set(n.id, { id: n.id, x: n.x, y: n.y });
+  }
+  return out;
+}
+
+export interface LiveSimulation {
+  tick: () => void;
+  alpha: () => number;
+  reheat: (target?: number) => void;
+  cool: () => void;
+  pin: (id: string, x: number, y: number) => void;
+  unpin: (id: string) => void;
+  positions: () => Map<string, Position2D>;
+}
+
+/**
+ * Build a live simulation seeded from `initialPositions`. The caller drives
+ * ticks via a rAF loop — read positions back via `positions()` after each tick.
+ * Used for drag-perturb: pin the dragged node, reheat alpha, tick, unpin on
+ * release, let alpha decay to settle.
+ */
+export function create2DLiveSimulation(
+  nodes: CausalNode[],
+  edges: CausalEdge[],
+  initialPositions: Map<string, Position2D>,
+): LiveSimulation {
+  const { sim, simNodes } = buildSim(nodes, edges);
+  const idIndex = new Map<string, LayoutNode2D>();
+  for (const n of simNodes) {
+    const seed = initialPositions.get(n.id);
+    if (seed) {
+      n.x = seed.x;
+      n.y = seed.y;
+      n.vx = 0;
+      n.vy = 0;
+    }
+    idIndex.set(n.id, n);
+  }
+  sim.alpha(0).stop();
+
+  return {
+    tick: () => sim.tick(),
+    alpha: () => sim.alpha() as number,
+    reheat: (target = 0.5) => {
+      sim.alpha(target).alphaTarget(0).restart();
+    },
+    cool: () => {
+      sim.alphaTarget(0);
+    },
+    pin: (id, x, y) => {
+      const n = idIndex.get(id);
+      if (!n) return;
+      n.fx = x;
+      n.fy = y;
+      n.x = x;
+      n.y = y;
+    },
+    unpin: (id) => {
+      const n = idIndex.get(id);
+      if (!n) return;
+      n.fx = null;
+      n.fy = null;
+    },
+    positions: () => {
+      const out = new Map<string, Position2D>();
+      for (const n of simNodes) {
+        out.set(n.id, { id: n.id, x: n.x, y: n.y });
+      }
+      return out;
+    },
+  };
+}
+
+/**
+ * Stable signature over the node and edge id sets. Layout is recomputed only
+ * when this changes — filter/isolation/replay don't trigger a re-layout.
+ */
+export function graphSignature(
+  nodes: CausalNode[],
+  edges: CausalEdge[],
+): string {
+  const ns = nodes.map((n) => n.id).sort().join("|");
+  const es = edges.map((e) => e.id).sort().join("|");
+  return `${ns}#${es}`;
+}


### PR DESCRIPTION
## Summary

Replaces the deterministic id-hash grid in `CausalDAG2D.tsx` with an Obsidian-style force-directed canvas. v1 ships all four interactions in one shot:

- **Force-directed layout.** New `src/lib/graph-layout-2d.ts` runs `d3-force-3d` at `nDim=2` with link, charge, center, and collide forces tuned for ~120px nodes. Computed once per graph signature (sorted node + edge id sets) and cached — filter / isolation / replay never trigger a re-layout.
- **Drag-to-perturb.** Live simulation handle (`pin` / `unpin` / `reheat` / `cool` / `tick` / `positions`) seeded from the cached layout. `onNodeDragStart` pins the node and reheats alpha; `onNodeDrag` updates the pin; `onNodeDragStop` unpins and lets alpha decay. Ticks run in a rAF loop while alpha > 0.005.
- **Hover-emphasize 1-hop, dim rest.** Node opacity drops to 0.18 with a 180ms ease for non-neighbors; edges not touching the hovered/focused node dim to 0.1.
- **Click-to-focus.** Tied to the existing `selectedNode` store value so the inspector flow is unchanged. Hover takes precedence over click for immediate feedback.

Preserved: shift+drag marquee selection (#101 / #25), isolation filter, refit on visible-set change (#77), replay contraction (now applied as offset over dynamic positions), edge inspector.

## Files

- **New** `src/lib/graph-layout-2d.ts` — `compute2DForceLayout` (one-shot offline) + `create2DLiveSimulation` (live handle) + `graphSignature`.
- **Modified** `src/components/CausalDAG2D.tsx` — id-hash grid replaced; hover/focus state; rAF loop; emphasis flows through `node.data.emphasis` → opacity in `CausalNode2D`; edges dim when out of emphasis scope; new `onNodeDragStart`/`onNodeDrag`/`onNodeDragStop`/`onNodeMouseEnter`/`onNodeMouseLeave` wired into `ReactFlow`.
- **New** `docs/sessions/rendering-perf.md` — running session log (per session-brief: tracks shipped work + in-progress + lets a fresh session resume after a crash).

## Test plan

Verified locally:
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean on changed files
- [x] `npx vitest run` — 330/330 pass

**Visual sign-off blocked here** — sandbox can't run the dev server (`critters` optional dep + Supabase env vars not configured locally). Vercel preview deploy will give a real URL to verify.

To verify on the Vercel preview, exercise:
- [ ] Open 2D view on a populated graph. Layout should look organic, not grid-like.
- [ ] Hover any node → it + 1-hop emphasized, others dimmed (~180ms fade).
- [ ] Click a node → same emphasis state persists; pane click clears it.
- [ ] Drag a node → springs perturb neighbors during drag; release lets the cluster settle.
- [ ] Shift+drag marquee still works; isolation toggle still works; replay still contracts shocked clusters; edge inspector still opens on edge click; refit still fires on visible-set change.
- [ ] Switch profiles / sandbox graphs — layout recomputes; no ghost positions or old graph overlap.

## Out of scope

Issue #1 (3D Sugiyama) is the next item — separate PR after this lands.

## Ship discipline

Marked **draft** until you confirm the canvas feels right on the Vercel preview. Do not auto-merge.

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_