### PR TITLE
feat: capability badges (LIVE / LIVE-SYNTHETIC / PORTING / AWAITING-DATA / PHASE-2)

### DIFF
--- a/src/components/CapabilityBadge.tsx
+++ b/src/components/CapabilityBadge.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import {
+  CAPABILITY_META,
+  tailwindClassesForTone,
+  type Capability,
+} from "@/lib/capability";
+
+// ─── CapabilityBadge ─────────────────────────────────────────────────
+//
+// Small reusable badge that surfaces the truth-state of any capability
+// in the platform. Matches the existing brand: monospace, small caps,
+// rounded border, tone-coloured. Hover reveals the description.
+//
+// Used by:
+//   - DiscoveryRunsPanel (per algorithm tab)
+//   - TissueCohortView (top of view, indicating "live-synthetic")
+//   - SystemCopilot intro (overall platform status)
+//   - Anywhere a capability label adds clarity.
+
+export interface CapabilityBadgeProps {
+  capability: Capability;
+  /** Optional override label if the canonical label doesn't fit context. */
+  labelOverride?: string;
+  /** Optional className passthrough. */
+  className?: string;
+}
+
+export default function CapabilityBadge({
+  capability,
+  labelOverride,
+  className = "",
+}: CapabilityBadgeProps) {
+  const meta = CAPABILITY_META[capability];
+  const tw = tailwindClassesForTone(meta.tone);
+  return (
+    <span
+      title={meta.description}
+      className={
+        `inline-flex items-center gap-1 px-1.5 py-0.5 rounded border ${tw.border} ${tw.bg} ${tw.text} ` +
+        `text-[7px] font-[family-name:var(--font-michroma)] tracking-wider whitespace-nowrap ${className}`
+      }
+    >
+      <span aria-hidden className="opacity-70">●</span>
+      {labelOverride ?? meta.label}
+    </span>
+  );
+}

--- a/src/components/DiscoveryRunsPanel.tsx
+++ b/src/components/DiscoveryRunsPanel.tsx
@@ -2,6 +2,19 @@
 
 import { useEffect, useMemo, useState } from "react";
 import type { DiscoveryRun } from "@/lib/discovery";
+import type { Capability } from "@/lib/capability";
+import CapabilityBadge from "./CapabilityBadge";
+
+// Per-algorithm capability tag. The discovery algorithms are all
+// running on the public D1NAMO cohort today; calibration is also live.
+// When they switch to real partner-cohort data, these stay "live"; the
+// distinction would be encoded as `live-synthetic` on the cohort, not
+// the algorithm.
+const CAPABILITY_BY_ALGORITHM: Record<string, Capability> = {
+  "lag-correlation": "live",
+  "pcmci-linear": "live",
+  "bocpd-hypo-calibration": "live",
+};
 
 // ─── DiscoveryRunsPanel ──────────────────────────────────────────────
 //
