### PR TITLE
fix(map): orbs anchored to edge lines, constant speed across edges

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -98,9 +98,24 @@ This is the running log for the Rendering & Perf session. Every change pushed fr
 
 **Lesson.** Sugiyama gives a clean causal-flow read but loses the organic/spatial feel of force-directed. If we revisit 3D layout later, the right approach is probably force-directed seeding + a light rank-influence pass (use rank as a soft y-bias on top of free force layout), not a strict rank assignment.
 
+### 2026-05-02 — Map view orb fixes (orbs on lines, constant speed)
+
+**Two bugs in `CausalDAGMap.tsx`** from prod feedback:
+
+1. **Orbs floating off the lines.** Edge lines were stored as `[source, controlPoint, target]` — three points which MapLibre renders as a kinked 2-segment polyline through the control point. Particles, however, used those same 3 points as a quadratic **bezier** where the control point is *off* the curve. The bezier path bulged away from the kinked line, so orbs visually floated above the edges they were supposed to trace.
+2. **Speed varied with edge length.** `phase += 0.003` per frame for every edge regardless of length, so all particles completed traversal in the same number of frames. Long edges felt fast, short edges felt sluggish.
+
+**Fixes** (single file: `src/components/CausalDAGMap.tsx`):
+- **Sample the bezier into 25 polyline points** when building each edge's `LineString`. MapLibre now renders a near-smooth curve, and the line geometry IS the particle path — they can't drift apart.
+- **Cumulative arc length** per polyline so the particle can interpolate by distance (not by raw vertex index, which would skew through curvature).
+- **Constant degrees-per-frame** velocity (`SPEED_DEG_PER_FRAME = 0.05` ≈ 36 px/s at zoom 2). Per-edge `dPhase = SPEED / totalLen` keeps the phase fraction in `[0, 1]` while absolute speed is constant.
+- While in the file, fixed a pre-existing `set-state-in-effect` lint violation by moving the empty-features clear into the rAF callback (instead of the effect body) and stopping the rAF loop when there are no temporal edges.
+
+**Verification.** `tsc --noEmit` clean; lint clean on changed file; vitest 522/522 pass.
+
 ### 2026-05-02 — Next up
 
-- **Map view (`CausalDAGMap.tsx`) orb fixes.** Two issues from prod feedback: (1) animated orbs float independently of the edge lines they should be tracing, and (2) all orbs reach point B in the same time regardless of edge length, so short edges have slow orbs and long edges have fast ones — should be constant px/s instead.
+- TBD — open for direction.
 
 ---
 

--- a/src/components/CausalDAGMap.tsx
+++ b/src/components/CausalDAGMap.tsx
@@ -227,7 +227,9 @@ function CausalDAGMapInner() {
         !(selectedSet.has(edge.source) && selectedSet.has(edge.target))
       ) return;
 
-      // Curved line via midpoint offset
+      // Curved line via midpoint offset (MapLibre renders LineStrings as
+      // straight segments between vertices, so we sample the quadratic
+      // bezier into BEZIER_SAMPLES+1 points to approximate a smooth curve).
       const midLng = (source[0] + target[0]) / 2;
       const midLat = (source[1] + target[1]) / 2;
       const dx = target[0] - source[0];
@@ -241,6 +243,23 @@ function CausalDAGMapInner() {
         const curveAmount = Math.min(dist * 0.15, 3);
         perpLng = midLng + (-dy / dist) * curveAmount;
         perpLat = midLat + (dx / dist) * curveAmount;
+      }
+
+      // Sample the quadratic bezier (source, control, target) into a
+      // dense polyline so the rendered line and the particle path
+      // (which lerps along this same array) are visually identical.
+      const BEZIER_SAMPLES = 24;
+      const coordinates: [number, number][] = [];
+      if (dist <= 0.0001) {
+        coordinates.push(source, target);
+      } else {
+        for (let i = 0; i <= BEZIER_SAMPLES; i++) {
+          const t = i / BEZIER_SAMPLES;
+          const u = 1 - t;
+          const lng = u * u * source[0] + 2 * u * t * perpLng + t * t * target[0];
+          const lat = u * u * source[1] + 2 * u * t * perpLat + t * t * target[1];
+          coordinates.push([lng, lat]);
+        }
       }
 
       // Edge color — matches 3D exactly. Severed gets a distinct slate color
