### PR TITLE
perf: apply #72 playbook leftovers (selectors, indexed lookups)

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -113,6 +113,17 @@ This is the running log for the Rendering & Perf session. Every change pushed fr
 
 **Verification.** `tsc --noEmit` clean; lint clean on changed file; vitest 522/522 pass.
 
+### 2026-05-02 — Perf sweep across canvas surfaces (#72 playbook leftovers)
+
+Audit found four spots where the #72 playbook patterns hadn't been fully applied. All low-risk swaps; no behavior change.
+
+1. **`CausalDAG2D.tsx:302–313`** — full-store destructure (`const { truthFilter, replayActive, currentEpoch, ... } = useApexStore()`) replaced with eight per-field selectors. The destructure re-rendered the entire 2D component on every store mutation including timeline scrub ticks (`currentEpoch` / `timelinePosition`) — even when those fields were irrelevant to the rendered output.
+2. **`dag3d/DAGOverlay.tsx`** — added a memoized `nodeById` Map and replaced three `activeGraph.nodes.find(...)` calls (one in `selectedNodes.map()`, two in the ANALYZE-SELECTION button handler). With 20+ selected nodes the previous code was O(N²); now O(1) per lookup.
+3. **`CausalDAG3D.tsx:907–912`** — edge inspector label resolution switched from `graphData.nodes.find(...)` to the existing `nodeById` Map. Same lookup used elsewhere in the file; no reason to re-walk the array per render.
+4. **`CausalDAG3D.tsx:573` (new)** — added a memoized `edgeById` Map alongside `nodeById`. `greyedOutNodes` now resolves severed edges via `edgeById.get(edgeId)` instead of `graphData.edges.find(...)` per cut.
+
+**Verification.** `tsc --noEmit` clean; lint clean on changed files; vitest 537/537 pass. (Three pre-existing lint errors at `CausalDAG3D.tsx:86, 91, 306` are unrelated — `posMapRef.current = ...` in render, an `any` cast, and `performance.now()` in `useRef` initializer. Out of scope for this sweep.)
+
 ### 2026-05-02 — Next up
 
 - TBD — open for direction.

--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -301,16 +301,16 @@ function FitViewOnVisible({ visibleKey, isEmpty }: { visibleKey: string; isEmpty
 
 function CausalDAG2DInner() {
   const graphData = useFilteredGraph();
-  const {
-    truthFilter,
-    replayActive,
-    currentEpoch,
-    baselineEpochs,
-    interventionEpochs,
-    activeTimeline,
-    isolateSelection,
-    selectedNodes: multiSelectedNodes,
-  } = useApexStore();
+  // Fine-grained selectors — full-store destructure re-renders this whole
+  // component on any unrelated mutation (timeline scrub fires every tick).
+  const truthFilter = useApexStore((s) => s.truthFilter);
+  const replayActive = useApexStore((s) => s.replayActive);
+  const currentEpoch = useApexStore((s) => s.currentEpoch);
+  const baselineEpochs = useApexStore((s) => s.baselineEpochs);
+  const interventionEpochs = useApexStore((s) => s.interventionEpochs);
+  const activeTimeline = useApexStore((s) => s.activeTimeline);
+  const isolateSelection = useApexStore((s) => s.isolateSelection);
+  const multiSelectedNodes = useApexStore((s) => s.selectedNodes);
 
   const [selectedEdge, setSelectedEdge] = useState<CausalEdge | null>(null);
 

--- a/src/components/CausalDAG3D.tsx
+++ b/src/components/CausalDAG3D.tsx
@@ -572,6 +572,15 @@ export default function CausalDAG3D() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [topologyKey]);
 
+  // Same pattern for edges — used by greyedOutNodes to resolve severed
+  // edges in O(1) instead of running graphData.edges.find per cut.
+  const edgeById = useMemo(() => {
+    const m = new Map<string, (typeof graphData.edges)[number]>();
+    for (const e of graphData.edges) m.set(e.id, e);
+    return m;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [topologyKey]);
+
   // Store baseline omega scores (live/initial values) as a reference point.
   // Movement during scrubbing is driven by the DELTA from baseline, not absolute omega.
   const baselineOmegaRef = useRef<Record<string, number>>({});
@@ -768,10 +777,11 @@ export default function CausalDAG3D() {
   // Compute greyed-out nodes: after a cut, nodes with Ω < 7 that are NOT downstream of cut points and NOT consequence nodes
   const greyedOutNodes = useMemo(() => {
     if (severedEdges.length === 0) return new Set<string>();
-    // Find all cut targets (downstream of severed edges)
+    // Find all cut targets (downstream of severed edges) — O(1) via edgeById
+    // instead of graphData.edges.find per cut.
     const cutTargets = new Set<string>();
     for (const edgeId of severedEdges) {
-      const edge = graphData.edges.find((e) => e.id === edgeId);
+      const edge = edgeById.get(edgeId);
       if (edge) cutTargets.add(edge.target);
     }
     // BFS downstream from cut targets
@@ -797,7 +807,7 @@ export default function CausalDAG3D() {
       }
     }
     return greyed;
-  }, [severedEdges, graphData]);
+  }, [severedEdges, graphData, edgeById]);
 
   // Compute disconnected nodes: find the largest connected component,
   // grey out any node not in it (floating imported clusters)
@@ -903,12 +913,13 @@ export default function CausalDAG3D() {
     return () => window.removeEventListener("keydown", handleKey);
   }, [selectedNode, setSelectedNode, selectedEdge]);
 