@@ -132,9 +145,16 @@ function RunTile({ run }: { run: DiscoveryRun }) {
     <div className="space-y-2 border border-[#40c4ff]/30 rounded bg-[#40c4ff]/5 p-3">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <span className="text-[9px] font-[family-name:var(--font-michroma)] tracking-wider text-[#40c4ff]">
-          {isCalibration ? "CALIBRATION RUN" : "DISCOVERY RUN"}
-        </span>
+        <div className="flex items-center gap-2">
+          <span className="text-[9px] font-[family-name:var(--font-michroma)] tracking-wider text-[#40c4ff]">
+            {isCalibration ? "CALIBRATION RUN" : "DISCOVERY RUN"}
+          </span>
+          {CAPABILITY_BY_ALGORITHM[run.algorithm.id] && (
+            <CapabilityBadge
+              capability={CAPABILITY_BY_ALGORITHM[run.algorithm.id]}
+            />
+          )}
+        </div>
         <span
           className={`text-[7px] font-mono ${
             run.status === "succeeded"

--- a/src/components/scientist/TissueCohortView.tsx
+++ b/src/components/scientist/TissueCohortView.tsx
@@ -9,6 +9,7 @@ import {
   type NpodStratum,
 } from "@/lib/discovery/fixtures/npod-synthetic-cohort";
 import type { Cohort, Subject } from "@/lib/discovery/cohort-types";
+import CapabilityBadge from "../CapabilityBadge";
 
 // ─── TissueCohortView ────────────────────────────────────────────────
 //
@@ -181,9 +182,12 @@ export default function TissueCohortView() {
 
       {/* Header */}
       <div className="flex items-center justify-between">
-        <span className="text-[9px] font-[family-name:var(--font-michroma)] tracking-wider text-foreground">
-          TISSUE COHORT — DISEASE-STAGE STRATA
-        </span>
+        <div className="flex items-center gap-2">
+          <span className="text-[9px] font-[family-name:var(--font-michroma)] tracking-wider text-foreground">
+            TISSUE COHORT — DISEASE-STAGE STRATA
+          </span>
+          <CapabilityBadge capability="live-synthetic" />
+        </div>
         <button
           type="button"
           onClick={() => setShowFormulas((v) => !v)}

--- a/src/lib/__tests__/capability.test.ts
+++ b/src/lib/__tests__/capability.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import {
+  CAPABILITY_META,
+  tailwindClassesForTone,
+  type Capability,
+} from "../capability";
+
+describe("capability metadata", () => {
+  const all: Capability[] = [
+    "live",
+    "live-synthetic",
+    "porting",
+    "awaiting-data",
+    "phase-2",
+  ];
+
+  it("every capability has meta with non-empty label and description", () => {
+    for (const c of all) {
+      const m = CAPABILITY_META[c];
+      expect(m).toBeDefined();
+      expect(m.label.length).toBeGreaterThan(0);
+      expect(m.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("every capability tone resolves to a non-empty class set", () => {
+    for (const c of all) {
+      const cls = tailwindClassesForTone(CAPABILITY_META[c].tone);
+      expect(cls.border.length).toBeGreaterThan(0);
+      expect(cls.bg.length).toBeGreaterThan(0);
+      expect(cls.text.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("descriptions are honest — they mention the limitation, not just the feature", () => {
+    // Quick guard against drift toward marketing copy. Each description
+    // should reference what is or isn't real.
+    expect(CAPABILITY_META.live.description.toLowerCase()).toMatch(
+      /production|verified|tests/,
+    );
+    expect(CAPABILITY_META["live-synthetic"].description.toLowerCase()).toMatch(
+      /synthetic|illustrative/,
+    );
+    expect(CAPABILITY_META.porting.description.toLowerCase()).toMatch(
+      /python|deferred|research/,
+    );
+    expect(CAPABILITY_META["awaiting-data"].description.toLowerCase()).toMatch(
+      /data|wired/,
+    );
+    expect(CAPABILITY_META["phase-2"].description.toLowerCase()).toMatch(
+      /roadmap|partnership/,
+    );
+  });
+
+  it("tailwindClassesForTone tolerates the muted fallback", () => {
+    const cls = tailwindClassesForTone("muted");
+    expect(cls.border.length).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/capability.ts
+++ b/src/lib/capability.ts
@@ -1,0 +1,112 @@
+// ─── Platform-wide Capability Tag ─────────────────────────────────────
+//
+// Generalises the existing `EstimatorAvailability` pattern from
+// `criticality-registry.ts` into a tag that can be applied to anything
+// the user sees in the platform: estimators, discovery algorithms,
+// ingesters, cohorts, UI sections.
+//
+// Why this matters:
+//   - The seven institutional outreach proposals (Joslin, nPOD, etc.)
+//     reference capabilities that are at different readiness levels.
+//     "Production-ready" overclaims; "coming soon" is empty.
+//     Capability tags surface the truth on every relevant surface so a
+//     PI viewing the platform sees what's real vs scaffolded.
+//   - The `EstimatorAvailability` shape was per-estimator. This is
+//     platform-wide and additive.
+
+export type Capability =
+  /** TS implementation runs, real data flows, in production. */
+  | "live"
+  /** TS implementation runs, but on illustrative / synthetic data
+   *  pending real-cohort access (DUA / DAC / contract). */
+  | "live-synthetic"
+  /** Python reference is canonical; TS port deferred (typically because
+   *  a linalg dep is needed). Functional via research/ scripts. */
+  | "porting"
+  /** TS-ready but the input data source isn't wired yet (e.g. BOCPD
+   *  on a real T1D longitudinal series before partnership data lands). */
+  | "awaiting-data"
+  /** Roadmap. Only built once a partnership / paying customer asks. */
+  | "phase-2";
+
+export interface CapabilityMeta {
+  label: string;
+  /** One-line explanation, surfaced as a tooltip / hover. */
+  description: string;
+  /** Tailwind colour-token suffix used by the badge component. */
+  tone: "green" | "amber" | "yellow" | "cyan" | "muted";
+}
+
+export const CAPABILITY_META: Record<Capability, CapabilityMeta> = {
+  live: {
+    label: "LIVE",
+    description:
+      "Implementation runs in production with real data flowing. Verified via tests and end-to-end runs.",
+    tone: "green",
+  },
+  "live-synthetic": {
+    label: "LIVE · SYNTHETIC",
+    description:
+      "Implementation runs in production, but on illustrative / synthetic data pending real-cohort access (DAC / DUA). Schema-identical to what the real ingester will produce.",
+    tone: "amber",
+  },
+  porting: {
+    label: "PORTING",
+    description:
+      "Python reference is canonical and validated; TS port is deferred behind a linalg dependency. Available today via research/ scripts; the platform UI will pick it up automatically when the port lands.",
+    tone: "yellow",
+  },
+  "awaiting-data": {
+    label: "AWAITING DATA",
+    description:
+      "TS implementation is ready but the data source it consumes isn't wired yet. Activates the moment a partnership-data ingester delivers the input series.",
+    tone: "yellow",
+  },
+  "phase-2": {
+    label: "PHASE 2",
+    description:
+      "Roadmap. Built only once a partnership engagement scopes it in. Listed for transparency about platform direction.",
+    tone: "cyan",
+  },
+};
+
+/** Tone → Tailwind colour pair (border + bg + text). */
+export function tailwindClassesForTone(tone: CapabilityMeta["tone"]): {
+  border: string;
+  bg: string;
+  text: string;
+} {
+  switch (tone) {
+    case "green":
+      return {
+        border: "border-accent-green/40",
+        bg: "bg-accent-green/10",
+        text: "text-accent-green",
+      };
+    case "amber":
+      return {
+        border: "border-accent-amber/40",
+        bg: "bg-accent-amber/10",
+        text: "text-accent-amber",
+      };
+    case "yellow":
+      return {
+        border: "border-yellow-500/40",
+        bg: "bg-yellow-500/10",
+        text: "text-yellow-400",
+      };
+    case "cyan":
+      return {
+        border: "border-accent-cyan/40",
+        bg: "bg-accent-cyan/10",
+        text: "text-accent-cyan",
+      };
+    case "muted":
+    default:
+      return {
+        border: "border-border",
+        bg: "bg-surface-elevated",
+        text: "text-text-muted",
+      };
+  }
+}


### PR DESCRIPTION
## Summary

Generalises the per-estimator `EstimatorAvailability` pattern from `criticality-registry.ts` into a platform-wide capability tag. Surfaces on every relevant surface so a viewer sees what's real vs scaffolded at-a-glance, not buried in caveat prose.

## Why now

The seven institutional outreach proposals reference capabilities at different readiness levels. "Production-ready" overclaims; "coming soon" is empty. The badge surfaces the truth.

## Capability vocabulary

| Tag | Meaning |
|---|---|
| LIVE | TS implementation, real data flowing, production. |
| LIVE · SYNTHETIC | TS implementation, illustrative data pending DAC/DUA. Schema-identical to real ingester output. |
| PORTING | Python canonical, TS port deferred. Functional via research/ scripts. |
| AWAITING DATA | TS-ready but data source not yet wired. |
| PHASE 2 | Roadmap, post-partnership only. |

## Where it shows up

- **DiscoveryRunsPanel** — each algorithm tab (lag-correlation, pcmci-linear, bocpd-hypo-calibration) now badged `LIVE` next to its run-record header.
- **TissueCohortView** — header badge `LIVE · SYNTHETIC` complementing the existing amber synthetic-banner. Badge is the at-a-glance; banner is the full disclosure.
- New surfaces register a capability id in their wiring map; auto-renders.

## Honesty guard

The test suite has a description-honesty guard that string-matches the limitation language in each description ("synthetic", "deferred", "data not wired", "roadmap", etc.). Catches accidental drift toward marketing copy on PR review.

## Test plan

- [x] 538 vitest tests pass (4 new in capability)
- [x] `tsc --noEmit` clean
- [ ] Vercel preview: SPIRTES module → algorithm tabs each show LIVE badge with hover description
- [ ] Vercel preview: Tissue Cohort view → LIVE · SYNTHETIC badge in header

🤖 Generated with [Claude Code](https://claude.com/claude-code)