### PR TITLE
feat(onboarding): "?" tutorial launcher on the Domain Workspace modal

### DIFF
--- a/src/components/DomainSelector.tsx
+++ b/src/components/DomainSelector.tsx
@@ -293,6 +293,7 @@ export function buildGraphFromDomains(domainIds: string[]): CausalGraph {
 export default function DomainSelector() {
   const domainSelectorOpen = useApexStore((s) => s.domainSelectorOpen);
   const setDomainSelectorOpen = useApexStore((s) => s.setDomainSelectorOpen);
+  const setTourActive = useApexStore((s) => s.setTourActive);
   const setIsMultiDomainMode = useApexStore((s) => s.setIsMultiDomainMode);
   const setSelectedDomains = useApexStore((s) => s.setSelectedDomains);
   const setVisibleCategories = useApexStore((s) => s.setVisibleCategories);
@@ -458,6 +459,16 @@ export default function DomainSelector() {
                   Select risk domain{localMulti ? "s" : ""} to initialize causal graph
                 </span>
               </div>
+              {/* Tutorial launcher — same affordance as the header "?" button,
+                  reachable before the user has even committed to a domain. */}
+              <button
+                onClick={() => setTourActive(true)}
+                className="flex items-center justify-center w-7 h-7 rounded border border-border text-[11px] font-[family-name:var(--font-michroma)] text-text-muted hover:text-accent-cyan hover:border-accent-cyan/40 transition-colors shrink-0"
+                title="Feature tour"
+                aria-label="Launch feature tour"
+              >
+                ?
+              </button>
             </div>
 
             {/* Persona Selector */}


### PR DESCRIPTION
## Summary

Adds a `?` button to the top-right of the Domain Workspace modal header so users can launch the feature tour from the very first screen — without first having to pick a domain and enter the platform.

Same 7×7 button as the existing header `?`, same hover/accent treatment. Wires to `setTourActive(true)`; `SpotlightTour`'s existing "tour was just re-opened externally" effect resets to the first-run welcome step automatically.

## Why

After #177 the tutorial flow assumes users find the `?` after they've already committed to a domain and entered the platform. For first-time visitors who want a walkthrough *before* picking a workspace, that's an unintuitive first step. Adding the same affordance directly on the modal makes it discoverable at the moment of arrival.

## Test plan

- [ ] Open Manifold in incognito (or `localStorage.removeItem("manifold:tour-seen")` then reload)
- [ ] The auto-launching tour appears on the welcome step as before
- [ ] Dismiss the tour with SKIP TOUR. The Domain Workspace modal stays visible.
- [ ] A `?` button is now visible at the top-right of the Domain Workspace modal, matching the header `?`
- [ ] Clicking it relaunches the tour at the welcome step
- [ ] Picking a domain and closing the modal still auto-advances to step 2 (canvas)
- [ ] The header `?` button still works the same way as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
