### PR TITLE
feat(onboarding-tour): two-phase, two-track, interactive restructure

### DIFF
--- a/docs/sessions/ux-onboarding.md
+++ b/docs/sessions/ux-onboarding.md
@@ -12,10 +12,14 @@ This session does **not** care about graph data, engines, canvas rendering, or p
 
 ### First-visit flow
 - Welcome modal + Domain Workspace + auto-launching SpotlightTour
-- Component: `src/components/SpotlightTour.tsx`
+- Component: `src/components/SpotlightTour.tsx` (rendering shell). Step data lives in `src/lib/tour-steps.ts`.
 - Storage flag: `localStorage["manifold:tour-seen"]`
 - Uses `data-tour="..."` anchors throughout the app to attach steps to UI elements
-- Tour currently has 22+ steps covering persona-based domain selector, 3D/2D/MAP views, text-size toggle, PEARL manual vs CASCADE DEFENSE auto-interdiction, feedback widget, etc.
+- **Two-phase structure**:
+  - **First run** (~9 steps): auto-launches on first visit. Tight, hands-on — three steps gate on user interaction (`awaitInteraction`) before advancing: click any node, switch to TARSKI, drag the time dial. Last step opens an opt-in deep-dive menu.
+  - **Deep dive** (opt-in, accessed from finish-step menu or via `?` button): three tracks the user picks from — `engines` (SPIRTES / TARSKI / PEARL / PARETO), `loop` (shocks · Cascade Defense · Compute), `customization` (views · text size · import · feedback).
+- **Track-aware copy**: each step's `copy` field can be `StepCopy` (shared) or `Record<TourTrack, StepCopy>` (per-track). The two tracks are `analyst` (used for `financial | macro | geopolitical | cross | analyst`) and `scientist`. `trackForPersona()` does the mapping. Five personas collapse to two tracks because financial/macro/geopolitical/cross share enough vocab to take the same tour with shared copy; scientist is a distinct domain that deserves its own framing.
+- **Escalating-hint stall recovery**: when a step has `awaitInteraction` and the user idles, after 8s the highlight starts a soft pulse (`tour-pulse-soft`); after 15s it pulses harder (`tour-pulse-strong`) and the in-tooltip hint goes bold. There is no "skip step" button — users can still bail from the whole tour via SKIP TOUR / Esc.
 
 ### Persona gating
 - `activePersona: "scientist" | "financial" | "macro" | "geopolitical" | "cross" | "analyst"` in `useApexStore`, default `"financial"`. (`"analyst"` is retained only to tolerate legacy persisted values from before the persona refactor — no UI surfaces it.)

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -285,3 +285,57 @@ body.ablation-cursor canvas {
 .maplibregl-popup-close-button {
   display: none !important;
 }
+
+/* Tour escalating-hint pulse — applied to a rect overlay on the highlighted
+   element when the user has stalled on an interactive step. Two intensities
+   plus a brief success state on satisfaction. The keyframes drive both the
+   stroke alpha and a drop-shadow glow so the pulse reads at small cutout
+   sizes (e.g. a single tab) and large ones (e.g. the whole canvas). */
+@keyframes tour-pulse-soft-frames {
+  0%, 100% {
+    stroke-opacity: 0.55;
+    filter: drop-shadow(0 0 4px rgba(0, 229, 255, 0.35));
+  }
+  50% {
+    stroke-opacity: 1;
+    filter: drop-shadow(0 0 10px rgba(0, 229, 255, 0.65));
+  }
+}
+@keyframes tour-pulse-strong-frames {
+  0%, 100% {
+    stroke-opacity: 0.7;
+    filter: drop-shadow(0 0 6px rgba(0, 229, 255, 0.55));
+    transform: scale(1);
+  }
+  50% {
+    stroke-opacity: 1;
+    filter: drop-shadow(0 0 16px rgba(0, 229, 255, 0.95));
+    transform: scale(1.012);
+  }
+}
+@keyframes tour-pulse-success-frames {
+  0% {
+    stroke: var(--accent-cyan);
+    stroke-opacity: 1;
+  }
+  100% {
+    stroke: var(--accent-green);
+    stroke-opacity: 1;
+    filter: drop-shadow(0 0 14px rgba(0, 230, 118, 0.85));
+  }
+}
+.tour-pulse-soft {
+  animation: tour-pulse-soft-frames 1.6s ease-in-out infinite;
+  transform-box: fill-box;
+  transform-origin: center;
+}
+.tour-pulse-strong {
+  animation: tour-pulse-strong-frames 0.9s ease-in-out infinite;
+  transform-box: fill-box;
+  transform-origin: center;
+}
+.tour-pulse-success {
+  animation: tour-pulse-success-frames 0.4s ease-out forwards;
+  transform-box: fill-box;
+  transform-origin: center;
+}

--- a/src/components/SpotlightTour.tsx
+++ b/src/components/SpotlightTour.tsx
@@ -1,224 +1,39 @@
 "use client";
 
-import { useEffect, useState, useCallback, useRef, useLayoutEffect } from "react";
+import { useEffect, useState, useCallback, useRef, useLayoutEffect, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useApexStore } from "@/stores/useApexStore";
+import {
+  TOUR_STEPS,
+  FIRST_RUN_IDS,
+  DEEP_DIVE_TRACKS,
+  STEP_PADDING,
+  DEFAULT_PADDING,
+  resolveCopy,
+  trackForPersona,
+  type TourStep,
+  type DeepDiveTrack,
+} from "@/lib/tour-steps";
 
-interface TourStep {
-  id: string;
-  targetSelector: string | null;
-  /** Optional extra element to highlight + arrow to, for steps where two
-   *  parts of the UI are being described at once (e.g. tabs + panel). */
-  secondaryTargetSelector?: string;
-  title: string;
-  description: string;
-  tooltipPosition: "top" | "bottom" | "left" | "right" | "center";
-  onEnter?: () => void;
-}
+// ─── Constants ──────────────────────────────────────────────────────────
 
-const TOUR_STEPS: TourStep[] = [
-  {
-    id: "welcome-and-domain",
-    targetSelector: '[data-tour="domain-selector-modal"]',
-    title: "WELCOME \u2014 PICK A DOMAIN",
-    description:
-      "Welcome to APEX Analytica MANIFOLD \u2014 a causal-inference platform for discovering, verifying, and stress-testing networks across sectors. Everything starts with a persona. Pick one of the five pills at the top of this modal: FINANCIAL (markets, credit, sovereign), MACRO (growth, inflation, policy), GEOPOLITICAL (energy, infrastructure, defense), SCIENTIST (life sciences, including Type-1 Diabetes \u03B2-cell dynamics), or CROSS-DOMAIN. Each persona narrows the visible domain cards; pick a card, confirm, and the tour continues on the platform. CROSS-DOMAIN is the only persona that lets you multi-select across dataset families. You can relaunch this tour anytime from the \u201C?\u201D in the top-right.",
-    tooltipPosition: "right",
-  },
-  {
-    id: "module-tabs",
-    targetSelector: '[data-tour="module-tabs"]',
-    secondaryTargetSelector: '[data-tour="module-panel"]',
-    title: "FOUR ANALYSIS ENGINES",
-    description:
-      "The four engine tabs drive the right-hand panel. SPIRTES discovers causal structure from data. TARSKI verifies edges against physical, regulatory, and heuristic constraints. PEARL runs do-calculus interventions and network interdiction. PARETO monitors tail risk and criticality horizons. Switching tabs updates the right panel \u2014 the graph stays put.",
-    tooltipPosition: "bottom",
-  },
-  {
-    id: "dag-canvas",
-    targetSelector: '[data-tour="dag-canvas"]',
-    title: "CAUSAL NETWORK CANVAS",
-    description:
-      "The center canvas renders your causal DAG. Node size and color intensity encode \u03A9-Fragility \u2014 hotter means more systemic risk. Solid arrows are directed causal edges; dashed lines are confounded or latent relationships. In 3D: drag to orbit, scroll to zoom. Click any node to open the inspector on the right. Shift+drag for box-select when you need a subgraph.",
-    tooltipPosition: "top",
-  },
-  {
-    id: "view-modes",
-    targetSelector: '[data-tour="dag-canvas"]',
-    title: "3D / 2D / MAP VIEWS",
-    description:
-      "Top-right of the canvas: three view-mode buttons. 3D (WebGL force-directed, the default), 2D (flat React Flow layout with animated causal flow), and MAP (geographic projection on MapLibre for domains with real-world coordinates, e.g. energy infrastructure). All three stay mounted to preserve WebGL context; you can flip between them without losing state.",
-    tooltipPosition: "top",
-  },
-  {
-    id: "node-inspection",
-    targetSelector: '[data-tour="module-panel"]',
-    title: "NODE INSPECTOR & \u03A9 PILLARS",
-    description:
-      "Click any node to open the Node Inspector in the right panel. The centerpiece is a \u03A9-Fragility radar pentagon \u2014 composite score (0\u201310) at the center, with each vertex labeled by pillar letter (I/R/J/C/T) and value: Irreplaceability, Restoration Latency, Jurisdictional Hazard, Cascade Load, Tail Depth. Click any vertex letter to drop in that pillar\u2019s explanation, detail, and formula inline; click again or hit \u00D7 to dismiss. The methodology toggle below explains how the composite is computed. Connected edges are listed further down with causal mechanisms.",
-    tooltipPosition: "left",
-  },
-  {
-    id: "spirtes-deep",
-    targetSelector: '[data-tour="module-panel"]',
-    title: "SPIRTES \u2014 STRUCTURE DISCOVERY",
-    description:
-      "SPIRTES runs three causal-discovery algorithms in parallel. DCD/NOTEARS for nonlinear structure, PCMCI+ for time-lagged effects across T-2/T-1/T-0 columns, and FCI for hidden-confounder detection (dashed edges with \u2018?\u2019 markers mean a latent common cause). The cascade header shows spectral radius \u03BBmax \u2014 below 1.0 the network is contractive and stable.",
-    tooltipPosition: "left",
-    onEnter: () => useApexStore.getState().setActiveModule("spirtes"),
-  },
-  {
-    id: "tarski-deep",
-    targetSelector: '[data-tour="module-panel"]',
-    title: "TARSKI \u2014 CONSTRAINT VERIFICATION",
-    description:
-      "TARSKI audits every edge against domain-aware axioms in three tiers: PHYSICAL (immutable laws), REGULATORY (sanctions, export controls, treaties), and HEURISTIC (anomaly flags). Constraints are auto-ranked by relevance to your active domains. Toggle any axiom, hit VERIFY, and the canvas recolors \u2014 violating edges turn red, with clickable proof traces explaining which constraint failed.",
-    tooltipPosition: "left",
-    onEnter: () => useApexStore.getState().setActiveModule("tarski"),
-  },
-  {
-    id: "pearl-interventions",
-    targetSelector: '[data-tour="module-panel"]',
-    title: "PEARL \u2014 DO-CALCULUS & ABLATIONS",
-    description:
-      "PEARL implements structural interventions. Select a do(X) target to isolate a node from its causes. Use SEVER to cut individual edges (they go amber \u2014 functionally removed but physically possible) or ABLATE to delete nodes/edges entirely. Run an intervention cascade and the Time Dial gains a second timeline so you can compare baseline vs. counterfactual outcomes side-by-side.",
-    tooltipPosition: "left",
-    onEnter: () => useApexStore.getState().setActiveModule("pearl"),
-  },
-  {
-    id: "pearl-interdiction",
-    targetSelector: '[data-tour="module-panel"]',
-    title: "CASCADE DEFENSE \u2014 AUTO-INTERDICTION",
-    description:
-      "Below the manual tools: CASCADE DEFENSE runs minimax optimization to find the cheapest set of edges whose removal maximally reduces downstream cascade damage. When an attacker-defender min-cut is solvable, you get explicit SEVER / ABLATE buttons per recommended cut. When it isn\u2019t, the panel falls back to a structural-vulnerability ranking of the next most brittle edges. Results auto-trigger a Monte Carlo forecast so you can see the expected damage distribution before committing.",
-    tooltipPosition: "left",
-    onEnter: () => useApexStore.getState().setActiveModule("pearl"),
-  },
-  {
-    id: "pareto-deep",
-    targetSelector: '[data-tour="module-panel"]',
-    title: "PARETO \u2014 CRITICALITY HORIZONS",
-    description:
-      "PARETO tracks a domain-tuned set of criticality estimators, each with its own T-N countdown, confidence, and assessment. For geopolitical/financial domains: CSD (Critical Slowing Down via \u03BBmax \u2192 1), Persistent Homology (topological fragility), and LPPLS (Sornette log-periodic crash model). For Life Sciences / T1D: BOCPD changepoints, Cox proportional hazards, transfer entropy, NLME C-peptide decay, Moran\u2019s I, and HTE meta-analysis \u2014 estimators calibrated to biological time-to-event signals rather than market crashes. Each card exposes observed vs. model signal, formula, methodology, and current assessment.",
-    tooltipPosition: "left",
-    onEnter: () => useApexStore.getState().setActiveModule("pareto"),
-  },
-  {
-    id: "pareto-charts",
-    targetSelector: '[data-tour="module-panel"]',
-    title: "INTERACTIVE CRITICALITY CHARTS",
-    description:
-      "Expand any criticality card to see its temporal chart \u2014 observed values as a solid line, model fit dashed. Hover for exact values. Click \u201C\u25C0 expand panel\u201D to widen the right panel for a more legible chart, including the residual. Each card exposes its model confidence, methodology, formula, and live assessment in one place.",
-    tooltipPosition: "left",
-    onEnter: () => useApexStore.getState().setActiveModule("pareto"),
-  },
-  {
-    id: "pareto-shocks",
-    targetSelector: '[data-tour="module-panel"]',
-    title: "SHOCK INJECTION & TOP CRITICAL NODES",
-    description:
-      "Under the criticality cards: the \u03A9-Fragility Assessment summarizes the buffer state \u2014 NOMINAL, ELEVATED, CRITICAL, or OMEGA_BREACH. The top critical nodes are ranked by \u03A9-score; click one to select it in the graph. The Scenario Injector loads preset shocks calibrated for your active domain (Strait of Hormuz closure, Abqaiq attack, LNG train outage, insulin supply-chain disruption, etc.) and each one depletes the buffer according to its severity.",
-    tooltipPosition: "left",
-    onEnter: () => useApexStore.getState().setActiveModule("pareto"),
-  },
-  {
-    id: "cd-omega",
-    targetSelector: '[data-tour="cd-omega"]',
-    title: "CD\u03A9 DOOMSDAY MONITOR",
-    description:
-      "The Causal-Distance-Omega monitor sits in the header, always on. The segmented bar shows buffer depletion (green \u2192 amber \u2192 red). It reports time-to-failure (T-Nd), regime classification (STABLE, MELT_UP, CRASH, PHASE_TRANSITION, STAGNATION), Dragon-King probability, and active-shock count. The bar flashes when the system enters OMEGA_BREACH \u2014 no matter which engine tab you\u2019re on.",
-    tooltipPosition: "bottom",
-  },
-  {
-    id: "system-copilot",
-    targetSelector: '[data-tour="system-copilot"]',
-    title: "AI SYSTEM COPILOT",
-    description:
-      "The left panel is your AI copilot. It has full context of the graph, active shocks, engine outputs, and recent interventions. Type questions, request explanations, or ask for analysis in plain language \u2014 the copilot responds with graph-grounded reasoning rather than generic prose. It also powers the click-to-speak behavior in the Node Inspector.",
-    tooltipPosition: "right",
-  },
-  {
-    id: "voice-features",
-    targetSelector: '[data-tour="system-copilot"]',
-    title: "VOICE I/O — SPEAKER & MIC",
-    description:
-      "Turn on the speaker icon and the copilot reads every response aloud in a Jarvis-style voice. Turn on the microphone and you can dictate queries instead of typing \u2014 useful when you\u2019re reading off a second screen or running Manifold from across the room.",
-    tooltipPosition: "right",
-  },
-  {
-    id: "compute-button",
-    targetSelector: '[data-tour="action-buttons"]',
-    title: "COMPUTE WITH CLAUDE",
-    description:
-      "COMPUTE WITH CLAUDE generates a full System State Snapshot \u2014 a structured digest of nodes, edges, engine outputs, and criticality metrics. Claude does the heavy computation; the copilot uses that snapshot as context for follow-up questions. If no Claude key is configured, a local snapshot is computed from graph structure instead. Snapshot status appears as a badge in the copilot header.",
-    tooltipPosition: "right",
-  },
-  {
-    id: "time-dial",
-    targetSelector: '[data-tour="risk-flow"]',
-    title: "TIME DIAL & CASCADE REPLAY",
-    description:
-      "The timeline scrubber at the bottom controls cascade replay. After injecting shocks or running an intervention, drag the dial to scrub epochs \u2014 watch nodes activate, edges propagate, and the \u03A9-buffer deplete step-by-step. When a counterfactual exists, the dial gains two timelines: BASELINE vs. INTERVENTION. Use arrow keys for fine control, or let it auto-play.",
-    tooltipPosition: "top",
-  },
-  {
-    id: "risk-flow",
-    targetSelector: '[data-tour="risk-flow"]',
-    title: "RISK PROPAGATION CARDS",
-    description:
-      "The horizontal card strip above the time dial shows per-node vulnerability scores in real time, color-coded by severity. Click any card to select that node and open its inspector. During cascade replay the cards update every epoch so you can watch which nodes light up first and how the shock spreads.",
-    tooltipPosition: "top",
-  },
-  {
-    id: "text-size-toggle",
-    targetSelector: '[data-tour="text-size-toggle"]',
-    title: "TEXT SIZE (S / M / L)",
-    description:
-      "Some analysts run Manifold on large displays or from a distance. Use the S / M / L toggle in the header to scale the readable text up or down. Layout, canvas, and icons stay put \u2014 only typography rescales, so dense panels stay legible without the graph reflowing. Your choice persists across sessions and is applied before the page renders so there\u2019s no flash.",
-    tooltipPosition: "bottom",
-  },
-  {
-    id: "import-button",
-    targetSelector: '[data-tour="import-button"]',
-    title: "IMPORT YOUR OWN DATA",
-    description:
-      "Bring your own graph. IMPORT accepts CSV, JSON, or adjacency matrices; the platform auto-detects format and maps columns into the \u03A9-Fragility framework. All four engines \u2014 discovery, verification, counterfactual, criticality \u2014 work on imported graphs exactly as they do on built-in domains. Multiple datasets can coexist and merge via cross-domain edges.",
-    tooltipPosition: "bottom",
-  },
-  {
-    id: "feedback-widget",
-    targetSelector: '[data-tour="feedback-widget"]',
-    title: "FEEDBACK & FEATURE REQUESTS",
-    description:
-      "The floating pill in the bottom-right corner is your direct line to the team. File bugs, request features, or ask for new datasets \u2014 each category routes into our triage pipeline and becomes a tracked GitHub issue. If a feature request is approved it can be auto-implemented and shipped back to you as a PR. Use it liberally.",
-    tooltipPosition: "left",
-  },
-  {
-    id: "finish",
-    targetSelector: null,
-    title: "YOU\u2019RE READY",
-    description:
-      "You\u2019ve seen every major feature. Typical flow: pick a domain \u2192 explore nodes \u2192 run SPIRTES or TARSKI \u2192 inject a shock or run PEARL interdiction \u2192 watch the cascade on the time dial \u2192 monitor PARETO horizons. The \u201C?\u201D button in the top-right replays this tour at any time. If something feels missing or off, use the feedback widget \u2014 it goes straight to us.",
-    tooltipPosition: "center",
-  },
-];
-
-const DEFAULT_PADDING = 8;
 const GAP = 16;
-
-// Step-specific padding overrides. The welcome-and-domain cutout sits on the
-// domain-selector modal, which already has its own bg-black/70 backdrop-blur
-// shell — any extra padding around the cutout exposes that blurred dim and
-// makes the modal look washed out. Zero padding here keeps the cutout flush
-// with the modal body.
-const STEP_PADDING: Record<string, number> = {
-  "welcome-and-domain": 0,
-};
-
-// Bump this whenever the tour content changes substantially enough that
-// already-onboarded users should see it again. Currently unused — the
-// first-visit auto-launch only triggers when nothing has been stored yet.
 const TOUR_STORAGE_KEY = "manifold:tour-seen";
+const TOOLTIP_WIDTH = 320; // w-80
+const VIEWPORT_MARGIN = 12;
+
+// Escalating-hint thresholds. After ESCALATE_1 ms with no interaction, the
+// cutout starts a slow pulse. After ESCALATE_2 ms it pulses faster + stronger
+// and the tooltip's hint goes bold. No skip button — the user can still bail
+// from the whole tour via SKIP TOUR / Esc.
+const ESCALATE_1_MS = 8000;
+const ESCALATE_2_MS = 15000;
+
+// After predicate flips true, hold the success state briefly so the user
+// sees the "you did it" feedback before the step changes.
+const SUCCESS_HOLD_MS = 400;
+
+// ─── Geometry helpers ───────────────────────────────────────────────────
 
 interface CutoutRect {
   x: number;
@@ -226,9 +41,6 @@ interface CutoutRect {
   width: number;
   height: number;
 }
-
-const TOOLTIP_WIDTH = 320; // w-80
-const VIEWPORT_MARGIN = 12;
 
 function computeArrow(
   cutout: CutoutRect | null,
@@ -267,9 +79,6 @@ function computeArrow(
   }
 }
 
-/** Auto-pick an arrow from the tooltip to an arbitrary cutout, choosing the
- *  tooltip edge / cutout edge that minimizes the crossing. Used for secondary
- *  highlights, which aren't aligned with the step's tooltipPosition. */
 function autoArrow(
   cutout: CutoutRect | null,
   tooltipTop: number,
@@ -311,11 +120,11 @@ function autoArrow(
 function computeTooltipPosition(
   cutout: CutoutRect | null,
   position: TourStep["tooltipPosition"],
-  tooltipHeight: number
+  tooltipHeight: number,
 ): { top: number; left: number } {
   const vw = window.innerWidth;
   const vh = window.innerHeight;
-  const th = tooltipHeight || 200; // fallback estimate before first measure
+  const th = tooltipHeight || 200;
 
   if (!cutout || position === "center") {
     return {
@@ -346,12 +155,15 @@ function computeTooltipPosition(
       break;
   }
 
-  // Clamp to viewport
   top = Math.max(VIEWPORT_MARGIN, Math.min(top, vh - th - VIEWPORT_MARGIN));
   left = Math.max(VIEWPORT_MARGIN, Math.min(left, vw - TOOLTIP_WIDTH - VIEWPORT_MARGIN));
 
   return { top, left };
 }
+
+// ─── Component ──────────────────────────────────────────────────────────
+
+type Mode = "first-run" | "deep-dive-menu" | DeepDiveTrack;
 
 export default function SpotlightTour() {
   const tourActive = useApexStore((s) => s.tourActive);
@@ -361,20 +173,52 @@ export default function SpotlightTour() {
   const domainSelectorOpen = useApexStore((s) => s.domainSelectorOpen);
   const setDomainSelectorOpen = useApexStore((s) => s.setDomainSelectorOpen);
   const selectedDomains = useApexStore((s) => s.selectedDomains);
+  const activePersona = useApexStore((s) => s.activePersona);
   const sawDomainSelectorRef = useRef(false);
+
+  // Which step list is active. First-run by default; switches to a deep-dive
+  // track when the user picks one from the menu after the first-run finish.
+  const [mode, setMode] = useState<Mode>("first-run");
 
   const [cutout, setCutout] = useState<CutoutRect | null>(null);
   const [secondaryCutout, setSecondaryCutout] = useState<CutoutRect | null>(null);
+  const [pulseCutout, setPulseCutout] = useState<CutoutRect | null>(null);
   const [viewport, setViewport] = useState<{ w: number; h: number }>({ w: 0, h: 0 });
   const [tooltipPos, setTooltipPos] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
   const [showDomainHint, setShowDomainHint] = useState(false);
+
+  // Escalating-hint state. 0 = idle, 1 = soft pulse, 2 = strong pulse.
+  const [escalation, setEscalation] = useState<0 | 1 | 2>(0);
+  // Brief success state flashed before auto-advancing on a satisfied predicate.
+  const [interactionSatisfied, setInteractionSatisfied] = useState(false);
+
   const tooltipRef = useRef<HTMLDivElement>(null);
   const tooltipHeightRef = useRef(200);
   const preTourModuleRef = useRef<string | null>(null);
 
-  const step = TOUR_STEPS[tourStep];
+  const track = trackForPersona(activePersona);
+
+  // Active step list driven by mode. Memoized so step indices stay stable.
+  const currentSteps = useMemo<TourStep[]>(() => {
+    if (mode === "first-run") return TOUR_STEPS.filter((s) => s.phase === "first-run");
+    if (mode === "deep-dive-menu") return [];
+    return TOUR_STEPS.filter(
+      (s) => s.phase === "deep-dive" && s.deepDiveTrack === mode,
+    );
+  }, [mode]);
+
+  const step = currentSteps[tourStep];
+  const isMenu = mode === "deep-dive-menu";
   const isFirst = tourStep === 0;
-  const isLast = tourStep === TOUR_STEPS.length - 1;
+  const isLast = currentSteps.length > 0 && tourStep === currentSteps.length - 1;
+
+  // Reset escalation + success on every step change.
+  useEffect(() => {
+    setEscalation(0);
+    setInteractionSatisfied(false);
+  }, [step?.id]);
+
+  // ─── Cutout measurement ──────────────────────────────────────────────
 
   const measureTarget = useCallback(() => {
     const pad = step ? STEP_PADDING[step.id] ?? DEFAULT_PADDING : DEFAULT_PADDING;
@@ -392,6 +236,7 @@ export default function SpotlightTour() {
     };
     setCutout(measure(step?.targetSelector ?? null));
     setSecondaryCutout(measure(step?.secondaryTargetSelector));
+    setPulseCutout(measure(step?.awaitInteraction?.pulseSelector ?? null));
     setViewport({ w: window.innerWidth, h: window.innerHeight });
   }, [step]);
 
@@ -399,39 +244,49 @@ export default function SpotlightTour() {
     measureTarget();
   }, [measureTarget]);
 
-  // Save pre-tour module on tour start
+  // Save pre-tour module on tour start so we can restore it on close.
   useEffect(() => {
     if (tourActive) {
       preTourModuleRef.current = useApexStore.getState().activeModule;
     }
   }, [tourActive]);
 
-  // First-visit auto-launch: open the tour exactly once per browser, keyed on
-  // localStorage. Dismissing (SKIP / close / finish) sets the flag so it won't
-  // trigger again. Users can still relaunch manually via the "?" button.
+  // First-visit auto-launch: open the tour exactly once per browser, keyed
+  // on localStorage. Dismissing sets the flag so it won't re-trigger.
   useEffect(() => {
     try {
       const seen = window.localStorage.getItem(TOUR_STORAGE_KEY);
       if (!seen) {
+        setMode("first-run");
         setTourActive(true);
       }
     } catch {
-      // localStorage unavailable (private mode, etc.) — skip auto-launch
+      // localStorage unavailable
     }
-    // Run once on mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Call onEnter when step changes
+  // When the tour is re-opened externally (the "?" button), reset to first-run.
+  // Without this, re-opening after a deep-dive ended in the same session would
+  // start mid-track.
+  const prevActiveRef = useRef(tourActive);
+  useEffect(() => {
+    if (tourActive && !prevActiveRef.current) {
+      setMode("first-run");
+      setTourStep(0);
+    }
+    prevActiveRef.current = tourActive;
+  }, [tourActive, setTourStep]);
+
+  // Run a step's onEnter side effect (e.g. switch active module).
   useEffect(() => {
     if (!tourActive || !step) return;
     step.onEnter?.();
   }, [tourActive, tourStep, step]);
 
-  // Auto-advance the welcome/domain step when the user closes the selector
-  // AFTER picking at least one domain. If they closed it without picking, we
-  // reopen it so the tour stays coherent (without a pick the workspace button
-  // in the header doesn't render either, so there's no recovery path).
+  // Welcome-step gating: auto-advance when the user closes the selector AFTER
+  // picking a domain. If they close without picking, reopen so the tour stays
+  // coherent.
   useEffect(() => {
     if (!tourActive || step?.id !== "welcome-and-domain") {
       sawDomainSelectorRef.current = false;
@@ -458,8 +313,6 @@ export default function SpotlightTour() {
     setDomainSelectorOpen,
   ]);
 
-  // Clear the "pick a domain" hint as soon as the user actually picks one, or
-  // when the tour moves past the welcome step.
   useEffect(() => {
     if (step?.id !== "welcome-and-domain" || selectedDomains.length > 0) {
       setShowDomainHint(false);
@@ -473,17 +326,14 @@ export default function SpotlightTour() {
     return () => window.removeEventListener("resize", updatePositions);
   }, [tourActive, tourStep, updatePositions]);
 
-  // Recompute tooltip position when cutout or step changes
   useLayoutEffect(() => {
     if (!tourActive || !step) return;
-    // Measure tooltip height from ref if available
     if (tooltipRef.current) {
       tooltipHeightRef.current = tooltipRef.current.offsetHeight;
     }
     setTooltipPos(computeTooltipPosition(cutout, step.tooltipPosition, tooltipHeightRef.current));
   }, [tourActive, step, cutout]);
 
-  // Re-clamp after tooltip renders (height may change per step)
   useEffect(() => {
     if (!tourActive || !step || !tooltipRef.current) return;
     const measured = tooltipRef.current.offsetHeight;
@@ -492,6 +342,52 @@ export default function SpotlightTour() {
       setTooltipPos(computeTooltipPosition(cutout, step.tooltipPosition, measured));
     }
   });
+
+  // ─── Interactive-gate subscription ───────────────────────────────────
+
+  const advance = useCallback(() => {
+    if (currentSteps.length === 0) return;
+    if (tourStep < currentSteps.length - 1) {
+      setTourStep(tourStep + 1);
+    }
+  }, [currentSteps, tourStep, setTourStep]);
+
+  // Subscribe to store changes; when the predicate is satisfied, flash success
+  // and advance.
+  useEffect(() => {
+    if (!tourActive || !step?.awaitInteraction) return;
+    const { predicate } = step.awaitInteraction;
+    // Check immediately — the user may have already done it.
+    if (predicate(useApexStore.getState())) {
+      setInteractionSatisfied(true);
+      const t = setTimeout(advance, SUCCESS_HOLD_MS);
+      return () => clearTimeout(t);
+    }
+    let advanceTimer: ReturnType<typeof setTimeout> | null = null;
+    const unsub = useApexStore.subscribe((s) => {
+      if (predicate(s) && !advanceTimer) {
+        setInteractionSatisfied(true);
+        advanceTimer = setTimeout(advance, SUCCESS_HOLD_MS);
+      }
+    });
+    return () => {
+      unsub();
+      if (advanceTimer) clearTimeout(advanceTimer);
+    };
+  }, [tourActive, step, advance]);
+
+  // Escalating-hint timers. Reset on step change; clear on satisfaction.
+  useEffect(() => {
+    if (!tourActive || !step?.awaitInteraction || interactionSatisfied) return;
+    const t1 = setTimeout(() => setEscalation(1), ESCALATE_1_MS);
+    const t2 = setTimeout(() => setEscalation(2), ESCALATE_2_MS);
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+    };
+  }, [tourActive, step?.id, step?.awaitInteraction, interactionSatisfied]);
+
+  // ─── Navigation ──────────────────────────────────────────────────────
 
   const close = useCallback(() => {
     if (preTourModuleRef.current) {
@@ -502,13 +398,21 @@ export default function SpotlightTour() {
     } catch {
       // ignore
     }
+    setMode("first-run");
+    setTourStep(0);
     setTourActive(false);
-  }, [setTourActive]);
+  }, [setTourActive, setTourStep]);
 
   const next = useCallback(() => {
     if (step?.id === "welcome-and-domain" && selectedDomains.length === 0) {
       setShowDomainHint(true);
       if (!domainSelectorOpen) setDomainSelectorOpen(true);
+      return;
+    }
+    if (step?.id === "first-run-finish") {
+      // First-run done → show the deep-dive menu instead of closing.
+      setMode("deep-dive-menu");
+      setTourStep(0);
       return;
     }
     if (isLast) {
@@ -531,38 +435,29 @@ export default function SpotlightTour() {
     if (!isFirst) setTourStep(tourStep - 1);
   }, [isFirst, setTourStep, tourStep]);
 
-  // Keyboard navigation
+  const launchDeepDive = useCallback(
+    (track: DeepDiveTrack) => {
+      setMode(track);
+      setTourStep(0);
+    },
+    [setTourStep],
+  );
+
+  // Keyboard navigation. Disabled on the menu (no step to advance).
   useEffect(() => {
     if (!tourActive) return;
     const handler = (e: KeyboardEvent) => {
       if (e.key === "Escape") close();
-      else if (e.key === "ArrowRight") next();
-      else if (e.key === "ArrowLeft") back();
+      else if (!isMenu && e.key === "ArrowRight") next();
+      else if (!isMenu && e.key === "ArrowLeft") back();
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [tourActive, close, next, back]);
+  }, [tourActive, close, next, back, isMenu]);
 
-  if (!tourActive || !step) return null;
+  if (!tourActive) return null;
 
-  const arrow = computeArrow(
-    cutout,
-    step.tooltipPosition,
-    tooltipPos.top,
-    tooltipPos.left,
-    tooltipHeightRef.current,
-  );
-  const secondaryArrow = autoArrow(
-    secondaryCutout,
-    tooltipPos.top,
-    tooltipPos.left,
-    tooltipHeightRef.current,
-  );
-
-  // Build a single dim path: outer viewport rect plus a rounded-rect
-  // sub-path per cutout. With fill-rule="evenodd" each inner sub-path
-  // subtracts from the fill, regardless of winding — so the highlighted
-  // element renders at full brightness. No SVG mask, no browser ambiguity.
+  // Build dim path with cutout holes (evenodd subtracts).
   const dimPath = (() => {
     const { w, h } = viewport;
     if (!w || !h) return "";
@@ -571,7 +466,6 @@ export default function SpotlightTour() {
       const r = Math.min(8, c.width / 2, c.height / 2);
       const x2 = c.x + c.width;
       const y2 = c.y + c.height;
-      // Standard CW rounded rect — evenodd subtracts it regardless.
       d += ` M${c.x + r} ${c.y}`;
       d += ` H${x2 - r}`;
       d += ` A${r} ${r} 0 0 1 ${x2} ${c.y + r}`;
@@ -588,16 +482,26 @@ export default function SpotlightTour() {
     return d;
   })();
 
+  const arrow = step
+    ? computeArrow(cutout, step.tooltipPosition, tooltipPos.top, tooltipPos.left, tooltipHeightRef.current)
+    : null;
+  const secondaryArrow = autoArrow(secondaryCutout, tooltipPos.top, tooltipPos.left, tooltipHeightRef.current);
+
+  // The element to pulse when the user is taking too long. Falls back to the
+  // primary cutout if no separate pulse selector was specified.
+  const effectivePulse = pulseCutout ?? cutout;
+  const pulseClass =
+    interactionSatisfied
+      ? "tour-pulse-success"
+      : escalation === 2
+        ? "tour-pulse-strong"
+        : escalation === 1
+          ? "tour-pulse-soft"
+          : "";
+
   return (
     <AnimatePresence>
       <div className="fixed inset-0 z-[60]" style={{ pointerEvents: "none" }}>
-        {/* Dim + borders + arrows via a single SVG. The dim is one
-            evenodd-filled path with the viewport as the outer ring and each
-            cutout as a hole — supports any number of cutouts and is
-            unambiguous across browsers (the prior SVG mask had inconsistent
-            behavior in some engines, leaving the cutout looking dim). SVG is
-            pointer-events-none so clicks pass through; the tour only closes
-            via SKIP TOUR / Esc / finishing. */}
         <svg className="absolute inset-0 w-full h-full pointer-events-none">
           <defs>
             <marker
@@ -612,15 +516,9 @@ export default function SpotlightTour() {
               <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--accent-cyan, #00e5ff)" />
             </marker>
           </defs>
-          {dimPath && (
-            <path
-              d={dimPath}
-              fillRule="evenodd"
-              fill="rgba(0, 0, 0, 0.78)"
-            />
-          )}
+          {dimPath && <path d={dimPath} fillRule="evenodd" fill="rgba(0, 0, 0, 0.78)" />}
           {/* Primary border */}
-          {cutout && (
+          {cutout && step && (
             <motion.rect
               x={cutout.x}
               y={cutout.y}
@@ -639,7 +537,7 @@ export default function SpotlightTour() {
             />
           )}
           {/* Secondary border */}
-          {secondaryCutout && (
+          {secondaryCutout && step && (
             <motion.rect
               x={secondaryCutout.x}
               y={secondaryCutout.y}
@@ -657,8 +555,24 @@ export default function SpotlightTour() {
               key={`border-secondary-${step.id}`}
             />
           )}
-          {/* Primary arrow */}
-          {arrow && (
+          {/* Pulse overlay — sits on top of the chosen pulse target when the
+              user has stalled. The animation drives a separate rect rather
+              than the primary border so the always-on border doesn't flicker. */}
+          {effectivePulse && pulseClass && (
+            <rect
+              key={`pulse-${step?.id ?? ""}-${pulseClass}`}
+              x={effectivePulse.x - 2}
+              y={effectivePulse.y - 2}
+              width={effectivePulse.width + 4}
+              height={effectivePulse.height + 4}
+              rx={10}
+              fill="none"
+              stroke="var(--accent-cyan, #00e5ff)"
+              strokeWidth={3}
+              className={pulseClass}
+            />
+          )}
+          {arrow && step && (
             <motion.line
               key={`arrow-${step.id}`}
               x1={arrow.from.x}
@@ -675,8 +589,7 @@ export default function SpotlightTour() {
               transition={{ duration: 0.25, delay: 0.1 }}
             />
           )}
-          {/* Secondary arrow */}
-          {secondaryArrow && (
+          {secondaryArrow && step && (
             <motion.line
               key={`arrow-secondary-${step.id}`}
               x1={secondaryArrow.from.x}
@@ -695,73 +608,279 @@ export default function SpotlightTour() {
           )}
         </svg>
 
-        {/* Tooltip card */}
-        <motion.div
-          ref={tooltipRef}
-          key={step.id}
-          className="w-80 rounded-lg border border-border bg-surface-elevated p-4 shadow-2xl"
-          style={{
-            position: "absolute",
-            top: tooltipPos.top,
-            left: tooltipPos.left,
-            zIndex: 61,
-            pointerEvents: "auto",
-          }}
-          initial={{ opacity: 0, scale: 0.95 }}
-          animate={{ opacity: 1, scale: 1 }}
-          exit={{ opacity: 0, scale: 0.95 }}
-          transition={{ duration: 0.2 }}
-          onClick={(e) => e.stopPropagation()}
-        >
-          {/* Step counter */}
-          <div className="text-[9px] font-mono tracking-wider text-text-muted mb-2">
-            {tourStep + 1} OF {TOUR_STEPS.length}
-          </div>
-
-          {/* Title */}
-          <h3 className="font-[family-name:var(--font-michroma)] text-sm tracking-wider text-accent-cyan mb-2">
-            {step.title}
-          </h3>
-
-          {/* Description */}
-          <p className="text-[11px] font-mono leading-relaxed text-text-muted mb-4">
-            {step.description}
-          </p>
-
-          {/* Inline hint when the user tries to advance without picking a domain */}
-          {showDomainHint && (
-            <div className="mb-3 rounded border border-amber-400/40 bg-amber-400/10 px-2 py-1.5 text-[10px] font-mono tracking-wider text-amber-300">
-              Pick a domain in the workspace first — the platform can&apos;t render without one.
-            </div>
-          )}
-
-          {/* Navigation buttons */}
-          <div className="flex items-center justify-between">
-            <button
-              onClick={close}
-              className="text-[9px] font-mono tracking-wider text-text-muted hover:text-foreground transition-colors"
-            >
-              SKIP TOUR
-            </button>
-            <div className="flex items-center gap-2">
-              {!isFirst && (
-                <button
-                  onClick={back}
-                  className="px-3 py-1.5 rounded border border-border text-[9px] font-mono tracking-wider text-text-muted hover:text-foreground hover:border-foreground/30 transition-colors"
-                >
-                  BACK
-                </button>
-              )}
-              <button
-                onClick={next}
-                className="px-3 py-1.5 rounded border border-accent-cyan/40 bg-accent-cyan/10 text-[9px] font-mono tracking-wider text-accent-cyan hover:bg-accent-cyan/20 transition-colors"
-              >
-                {isLast ? "FINISH" : "NEXT"}
-              </button>
-            </div>
-          </div>
-        </motion.div>
+        {/* Tooltip card OR deep-dive menu */}
+        {isMenu ? (
+          <DeepDiveMenu
+            onPick={launchDeepDive}
+            onClose={close}
+          />
+        ) : step ? (
+          <TooltipCard
+            step={step}
+            track={track}
+            tourStep={tourStep}
+            totalSteps={currentSteps.length}
+            tooltipPos={tooltipPos}
+            tooltipRef={tooltipRef}
+            isFirst={isFirst}
+            isLast={isLast}
+            mode={mode}
+            interactionSatisfied={interactionSatisfied}
+            escalation={escalation}
+            showDomainHint={showDomainHint}
+            onNext={next}
+            onBack={back}
+            onClose={close}
+            onReturnToMenu={
+              mode === "engines" || mode === "loop" || mode === "customization"
+                ? () => {
+                    setMode("deep-dive-menu");
+                    setTourStep(0);
+                  }
+                : null
+            }
+          />
+        ) : null}
       </div>
     </AnimatePresence>
   );
 }
+
+// ─── Tooltip card ───────────────────────────────────────────────────────
+
+interface TooltipCardProps {
+  step: TourStep;
+  track: ReturnType<typeof trackForPersona>;
+  tourStep: number;
+  totalSteps: number;
+  tooltipPos: { top: number; left: number };
+  tooltipRef: React.RefObject<HTMLDivElement | null>;
+  isFirst: boolean;
+  isLast: boolean;
+  mode: Mode;
+  interactionSatisfied: boolean;
+  escalation: 0 | 1 | 2;
+  showDomainHint: boolean;
+  onNext: () => void;
+  onBack: () => void;
+  onClose: () => void;
+  onReturnToMenu: (() => void) | null;
+}
+
+function TooltipCard({
+  step,
+  track,
+  tourStep,
+  totalSteps,
+  tooltipPos,
+  tooltipRef,
+  isFirst,
+  isLast,
+  mode,
+  interactionSatisfied,
+  escalation,
+  showDomainHint,
+  onNext,
+  onBack,
+  onClose,
+  onReturnToMenu,
+}: TooltipCardProps) {
+  const copy = resolveCopy(step, track);
+  const isFirstRunFinish = step.id === "first-run-finish";
+  const phaseLabel =
+    mode === "first-run"
+      ? "FIRST RUN"
+      : mode === "engines"
+        ? "DEEP DIVE · ENGINES"
+        : mode === "loop"
+          ? "DEEP DIVE · LOOP"
+          : mode === "customization"
+            ? "DEEP DIVE · CUSTOMIZATION"
+            : "";
+
+  return (
+    <motion.div
+      ref={tooltipRef}
+      key={step.id}
+      className="w-80 rounded-lg border border-border bg-surface-elevated p-4 shadow-2xl"
+      style={{
+        position: "absolute",
+        top: tooltipPos.top,
+        left: tooltipPos.left,
+        zIndex: 61,
+        pointerEvents: "auto",
+      }}
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.95 }}
+      transition={{ duration: 0.2 }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div className="text-[9px] font-mono tracking-wider text-text-muted mb-2 flex items-center justify-between">
+        <span>
+          {phaseLabel} · {tourStep + 1} OF {totalSteps}
+        </span>
+        {onReturnToMenu && (
+          <button
+            onClick={onReturnToMenu}
+            className="text-text-muted hover:text-foreground transition-colors"
+          >
+            ◂ MENU
+          </button>
+        )}
+      </div>
+
+      <h3 className="font-[family-name:var(--font-michroma)] text-sm tracking-wider text-accent-cyan mb-2">
+        {copy.title}
+      </h3>
+
+      <p className="text-[11px] font-mono leading-relaxed text-text-muted mb-3">
+        {copy.description}
+      </p>
+
+      {/* Interactive-gate hint */}
+      {step.awaitInteraction && (
+        <div
+          className={`mb-3 rounded border px-2 py-1.5 text-[10px] font-mono tracking-wider ${
+            interactionSatisfied
+              ? "border-accent-green/50 bg-accent-green/10 text-accent-green"
+              : escalation === 2
+                ? "border-accent-cyan bg-accent-cyan/15 text-accent-cyan font-bold"
+                : escalation === 1
+                  ? "border-accent-cyan/60 bg-accent-cyan/10 text-accent-cyan"
+                  : "border-accent-cyan/30 bg-accent-cyan/5 text-accent-cyan/80"
+          }`}
+        >
+          {interactionSatisfied ? "✓ Got it." : step.awaitInteraction.hint}
+        </div>
+      )}
+
+      {showDomainHint && (
+        <div className="mb-3 rounded border border-amber-400/40 bg-amber-400/10 px-2 py-1.5 text-[10px] font-mono tracking-wider text-amber-300">
+          Pick a domain in the workspace first — the platform can&apos;t render without one.
+        </div>
+      )}
+
+      <div className="flex items-center justify-between">
+        <button
+          onClick={onClose}
+          className="text-[9px] font-mono tracking-wider text-text-muted hover:text-foreground transition-colors"
+        >
+          SKIP TOUR
+        </button>
+        <div className="flex items-center gap-2">
+          {!isFirst && (
+            <button
+              onClick={onBack}
+              className="px-3 py-1.5 rounded border border-border text-[9px] font-mono tracking-wider text-text-muted hover:text-foreground hover:border-foreground/30 transition-colors"
+            >
+              BACK
+            </button>
+          )}
+          <button
+            onClick={onNext}
+            disabled={!!step.awaitInteraction && !interactionSatisfied}
+            className="px-3 py-1.5 rounded border border-accent-cyan/40 bg-accent-cyan/10 text-[9px] font-mono tracking-wider text-accent-cyan hover:bg-accent-cyan/20 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            {isFirstRunFinish ? "OPEN DEEP DIVE ▸" : isLast ? "FINISH" : "NEXT"}
+          </button>
+        </div>
+      </div>
+    </motion.div>
+  );
+}
+
+// ─── Deep-dive menu ─────────────────────────────────────────────────────
+
+function DeepDiveMenu({
+  onPick,
+  onClose,
+}: {
+  onPick: (track: DeepDiveTrack) => void;
+  onClose: () => void;
+}) {
+  return (
+    <motion.div
+      key="deep-dive-menu"
+      className="rounded-lg border border-border bg-surface-elevated p-5 shadow-2xl"
+      style={{
+        position: "absolute",
+        top: "50%",
+        left: "50%",
+        transform: "translate(-50%, -50%)",
+        zIndex: 61,
+        pointerEvents: "auto",
+        width: 380,
+      }}
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.95 }}
+      transition={{ duration: 0.2 }}
+    >
+      <div className="text-[9px] font-mono tracking-wider text-text-muted mb-2">
+        DEEP DIVE · OPT-IN
+      </div>
+      <h3 className="font-[family-name:var(--font-michroma)] text-sm tracking-wider text-accent-cyan mb-3">
+        PICK A DEEPER LOOK
+      </h3>
+      <p className="text-[11px] font-mono leading-relaxed text-text-muted mb-4">
+        First run done. Pick a track for a deeper walkthrough, or close out and explore on your own. You can always relaunch this from the “?” in the top-right.
+      </p>
+      <div className="space-y-2 mb-4">
+        {DEEP_DIVE_TRACKS.map((t) => (
+          <FILTERED_TRACK_BUTTON
+            key={t.id}
+            id={t.id}
+            label={t.label}
+            desc={t.desc}
+            onPick={onPick}
+          />
+        ))}
+      </div>
+      <div className="flex items-center justify-end">
+        <button
+          onClick={onClose}
+          className="px-3 py-1.5 rounded border border-border text-[9px] font-mono tracking-wider text-text-muted hover:text-foreground hover:border-foreground/30 transition-colors"
+        >
+          CLOSE
+        </button>
+      </div>
+    </motion.div>
+  );
+}
+
+// PascalCase wrapper — JSX needs an uppercase identifier.
+function FILTERED_TRACK_BUTTON({
+  id,
+  label,
+  desc,
+  onPick,
+}: {
+  id: DeepDiveTrack;
+  label: string;
+  desc: string;
+  onPick: (track: DeepDiveTrack) => void;
+}) {
+  // Count steps so the button shows "ENGINES (4 steps)".
+  const count = TOUR_STEPS.filter(
+    (s) => s.phase === "deep-dive" && s.deepDiveTrack === id,
+  ).length;
+  return (
+    <button
+      onClick={() => onPick(id)}
+      className="w-full text-left rounded border border-border hover:border-accent-cyan/50 hover:bg-accent-cyan/5 transition-colors px-3 py-2.5"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[11px] font-mono font-bold text-accent-cyan tracking-wider">
+          {label}
+        </span>
+        <span className="text-[9px] font-mono text-text-muted">{count} STEPS</span>
+      </div>
+      <div className="text-[10px] font-mono text-text-muted mt-0.5">{desc}</div>
+    </button>
+  );
+}
+
+// Suppress unused ID-export warnings if any code wants to reference these
+// without re-importing.
+export { FIRST_RUN_IDS };

--- a/src/lib/tour-steps.ts
+++ b/src/lib/tour-steps.ts
@@ -1,0 +1,408 @@
+/**
+ * Tour step data. Two tracks (analyst-family vs scientist) share a skeleton
+ * but carry distinct copy. The rendering shell lives in SpotlightTour.tsx;
+ * everything domain-shaped lives here so a copy edit doesn't require
+ * touching component code.
+ *
+ * Track resolution:
+ *   activePersona === "scientist"  → "scientist" track
+ *   anything else                  → "analyst" track
+ *
+ * Phases:
+ *   "first-run"     — auto-launches on first visit, ~9 steps, lots of "do this"
+ *   "deep-dive"     — opt-in from a menu shown after first-run finishes (or
+ *                     re-launched from the "?" button), grouped by deepDiveTrack.
+ */
+import { useApexStore } from "@/stores/useApexStore";
+
+type Store = ReturnType<typeof useApexStore.getState>;
+
+export type TourTrack = "analyst" | "scientist";
+export type TourPhase = "first-run" | "deep-dive";
+export type DeepDiveTrack = "engines" | "loop" | "customization";
+
+export interface StepCopy {
+  title: string;
+  description: string;
+}
+
+/** "Wait for X to happen before letting the user advance." Predicate is
+ *  evaluated against the live useApexStore state on every store change.
+ *  When it flips true, the step auto-advances. */
+export interface AwaitInteractionConfig {
+  /** Short directive shown in the tooltip footer. */
+  hint: string;
+  /** Reads zustand state, returns true once the user has done the thing. */
+  predicate: (s: Store) => boolean;
+  /**
+   * The element to pulse when the user is taking too long. Defaults to the
+   * step's primary targetSelector. For "click any node" we don't have a
+   * single element so it can stay null and we'll pulse the whole canvas
+   * cutout border instead.
+   */
+  pulseSelector?: string;
+}
+
+export interface TourStep {
+  id: string;
+  phase: TourPhase;
+  /** Only set when phase === "deep-dive". */
+  deepDiveTrack?: DeepDiveTrack;
+  /** CSS selector for the element being highlighted. null = centered tooltip. */
+  targetSelector: string | null;
+  /** Optional second highlight + arrow, e.g. tabs + panel. */
+  secondaryTargetSelector?: string;
+  tooltipPosition: "top" | "bottom" | "left" | "right" | "center";
+  /** Copy can be shared across tracks (StepCopy) or per-track. */
+  copy: StepCopy | Record<TourTrack, StepCopy>;
+  /** Wait for this user interaction before advancing. */
+  awaitInteraction?: AwaitInteractionConfig;
+  /** Optional side effect when the step opens (e.g. switch active module). */
+  onEnter?: () => void;
+}
+
+/** Returns the right StepCopy for the active track. */
+export function resolveCopy(step: TourStep, track: TourTrack): StepCopy {
+  if ("title" in step.copy) return step.copy;
+  return step.copy[track];
+}
+
+/** Persona → track mapping. Five personas collapse into two tracks because
+ *  financial / macro / geopolitical / cross share enough vocab to take the
+ *  same tour with shared copy; scientist is a distinct domain that deserves
+ *  its own framing. */
+export function trackForPersona(persona: string | null | undefined): TourTrack {
+  return persona === "scientist" ? "scientist" : "analyst";
+}
+
+// ─── First-run track (~9 steps, both tracks) ─────────────────────────────
+
+const FIRST_RUN_STEPS: TourStep[] = [
+  {
+    id: "welcome-and-domain",
+    phase: "first-run",
+    targetSelector: '[data-tour="domain-selector-modal"]',
+    tooltipPosition: "right",
+    copy: {
+      title: "WELCOME — PICK A PERSONA",
+      description:
+        "Welcome to APEX Analytica MANIFOLD — a causal-inference platform for discovering, verifying, and stress-testing networks. Start by picking one of the five persona pills above: FINANCIAL, MACRO, GEOPOLITICAL, SCIENTIST (Life Sciences), or CROSS-DOMAIN. Each one filters the visible domain cards. Pick a card, confirm, and the tour will continue on the platform. You can relaunch this tour anytime from the “?” in the top-right.",
+    },
+  },
+  {
+    id: "canvas-and-node",
+    phase: "first-run",
+    targetSelector: '[data-tour="dag-canvas"]',
+    tooltipPosition: "right",
+    copy: {
+      analyst: {
+        title: "THE CAUSAL CANVAS",
+        description:
+          "This is the causal DAG. Node size and color encode Ω-Fragility — hotter is more systemic risk. Solid arrows are directed causal edges; dashed lines are confounded or latent. Drag to orbit, scroll to zoom in 3D. Click any node now to open its inspector.",
+      },
+      scientist: {
+        title: "THE CAUSAL CANVAS",
+        description:
+          "This is the biological causal DAG. Node size and color encode CRITICALITY — hotter means a mechanism whose failure cascades across metabolic, vascular, and neurological subsystems. Solid arrows are directed causal edges; dashed lines are latent or confounded. Drag to orbit, scroll to zoom. Click any node now to open its inspector.",
+      },
+    },
+    awaitInteraction: {
+      hint: "Click any node on the canvas to continue.",
+      predicate: (s) => s.selectedNode !== null,
+    },
+  },
+  {
+    id: "node-inspector",
+    phase: "first-run",
+    targetSelector: '[data-tour="module-panel"]',
+    tooltipPosition: "left",
+    copy: {
+      analyst: {
+        title: "NODE INSPECTOR — Ω PILLARS",
+        description:
+          "The inspector centerpiece is a fragility radar pentagon. Composite ΩF (0–10) sits at the center; each vertex is labeled with a pillar letter — I (Irreplaceability), R (Restoration Latency), J (Jurisdictional Hazard), C (Cascade Load), T (Tail Depth) — and its score. Click any vertex letter to drop in that pillar's explanation, detail, and formula inline.",
+      },
+      scientist: {
+        title: "NODE INSPECTOR — CRITICALITY PILLARS",
+        description:
+          "The inspector centerpiece is a criticality radar pentagon. Composite score (0–10) sits at the center; each vertex carries a pillar letter — I (Irreplaceability of mechanism), R (Restoration latency), J (Regulatory exposure), C (Complication load), T (Outcome tail) — and its score. Click any vertex letter to drop in that pillar's explanation, detail, and formula inline.",
+      },
+    },
+  },
+  {
+    id: "engines-overview",
+    phase: "first-run",
+    targetSelector: '[data-tour="module-tabs"]',
+    secondaryTargetSelector: '[data-tour="module-panel"]',
+    tooltipPosition: "bottom",
+    copy: {
+      analyst: {
+        title: "FOUR ANALYSIS ENGINES",
+        description:
+          "Four engine tabs drive the right-hand panel. SPIRTES learns causal structure from data. TARSKI verifies edges against physical, regulatory, and heuristic constraints. PEARL runs do-calculus interventions and cascade defense. PARETO tracks tail-risk criticality horizons. Switching tabs only updates the right panel — the graph stays put.",
+      },
+      scientist: {
+        title: "FOUR ANALYSIS ENGINES",
+        description:
+          "Four engine tabs drive the right-hand panel. The Discovery engine learns causal structure from biological data. The Verification engine audits each edge against physical, regulatory, and clinical-heuristic constraints. The Counterfactual engine runs do-calculus interventions on candidate mechanisms. The Criticality engine tracks per-domain risk estimators (BOCPD, Cox PH, NLME, transfer entropy). Switching tabs only updates the right panel — the graph stays put.",
+      },
+    },
+  },
+  {
+    id: "engine-pick-tarski",
+    phase: "first-run",
+    targetSelector: '[data-tour="module-tabs"]',
+    secondaryTargetSelector: '[data-tour="module-panel"]',
+    tooltipPosition: "bottom",
+    copy: {
+      analyst: {
+        title: "TRY IT — SWITCH TO TARSKI",
+        description:
+          "Switch to the TARSKI tab now to see edge-constraint verification in action. Once TARSKI is active you can toggle physical/regulatory/heuristic axioms and hit VERIFY — violating edges turn red with clickable proof traces.",
+      },
+      scientist: {
+        title: "TRY IT — SWITCH TO VERIFICATION",
+        description:
+          "Switch to the TARSKI (verification) tab now to see edge-constraint auditing in action. With TARSKI active you can toggle physical, regulatory, and clinical-heuristic axioms and hit VERIFY — edges that fail an axiom turn red with clickable proof traces (e.g. dose-response monotonicity, mechanism plausibility).",
+      },
+    },
+    awaitInteraction: {
+      hint: "Click the TARSKI tab to continue.",
+      predicate: (s) => s.activeModule === "tarski",
+      pulseSelector: '[data-tour="module-tabs"]',
+    },
+  },
+  {
+    id: "time-dial-and-cascade",
+    phase: "first-run",
+    targetSelector: '[data-tour="risk-flow"]',
+    tooltipPosition: "top",
+    copy: {
+      analyst: {
+        title: "TIME DIAL — CASCADE REPLAY",
+        description:
+          "The timeline scrubber controls cascade replay. After a shock or intervention, drag the dial to scrub epochs and watch nodes activate, edges propagate, and the Ω-buffer deplete. The horizontal cards above show per-node vulnerability, color-coded by severity. Drag the dial back a few epochs now to feel the replay.",
+      },
+      scientist: {
+        title: "TIME DIAL — TRAJECTORY REPLAY",
+        description:
+          "The timeline scrubber controls mechanism-trajectory replay. After an intervention or natural-history step, drag the dial to scrub time and watch C-peptide, antigen exposure, and downstream phenotypes evolve epoch-by-epoch. The horizontal cards above show per-mechanism risk in real time. Drag the dial back a few epochs now to feel the replay.",
+      },
+    },
+    awaitInteraction: {
+      hint: "Drag the time dial back a few epochs to continue.",
+      predicate: (s) => s.currentEpoch > 0,
+      pulseSelector: '[data-tour="risk-flow"]',
+    },
+  },
+  {
+    id: "cd-omega-monitor",
+    phase: "first-run",
+    targetSelector: '[data-tour="cd-omega"]',
+    tooltipPosition: "bottom",
+    copy: {
+      analyst: {
+        title: "CDΩ — DOOMSDAY MONITOR",
+        description:
+          "The Causal-Distance-Omega monitor in the header is always on. The segmented bar shows buffer depletion (green → amber → red), time-to-failure (T-Nd), regime classification (STABLE / MELT_UP / CRASH / PHASE_TRANSITION / STAGNATION), Dragon-King probability, and active shocks. The bar flashes when the system enters OMEGA_BREACH — no matter which engine tab you're on.",
+      },
+      scientist: {
+        title: "CDΩ — TRAJECTORY MONITOR",
+        description:
+          "The Causal-Distance-Omega monitor in the header is always on. The segmented bar shows mechanism-buffer depletion (green → amber → red), time-to-event (T-Nd), trajectory regime (STABLE / DETERIORATING / RAPID-DECLINE / RECOVERY), tail probability, and active stressors. The bar flashes on critical-threshold breach regardless of which engine tab you're in.",
+      },
+    },
+  },
+  {
+    id: "system-copilot",
+    phase: "first-run",
+    targetSelector: '[data-tour="system-copilot"]',
+    tooltipPosition: "right",
+    copy: {
+      title: "AI SYSTEM COPILOT",
+      description:
+        "The left panel is your AI copilot. It has full context of the graph, active stressors, engine outputs, and recent interventions — ask questions, request explanations, or run analysis in plain language and it answers with graph-grounded reasoning rather than generic prose. Speaker icon for voice readback, microphone for dictation.",
+    },
+  },
+  {
+    id: "first-run-finish",
+    phase: "first-run",
+    targetSelector: null,
+    tooltipPosition: "center",
+    copy: {
+      title: "YOU'RE SET",
+      description:
+        "That's the loop: pick a domain → click nodes → switch engines → run interventions → scrub the dial. The “?” button in the top-right relaunches this tour or opens a deeper dive into a specific area. Optional deep-dive tracks below — pick what looks useful or close out and start exploring.",
+    },
+  },
+];
+
+// ─── Deep-dive track (opt-in, accessed from finish-step menu or "?") ─────
+//
+// One shared copy across tracks for now. Per-track copy here is the next
+// layer of polish; this PR establishes the structure.
+
+const DEEP_DIVE_STEPS: TourStep[] = [
+  // Engines deep dive
+  {
+    id: "spirtes-deep",
+    phase: "deep-dive",
+    deepDiveTrack: "engines",
+    targetSelector: '[data-tour="module-panel"]',
+    tooltipPosition: "left",
+    copy: {
+      title: "SPIRTES — STRUCTURE DISCOVERY",
+      description:
+        "SPIRTES runs three causal-discovery algorithms in parallel. DCD/NOTEARS for nonlinear structure, PCMCI+ for time-lagged effects across T-2/T-1/T-0 columns, and FCI for hidden-confounder detection (dashed edges with '?' markers mean a latent common cause). The cascade header shows spectral radius λmax — below 1.0 the network is contractive and stable.",
+    },
+    onEnter: () => useApexStore.getState().setActiveModule("spirtes"),
+  },
+  {
+    id: "tarski-deep",
+    phase: "deep-dive",
+    deepDiveTrack: "engines",
+    targetSelector: '[data-tour="module-panel"]',
+    tooltipPosition: "left",
+    copy: {
+      title: "TARSKI — CONSTRAINT VERIFICATION",
+      description:
+        "TARSKI audits every edge against domain-aware axioms in three tiers: PHYSICAL (immutable laws), REGULATORY (sanctions, export controls, treaties; for life sciences: trial protocols and IRB constraints), and HEURISTIC (anomaly flags). Constraints are auto-ranked by relevance to your active domain. Toggle any axiom, hit VERIFY, and the canvas recolors — violating edges turn red, with clickable proof traces.",
+    },
+    onEnter: () => useApexStore.getState().setActiveModule("tarski"),
+  },
+  {
+    id: "pearl-deep",
+    phase: "deep-dive",
+    deepDiveTrack: "engines",
+    targetSelector: '[data-tour="module-panel"]',
+    tooltipPosition: "left",
+    copy: {
+      title: "PEARL — DO-CALCULUS & CASCADE DEFENSE",
+      description:
+        "PEARL implements structural interventions. do(X) isolates a node from its causes. SEVER cuts individual edges (amber — functionally removed, physically possible); ABLATE deletes nodes/edges entirely. Below the manual tools, CASCADE DEFENSE runs minimax optimization to find the cheapest set of edges whose removal maximally reduces downstream damage, with automatic Monte Carlo damage forecasts.",
+    },
+    onEnter: () => useApexStore.getState().setActiveModule("pearl"),
+  },
+  {
+    id: "pareto-deep",
+    phase: "deep-dive",
+    deepDiveTrack: "engines",
+    targetSelector: '[data-tour="module-panel"]',
+    tooltipPosition: "left",
+    copy: {
+      title: "PARETO — CRITICALITY HORIZONS",
+      description:
+        "PARETO tracks a domain-tuned set of criticality estimators with per-card T-N countdowns and confidence. Geopolitical/financial: CSD (λmax → 1), Persistent Homology, LPPLS (Sornette crash). Life Sciences / T1D: BOCPD changepoints, Cox proportional hazards, transfer entropy, NLME C-peptide decay, Moran's I, HTE meta-analysis. Each card exposes observed vs. model signal, formula, and live assessment.",
+    },
+    onEnter: () => useApexStore.getState().setActiveModule("pareto"),
+  },
+
+  // Analysis loop
+  {
+    id: "shock-injection",
+    phase: "deep-dive",
+    deepDiveTrack: "loop",
+    targetSelector: '[data-tour="module-panel"]',
+    tooltipPosition: "left",
+    copy: {
+      title: "SHOCK / STRESSOR INJECTION",
+      description:
+        "Under the criticality cards, the Scenario Injector loads preset shocks calibrated for your active domain. Geopolitical examples: Strait of Hormuz closure, Abqaiq attack, LNG train outage, sovereign default. Life Sciences examples: insulin supply disruption, β-cell antigen exposure spike, HLA-mismatch graft rejection. Each shock depletes the buffer according to severity and propagates through the cascade.",
+    },
+    onEnter: () => useApexStore.getState().setActiveModule("pareto"),
+  },
+  {
+    id: "cascade-defense",
+    phase: "deep-dive",
+    deepDiveTrack: "loop",
+    targetSelector: '[data-tour="module-panel"]',
+    tooltipPosition: "left",
+    copy: {
+      title: "CASCADE DEFENSE — AUTO-INTERDICTION",
+      description:
+        "When an attacker-defender min-cut is solvable, CASCADE DEFENSE proposes the cheapest edge set whose removal maximally reduces downstream damage, with explicit SEVER / ABLATE buttons per recommended cut. When the min-cut isn't solvable, the panel falls back to a structural-vulnerability ranking. Every recommendation auto-triggers a Monte Carlo forecast so you see the expected damage distribution before committing.",
+    },
+    onEnter: () => useApexStore.getState().setActiveModule("pearl"),
+  },
+  {
+    id: "compute-with-claude",
+    phase: "deep-dive",
+    deepDiveTrack: "loop",
+    targetSelector: '[data-tour="action-buttons"]',
+    tooltipPosition: "right",
+    copy: {
+      title: "COMPUTE WITH CLAUDE",
+      description:
+        "COMPUTE WITH CLAUDE generates a System State Snapshot — a structured digest of nodes, edges, engine outputs, and criticality metrics. Claude does the heavy reasoning; the copilot uses that snapshot as context for follow-up questions. If no Claude key is configured, a local snapshot is computed from graph structure instead. Snapshot status appears as a badge in the copilot header.",
+    },
+  },
+
+  // Customization
+  {
+    id: "view-modes",
+    phase: "deep-dive",
+    deepDiveTrack: "customization",
+    targetSelector: '[data-tour="dag-canvas"]',
+    tooltipPosition: "top",
+    copy: {
+      title: "3D / 2D / MAP VIEWS",
+      description:
+        "Top-right of the canvas: three view-mode buttons. 3D (WebGL force-directed), 2D (flat React Flow with animated causal flow), and MAP (geographic projection on MapLibre, for domains with real-world coordinates). All three stay mounted to preserve WebGL context — flip between them without losing state.",
+    },
+  },
+  {
+    id: "text-size",
+    phase: "deep-dive",
+    deepDiveTrack: "customization",
+    targetSelector: '[data-tour="text-size-toggle"]',
+    tooltipPosition: "bottom",
+    copy: {
+      title: "TEXT SIZE (S / M / L)",
+      description:
+        "Use the S / M / L toggle in the header to scale the readable text up or down. Layout, canvas, and icons stay put — only typography rescales, so dense panels stay legible without the graph reflowing. Persists across sessions and is applied before the page renders so there's no flash.",
+    },
+  },
+  {
+    id: "import",
+    phase: "deep-dive",
+    deepDiveTrack: "customization",
+    targetSelector: '[data-tour="import-button"]',
+    tooltipPosition: "bottom",
+    copy: {
+      title: "IMPORT YOUR OWN DATA",
+      description:
+        "Bring your own graph. IMPORT accepts CSV, JSON, or adjacency matrices; the platform auto-detects format and maps columns into the fragility framework. All four engines work on imported graphs exactly as they do on built-in domains. Multiple datasets can coexist and merge via cross-domain edges.",
+    },
+  },
+  {
+    id: "feedback",
+    phase: "deep-dive",
+    deepDiveTrack: "customization",
+    targetSelector: '[data-tour="feedback-widget"]',
+    tooltipPosition: "left",
+    copy: {
+      title: "FEEDBACK & FEATURE REQUESTS",
+      description:
+        "The floating pill in the bottom-right corner is your direct line to the team. File bugs, request features, or ask for new datasets — each category routes into our triage pipeline and becomes a tracked GitHub issue. Approved feature requests can be auto-implemented by an AI agent and shipped back as a PR. Use it liberally.",
+    },
+  },
+];
+
+export const TOUR_STEPS: TourStep[] = [...FIRST_RUN_STEPS, ...DEEP_DIVE_STEPS];
+
+export const FIRST_RUN_IDS = FIRST_RUN_STEPS.map((s) => s.id);
+
+export const DEEP_DIVE_TRACKS: { id: DeepDiveTrack; label: string; desc: string }[] = [
+  { id: "engines", label: "ENGINES", desc: "SPIRTES · TARSKI · PEARL · PARETO" },
+  { id: "loop", label: "ANALYSIS LOOP", desc: "Shocks · Cascade Defense · Compute" },
+  { id: "customization", label: "CUSTOMIZATION", desc: "Views · Text · Import · Feedback" },
+];
+
+/** Per-step padding override on the cutout. The welcome modal already has
+ *  its own bg-black/70 backdrop-blur, so any extra padding around the
+ *  cutout exposes blurred dim and washes the modal out. */
+export const STEP_PADDING: Record<string, number> = {
+  "welcome-and-domain": 0,
+};
+
+export const DEFAULT_PADDING = 8;


### PR DESCRIPTION
Replaces the 22-step linear tour with a tight first-run + opt-in deep dive, persona-aware copy, and three interactive "do this to continue" gates.

## Summary

| Before | After |
|---|---|
| 22 steps, all linear, all forced | **9 first-run** + **opt-in deep dive** the user picks tracks from |
| Same copy for every persona | **Two tracks** — `analyst` (financial/macro/geopolitical/cross) and `scientist` |
| All steps describe features | **3 first-run steps gate on user action** — click any node, switch to TARSKI, drag the time dial |
| Stuck users get no help | **Escalating pulse**: 8s soft pulse, 15s stronger pulse + bold hint |

## What's in the new flow

### First run (9 steps)
1. **Welcome — pick a persona** (gated on domain pick, existing logic)
2. **The causal canvas** — *click any node to continue* 🖱️
3. **Node Inspector — pillars** (passive, describes the radar pentagon)
4. **Four analysis engines** (passive)
5. **Try it — switch to TARSKI** — *click the TARSKI tab* 🖱️
6. **Time Dial — cascade replay** — *drag the dial back a few epochs* 🖱️
7. **CDΩ Doomsday Monitor** (passive)
8. **AI System Copilot** (passive)
9. **You're set** — opens the deep-dive menu (or close out)

### Deep dive (opt-in)
- **ENGINES** (4 steps): SPIRTES / TARSKI / PEARL / PARETO
- **ANALYSIS LOOP** (3 steps): shocks · Cascade Defense · Compute with Claude
- **CUSTOMIZATION** (4 steps): views · text size · import · feedback

User picks any combination from a menu that appears after first-run finish, or via the existing `?` button anytime.

## Per-track copy

Five personas → 2 tracks. The `scientist` track gets its own framing for everything domain-shaped:
- **Pillars**: I/R/J/C/T expand to *Irreplaceability of mechanism / Restoration latency / Regulatory exposure / Complication load / Outcome tail* (vs. *Irreplaceability / Restoration Latency / Jurisdictional Hazard / Cascade Load / Tail Depth* for analyst).
- **Estimators**: BOCPD, Cox-PH, NLME, transfer entropy (vs. CSD/PH/LPPLS).
- **Shocks**: insulin supply disruption, β-cell antigen exposure, HLA-mismatch graft rejection (vs. Hormuz, Abqaiq, LNG outage).
- **Canvas framing**: "biological causal DAG ... metabolic, vascular, neurological subsystems" vs. "causal DAG ... systemic risk".

Step-by-step: each `TourStep.copy` is either `StepCopy` (shared) or `Record<TourTrack, StepCopy>` (per-track). `resolveCopy()` picks at render time. `trackForPersona()` collapses 5 personas to 2 tracks.

## Interactive gates

Three first-run steps wait for user action via `useApexStore.subscribe()`:

```ts
awaitInteraction: {
  hint: "Click any node on the canvas to continue.",
  predicate: (s) => s.selectedNode !== null,
}
```

When the predicate flips true, the tooltip flashes "✓ Got it" and the step auto-advances after 400ms. The Next button is disabled until satisfied. No skip-step button — users can still bail the whole tour via SKIP TOUR / Esc.

## Escalating-hint stall recovery

When the user idles on an interactive step:
- **t=8s** — highlight starts a soft pulse (`tour-pulse-soft`, 1.6s ease-in-out, infinite)
- **t=15s** — pulse intensifies (`tour-pulse-strong`, 0.9s, slight scale-up + bigger glow), in-tooltip hint goes **bold**
- **on success** — brief green flash (`tour-pulse-success`)

Three CSS keyframes in `globals.css`. The pulse drives a separate `<rect>` overlay so the always-on cutout border doesn't flicker.

## File layout

- **New**: `src/lib/tour-steps.ts` — all step data, types, `resolveCopy`, `trackForPersona`. 408 lines.
- **Rewritten**: `src/components/SpotlightTour.tsx` — same cutout/dim/arrow math, plus interactive-gate subscription, escalation timers, and the deep-dive menu component.
- **Appended**: `src/app/globals.css` — three pulse keyframes + classes.
- **Updated**: `docs/sessions/ux-onboarding.md` — describes the new two-phase, two-track structure.

## Test plan

To re-trigger the first-visit flow: `localStorage.removeItem("manifold:tour-seen")` in DevTools, then reload.

### Analyst track (default — pick FINANCIAL / MACRO / GEOPOLITICAL / CROSS-DOMAIN persona)

- [ ] **Step 1** — welcome modal lists 5 persona pills with descriptions; advancing without picking a domain shows the amber hint
- [ ] **Step 2** — copy mentions Ω-Fragility (not CRITICALITY); clicking any node auto-advances after a brief "✓ Got it" flash
- [ ] **Step 2 stall test**: don't click for 8s → cutout starts pulsing softly. 15s → pulses harder, in-tooltip hint bolds.
- [ ] **Step 3** — Node Inspector section describes vertex-click pattern (post-#155)
- [ ] **Step 4** — describes SPIRTES / TARSKI / PEARL / PARETO by name
- [ ] **Step 5** — clicking the TARSKI tab auto-advances; otherwise pulses the tabs strip after 8s
- [ ] **Step 6** — dragging the time dial back a few epochs auto-advances
- [ ] **Steps 7–8** — CDΩ + Copilot copy as expected
- [ ] **Step 9** — "OPEN DEEP DIVE ▸" button shows the menu

### Scientist track (pick SCIENTIST persona, then a Life Sciences card)

- [ ] **Step 2** — copy mentions CRITICALITY and "metabolic, vascular, neurological subsystems" instead of Ω-Fragility
- [ ] **Step 3** — Node Inspector describes the biological pillar vocabulary
- [ ] **Step 4** — describes the four engines in Life-Sciences-friendly framing (BOCPD, Cox-PH, NLME mentioned)
- [ ] **Step 5** — TARSKI step references clinical/IRB axioms
- [ ] **Step 6** — Time Dial step talks about C-peptide and antigen exposure

### Deep-dive menu

- [ ] After first-run finish, three track buttons render: ENGINES (4 steps) / ANALYSIS LOOP (3 steps) / CUSTOMIZATION (4 steps)
- [ ] Each track runs as expected; "◂ MENU" returns to picker
- [ ] CLOSE on the menu dismisses the tour entirely
- [ ] Re-opening via the `?` button restarts at the first-run welcome step

### General

- [ ] Esc closes the tour at any point
- [ ] Arrow keys advance/back (disabled on the menu screen)
- [ ] Existing `data-tour` anchors still resolve (no broken cutouts)
- [ ] No regression in the welcome-step domain-selector gating

🤖 Generated with [Claude Code](https://claude.com/claude-code)
