### PR TITLE
feat(2d): replace rectangular node boxes with Obsidian-style circles

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -40,25 +40,27 @@ This is the running log for the Rendering & Perf session. Every change pushed fr
 
 **Out of scope.** Diagnosing whether the original "NO DATA" reports were also driven by the engine-side `loadRealTemporalData` producer (Pass 2 1-point fallback) was punted — the Explore agent's earlier read of `real-timeseries.ts:317–318` was misled by a stale comment; current rendering at `TimeSeriesOverlay.tsx:151–154` does render 1-point histories as flat lines with a "STATIC" badge. So "STATIC" is working as designed; only the "NO DATA" path was the bug, and it's mine.
 
-### 2026-05-02 — In progress: 2D Obsidian-style layout v1
+### 2026-05-02 — Shipped: 2D Obsidian-style layout v1
 
-**Branch state:** unpushed local changes on `claude/rendering-perf-manifold-UblqD`.
+**PR:** [#159 — feat(2d): Obsidian-style force layout, hover emphasis, drag perturb, focus](https://github.com/ApexAnalytica/apex-terminal/pull/159) — merged `38c56bd`.
 
-**Goal.** Make `CausalDAG2D.tsx` feel like Obsidian's graph view — force-directed positions, hover-emphasize-1-hop dim-rest, click-to-focus, drag-to-perturb. The deterministic id-hash grid is replaced.
+**What shipped.** `CausalDAG2D.tsx`'s deterministic id-hash grid is replaced with a 2D force-directed canvas. v1 covers all four interactions in one shot:
+- Force-directed layout via `d3-force-3d` at `nDim=2`, cached on graph signature (sorted node + edge id sets) — filter / isolation / replay never trigger a re-layout.
+- Drag-to-perturb: pin the node (`fx`/`fy`), reheat alpha, tick via rAF, unpin on drop, alpha decays naturally.
+- Hover emphasizes the node + 1-hop neighbors; everything else dims to opacity 0.18 with a 180ms ease. Edges out of scope drop to opacity 0.1.
+- Click-to-focus is tied to the existing `selectedNode` store value, so the inspector flow is unchanged. Hover takes precedence over click.
 
-**Decisions.**
-- **Force engine:** 2D-tuned `d3-force-3d` with `nDim=2` (existing dep, no new package).
-- **Surface:** `CausalDAG2D.tsx` only — `CausalDAGMap.tsx` keeps real geographic lat/lng.
-- **Caching:** layout computed once per graph signature (sorted node-id ∪ edge-id join). Filter / isolation / replay never trigger a re-layout.
-- **Live perturb:** drag pins the node (`fx`/`fy`), reheats alpha, ticks via rAF, releases on drop, alpha decays naturally.
-
-**Files touched (uncommitted):**
+**Files.**
 - `src/lib/graph-layout-2d.ts` (new) — `compute2DForceLayout` (one-shot offline) + `create2DLiveSimulation` (live handle: `tick`, `pin`, `unpin`, `reheat`, `cool`, `positions`) + `graphSignature`.
-- `src/components/CausalDAG2D.tsx` — replaced id-hash grid with force-layout positions; added hover/focus state; rAF loop pushes live positions during drag; emphasis flows through `node.data.emphasis` → opacity in `CausalNode2D`; edges dim when out of emphasis scope; preserved marquee selection, isolation filter, refit-on-visible-set, and replay contraction (now applied as offset over dynamic positions).
+- `src/components/CausalDAG2D.tsx` — id-hash grid replaced; hover/focus state; rAF loop pushes live positions during drag; emphasis flows through `node.data.emphasis` → opacity in `CausalNode2D`; edges dim when out of emphasis scope. Preserved: hand-rolled shift+drag marquee (was already on main as #157/#158-era work), isolation filter, refit-on-visible-set, replay contraction (now applied as offset over dynamic positions).
 
-**Verified locally:** `tsc --noEmit` clean; lint clean on changed files; vitest 330/330 pass. Visual smoke test in dev server: pending.
+**Verification.** `tsc --noEmit` clean; lint clean on changed files; vitest 511/511 pass. Visual smoke test in the sandbox dev server was blocked (`critters` + Supabase env vars not configured locally) — visual sign-off happens on the Vercel preview / production deploy.
 
-**Next:** dev-server smoke test (golden path + edge cases: empty graph, single domain, large graph, replay-while-dragging, isolate-then-drag), then commit + push + PR. Will not auto-merge until visual sign-off.
+**Rebase note.** Branch had to rebase onto main to drop the duplicate `bda9da6` commit (squashed into `20c3389` via #156) and resolve a JSX conflict with main's hand-rolled shift+drag marquee (`flowWrapperRef` + `selectionRect` overlay + `selectionKeyCode={null}`). The marquee is preserved end-to-end; my new hover/drag handlers slot in alongside it.
+
+### 2026-05-02 — Next up
+
+- **Issue #1 — 3D Sugiyama layout.** Highest-leverage rendering item still open. Next on deck unless redirected.
 
 ---
 

--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -58,6 +58,19 @@ This is the running log for the Rendering & Perf session. Every change pushed fr
 
 **Rebase note.** Branch had to rebase onto main to drop the duplicate `bda9da6` commit (squashed into `20c3389` via #156) and resolve a JSX conflict with main's hand-rolled shift+drag marquee (`flowWrapperRef` + `selectionRect` overlay + `selectionKeyCode={null}`). The marquee is preserved end-to-end; my new hover/drag handlers slot in alongside it.
 
+### 2026-05-02 — Visual refinement v1.1: rectangular boxes → Obsidian-style circles
+
+**Trigger.** Live-prod feedback: layout was force-directed correctly, but the **node visuals** were still the rich rectangular info-cards (`CausalNode2D`'s box with category fill, label, domain, ΩF, glow border). User wanted the actual Obsidian "little circles in a network" aesthetic — picked Option 2 (circles with ΩF visible) over Option 1 (pure circles).
+
+**Change scope.**
+- `CausalNode2D` rewritten as a circular node. Diameter scales with ΩF (`14 + clamp(omega, 0..10) * 2`) so high-risk nodes are visually larger. Layered box-shadow: selection ring (sharp 2px cyan + soft halo) + shock pulse + base ΩF glow. Fracture / stressed / shock animations preserved (now scale-pulse on the circle instead of border-color flash on a box). `RESTRICTED` becomes a 1px red circle border instead of inline text.
+- ΩF value + label rendered as small text, absolutely positioned below the circle so the React Flow node bounding box stays circle-sized (edges anchor at circle edges, not at the label). Label colors cyan when focused/selected, gray otherwise; hidden into opacity 0.18 with the rest of the node when out of emphasis scope.
+- `graph-layout-2d.ts` re-tuned for the smaller footprint: `NODE_COLLISION_R` 78 → 48; link distance `110 + (1-w)*140` → `65 + (1-w)*100`; charge connected `-900` → `-550`, isolated `-250` → `-150`. Mild label overlap is acceptable for the Obsidian-style density; circles themselves don't touch.
+
+**Files touched.** `src/components/CausalDAG2D.tsx` (CausalNode2D body), `src/lib/graph-layout-2d.ts` (collision + link + charge tuning). All hover/focus/drag/marquee/refit/isolation behavior from #159 preserved unchanged.
+
+**Verification.** `tsc --noEmit` clean; lint clean on changed files; vitest 511/511 pass. Visual sign-off on Vercel preview.
+
 ### 2026-05-02 — Next up
 
 - **Issue #1 — 3D Sugiyama layout.** Highest-leverage rendering item still open. Next on deck unless redirected.

--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -39,7 +39,7 @@ import { AnimatePresence } from "framer-motion";
 type NodeEmphasis = "focus" | "neighbor" | "dim" | "none";
 
 function CausalNode2D({ data, selected }: NodeProps) {
-  const { label, category, omegaComposite, isRestricted, domain, datasetColor, shockIntensity, emphasis } = data;
+  const { label, category, omegaComposite, isRestricted, datasetColor, shockIntensity, emphasis } = data;
   const color = datasetColor ?? getCategoryColor(category);
   const isFractured = omegaComposite > 9;
   const isStressed = omegaComposite > 7;
@@ -47,70 +47,97 @@ function CausalNode2D({ data, selected }: NodeProps) {
   const nodeEmphasis: NodeEmphasis = emphasis ?? "none";
   const isDim = nodeEmphasis === "dim";
   const isFocus = nodeEmphasis === "focus";
+  const isRinged = selected || isFocus;
 
-  const selectionGlow = selected || isFocus
-    ? "0 0 12px #00e5ff80, 0 0 24px #00e5ff40"
+  // Diameter scales with \u03A9F: low-risk nodes are small, high-risk are larger.
+  const diameter = 14 + Math.min(10, Math.max(0, omegaComposite)) * 2;
+
+  // Layered box-shadow: selection ring (sharp), shock glow (pulsing), base
+  // omega glow (soft halo). All applied to the same circle element.
+  const selectionRing = isRinged ? "0 0 0 2px #00e5ff, 0 0 12px #00e5ffaa" : "";
+  const shockShadow = shockGlow > 0
+    ? `0 0 ${Math.round(shockGlow * 24)}px ${color}, 0 0 ${Math.round(shockGlow * 12)}px ${color}cc`
     : "";
+  const baseShadow = omegaComposite > 0
+    ? `0 0 ${Math.round((omegaComposite / 10) * 14)}px ${color}88`
+    : "";
+  const boxShadow = [selectionRing, shockShadow, baseShadow].filter(Boolean).join(", ") || "none";
 
   return (
     <motion.div
-      className="relative px-5 py-3 rounded border font-mono text-[11px] tracking-wider text-center min-w-[120px]"
+      className="relative"
       style={{
-        borderColor: selected || isFocus ? "#00e5ff" : isRestricted ? "#ff1744" : color,
-        backgroundColor: `color-mix(in srgb, ${color} ${Math.round(5 + (omegaComposite / 10) * 15)}%, #0a0b10)`,
-        color,
+        width: diameter,
+        height: diameter,
         opacity: isDim ? 0.18 : 1,
         transition: "opacity 180ms ease-out",
-        boxShadow: [
-          selectionGlow,
-          shockGlow > 0
-            ? `0 0 ${Math.round(shockGlow * 30)}px ${color}80, 0 0 ${Math.round(shockGlow * 15)}px ${color}40, inset 0 0 ${Math.round(shockGlow * 10)}px ${color}30`
-            : omegaComposite > 0
-              ? `0 0 ${Math.round((omegaComposite / 10) * 20)}px ${color}40, inset 0 0 ${Math.round((omegaComposite / 10) * 10)}px ${color}20`
-              : "",
-        ].filter(Boolean).join(", ") || "none",
       }}
-      animate={
-        shockGlow > 0.3
-          ? {
-              scale: [1, 1 + shockGlow * 0.06, 1],
-              borderColor: [color, "#ffab00", color],
-            }
-          : isFractured
-            ? { borderColor: [color, "#ff1744", color], scale: [1, 1.02, 1] }
-            : isStressed
-              ? { opacity: [1, 0.7, 1] }
-              : {}
-      }
-      transition={
-        shockGlow > 0.3
-          ? { duration: 0.6, repeat: Infinity, ease: "easeInOut" }
-          : isFractured
-            ? { duration: 0.8, repeat: Infinity }
-            : isStressed
-              ? { duration: 1.5, repeat: Infinity }
-              : {}
-      }
+      animate={isRinged ? { scale: 1.1 } : { scale: 1 }}
+      transition={{ duration: 0.15, ease: "easeOut" }}
     >
       <Handle type="target" position={Position.Top} style={{ background: "transparent", border: "none", width: 0, height: 0 }} />
       <Handle type="source" position={Position.Bottom} style={{ background: "transparent", border: "none", width: 0, height: 0 }} />
       <Handle type="target" position={Position.Left} style={{ background: "transparent", border: "none", width: 0, height: 0 }} id="left-target" />
       <Handle type="source" position={Position.Right} style={{ background: "transparent", border: "none", width: 0, height: 0 }} id="right-source" />
 
-      <div className="font-[family-name:var(--font-michroma)] text-[10px]">
-        {label}
-      </div>
-      <div className="text-[8px] mt-0.5 opacity-50">
-        {domain}
-      </div>
-      {omegaComposite > 0 && (
-        <div className="text-[9px] mt-1 opacity-70">
-          {"\u03A9"} {omegaComposite.toFixed(1)}
+      <motion.div
+        className="rounded-full absolute inset-0"
+        style={{
+          backgroundColor: color,
+          border: isRestricted ? `1px solid #ff1744` : "none",
+          boxShadow,
+        }}
+        animate={
+          shockGlow > 0.3
+            ? { scale: [1, 1 + shockGlow * 0.18, 1] }
+            : isFractured
+              ? { scale: [1, 1.08, 1] }
+              : isStressed
+                ? { opacity: [1, 0.7, 1] }
+                : {}
+        }
+        transition={
+          shockGlow > 0.3
+            ? { duration: 0.6, repeat: Infinity, ease: "easeInOut" }
+            : isFractured
+              ? { duration: 0.8, repeat: Infinity }
+              : isStressed
+                ? { duration: 1.5, repeat: Infinity }
+                : {}
+        }
+      />
+
+      {/* \u03A9F + label below the circle. Absolute so the node bounding box stays
+          circle-sized and edges anchor at the circle's edges, not the label's. */}
+      <div
+        className="absolute left-1/2 -translate-x-1/2 flex flex-col items-center pointer-events-none"
+        style={{ top: diameter + 3 }}
+      >
+        {omegaComposite > 0 && (
+          <div
+            className="text-[8px] font-mono leading-tight"
+            style={{
+              color: `${color}cc`,
+              textShadow: "0 0 4px rgba(0,0,0,0.85)",
+            }}
+          >
+            {"\u03A9"} {omegaComposite.toFixed(1)}
+          </div>
+        )}
+        <div
+          className="text-[8px] font-mono leading-tight whitespace-nowrap"
+          style={{
+            color: isRinged ? "#00e5ff" : "rgba(220,220,230,0.75)",
+            textShadow: "0 0 4px rgba(0,0,0,0.85)",
+            maxWidth: 140,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            transition: "color 180ms ease-out",
+          }}
+        >
+          {label}
         </div>
-      )}
-      {isRestricted && (
-        <div className="text-[8px] mt-0.5 text-accent-red">RESTRICTED</div>
-      )}
+      </div>
     </motion.div>
   );
 }

--- a/src/lib/graph-layout-2d.ts
+++ b/src/lib/graph-layout-2d.ts
@@ -30,9 +30,11 @@ interface LayoutLink2D {
   weight: number;
 }
 
-// Matches CausalNode2D's rendered footprint (~120px wide × ~70px tall).
-// Collision radius needs to clear the diagonal so dense clusters don't overlap.
-const NODE_COLLISION_R = 78;
+// Tuned for CausalNode2D's circular footprint: ~14–34px diameter circles
+// plus an absolute-positioned label below. Collision is sized for the
+// circles with mild label overlap allowed — keeps the Obsidian-style
+// density without the circles themselves touching.
+const NODE_COLLISION_R = 48;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnySim = any;
@@ -70,14 +72,14 @@ function buildSim(
       "link",
       (forceLink as AnySim)(simLinks)
         .id((d: AnySim) => d.id)
-        // Strong correlation → shorter spring. Range tuned for ~120px nodes.
-        .distance((d: AnySim) => 110 + (1 - d.weight) * 140)
+        // Strong correlation → shorter spring. Range tuned for circle nodes.
+        .distance((d: AnySim) => 65 + (1 - d.weight) * 100)
         .strength((d: AnySim) => 0.45 + d.weight * 0.35),
     )
     .force(
       "charge",
       (forceManyBody as AnySim)().strength((d: AnySim) =>
-        connected.has(d.id) ? -900 : -250,
+        connected.has(d.id) ? -550 : -150,
       ),
     )
     .force("center", forceCenter(0, 0))


### PR DESCRIPTION
## Summary

Live-prod feedback after #159: layout was force-directed correctly, but the node visuals were still the rich rectangular info-cards from before. The user asked for the actual Obsidian "little circles in a network" aesthetic.

This swaps `CausalNode2D` itself:
- **Circle node** whose diameter scales with ΩF (`14 + clamp(omega, 0..10) * 2` px). Layered box-shadow: sharp 2px cyan ring on selection/focus + soft cyan halo, shock pulse halo, base ΩF glow.
- **Animations preserved**: fracture / stressed / shock now express as scale-pulse on the circle instead of border-color flash on a box.
- **`RESTRICTED`** becomes a 1px red circle border instead of inline text — color tells, not label noise.
- **ΩF + label** rendered as small text absolutely positioned below the circle so the React Flow node bounding box stays circle-sized — edges anchor at the circle's edges, not at the label's. Label flips cyan on focus/selection, gray otherwise; opacity fades with the rest of the node when out of emphasis scope.

Layout retuned for the smaller footprint:
- `NODE_COLLISION_R` 78 → 48 (mild label overlap allowed; circles themselves don't touch)
- Link distance range 110-250 → 65-165
- Charge: connected `-900` → `-550`, isolated `-250` → `-150`

All hover / focus / drag / marquee / refit / isolation behavior from #159 preserved unchanged.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [x] `vitest` 522/522 pass
- [ ] Vercel preview: nodes are colored circles, label sits below, edges anchor at circle edges (not at label area), focus draws a sharp cyan ring, hover dim/highlight still works, drag still perturbs the cluster.

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_