### PR TITLE
chore(3d): clear pre-existing lint errors in CausalDAG3D

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -124,6 +124,18 @@ Audit found four spots where the #72 playbook patterns hadn't been fully applied
 
 **Verification.** `tsc --noEmit` clean; lint clean on changed files; vitest 537/537 pass. (Three pre-existing lint errors at `CausalDAG3D.tsx:86, 91, 306` are unrelated — `posMapRef.current = ...` in render, an `any` cast, and `performance.now()` in `useRef` initializer. Out of scope for this sweep.)
 
+### 2026-05-02 — Cleanup: pre-existing lint errors in CausalDAG3D
+
+Cleared the three pre-existing lint errors flagged in the perf-sweep audit (PR #185 noted them as out of scope):
+
+1. **`react-hooks/refs` at `:86`** — `posMapRef.current = posMap` in render body. Moved into a `useEffect(() => { posMapRef.current = posMap; }, [posMap])`. Render function is now pure; the effect runs after every render so the ref still tracks the latest `posMap` for downstream effects to read.
+2. **`@typescript-eslint/no-explicit-any` at `:91`** — `useRef<any>(null)` for the OrbitControls handle. Typed it as `React.ComponentRef<typeof OrbitControls> | null`, which derives the imperative-handle type directly from the drei component without a separate import.
+3. **`react-hooks/purity` at `:306`** — `useRef(performance.now())` in `FrameMonitor`. Initialized to `0` and set on mount in a `useEffect`. The `useFrame` callback overwrites it on the first rendered frame, so the `0` value is observed for at most one tick.
+
+Also cleared two warnings while the file was open: removed the unused `NodeMetrics` import and the unused `HOME_POS` constant. The remaining `set-state-in-effect` error at the camera-animation `setControlsEnabled(false)` call (line ~161) was suppressed with a single targeted `eslint-disable-next-line` + rationale comment — it's legitimate event-driven external-system sync (toggle OrbitControls during scripted camera animations) and the cascading render is bounded by the `prevSelectionKey` guard. Refactoring it into ref-based imperative mutation would have been higher risk for the animation pipeline.
+
+**Verification.** `tsc --noEmit` clean; lint clean on `CausalDAG3D.tsx`; vitest 567/567 pass.
+
 ### 2026-05-02 — Next up
 
 - TBD — open for direction.

--- a/src/components/CausalDAG3D.tsx
+++ b/src/components/CausalDAG3D.tsx
@@ -6,7 +6,7 @@ import { OrbitControls } from "@react-three/drei";
 import * as THREE from "three";
 import { useApexStore } from "@/stores/useApexStore";
 import { useFilteredGraph } from "@/hooks/useFilteredGraph";
-import { computeLayout3D, computeNetworkMetrics, NodePosition, NodeMetrics } from "@/lib/graph-layout";
+import { computeLayout3D, computeNetworkMetrics, NodePosition } from "@/lib/graph-layout";
 import { severEdgeAndSpawnConsequences } from "@/lib/intervention-engine";
 import { getNodeDomainMap } from "@/lib/graph-data";
 import DAGNode3D, { orbitActiveRef } from "./dag3d/DAGNode3D";
@@ -59,7 +59,6 @@ class DAGErrorBoundary extends React.Component<
   }
 }
 
-const HOME_POS = new THREE.Vector3(40, 30, 80);
 const HOME_TARGET = new THREE.Vector3(0, 0, 0);
 
 function CameraRig({
@@ -81,14 +80,18 @@ function CameraRig({
   const endPos = useRef(new THREE.Vector3());
   const startTarget = useRef(new THREE.Vector3());
   const endTarget = useRef(new THREE.Vector3());
-  // Keep a ref to posMap so the effect can read current positions without depending on them
+  // Keep a ref to posMap so the effect can read current positions without
+  // depending on them. Updating the ref in an effect (instead of during
+  // render) keeps the render function pure.
   const posMapRef = useRef(posMap);
-  posMapRef.current = posMap;
+  useEffect(() => {
+    posMapRef.current = posMap;
+  }, [posMap]);
   // Track previous selection to only animate on actual changes
   const prevSelectionKey = useRef("");
   const prevTopologyKey = useRef(topologyKey);
 
-  const orbitControlsRef = useRef<any>(null);
+  const orbitControlsRef = useRef<React.ComponentRef<typeof OrbitControls> | null>(null);
 
   // Helper: compute centroid and camera position to fit a set of node positions
   const computeFitCamera = useCallback((nodeIds: string[], currentPosMap: Record<string, [number, number, number]>) => {
@@ -155,6 +158,11 @@ function CameraRig({
         endTarget.current.copy(fit.target);
         progress.current = 0;
         animating.current = true;
+        // Event-driven external-system sync: disable orbit controls while the
+        // scripted camera animation runs. The cascading render the lint rule
+        // worries about is bounded — the effect bails on subsequent fires via
+        // the prevSelectionKey guard above.
+        // eslint-disable-next-line react-hooks/set-state-in-effect
         setControlsEnabled(false);
       }
       return;
@@ -303,11 +311,19 @@ function useWebGLRecovery() {
 // forces a scene invalidate to recover from frozen/black state
 function FrameMonitor() {
   const { invalidate, gl } = useThree();
-  const lastFrameTime = useRef(performance.now());
+  // Initialize to 0 and set on mount — calling performance.now() during
+  // render is impure. The useFrame callback below replaces this on the
+  // first rendered frame, so the 0 value is observed for at most one
+  // tick before useFrame fires.
+  const lastFrameTime = useRef(0);
 
   useFrame(() => {
     lastFrameTime.current = performance.now();
   });
+
+  useEffect(() => {
+    lastFrameTime.current = performance.now();
+  }, []);
 
   useEffect(() => {
     const check = setInterval(() => {


### PR DESCRIPTION
## Summary

Cleanup pass on the three pre-existing lint errors in `CausalDAG3D.tsx` flagged out-of-scope in #185's audit.

1. **`react-hooks/refs` at `:86`** — `posMapRef.current = posMap` in render body. Moved into a `useEffect(() => { posMapRef.current = posMap; }, [posMap])`. Render is pure; ref still tracks latest `posMap` for downstream effects.
2. **`@typescript-eslint/no-explicit-any` at `:91`** — `useRef<any>(null)` for the OrbitControls handle. Typed as `React.ComponentRef<typeof OrbitControls> | null` — derives the imperative-handle type from the drei component without a separate import.
3. **`react-hooks/purity` at `:306`** — `useRef(performance.now())` in `FrameMonitor`. Initialized to `0` and set on mount via `useEffect`; `useFrame` overwrites on the first rendered frame, so the `0` is observed for at most one tick.

Also cleared two warnings while in the file: removed the unused `NodeMetrics` import and `HOME_POS` constant. The remaining `set-state-in-effect` error at the camera-animation `setControlsEnabled(false)` call was suppressed with a single targeted `eslint-disable-next-line` + rationale comment — it's legitimate event-driven external-system sync (toggle OrbitControls during scripted camera animations) and the cascading render is bounded by the `prevSelectionKey` guard. Refactoring it into ref-based imperative mutation would have been higher risk for the animation pipeline.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean on `CausalDAG3D.tsx`
- [x] `vitest` 567/567 pass
- [ ] Vercel preview: 3D camera animations still trigger on selection change; OrbitControls still get disabled during the scripted fly-to and re-enabled when the animation completes; FrameMonitor still recovers from frozen state after 3s.

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_