-  // Resolve labels for edge inspector
+  // Resolve labels for edge inspector via the existing nodeById Map (O(1))
+  // instead of two Array.find calls per render.
   const selectedEdgeSourceLabel = selectedEdge
-    ? graphData.nodes.find((n) => n.id === selectedEdge.source)?.label ?? selectedEdge.source
+    ? nodeById.get(selectedEdge.source)?.label ?? selectedEdge.source
     : "";
   const selectedEdgeTargetLabel = selectedEdge
-    ? graphData.nodes.find((n) => n.id === selectedEdge.target)?.label ?? selectedEdge.target
+    ? nodeById.get(selectedEdge.target)?.label ?? selectedEdge.target
     : "";
 
   return (

--- a/src/components/dag3d/DAGOverlay.tsx
+++ b/src/components/dag3d/DAGOverlay.tsx
@@ -27,10 +27,18 @@ export default function DAGOverlay() {
   const activeGraph = isLive ? graphData : temporalGraph;
   const meta = activeGraph.metadata;
 
+  // O(1) id → node lookup, used both inside this component and by the
+  // selection / domain-filter handlers below. Replaces O(N²) Array.find
+  // calls that ran inside selectedNodes.map() loops.
+  const nodeById = useMemo(
+    () => new Map(activeGraph.nodes.map((n) => [n.id, n] as const)),
+    [activeGraph.nodes],
+  );
+
   const selectedNodeData = useMemo(() => {
     if (!selectedNode) return null;
-    return activeGraph.nodes.find((n) => n.id === selectedNode) ?? null;
-  }, [selectedNode, activeGraph.nodes]);
+    return nodeById.get(selectedNode) ?? null;
+  }, [selectedNode, nodeById]);
 
   // Domain legend: count nodes per domain
   const domainCounts = useMemo(() => {
@@ -187,7 +195,7 @@ export default function DAGOverlay() {
             </div>
             <div className="flex flex-col gap-0.5 max-h-[120px] overflow-y-auto">
               {selectedNodes.map((nodeId) => {
-                const node = activeGraph.nodes.find((n) => n.id === nodeId);
+                const node = nodeById.get(nodeId);
                 return (
                   <div key={nodeId} className="flex items-center justify-between gap-1 py-0.5">
                     <span className="text-[8px] text-text-muted truncate">{node?.label ?? nodeId}</span>
@@ -219,15 +227,12 @@ export default function DAGOverlay() {
               </button>
               <button
                 onClick={() => {
-                  const nodeLabels = selectedNodes.map((id) => {
-                    const n = activeGraph.nodes.find((node) => node.id === id);
-                    return n ? n.label : id;
-                  });
+                  const nodeLabels = selectedNodes.map((id) => nodeById.get(id)?.label ?? id);
                   const selSet = new Set(selectedNodes);
                   const subEdges = activeGraph.edges.filter((e) => selSet.has(e.source) && selSet.has(e.target));
                   const edgeDescs = subEdges.map((e) => {
-                    const src = activeGraph.nodes.find((n) => n.id === e.source)?.label ?? e.source;
-                    const tgt = activeGraph.nodes.find((n) => n.id === e.target)?.label ?? e.target;
+                    const src = nodeById.get(e.source)?.label ?? e.source;
+                    const tgt = nodeById.get(e.target)?.label ?? e.target;
                     return `${src} → ${tgt} (${e.type}, w=${e.weight}, mechanism: ${e.physicalMechanism || "N/A"})`;
                   });
                   const prompt = `ANALYZE SELECTION: The user has selected ${selectedNodes.length} nodes in the causal DAG. Provide a macro analysis of this subgraph — what are the key causal pathways, systemic risks, and cascading vulnerabilities? How do these nodes interact and what are the implications?\n\nSelected nodes: ${nodeLabels.join(", ")}\n\nEdges within selection (${subEdges.length}):\n${edgeDescs.join("\n")}`;


### PR DESCRIPTION
## Summary

Audit-driven perf sweep applying the #72 playbook patterns where they hadn't been fully applied across the rendering surfaces. No behavior change — pure optimization.

1. **`CausalDAG2D.tsx`** — full-store destructure (`const { truthFilter, replayActive, currentEpoch, ... } = useApexStore()`) replaced with eight per-field selectors. The destructure re-rendered the entire 2D component on every store mutation including timeline scrub ticks, even when the touched fields were irrelevant.
2. **`DAGOverlay.tsx`** — added a memoized `nodeById` Map and replaced three `activeGraph.nodes.find()` calls (one in `selectedNodes.map()`, two in the ANALYZE-SELECTION handler). With 20+ selected nodes the previous code was O(N²); now O(1) per lookup.
3. **`CausalDAG3D.tsx`** — edge inspector label resolution switched from `graphData.nodes.find()` to the existing `nodeById` Map. Same lookup pattern used elsewhere in the file.
4. **`CausalDAG3D.tsx`** — added a memoized `edgeById` Map alongside `nodeById`. `greyedOutNodes` now resolves severed edges via `edgeById.get(edgeId)` instead of `graphData.edges.find()` per cut.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean on all four changed files
- [x] `vitest` 537/537 pass
- [ ] Vercel preview: spot-check that the 2D timeline scrub is smoother (no full 2D re-render per tick), the 3D edge inspector + severed-edge greying still work, and the DAGOverlay selection panel doesn't lag with many nodes selected.

## Out of scope

Three pre-existing lint errors at `CausalDAG3D.tsx:86, 91, 306` (`posMapRef.current = ...` in render, an `any` cast, `performance.now()` in `useRef` initializer) are unrelated and untouched.

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_