@@ -265,7 +284,7 @@ function CausalDAGMapInner() {
         type: "Feature",
         geometry: {
           type: "LineString",
-          coordinates: [source, [perpLng, perpLat], target],
+          coordinates,
         },
         properties: {
           id: edge.id,
@@ -291,14 +310,29 @@ function CausalDAGMapInner() {
   }, [activeGraph.nodes, activeGraph.edges, selectedNodes, isolateSelection]);
 
   // Extract temporal edge paths directly from the solid edge GeoJSON features
-  // so particles follow the exact same curves as the rendered lines
+  // so particles follow the exact same sampled bezier polyline as the
+  // rendered line. Pre-compute cumulative arc length per vertex so we can
+  // lerp by distance (not by raw vertex index, which would skew speed
+  // through curvature) and so per-frame advance can be a constant in
+  // degrees rather than a fixed phase fraction.
   const temporalEdgePaths = useMemo(() => {
     return solidEdgeGeoJSON.features
       .filter((f) => f.properties?.type === "temporal" && (f.properties?.opacity ?? 1) > 0.1)
-      .map((f) => ({
-        id: f.properties!.id as string,
-        points: f.geometry.coordinates as [number, number][],
-      }));
+      .map((f) => {
+        const points = f.geometry.coordinates as [number, number][];
+        const cumDist: number[] = [0];
+        for (let i = 1; i < points.length; i++) {
+          const dx = points[i][0] - points[i - 1][0];
+          const dy = points[i][1] - points[i - 1][1];
+          cumDist.push(cumDist[i - 1] + Math.sqrt(dx * dx + dy * dy));
+        }
+        return {
+          id: f.properties!.id as string,
+          points,
+          cumDist,
+          totalLen: cumDist[cumDist.length - 1] ?? 0,
+        };
+      });
   }, [solidEdgeGeoJSON]);
 
   // Animated particle GeoJSON — updated every frame via requestAnimationFrame
@@ -309,40 +343,59 @@ function CausalDAGMapInner() {
   const particlePhases = useRef<Map<string, number>>(new Map());
 
   useEffect(() => {
-    if (temporalEdgePaths.length === 0) {
-      setParticleGeoJSON({ type: "FeatureCollection", features: [] });
-      return;
-    }
-
-    // Initialize random phases
+    // Initialize random phases for any new edges
     temporalEdgePaths.forEach(({ id }) => {
       if (!particlePhases.current.has(id)) {
         particlePhases.current.set(id, Math.random());
       }
     });
 
-    let animFrameId: number;
+    // Constant geographic-degrees-per-frame so every orb moves at the same
+    // visual speed across the map regardless of edge length. At zoom ~2,
+    // 1° ≈ 12 px, so this is roughly 36 px/s at 60 fps.
+    const SPEED_DEG_PER_FRAME = 0.05;
+
+    let animFrameId: number | null = null;
     const animate = () => {
+      // No temporal edges → emit one empty frame and stop the loop until
+      // the next dependency change. Avoids a 60fps idle loop and keeps
+      // setState inside the rAF callback (out of the effect body).
+      if (temporalEdgePaths.length === 0) {
+        setParticleGeoJSON({ type: "FeatureCollection", features: [] });
+        animFrameId = null;
+        return;
+      }
+
       const features: Feature<Point>[] = [];
 
       for (const edge of temporalEdgePaths) {
         let phase = particlePhases.current.get(edge.id) ?? 0;
-        phase = (phase + 0.003) % 1;
+        // Per-edge dPhase is normalized so the absolute degrees-per-frame
+        // stays constant; long edges advance their phase fraction more
+        // slowly, short edges more quickly — net result: same px/s.
+        const dPhase = edge.totalLen > 0 ? SPEED_DEG_PER_FRAME / edge.totalLen : 0;
+        phase = (phase + dPhase) % 1;
         particlePhases.current.set(edge.id, phase);
 
-        // 2 particles per edge, staggered
+        // 2 particles per edge, staggered by half the edge length.
         for (let p = 0; p < 2; p++) {
           const t = (phase + p * 0.5) % 1;
-          const oneMinusT = 1 - t;
-          // Quadratic bezier in geographic coordinates
-          const lng =
-            oneMinusT * oneMinusT * edge.points[0][0] +
-            2 * oneMinusT * t * edge.points[1][0] +
-            t * t * edge.points[2][0];
-          const lat =
-            oneMinusT * oneMinusT * edge.points[0][1] +
-            2 * oneMinusT * t * edge.points[1][1] +
-            t * t * edge.points[2][1];
+          const targetDist = t * edge.totalLen;
+          // Find the polyline segment containing targetDist. Linear scan
+          // is fine for ~25 segments; binary search is overkill here.
+          let i = 0;
+          while (
+            i < edge.cumDist.length - 2 &&
+            edge.cumDist[i + 1] < targetDist
+          ) {
+            i++;
+          }
+          const segLen = edge.cumDist[i + 1] - edge.cumDist[i];
+          const localT = segLen > 0 ? (targetDist - edge.cumDist[i]) / segLen : 0;
+          const a = edge.points[i];
+          const b = edge.points[i + 1];
+          const lng = a[0] + (b[0] - a[0]) * localT;
+          const lat = a[1] + (b[1] - a[1]) * localT;
 
           features.push({
             type: "Feature",
@@ -357,7 +410,9 @@ function CausalDAGMapInner() {
     };
 
     animFrameId = requestAnimationFrame(animate);
-    return () => cancelAnimationFrame(animFrameId);
+    return () => {
+      if (animFrameId !== null) cancelAnimationFrame(animFrameId);
+    };
   }, [temporalEdgePaths]);
 
   // Click handler — handles both node and edge clicks


### PR DESCRIPTION
## Summary

Two bugs in the map view from prod feedback:

1. **Orbs floating off the lines.** Edge lines were stored as `[source, controlPoint, target]` — three points which MapLibre renders as a kinked 2-segment polyline through the control point. The particle code, however, used those same 3 points as a quadratic **bezier** where the control point is *off* the curve. The bezier path bulged away from the kinked line, so orbs visually floated above the edges they were supposed to trace.

2. **Speed varied with edge length.** `phase += 0.003` per frame for every edge regardless of length, so all particles completed traversal in the same number of frames. Long edges felt fast, short edges felt sluggish.

## Fixes (one file: `src/components/CausalDAGMap.tsx`)

- **Sample the bezier into 25 polyline points** when building each edge's `LineString`. MapLibre now renders a near-smooth curve, and the line geometry IS the particle path — they can't drift apart by construction.
- **Cumulative arc length** per polyline so the particle interpolates by distance (not raw vertex index, which would skew through curvature).
- **Constant degrees-per-frame velocity** (`SPEED_DEG_PER_FRAME = 0.05` ≈ 36 px/s at zoom 2). Per-edge `dPhase = SPEED / totalLen` keeps the phase fraction in `[0, 1]` while absolute speed is constant across all edges.
- While in the file, moved the empty-features clear into the rAF callback (instead of the effect body) so the `react-hooks/set-state-in-effect` rule is honored. Also stops the rAF loop when there are no temporal edges (no more 60fps idle loop).

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed file (was 1 pre-existing error before this PR)
- [x] `vitest` 522/522 pass
- [ ] Vercel preview: zoom into a temporal edge — orbs trace exactly along the rendered curve; orb speed is uniform whether the edge is short (intra-region) or long (cross-continent).

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_