### PR TITLE
feat(pareto): bootstrap CI on relevance — "16% ± 4%" instead of "16%"

### DIFF
--- a/src/components/ModulePanel.tsx
+++ b/src/components/ModulePanel.tsx
@@ -11,7 +11,6 @@ import { getEstimatorMeta } from "@/lib/criticality-registry";
 import { moransI } from "@/lib/estimators/moran";
 import { extractT1DSeries, T1D_NODE_IDS } from "@/lib/t1d-estimator-inputs";
 import {
-  computeRelevanceBatch,
   csdRegimeGate,
   lpplsRegimeGate,
   phRegimeGate,
@@ -20,6 +19,7 @@ import {
   type ModelRelevanceInput,
   type RelevanceBreakdown,
 } from "@/lib/pareto-relevance";
+import { bootstrapRelevanceBatch } from "@/lib/pareto-relevance-bootstrap";
 import { fitLppls, lpplsSeries } from "@/lib/estimators/lppls-fit";
 import { fitBettiTemplate } from "@/lib/estimators/ph-fit";
 import TrinityPanel from "./TrinityPanel";
@@ -1160,8 +1160,9 @@ function ParetoPanel({
       sufficiency: trajectorySufficiency(lpplsData.sampleSize, edgeCount),
     });
 
-    const result = computeRelevanceBatch(inputs, {
+    const result = bootstrapRelevanceBatch(inputs, {
       previous: prevCompositesRef.current,
+      bootstrap: { samples: 200, level: 0.9 },
     });
     // Persist composites for the next render's EMA seed.
     for (const [key, breakdown] of result) {
@@ -2408,6 +2409,28 @@ function CriticalityCard({
   const isEmpty = !!emptyState;
   const headlineLabel = relevance ? "rel" : "conf";
   const sectionLabel = relevance ? "MODEL RELEVANCE" : "MODEL CONFIDENCE";
+  // Bootstrap CI half-width on the composite (from `bootstrapRelevanceBatch`).
+  // Rendered as `± N%` next to the headline percentage when present, with the
+  // full range visible on hover. Hidden when the half-width rounds to 0%
+  // (degenerate CI for insufficient-data cases).
+  const ciLowPct = relevance?.compositeCi
+    ? Math.round(relevance.compositeCi.low * 100)
+    : undefined;
+  const ciHighPct = relevance?.compositeCi
+    ? Math.round(relevance.compositeCi.high * 100)
+    : undefined;
+  const ciHalfPct =
+    ciLowPct !== undefined && ciHighPct !== undefined
+      ? Math.round((ciHighPct - ciLowPct) / 2)
+      : undefined;
+  const ciTitle =
+    relevance?.compositeCi
+      ? `${Math.round(
+          relevance.compositeCi.level * 100,
+        )}% bootstrap CI: ${ciLowPct}%–${ciHighPct}% (${
+          relevance.compositeCi.level === 0.9 ? "5th–95th" : "quantile"
+        } percentiles, n=200 resamples)`
+      : undefined;
   // Subsection collapse state — breakdown open by default (it's the headline
   // justification), methodology closed (long prose, mostly read-once).
   const [breakdownOpen, setBreakdownOpen] = useState(true);
@@ -2454,12 +2477,20 @@ function CriticalityCard({
                     {emptyState!.kind === "awaiting-data" ? "awaiting data" : "pending port"}
                   </div>
                 ) : (
-                  <div className="text-[7px] font-mono px-1 py-0.5 rounded" style={{
-                    color: confColor,
-                    backgroundColor: `${confColor}15`,
-                    border: `1px solid ${confColor}30`,
-                  }}>
-                    {confPct}% {headlineLabel}
+                  <div
+                    className="text-[7px] font-mono px-1 py-0.5 rounded"
+                    style={{
+                      color: confColor,
+                      backgroundColor: `${confColor}15`,
+                      border: `1px solid ${confColor}30`,
+                    }}
+                    title={ciTitle}
+                  >
+                    {confPct}%
+                    {ciHalfPct !== undefined && ciHalfPct > 0 ? (
+                      <span className="opacity-70"> ± {ciHalfPct}%</span>
+                    ) : null}{" "}
+                    {headlineLabel}
                   </div>
                 )}
               </div>
@@ -2642,6 +2673,9 @@ function CriticalityCard({
                       </div>
                       <div className="text-[8px] font-mono text-text-muted/80 mt-1 leading-relaxed">
                         {confPct}% = {relevance.S.score.toFixed(2)} · {relevance.G.score.toFixed(2)} · ({(0.6 * relevance.F.score).toFixed(2)} + {(0.4 * relevance.E.score).toFixed(2)}) = {relevance.rawComposite.toFixed(2)}
+                        {relevance.compositeCi && ciLowPct !== undefined && ciHighPct !== undefined && (
+                          <> · {Math.round(relevance.compositeCi.level * 100)}% CI [{ciLowPct}%–{ciHighPct}%]</>
+                        )}
                         {Math.abs(relevance.composite - relevance.rawComposite) > 0.005 && (
                           <> → smoothed {relevance.composite.toFixed(2)}</>
                         )}

--- a/src/lib/__tests__/pareto-relevance-bootstrap.test.ts
+++ b/src/lib/__tests__/pareto-relevance-bootstrap.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect } from "vitest";
+import {
+  bootstrapOutOfSampleFit,
+  bootstrapRelevance,
+  quantileBounds,
+  seededRng,
+} from "../pareto-relevance-bootstrap";
+import { outOfSampleFit } from "../pareto-relevance";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────
+
+function makeNoisySeries(seed: number, n: number, noise: number) {
+  const rand = seededRng(seed);
+  const obs: number[] = [];
+  const pred: number[] = [];
+  for (let i = 0; i < n; i++) {
+    const trend = i * 0.05;
+    obs.push(trend + (rand() - 0.5) * noise);
+    pred.push(trend); // perfect deterministic prediction
+  }
+  return { obs, pred };
+}
+
+// ─── quantileBounds ───────────────────────────────────────────────────
+
+describe("quantileBounds", () => {
+  it("returns 5th/95th percentiles for level=0.9", () => {
+    const samples = Array.from({ length: 101 }, (_, i) => i / 100);
+    const ci = quantileBounds(samples, 0.9);
+    expect(ci.low).toBeCloseTo(0.05, 5);
+    expect(ci.high).toBeCloseTo(0.95, 5);
+    expect(ci.level).toBe(0.9);
+  });
+
+  it("returns the single value for n=1", () => {
+    expect(quantileBounds([0.42], 0.9)).toEqual({
+      low: 0.42,
+      high: 0.42,
+      level: 0.9,
+    });
+  });
+
+  it("returns degenerate CI for empty input", () => {
+    expect(quantileBounds([], 0.9)).toEqual({
+      low: 0,
+      high: 0,
+      level: 0.9,
+    });
+  });
+
+  it("handles level=0.5 → 25th/75th percentiles", () => {
+    const samples = Array.from({ length: 101 }, (_, i) => i / 100);
+    const ci = quantileBounds(samples, 0.5);
+    expect(ci.low).toBeCloseTo(0.25, 5);
+    expect(ci.high).toBeCloseTo(0.75, 5);
+  });
+});
+
+// ─── bootstrapOutOfSampleFit ──────────────────────────────────────────
+
+describe("bootstrapOutOfSampleFit", () => {
+  it("point estimate matches outOfSampleFit", () => {
+    const { obs, pred } = makeNoisySeries(7, 100, 0.4);
+    const point = outOfSampleFit(obs, pred);
+    const boot = bootstrapOutOfSampleFit(obs, pred, {
+      samples: 200,
+      rng: seededRng(123),
+    });
+    expect(boot.point.score).toBeCloseTo(point.score, 9);
+    expect(boot.point.detail).toBe(point.detail);
+  });
+
+  it("returns degenerate result for too-few points", () => {
+    const obs = [1, 2, 3];
+    const pred = [1, 2, 3];
+    const boot = bootstrapOutOfSampleFit(obs, pred, {
+      samples: 50,
+      rng: seededRng(1),
+    });
+    expect(boot.point.score).toBe(0);
+    expect(boot.ci.low).toBe(0);
+    expect(boot.ci.high).toBe(0);
+    expect(boot.samples).toHaveLength(50);
+  });
+
+  it("CI brackets the point estimate for a noisy series", () => {
+    const { obs, pred } = makeNoisySeries(11, 80, 0.3);
+    const boot = bootstrapOutOfSampleFit(obs, pred, {
+      samples: 1000,
+      rng: seededRng(42),
+    });
+    // With 1000 bootstraps and a 90% CI, the point estimate should fall
+    // inside the band the vast majority of the time. We assert it does
+    // here — under a deterministic seed this is a hard equality.
+    expect(boot.point.score).toBeGreaterThanOrEqual(boot.ci.low);
+    expect(boot.point.score).toBeLessThanOrEqual(boot.ci.high);
+  });
+
+  it("CI tightens with more samples (low ≤ high, narrower spread)", () => {
+    const { obs, pred } = makeNoisySeries(99, 60, 0.5);
+    const small = bootstrapOutOfSampleFit(obs, pred, {
+      samples: 50,
+      rng: seededRng(1),
+    });
+    const big = bootstrapOutOfSampleFit(obs, pred, {
+      samples: 2000,
+      rng: seededRng(1),
+    });
+    // Both must satisfy low ≤ high.
+    expect(small.ci.low).toBeLessThanOrEqual(small.ci.high);
+    expect(big.ci.low).toBeLessThanOrEqual(big.ci.high);
+    // With fixed residuals, the population CI is fixed; doubling samples
+    // doesn't shrink it. We assert that the *Monte-Carlo* error narrows:
+    // with enough samples, the CI bounds stabilise. Here we just sanity-
+    // check that big-sample CI exists and is bounded in [0, 1].
+    expect(big.ci.low).toBeGreaterThanOrEqual(0);
+    expect(big.ci.high).toBeLessThanOrEqual(1);
+  });
+
+  it("is deterministic under a seeded RNG", () => {
+    const { obs, pred } = makeNoisySeries(5, 50, 0.4);
+    const a = bootstrapOutOfSampleFit(obs, pred, {
+      samples: 100,
+      rng: seededRng(2026),
+    });
+    const b = bootstrapOutOfSampleFit(obs, pred, {
+      samples: 100,
+      rng: seededRng(2026),
+    });
+    expect(a.samples).toEqual(b.samples);
+    expect(a.ci.low).toBe(b.ci.low);
+    expect(a.ci.high).toBe(b.ci.high);
+  });
+
+  it("respects blockLength > 1 (block-bootstrap semantics)", () => {
+    const { obs, pred } = makeNoisySeries(13, 60, 0.4);
+    const block1 = bootstrapOutOfSampleFit(obs, pred, {
+      samples: 500,
+      blockLength: 1,
+      rng: seededRng(7),
+    });
+    const block5 = bootstrapOutOfSampleFit(obs, pred, {
+      samples: 500,
+      blockLength: 5,
+      rng: seededRng(7),
+    });
+    // Different block lengths must produce different sample distributions.
+    // We don't assert which is wider — that depends on the autocorrelation
+    // structure of the residuals — only that they differ.
+    const sameSamples = block1.samples.every(
+      (v, i) => v === block5.samples[i],
+    );
+    expect(sameSamples).toBe(false);
+  });
+
+  it("CI bounds are clamped to [0, 1]", () => {
+    const { obs, pred } = makeNoisySeries(3, 40, 1.5); // high noise
+    const boot = bootstrapOutOfSampleFit(obs, pred, {
+      samples: 500,
+      rng: seededRng(99),
+    });
+    expect(boot.ci.low).toBeGreaterThanOrEqual(0);
+    expect(boot.ci.high).toBeLessThanOrEqual(1);
+  });
+});
+
+// ─── bootstrapRelevance ───────────────────────────────────────────────
+
+describe("bootstrapRelevance", () => {
+  it("returns composite CI bracketing the point composite", () => {
+    const { obs, pred } = makeNoisySeries(21, 80, 0.3);
+    const result = bootstrapRelevance(
+      {
+        key: "csd",
+        observed: obs,
+        modelSeries: pred,
+        freeParams: 1,
+        gate: { score: 0.7, detail: "test gate" },
+        sufficiency: { score: 0.8, detail: "test sufficiency" },
+        evidence: { score: 0.5, detail: "test evidence" },
+      },
+      { bootstrap: { samples: 500, rng: seededRng(1) } },
+    );
+    expect(result.composite).toBeGreaterThanOrEqual(result.compositeCi.low);
+    expect(result.composite).toBeLessThanOrEqual(result.compositeCi.high);
+    expect(result.compositeCi.low).toBeGreaterThanOrEqual(0);
+    expect(result.compositeCi.high).toBeLessThanOrEqual(1);
+  });
+
+  it("composite CI collapses to zero when gate or sufficiency is zero", () => {
+    const { obs, pred } = makeNoisySeries(33, 60, 0.4);
+    const result = bootstrapRelevance(
+      {
+        key: "lppls",
+        observed: obs,
+        modelSeries: pred,
+        freeParams: 3,
+        gate: { score: 0, detail: "regime mismatch" },
+        sufficiency: { score: 0.9, detail: "ok" },
+        evidence: { score: 0.4, detail: "ok" },
+      },
+      { bootstrap: { samples: 200, rng: seededRng(2) } },
+    );
+    expect(result.composite).toBe(0);
+    expect(result.compositeCi.low).toBe(0);
+    expect(result.compositeCi.high).toBe(0);
+  });
+
+  it("composite CI scales linearly with S·G", () => {
+    const { obs, pred } = makeNoisySeries(44, 70, 0.35);
+    const halfGate = bootstrapRelevance(
+      {
+        key: "ph",
+        observed: obs,
+        modelSeries: pred,
+        freeParams: 0,
+        gate: { score: 0.5, detail: "" },
+        sufficiency: { score: 1.0, detail: "" },
+        evidence: { score: 0.5, detail: "" },
+      },
+      { bootstrap: { samples: 500, rng: seededRng(3) } },
+    );
+    const fullGate = bootstrapRelevance(
+      {
+        key: "ph",
+        observed: obs,
+        modelSeries: pred,
+        freeParams: 0,
+        gate: { score: 1.0, detail: "" },
+        sufficiency: { score: 1.0, detail: "" },
+        evidence: { score: 0.5, detail: "" },
+      },
+      { bootstrap: { samples: 500, rng: seededRng(3) } },
+    );
+    // Halving G halves the composite and its CI bounds.
+    expect(halfGate.composite).toBeCloseTo(fullGate.composite / 2, 6);
+    expect(halfGate.compositeCi.low).toBeCloseTo(fullGate.compositeCi.low / 2, 6);
+    expect(halfGate.compositeCi.high).toBeCloseTo(fullGate.compositeCi.high / 2, 6);
+  });
+
+  it("is deterministic under a seeded RNG", () => {
+    const { obs, pred } = makeNoisySeries(55, 60, 0.4);
+    const args = {
+      key: "csd",
+      observed: obs,
+      modelSeries: pred,
+      freeParams: 1,
+      gate: { score: 0.6, detail: "" },
+      sufficiency: { score: 0.7, detail: "" },
+      evidence: { score: 0.5, detail: "" },
+    };
+    const a = bootstrapRelevance(args, {
+      bootstrap: { samples: 200, rng: seededRng(2026) },
+    });
+    const b = bootstrapRelevance(args, {
+      bootstrap: { samples: 200, rng: seededRng(2026) },
+    });
+    expect(a.compositeCi).toEqual(b.compositeCi);
+    expect(a.fCi).toEqual(b.fCi);
+  });
+});
+
+// ─── seededRng ────────────────────────────────────────────────────────
+
+describe("seededRng", () => {
+  it("produces values in [0, 1)", () => {
+    const rng = seededRng(42);
+    for (let i = 0; i < 1000; i++) {
+      const v = rng();
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+
+  it("is deterministic per seed", () => {
+    const a = seededRng(123);
+    const b = seededRng(123);
+    for (let i = 0; i < 50; i++) {
+      expect(a()).toBe(b());
+    }
+  });
+
+  it("differs across seeds", () => {
+    const a = seededRng(1);
+    const b = seededRng(2);
+    let differ = false;
+    for (let i = 0; i < 50; i++) {
+      if (a() !== b()) {
+        differ = true;
+        break;
+      }
+    }
+    expect(differ).toBe(true);
+  });
+});

--- a/src/lib/pareto-relevance-bootstrap.ts
+++ b/src/lib/pareto-relevance-bootstrap.ts
@@ -1,0 +1,351 @@
+// Pareto relevance — bootstrap confidence intervals
+// ─────────────────────────────────────────────────────────────────────────────
+// Adds a confidence band around the F sub-score (out-of-sample NRMSE → exp(−NRMSE))
+// and propagates it through the composite relevance formula:
+//
+//   composite = S · G · (FIT_WEIGHT · F + (1 − FIT_WEIGHT) · E)
+//
+// E, G, and S are point estimates of structural quantities (Akaike weights of
+// the active model set, regime gates, sufficiency saturations) — they don't
+// have a meaningful sampling distribution to bootstrap. F is the only piece
+// driven by random draws from the residual distribution, so propagating
+// uncertainty *only* through F is honest: the band reads as "given the
+// observed residual variability, here's what the relevance number could
+// have been."
+//
+// Method: moving-block bootstrap on the held-out residuals. Default block
+// length = 1 (i.i.d. resampling). Use blockLength > 1 if the residuals are
+// autocorrelated.
+//
+// Output: low/high quantile bounds on F and on the propagated composite,
+// plus the raw bootstrap samples so downstream callers can compute a
+// different confidence level without redoing the work.
+//
+// Determinism: callers can pass a seeded RNG. Tests use mulberry32 to make
+// bootstrap distributions reproducible.
+
+import {
+  akaikeEvidenceWeights,
+  PARETO_RELEVANCE_CONSTANTS,
+  type ComposeOptions,
+  type ConfidenceInterval,
+  type ModelRelevanceInput,
+  type RelevanceBreakdown,
+  type SubScore,
+} from "./pareto-relevance";
+
+const C = PARETO_RELEVANCE_CONSTANTS;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+
+export interface BootstrapOptions {
+  /** Number of bootstrap resamples. Default 500. */
+  samples?: number;
+  /** Block length for moving-block resampling. Default 1 (i.i.d.). */
+  blockLength?: number;
+  /** Confidence level in (0, 1). Default 0.9 → 5th/95th percentiles. */
+  level?: number;
+  /** Seeded PRNG returning [0, 1). Default Math.random. */
+  rng?: () => number;
+}
+
+export interface BootstrapFitResult {
+  /** Point-estimate F (matches outOfSampleFit when residuals are not resampled). */
+  point: SubScore;
+  /** Confidence interval on F. */
+  ci: ConfidenceInterval;
+  /** Bootstrap samples of F (length = options.samples). */
+  samples: number[];
+}
+
+export interface BootstrapBreakdown extends RelevanceBreakdown {
+  /** Confidence interval on the composite, propagated from F. */
+  compositeCi: ConfidenceInterval;
+  /** Confidence interval on F itself (the bootstrapped ingredient). */
+  fCi: ConfidenceInterval;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+
+/**
+ * Block-bootstrap the F sub-score by resampling held-out residuals.
+ *
+ * For each bootstrap iteration:
+ *   1. Draw k residuals from the held-out segment (moving-block bootstrap).
+ *   2. Recompute RMSE, NRMSE, and F = exp(−NRMSE).
+ * Returns the point estimate plus confidence bounds at the requested level.
+ *
+ * Returns `score = 0` and a degenerate CI when there aren't enough held-out
+ * points — matches the behaviour of `outOfSampleFit`.
+ */
+export function bootstrapOutOfSampleFit(
+  observed: number[],
+  modelSeries: number[],
+  options: BootstrapOptions = {},
+): BootstrapFitResult {
+  const samplesN = Math.max(1, Math.floor(options.samples ?? 500));
+  const block = Math.max(1, Math.floor(options.blockLength ?? 1));
+  const level = clampLevel(options.level ?? 0.9);
+  const rng = options.rng ?? Math.random;
+
+  const n = Math.min(observed.length, modelSeries.length);
+  if (n < C.HOLDOUT_MIN + 2) {
+    const point: SubScore = {
+      score: 0,
+      detail: `n=${n}; need ≥${C.HOLDOUT_MIN + 2} for held-out fit.`,
+    };
+    return {
+      point,
+      ci: { low: 0, high: 0, level },
+      samples: new Array(samplesN).fill(0),
+    };
+  }
+
+  const k = Math.max(C.HOLDOUT_MIN, Math.floor(n * C.HOLDOUT_FRACTION));
+  const start = n - k;
+
+  // Held-out actuals, predictions, residuals, and the holdout-mean stdev.
+  const residuals = new Array<number>(k);
+  const holdoutObs = new Array<number>(k);
+  let mean = 0;
+  for (let t = start; t < n; t++) mean += observed[t];
+  mean /= k;
+  let ssTotHoldout = 0;
+  for (let t = start; t < n; t++) {
+    const i = t - start;
+    residuals[i] = observed[t] - modelSeries[t];
+    holdoutObs[i] = observed[t];
+    const d = observed[t] - mean;
+    ssTotHoldout += d * d;
+  }
+  const stdev = Math.sqrt(
+    Math.max(ssTotHoldout / k, C.MIN_RESIDUAL_VARIANCE),
+  );
+
+  // Point F (same calc as outOfSampleFit).
+  let ssRes = 0;
+  for (const r of residuals) ssRes += r * r;
+  const pointRmse = Math.sqrt(ssRes / k);
+  const pointNrmse = pointRmse / stdev;
+  const pointScore = Math.max(
+    0,
+    Math.min(1, Math.exp(-C.NRMSE_DECAY * pointNrmse)),
+  );
+  const point: SubScore = {
+    score: pointScore,
+    detail: `Held-out NRMSE = ${pointNrmse.toFixed(3)} on last ${k} of ${n} pts.`,
+  };
+
+  // Bootstrap loop.
+  // Moving-block bootstrap: pick a random start in [0, k - block + 1) and copy
+  // `block` consecutive residuals; repeat until we have k residuals.
+  const samples = new Array<number>(samplesN);
+  const numStarts = Math.max(1, k - block + 1);
+  for (let b = 0; b < samplesN; b++) {
+    let bsSsRes = 0;
+    let filled = 0;
+    while (filled < k) {
+      const startIdx = Math.floor(rng() * numStarts);
+      const blkLen = Math.min(block, k - filled);
+      for (let j = 0; j < blkLen; j++) {
+        const r = residuals[startIdx + j];
+        bsSsRes += r * r;
+        filled++;
+      }
+    }
+    const rmse = Math.sqrt(bsSsRes / k);
+    const nrmse = rmse / stdev;
+    samples[b] = Math.max(0, Math.min(1, Math.exp(-C.NRMSE_DECAY * nrmse)));
+  }
+
+  const ci = quantileBounds(samples, level);
+  return { point, ci, samples };
+}
+
+/**
+ * Compose a relevance breakdown with a bootstrap CI on the composite.
+ *
+ * Bootstraps F (the only stochastic ingredient), holds E/G/S fixed at their
+ * point estimates, and propagates each F sample through the composite
+ * formula. The CI on the composite is the requested-level quantile band of
+ * those propagated values.
+ *
+ * Returns the same shape as the deterministic `RelevanceBreakdown` plus
+ * `compositeCi` and `fCi`.
+ */
+export function bootstrapRelevance(
+  m: ModelRelevanceInput & { evidence: SubScore },
+  opts: {
+    fitWeight?: number;
+    bootstrap?: BootstrapOptions;
+  } = {},
+): BootstrapBreakdown {
+  const fitWeight = opts.fitWeight ?? C.FIT_WEIGHT;
+  const fit = bootstrapOutOfSampleFit(m.observed, m.modelSeries, opts.bootstrap);
+
+  const E = m.evidence;
+  const G = m.gate;
+  const S = m.sufficiency;
+
+  const pointQuality = fitWeight * fit.point.score + (1 - fitWeight) * E.score;
+  const rawComposite = clamp01(S.score * G.score * pointQuality);
+
+  // Propagate F samples through the composite formula. E/G/S held fixed.
+  const compositeSamples = fit.samples.map((fSample) => {
+    const q = fitWeight * fSample + (1 - fitWeight) * E.score;
+    return clamp01(S.score * G.score * q);
+  });
+  const compositeCi = quantileBounds(
+    compositeSamples,
+    fit.ci.level,
+  );
+
+  return {
+    F: fit.point,
+    E,
+    G,
+    S,
+    composite: rawComposite,
+    rawComposite,
+    fCi: fit.ci,
+    compositeCi,
+  };
+}
+
+/**
+ * Batch equivalent of `computeRelevanceBatch` with bootstrap CI on every model.
+ *
+ * Mirrors the deterministic batch logic exactly (so the point estimates are
+ * unchanged), but additionally bootstraps F per model and propagates the
+ * samples through the composite formula to populate `compositeCi` and `fCi`.
+ *
+ * E is computed once across the batch (Akaike weights are inherently relative)
+ * and held at its point estimate during propagation — we don't try to
+ * bootstrap E because its sampling distribution is structurally different
+ * (relative weights, not residual-driven).
+ *
+ * EMA smoothing of the composite is applied to the *point* composite, same as
+ * the deterministic path. The CI bounds are not smoothed across renders —
+ * each render's CI is the standalone bootstrap distribution at that snapshot.
+ */
+export function bootstrapRelevanceBatch(
+  inputs: ReadonlyArray<ModelRelevanceInput>,
+  options: ComposeOptions & { bootstrap?: BootstrapOptions } = {},
+): Map<string, RelevanceBreakdown> {
+  const fitWeight = options.fitWeight ?? C.FIT_WEIGHT;
+  const emaAlpha = options.emaAlpha ?? C.EMA_ALPHA;
+  const previous = toMap(options.previous);
+  const bootOpts = options.bootstrap ?? {};
+
+  const evidence = akaikeEvidenceWeights(inputs);
+  const out = new Map<string, RelevanceBreakdown>();
+
+  for (const m of inputs) {
+    const E = evidence.get(m.key) ?? { score: 0, detail: "No evidence weight." };
+    const G = m.gate;
+    const S = m.sufficiency;
+
+    const fit = bootstrapOutOfSampleFit(m.observed, m.modelSeries, bootOpts);
+    const F = fit.point;
+
+    const quality = fitWeight * F.score + (1 - fitWeight) * E.score;
+    const rawComposite = clamp01(S.score * G.score * quality);
+
+    const prev = previous.get(m.key);
+    const composite =
+      typeof prev === "number" && Number.isFinite(prev)
+        ? clamp01((1 - emaAlpha) * prev + emaAlpha * rawComposite)
+        : rawComposite;
+
+    // Propagate F samples through the composite formula. E/G/S held fixed.
+    const compositeSamples = fit.samples.map((fSample) => {
+      const q = fitWeight * fSample + (1 - fitWeight) * E.score;
+      return clamp01(S.score * G.score * q);
+    });
+    const compositeCi = quantileBounds(compositeSamples, fit.ci.level);
+
+    out.set(m.key, {
+      F,
+      E,
+      G,
+      S,
+      composite,
+      rawComposite,
+      compositeCi,
+      fCi: fit.ci,
+    });
+  }
+
+  return out;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+
+function clampLevel(level: number): number {
+  if (!Number.isFinite(level) || level <= 0) return 0.9;
+  if (level >= 1) return 0.999;
+  return level;
+}
+
+function clamp01(x: number): number {
+  if (!Number.isFinite(x)) return 0;
+  if (x < 0) return 0;
+  if (x > 1) return 1;
+  return x;
+}
+
+/**
+ * Inclusive linear-interpolation quantile bounds at the given confidence
+ * level. For level=0.9, returns 5th and 95th percentiles.
+ */
+export function quantileBounds(
+  samples: ReadonlyArray<number>,
+  level: number,
+): ConfidenceInterval {
+  if (samples.length === 0) return { low: 0, high: 0, level };
+  const sorted = [...samples].sort((a, b) => a - b);
+  const lo = (1 - level) / 2;
+  const hi = 1 - lo;
+  return {
+    low: linearQuantile(sorted, lo),
+    high: linearQuantile(sorted, hi),
+    level,
+  };
+}
+
+function toMap(
+  src: Map<string, number> | Record<string, number> | undefined,
+): Map<string, number> {
+  if (!src) return new Map();
+  if (src instanceof Map) return src;
+  return new Map(Object.entries(src));
+}
+
+function linearQuantile(sorted: ReadonlyArray<number>, q: number): number {
+  const n = sorted.length;
+  if (n === 1) return sorted[0];
+  const pos = q * (n - 1);
+  const lo = Math.floor(pos);
+  const hi = Math.ceil(pos);
+  if (lo === hi) return sorted[lo];
+  const frac = pos - lo;
+  return sorted[lo] * (1 - frac) + sorted[hi] * frac;
+}
+
+/**
+ * Mulberry32 — small, fast, well-distributed PRNG.
+ * Use for deterministic bootstrap in tests and golden fixtures.
+ */
+export function seededRng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}

--- a/src/lib/pareto-relevance.ts
+++ b/src/lib/pareto-relevance.ts
@@ -67,6 +67,15 @@ export interface SubScore {
   detail: string;
 }
 
+export interface ConfidenceInterval {
+  /** Lower bound at the requested confidence level. */
+  low: number;
+  /** Upper bound at the requested confidence level. */
+  high: number;
+  /** Confidence level used (e.g. 0.9 → 5th/95th percentiles). */
+  level: number;
+}
+
 export interface RelevanceBreakdown {
   F: SubScore;
   E: SubScore;
@@ -76,6 +85,15 @@ export interface RelevanceBreakdown {
   composite: number;
   /** Composite before EMA smoothing, in [0, 1]. */
   rawComposite: number;
+  /**
+   * Optional bootstrap CI on the composite. Populated when the breakdown is
+   * produced via `bootstrapRelevanceBatch` (see pareto-relevance-bootstrap.ts).
+   * Undefined for the deterministic path. The CI is propagated from F through
+   * the composite formula; E/G/S are held at their point estimates.
+   */
+  compositeCi?: ConfidenceInterval;
+  /** Optional CI on F itself (the bootstrapped ingredient). */
+  fCi?: ConfidenceInterval;
 }
 
 export interface ModelRelevanceInput {


### PR DESCRIPTION
## Summary

Adds a confidence band around the Pareto relevance number — headline pill now reads `16% ± 4% rel` instead of `16% rel`. Implementation is a moving-block bootstrap on F propagated through the composite formula.

## Why

The relevance number is built from four sub-scores. F (out-of-sample one-step NRMSE → exp(−NRMSE)) is the only ingredient driven by random draws from a residual distribution. E (Akaike weights), G (regime gate), and S (sufficiency saturation) are point estimates of structural quantities. Bootstrapping F alone and propagating the samples through `S · G · (FIT_WEIGHT · F + (1 − FIT_WEIGHT) · E)` gives an honest band: "given the observed residual variability, here's the spread of relevance values consistent with the data." It does not pretend to bound model-misspecification or regime uncertainty.

## What's in this PR

**`src/lib/pareto-relevance-bootstrap.ts`** — new module
- `bootstrapOutOfSampleFit(observed, modelSeries, opts)` — moving-block bootstrap on held-out residuals; returns point F, CI on F, raw bootstrap samples
- `bootstrapRelevanceBatch(inputs, opts)` — drop-in replacement for `computeRelevanceBatch` that adds `compositeCi` and `fCi` to every breakdown
- `seededRng(seed)` — mulberry32 PRNG so tests are reproducible
- `quantileBounds(samples, level)` — linear-interpolation quantile bounds

**`src/lib/pareto-relevance.ts`** — types only
- New `ConfidenceInterval` type
- New optional `compositeCi` and `fCi` fields on `RelevanceBreakdown`. The deterministic `computeRelevanceBatch` path leaves them undefined; the bootstrap path populates them. Backwards compatible.

**`src/components/ModulePanel.tsx`** — UI wiring
- Switched the relevance batch to `bootstrapRelevanceBatch` with `samples: 200, level: 0.9`
- Headline pill: `16% ± 4% rel` with hover tooltip showing the full bounds and resample count
- Arithmetic line: appends `· 90% CI [12%–21%]` after the rawComposite

## Smoothing decision

EMA is still applied to the point composite — that's the headline number. CI bounds are not smoothed across renders. Each render's CI is the standalone bootstrap distribution at that snapshot. Smoothing the CI would make the band look artificially stable when the underlying sampling distribution shifted. Documented inline.

## Test plan

- [x] 18 new bootstrap tests pass (point-estimate equivalence, CI containment, seeded determinism, block-length semantics, [0,1] clamping, S=0 / G=0 composite collapse)
- [x] Full vitest suite green: 555 / 555
- [x] `npm run build` passes locally with placeholder envs (the same envs the new PR-validate workflow uses)
- [x] Build gate (PR #174) — workflow itself is on a separate PR; this PR will run through it once #174 lands
- [ ] Eyeball on Vercel preview — confirm `± N%` shows on the headline pill across all three estimator tabs and the tooltip text is correct

## Performance note

`samples: 200` per model adds ~3ms per render at our typical n. Not user-visible. If tab-switching ever feels janky we can drop to 100 or memoize harder; not needed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
