### PR TITLE
ci: add PR build gate to catch production-only failures

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -1,0 +1,67 @@
+# ─── PR validation ─────────────────────────────────────────────────────
+#
+# Runs on every PR (and main pushes) — same checks Vercel runs at deploy
+# time, plus the test suite. Goal: catch production-only build failures
+# at PR review time, not after merge.
+#
+# Concretely guards against the failure mode that caused the 9-hour
+# outage on 2026-04-30: a code change that compiled fine locally and
+# passed `vitest run` but broke `next build` in Vercel's Node-only
+# environment (in that case, `node:`-prefixed imports interacting with
+# vitest's default `happy-dom` environment).
+#
+# Concurrency: cancels stale runs when a PR is force-pushed.
+
+name: PR validate
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: pr-validate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: test · build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test
+        run: npm test
+
+      # ─── The gate that would have caught PR #137's first nine attempts.
+      # Runs the same `next build` Vercel runs in production. Any failure
+      # here means the PR cannot deploy, full stop.
+      #
+      # NOTE: lint is intentionally NOT gated here. main currently has
+      # ~36 pre-existing lint errors; gating on lint would block every
+      # PR for unrelated reasons. The job is scoped to the failure mode
+      # the 9-hour outage taught us about: code that compiles locally
+      # but breaks `next build` in Vercel's Node-only environment.
+      - name: Build (production)
+        run: npm run build
+        env:
+          # Build needs envs that are read at module load time. Use harmless
+          # placeholders so the build can complete; runtime values come from
+          # Vercel.
+          NEXT_PUBLIC_SUPABASE_URL: "https://placeholder.supabase.co"
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: "placeholder-anon-key"
+          SUPABASE_SERVICE_ROLE_KEY: "placeholder-service-role-key"
+          GITHUB_WEBHOOK_SECRET: "placeholder-webhook-secret"


### PR DESCRIPTION
## Summary

Adds a PR validation workflow that runs `npm test` + `npm run build` on every PR and on main pushes, with the same env shape Vercel uses at deploy time. Insurance against the failure mode that caused the 9-hour outage on 2026-04-30.

## Why

PR #137 took 4 commits to land because the failing build only manifested in Vercel's Node-only environment — `vitest run` passed locally, `next build` did not. The fix landed, but nothing today prevents a similar PR from merging into main and breaking production again.

This gate runs the production build at PR review time. Any failure here means the PR cannot deploy.

## Scope decisions

- **Lint deliberately not gated.** Main has ~36 pre-existing lint errors; gating lint blocks every PR for unrelated reasons. Scope kept tight on the failure mode the outage taught us about.
- **Build env vars** — placeholder Supabase/webhook values are fine because they're only read at build module-load time. Runtime values come from Vercel's secret store and are not affected.
- **Concurrency** — cancel-in-progress on the PR ref so force-push doesn't waste CI minutes.

## Test plan

- [x] `npm test` passes locally — 522 / 522
- [x] `npm run build` passes locally with the placeholder env vars declared in the workflow
- [ ] Workflow itself runs green on this PR — verify after push
- [ ] Smoke test once merged — open a throwaway branch with a deliberate Node-only break and confirm the gate goes red

🤖 Generated with [Claude Code](https://claude.com/claude-code)
