### PR TITLE
feat(discovery): persistence layer — durable run records via Supabase

### DIFF
--- a/src/app/api/discovery/run/route.ts
+++ b/src/app/api/discovery/run/route.ts
@@ -30,6 +30,7 @@ import {
   validateCohort,
 } from "@/lib/discovery/cohort-validator";
 import { buildDiscoveryRun } from "@/lib/discovery/run-types";
+import { persistRun } from "@/lib/discovery/persistence";
 
 interface RunRequestBody {
   cohort: unknown;
@@ -104,5 +105,21 @@ export async function POST(req: NextRequest) {
     result,
   });
 
-  return NextResponse.json(run, { status: 200 });
+  // Best-effort persistence. The compute-and-return path is load-
+  // bearing; persistence is durability gravy. If Supabase is
+  // unavailable (CI stub env, network blip, schema not migrated yet),
+  // `persistRun` returns {persisted:false} without throwing and we
+  // surface that to the caller via a header so they can retry later
+  // if they care about audit trail.
+  const persistResult = await persistRun(run);
+
+  return NextResponse.json(run, {
+    status: 200,
+    headers: {
+      "x-discovery-persisted": persistResult.persisted ? "true" : "false",
+      ...(persistResult.persisted
+        ? {}
+        : { "x-discovery-persistence-skipped": persistResult.reason ?? "unknown" }),
+    },
+  });
 }

--- a/src/app/api/discovery/runs/[id]/route.ts
+++ b/src/app/api/discovery/runs/[id]/route.ts
@@ -1,0 +1,37 @@
+// ─── GET /api/discovery/runs/[id] ────────────────────────────────────
+//
+// Fetches a previously-persisted DiscoveryRun by id. Used by anyone
+// who wants to retrieve a run after the original /api/discovery/run
+// response has been discarded — audit trail, cross-time comparison,
+// reproducibility.
+
+import { NextResponse } from "next/server";
+import { getRun, isPersistenceAvailable } from "@/lib/discovery/persistence";
+
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(_req: Request, ctx: RouteContext) {
+  const { id } = await ctx.params;
+  if (!id || typeof id !== "string") {
+    return NextResponse.json({ error: "id is required" }, { status: 400 });
+  }
+
+  if (!isPersistenceAvailable()) {
+    return NextResponse.json(
+      {
+        error: "persistence layer unavailable",
+        hint:
+          "the discovery API is deployed without a Supabase backend; runs are computed but not durably stored",
+      },
+      { status: 503 },
+    );
+  }
+
+  const run = await getRun(id);
+  if (!run) {
+    return NextResponse.json({ error: "run not found", id }, { status: 404 });
+  }
+  return NextResponse.json(run, { status: 200 });
+}

--- a/src/app/api/discovery/runs/route.ts
+++ b/src/app/api/discovery/runs/route.ts
@@ -1,0 +1,47 @@
+// ─── GET /api/discovery/runs ─────────────────────────────────────────
+//
+// Lists persisted DiscoveryRuns, newest first. Optional filters by
+// cohortId / algorithmId. Hard limit 200 / default 50.
+//
+// Query params:
+//   ?cohortId=<string>      — filter to runs of a specific cohort
+//   ?algorithmId=<string>   — filter to runs of a specific algorithm
+//   ?limit=<int 1-200>      — max rows (default 50)
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  listRuns,
+  isPersistenceAvailable,
+} from "@/lib/discovery/persistence";
+
+export async function GET(req: NextRequest) {
+  if (!isPersistenceAvailable()) {
+    return NextResponse.json(
+      {
+        error: "persistence layer unavailable",
+        hint:
+          "the discovery API is deployed without a Supabase backend; runs are computed but not durably stored",
+      },
+      { status: 503 },
+    );
+  }
+
+  const url = new URL(req.url);
+  const cohortId = url.searchParams.get("cohortId") ?? undefined;
+  const algorithmId = url.searchParams.get("algorithmId") ?? undefined;
+  const limitRaw = url.searchParams.get("limit");
+  let limit: number | undefined;
+  if (limitRaw !== null) {
+    const n = Number(limitRaw);
+    if (!Number.isFinite(n) || n < 1 || n > 200) {
+      return NextResponse.json(
+        { error: "limit must be an integer in [1, 200]" },
+        { status: 400 },
+      );
+    }
+    limit = Math.floor(n);
+  }
+
+  const runs = await listRuns({ cohortId, algorithmId, limit });
+  return NextResponse.json({ runs, count: runs.length }, { status: 200 });
+}

--- a/src/lib/discovery/__tests__/api-runs-routes.test.ts
+++ b/src/lib/discovery/__tests__/api-runs-routes.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment node
+//
+// Tests for GET /api/discovery/runs and GET /api/discovery/runs/[id].
+// Uses the persistence layer's setServiceClientForTesting hook to swap
+// in a fake Supabase client. Verifies:
+//   - 503 when persistence unavailable (stub env)
+//   - 200 + run on hit
+//   - 404 on miss
+//   - list endpoint with filters and limit validation
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { GET as GET_BY_ID } from "@/app/api/discovery/runs/[id]/route";
+import { GET as GET_LIST } from "@/app/api/discovery/runs/route";
+import { setServiceClientForTesting } from "../persistence";
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+function makeFakeRow(id = "run-X") {
+  return {
+    id,
+    cohort_id: "c1",
+    cohort_source_hash: "h",
+    algorithm_id: "lag-correlation",
+    algorithm_version: "0.1.0",
+    params: {},
+    started_at: "2026-05-02T00:00:00Z",
+    completed_at: "2026-05-02T00:00:01Z",
+    status: "succeeded" as const,
+    error: null,
+    result: { variables: ["x"], edges: [] },
+  };
+}
+
+function makeFakeServiceClient(opts: {
+  getResult?: { data: unknown; error: unknown };
+  listResult?: { data: unknown[]; error: unknown };
+} = {}) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const queryBuilder: any = {
+    select() { return queryBuilder; },
+    eq() { return queryBuilder; },
+    order() { return queryBuilder; },
+    limit() {
+      return Promise.resolve(opts.listResult ?? { data: [], error: null });
+    },
+    maybeSingle() {
+      return Promise.resolve(opts.getResult ?? { data: null, error: null });
+    },
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return { from: vi.fn().mockReturnValue(queryBuilder) } as any;
+}
+
+beforeEach(() => setServiceClientForTesting(null));
+afterEach(() => setServiceClientForTesting(null));
+
+// ─── Tests ────────────────────────────────────────────────────────────
+
+describe("GET /api/discovery/runs/[id]", () => {
+  it("503 when persistence unavailable", async () => {
+    const res = await GET_BY_ID(new Request("http://localhost/api/discovery/runs/x"), {
+      params: Promise.resolve({ id: "x" }),
+    });
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/unavailable/);
+  });
+
+  it("200 + DiscoveryRun on hit", async () => {
+    setServiceClientForTesting(
+      makeFakeServiceClient({
+        getResult: { data: makeFakeRow("run-Z"), error: null },
+      }),
+    );
+    const res = await GET_BY_ID(new Request("http://localhost/api/discovery/runs/run-Z"), {
+      params: Promise.resolve({ id: "run-Z" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { id: string; cohortId: string };
+    expect(body.id).toBe("run-Z");
+    expect(body.cohortId).toBe("c1");
+  });
+
+  it("404 on miss", async () => {
+    setServiceClientForTesting(
+      makeFakeServiceClient({
+        getResult: { data: null, error: null },
+      }),
+    );
+    const res = await GET_BY_ID(new Request("http://localhost/api/discovery/runs/nope"), {
+      params: Promise.resolve({ id: "nope" }),
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /api/discovery/runs", () => {
+  it("503 when persistence unavailable", async () => {
+    const res = await GET_LIST(new NextRequest("http://localhost/api/discovery/runs"));
+    expect(res.status).toBe(503);
+  });
+
+  it("200 + empty list when no runs", async () => {
+    setServiceClientForTesting(
+      makeFakeServiceClient({ listResult: { data: [], error: null } }),
+    );
+    const res = await GET_LIST(new NextRequest("http://localhost/api/discovery/runs"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { runs: unknown[]; count: number };
+    expect(body.count).toBe(0);
+    expect(body.runs).toEqual([]);
+  });
+
+  it("200 + mapped runs when populated", async () => {
+    setServiceClientForTesting(
+      makeFakeServiceClient({
+        listResult: {
+          data: [makeFakeRow("run-1"), makeFakeRow("run-2")],
+          error: null,
+        },
+      }),
+    );
+    const res = await GET_LIST(new NextRequest("http://localhost/api/discovery/runs"));
+    const body = (await res.json()) as {
+      runs: { id: string; cohortId: string }[];
+      count: number;
+    };
+    expect(body.count).toBe(2);
+    expect(body.runs[0].id).toBe("run-1");
+    expect(body.runs[1].id).toBe("run-2");
+  });
+
+  it("400 on invalid limit param", async () => {
+    setServiceClientForTesting(
+      makeFakeServiceClient({ listResult: { data: [], error: null } }),
+    );
+    const res = await GET_LIST(
+      new NextRequest("http://localhost/api/discovery/runs?limit=999"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts cohortId + algorithmId + limit query params", async () => {
+    setServiceClientForTesting(
+      makeFakeServiceClient({ listResult: { data: [], error: null } }),
+    );
+    const res = await GET_LIST(
+      new NextRequest(
+        "http://localhost/api/discovery/runs?cohortId=c1&algorithmId=pcmci-linear&limit=20",
+      ),
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/lib/discovery/__tests__/persistence.test.ts
+++ b/src/lib/discovery/__tests__/persistence.test.ts
@@ -1,0 +1,262 @@
+// @vitest-environment node
+//
+// Persistence layer unit tests. The Supabase client is mocked so these
+// tests don't depend on a real DB / network. Verifies:
+//   - graceful degrade under stub env (or no service client)
+//   - successful insert path
+//   - error path (insert fails, function returns {persisted:false})
+//   - row ↔ DiscoveryRun round-trip
+//   - getRun null on miss / null on service error
+//   - listRuns ordering / filter / limit
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  persistRun,
+  getRun,
+  listRuns,
+  setServiceClientForTesting,
+  isPersistenceAvailable,
+} from "../persistence";
+import type { DiscoveryRun } from "../run-types";
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+function makeRun(overrides: Partial<DiscoveryRun> = {}): DiscoveryRun {
+  return {
+    id: "run-001",
+    cohortId: "test-cohort",
+    cohortSourceHash: "deadbeef",
+    algorithm: { id: "lag-correlation", version: "0.1.0" },
+    params: { alpha: 0.05 },
+    startedAt: "2026-05-02T00:00:00Z",
+    completedAt: "2026-05-02T00:00:01Z",
+    status: "succeeded",
+    result: {
+      variables: ["x", "y"],
+      edges: [
+        {
+          source: "x",
+          target: "y",
+          strength: 0.8,
+          evidence: "test",
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+/** Fluent fake matching the slice of the Supabase JS API we use. */
+function makeFakeServiceClient(opts: {
+  insertResult?: { error: { message: string } | null };
+  selectMaybeSingle?: { data: unknown; error: { message: string } | null };
+  selectList?: { data: unknown[]; error: { message: string } | null };
+} = {}) {
+  const insertSpy = vi.fn().mockResolvedValue(
+    opts.insertResult ?? { error: null },
+  );
+  const lastQuery: { eqs: Array<[string, string]>; limit?: number; order?: string } = {
+    eqs: [],
+  };
+  const single = vi.fn().mockResolvedValue(
+    opts.selectMaybeSingle ?? { data: null, error: null },
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const queryBuilder: any = {
+    insert: insertSpy,
+    select() {
+      return queryBuilder;
+    },
+    eq(col: string, val: string) {
+      lastQuery.eqs.push([col, val]);
+      return queryBuilder;
+    },
+    order(col: string) {
+      lastQuery.order = col;
+      return queryBuilder;
+    },
+    limit(n: number) {
+      lastQuery.limit = n;
+      return Promise.resolve(
+        opts.selectList ?? { data: [], error: null },
+      );
+    },
+    maybeSingle: single,
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fake: any = {
+    from: vi.fn().mockReturnValue(queryBuilder),
+  };
+  return { fake, insertSpy, single, lastQuery };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────
+
+describe("persistence — graceful degrade", () => {
+  beforeEach(() => {
+    setServiceClientForTesting(null);
+  });
+  afterEach(() => {
+    setServiceClientForTesting(null);
+  });
+
+  it("isPersistenceAvailable() reports false when no service client wired", () => {
+    expect(isPersistenceAvailable()).toBe(false);
+  });
+
+  it("persistRun returns {persisted:false, reason:'service-unavailable'} when no service", async () => {
+    const r = await persistRun(makeRun());
+    expect(r.persisted).toBe(false);
+    expect(r.reason).toBe("service-unavailable");
+  });
+
+  it("getRun returns null when no service", async () => {
+    expect(await getRun("run-001")).toBeNull();
+  });
+
+  it("listRuns returns [] when no service", async () => {
+    expect(await listRuns()).toEqual([]);
+  });
+});
+
+describe("persistence — service connected", () => {
+  beforeEach(() => {
+    setServiceClientForTesting(null);
+  });
+  afterEach(() => {
+    setServiceClientForTesting(null);
+  });
+
+  it("persistRun translates DiscoveryRun → DB row and inserts", async () => {
+    const { fake, insertSpy } = makeFakeServiceClient();
+    setServiceClientForTesting(fake);
+
+    const r = await persistRun(makeRun());
+    expect(r.persisted).toBe(true);
+    expect(insertSpy).toHaveBeenCalledTimes(1);
+
+    const insertedRow = insertSpy.mock.calls[0][0];
+    expect(insertedRow.id).toBe("run-001");
+    expect(insertedRow.cohort_id).toBe("test-cohort");
+    expect(insertedRow.cohort_source_hash).toBe("deadbeef");
+    expect(insertedRow.algorithm_id).toBe("lag-correlation");
+    expect(insertedRow.algorithm_version).toBe("0.1.0");
+    expect(insertedRow.status).toBe("succeeded");
+    expect(insertedRow.result.edges).toHaveLength(1);
+  });
+
+  it("persistRun returns {persisted:false, reason:<msg>} on insert error", async () => {
+    const { fake } = makeFakeServiceClient({
+      insertResult: { error: { message: "duplicate key" } },
+    });
+    setServiceClientForTesting(fake);
+
+    const r = await persistRun(makeRun());
+    expect(r.persisted).toBe(false);
+    expect(r.reason).toBe("duplicate key");
+  });
+
+  it("persistRun never throws on unexpected client error", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const exploding: any = {
+      from: () => {
+        throw new Error("network died");
+      },
+    };
+    setServiceClientForTesting(exploding);
+    const r = await persistRun(makeRun());
+    expect(r.persisted).toBe(false);
+    expect(r.reason).toMatch(/network died/);
+  });
+
+  it("getRun translates DB row → DiscoveryRun on hit", async () => {
+    const { fake } = makeFakeServiceClient({
+      selectMaybeSingle: {
+        data: {
+          id: "run-002",
+          cohort_id: "c2",
+          cohort_source_hash: null,
+          algorithm_id: "pcmci-linear",
+          algorithm_version: "0.1.0",
+          params: {},
+          started_at: "2026-05-02T00:00:00Z",
+          completed_at: "2026-05-02T00:00:01Z",
+          status: "succeeded",
+          error: null,
+          result: { variables: ["x"], edges: [] },
+        },
+        error: null,
+      },
+    });
+    setServiceClientForTesting(fake);
+
+    const run = await getRun("run-002");
+    expect(run).not.toBeNull();
+    expect(run!.id).toBe("run-002");
+    expect(run!.cohortId).toBe("c2");
+    expect(run!.cohortSourceHash).toBeUndefined(); // null → undefined
+    expect(run!.algorithm.id).toBe("pcmci-linear");
+  });
+
+  it("getRun returns null on miss", async () => {
+    const { fake } = makeFakeServiceClient({
+      selectMaybeSingle: { data: null, error: null },
+    });
+    setServiceClientForTesting(fake);
+    expect(await getRun("nonexistent")).toBeNull();
+  });
+
+  it("getRun returns null on db error", async () => {
+    const { fake } = makeFakeServiceClient({
+      selectMaybeSingle: { data: null, error: { message: "boom" } },
+    });
+    setServiceClientForTesting(fake);
+    expect(await getRun("any")).toBeNull();
+  });
+
+  it("listRuns applies filters and respects the 200 hard cap", async () => {
+    const { fake, lastQuery } = makeFakeServiceClient({
+      selectList: { data: [], error: null },
+    });
+    setServiceClientForTesting(fake);
+
+    await listRuns({ cohortId: "c1", algorithmId: "lag-correlation", limit: 500 });
+    expect(lastQuery.eqs).toEqual([
+      ["cohort_id", "c1"],
+      ["algorithm_id", "lag-correlation"],
+    ]);
+    expect(lastQuery.limit).toBe(200); // hard-capped from 500
+    expect(lastQuery.order).toBe("created_at");
+  });
+
+  it("listRuns returns rowToRun-mapped runs", async () => {
+    const { fake } = makeFakeServiceClient({
+      selectList: {
+        data: [
+          {
+            id: "run-A",
+            cohort_id: "c1",
+            cohort_source_hash: "hashA",
+            algorithm_id: "lag-correlation",
+            algorithm_version: "0.1.0",
+            params: {},
+            started_at: "2026-05-02T00:00:00Z",
+            completed_at: "2026-05-02T00:00:01Z",
+            status: "succeeded",
+            error: null,
+            result: { variables: [], edges: [] },
+          },
+        ],
+        error: null,
+      },
+    });
+    setServiceClientForTesting(fake);
+
+    const runs = await listRuns({ limit: 10 });
+    expect(runs).toHaveLength(1);
+    expect(runs[0].id).toBe("run-A");
+    expect(runs[0].cohortSourceHash).toBe("hashA");
+  });
+});

--- a/src/lib/discovery/persistence.ts
+++ b/src/lib/discovery/persistence.ts
@@ -14,40 +14,78 @@
 import { createClient as createServiceClient, type SupabaseClient } from "@supabase/supabase-js";
 import type { DiscoveryRun, DiscoveryResult } from "./run-types";
 
-// ─── Module-level service client ──────────────────────────────────────
+// ─── Module-level service client (state machine) ─────────────────────
 //
-// Initialized lazily so build-time stub env vars don't crash module
-// load. The Supabase JS client only validates env vars at request time.
+// Three states:
+//   - "uninit"   : lazy init pending; first getService() call reads env
+//   - "live"     : a SupabaseClient is available (either lazy-initialised
+//                  from real env or injected via a test hook)
+//   - "disabled" : explicit no-op; getService() always returns null
+//                  (used in tests AND when stub env detected)
+//
+// The explicit "disabled" state is necessary because tests run in
+// environments (Vercel build) where the real env vars exist but we
+// want graceful-degrade behaviour. Without it, the lazy init succeeds
+// against real Supabase and tests assert against real responses.
 
-let _service: SupabaseClient | null = null;
+type ServiceState =
+  | { kind: "uninit" }
+  | { kind: "live"; client: SupabaseClient }
+  | { kind: "disabled" };
+
+let _state: ServiceState = { kind: "uninit" };
+
+function isStubEnv(url: string, key: string): boolean {
+  // Detect CI placeholder values. Must stay in sync with
+  // .github/workflows/pr-validate.yml.
+  if (!url || !key) return true;
+  if (
+    url.includes("placeholder") ||
+    url.includes("ci-stub") ||
+    url.includes("example.invalid")
+  ) return true;
+  if (key.includes("placeholder") || key.includes("ci-stub")) return true;
+  return false;
+}
 
 function getService(): SupabaseClient | null {
-  if (_service !== null) return _service;
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!url || !key) return null;
-  // Detect placeholder/stub values used by CI builds. These match the
-  // values in `.github/workflows/pr-validate.yml`.
-  if (url.includes("placeholder") || url.includes("ci-stub") ||
-      url.includes("example.invalid") || url === "") {
+  if (_state.kind === "live") return _state.client;
+  if (_state.kind === "disabled") return null;
+
+  // uninit → consult env and either materialize or disable.
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
+  if (isStubEnv(url, key)) {
+    _state = { kind: "disabled" };
     return null;
   }
-  if (key.includes("placeholder") || key.includes("ci-stub") || key === "") {
-    return null;
-  }
-  _service = createServiceClient(url, key, {
+  const client = createServiceClient(url, key, {
     auth: { persistSession: false, autoRefreshToken: false },
   });
-  return _service;
+  _state = { kind: "live", client };
+  return client;
 }
 
 /**
- * Inject a service client. Used in tests to swap a mock; production
- * callers shouldn't pass anything and let the lazy initialiser pick up
- * env vars.
+ * Inject a service client. Used in tests:
+ *   - pass a fake → forces "live" with the fake
+ *   - pass null   → forces "disabled" regardless of env vars
+ *
+ * The graceful-degrade tests need the disabled state explicitly because
+ * they run on Vercel's build env where the real env vars exist; without
+ * the explicit disable, the lazy init would create a real client and
+ * the tests would assert against real Supabase responses.
  */
 export function setServiceClientForTesting(client: SupabaseClient | null): void {
-  _service = client;
+  _state = client === null ? { kind: "disabled" } : { kind: "live", client };
+}
+
+/**
+ * Clear the test override and restore lazy-init behaviour. Use in
+ * afterEach so subsequent tests start from the default state.
+ */
+export function resetServiceClientForTesting(): void {
+  _state = { kind: "uninit" };
 }
 
 // ─── Row shape (the database mirror of DiscoveryRun) ──────────────────

--- a/src/lib/discovery/persistence.ts
+++ b/src/lib/discovery/persistence.ts
@@ -1,0 +1,196 @@
+// ─── Discovery Run Persistence ────────────────────────────────────────
+//
+// Service layer for writing/reading `DiscoveryRun` records to/from
+// Supabase. All access is mediated by the `/api/discovery/*` routes
+// using the service-role key (RLS-bypassing). When auth lands, the
+// gate moves up into the route layer; this service layer doesn't change.
+//
+// The functions here are GRACEFULLY DEGRADING — the discovery pipeline
+// is the load-bearing path. If Supabase is down or env vars are stub,
+// `persistRun` returns null/error and the caller continues. The run is
+// still computed and returned to the caller; only the durability story
+// degrades. Tests assert this behaviour.
+
+import { createClient as createServiceClient, type SupabaseClient } from "@supabase/supabase-js";
+import type { DiscoveryRun, DiscoveryResult } from "./run-types";
+
+// ─── Module-level service client ──────────────────────────────────────
+//
+// Initialized lazily so build-time stub env vars don't crash module
+// load. The Supabase JS client only validates env vars at request time.
+
+let _service: SupabaseClient | null = null;
+
+function getService(): SupabaseClient | null {
+  if (_service !== null) return _service;
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  // Detect placeholder/stub values used by CI builds. These match the
+  // values in `.github/workflows/pr-validate.yml`.
+  if (url.includes("placeholder") || url.includes("ci-stub") ||
+      url.includes("example.invalid") || url === "") {
+    return null;
+  }
+  if (key.includes("placeholder") || key.includes("ci-stub") || key === "") {
+    return null;
+  }
+  _service = createServiceClient(url, key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  return _service;
+}
+
+/**
+ * Inject a service client. Used in tests to swap a mock; production
+ * callers shouldn't pass anything and let the lazy initialiser pick up
+ * env vars.
+ */
+export function setServiceClientForTesting(client: SupabaseClient | null): void {
+  _service = client;
+}
+
+// ─── Row shape (the database mirror of DiscoveryRun) ──────────────────
+
+interface DiscoveryRunRow {
+  id: string;
+  cohort_id: string;
+  cohort_source_hash: string | null;
+  algorithm_id: string;
+  algorithm_version: string;
+  params: Record<string, unknown>;
+  started_at: string;
+  completed_at: string;
+  status: "succeeded" | "failed" | "partial";
+  error: string | null;
+  result: DiscoveryResult;
+}
+
+function runToRow(run: DiscoveryRun): DiscoveryRunRow {
+  return {
+    id: run.id,
+    cohort_id: run.cohortId,
+    cohort_source_hash: run.cohortSourceHash ?? null,
+    algorithm_id: run.algorithm.id,
+    algorithm_version: run.algorithm.version,
+    params: run.params,
+    started_at: run.startedAt,
+    completed_at: run.completedAt,
+    status: run.status,
+    error: run.error ?? null,
+    result: run.result,
+  };
+}
+
+function rowToRun(row: DiscoveryRunRow): DiscoveryRun {
+  return {
+    id: row.id,
+    cohortId: row.cohort_id,
+    cohortSourceHash: row.cohort_source_hash ?? undefined,
+    algorithm: { id: row.algorithm_id, version: row.algorithm_version },
+    params: row.params,
+    startedAt: row.started_at,
+    completedAt: row.completed_at,
+    status: row.status,
+    error: row.error ?? undefined,
+    result: row.result,
+  };
+}
+
+// ─── Public API ───────────────────────────────────────────────────────
+
+export interface PersistResult {
+  /** True if the row was persisted; false if persistence was skipped or failed. */
+  persisted: boolean;
+  /** Reason persistence was skipped or failed (when persisted=false). */
+  reason?: string;
+}
+
+/**
+ * Persist a DiscoveryRun. Gracefully degrades:
+ *   - If service client unavailable (stub env / no Supabase) → returns
+ *     {persisted:false, reason:"service-unavailable"}.
+ *   - If insert fails → returns {persisted:false, reason:<error>}.
+ *   - On success → {persisted:true}.
+ *
+ * Never throws.
+ */
+export async function persistRun(run: DiscoveryRun): Promise<PersistResult> {
+  const service = getService();
+  if (!service) {
+    return { persisted: false, reason: "service-unavailable" };
+  }
+  try {
+    const row = runToRow(run);
+    const { error } = await service.from("discovery_runs").insert(row);
+    if (error) {
+      return { persisted: false, reason: error.message };
+    }
+    return { persisted: true };
+  } catch (e) {
+    return {
+      persisted: false,
+      reason: `unexpected: ${(e as Error).message}`,
+    };
+  }
+}
+
+/** Read a run by id. Returns null on miss or service unavailability. */
+export async function getRun(id: string): Promise<DiscoveryRun | null> {
+  const service = getService();
+  if (!service) return null;
+  try {
+    const { data, error } = await service
+      .from("discovery_runs")
+      .select("*")
+      .eq("id", id)
+      .maybeSingle();
+    if (error || !data) return null;
+    return rowToRun(data as DiscoveryRunRow);
+  } catch {
+    return null;
+  }
+}
+
+export interface ListRunsOptions {
+  cohortId?: string;
+  algorithmId?: string;
+  /** Max rows to return. Default 50, hard cap 200. */
+  limit?: number;
+}
+
+/**
+ * List runs, newest first. Filtering is index-supported via
+ * (cohort_id, created_at desc) and (algorithm_id, created_at desc).
+ * Returns [] on service unavailability.
+ */
+export async function listRuns(
+  options: ListRunsOptions = {},
+): Promise<DiscoveryRun[]> {
+  const service = getService();
+  if (!service) return [];
+  const limit = Math.min(options.limit ?? 50, 200);
+  try {
+    // Chain order: eq filters first (so they apply before order/limit
+    // and so the test fake's terminal `.limit()` sees them).
+    let query = service.from("discovery_runs").select("*");
+    if (options.cohortId) query = query.eq("cohort_id", options.cohortId);
+    if (options.algorithmId) query = query.eq("algorithm_id", options.algorithmId);
+    const { data, error } = await query
+      .order("created_at", { ascending: false })
+      .limit(limit);
+    if (error || !data) return [];
+    return (data as DiscoveryRunRow[]).map(rowToRun);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * For tests: explicitly check whether the persistence layer would
+ * actually try to talk to Supabase given the current env. Lets tests
+ * assert the graceful-degrade path runs under stub envs.
+ */
+export function isPersistenceAvailable(): boolean {
+  return getService() !== null;
+}

--- a/supabase-discovery-runs.sql
+++ b/supabase-discovery-runs.sql
@@ -1,0 +1,57 @@
+-- =============================================================
+-- APEX Terminal — Discovery Run Persistence
+-- Run this in the Supabase SQL Editor after supabase-setup.sql
+--
+-- Why: turns the discovery API from stateless (compute and return)
+-- into durable (compute, persist, return). Lets a customer hit
+-- POST /api/discovery/run from their pipeline and later retrieve
+-- the same run via GET /api/discovery/runs/<id> — for audit trail,
+-- cross-time comparison, and reproducibility.
+-- =============================================================
+
+-- 1. Discovery runs table
+--
+-- Mirrors the TypeScript DiscoveryRun shape in
+-- src/lib/discovery/run-types.ts. Strongly-typed primary fields,
+-- jsonb for params and result so the algorithm-specific structure
+-- doesn't dictate the schema.
+create table if not exists public.discovery_runs (
+  id text primary key,
+  cohort_id text not null,
+  cohort_source_hash text,
+  algorithm_id text not null,
+  algorithm_version text not null,
+  params jsonb not null default '{}'::jsonb,
+  started_at timestamptz not null,
+  completed_at timestamptz not null,
+  status text not null check (status in ('succeeded', 'failed', 'partial')),
+  error text,
+  result jsonb not null,
+  created_at timestamptz not null default now()
+);
+
+-- 2. Indexes for the queries the service layer makes
+create index if not exists discovery_runs_cohort_id_idx
+  on public.discovery_runs (cohort_id, created_at desc);
+
+create index if not exists discovery_runs_algorithm_id_idx
+  on public.discovery_runs (algorithm_id, created_at desc);
+
+create index if not exists discovery_runs_created_at_idx
+  on public.discovery_runs (created_at desc);
+
+-- 3. Row-level security: service-role only (v0)
+--
+-- All access to this table is mediated by the /api/discovery/*
+-- endpoints, which use the SUPABASE_SERVICE_ROLE_KEY and bypass RLS
+-- entirely. Anon-key clients hitting the table directly get nothing.
+-- When auth lands (api-key or session-based), this stays the same;
+-- the auth gate moves up into the API endpoint layer.
+alter table public.discovery_runs enable row level security;
+
+-- Explicit deny-all-non-service-role policy. RLS-enabled-with-no-
+-- policies already produces this behaviour; this policy is here for
+-- clarity in the SQL editor.
+create policy "service-role-only" on public.discovery_runs
+  for all
+  using (false);


### PR DESCRIPTION
## Summary

Closes the loop on the discovery API: previously stateless (compute, return, forget). Now every successful POST persists the DiscoveryRun to Supabase, and two new GET endpoints let a customer retrieve it later for audit / comparison / reproducibility.

## What's new

| File | Role |
|---|---|
| `supabase-discovery-runs.sql` | New `discovery_runs` table + indexes + RLS (service-role-only) |
| `src/lib/discovery/persistence.ts` | Service layer: `persistRun` / `getRun` / `listRuns`. All gracefully degrade — return `null`/`[]`/`{persisted:false}` under stub env without throwing |
| `src/app/api/discovery/run/route.ts` | POST now calls `persistRun` after building. Surfaces state via `x-discovery-persisted` + `x-discovery-persistence-skipped` response headers. Compute path remains load-bearing — body is unchanged |
| `src/app/api/discovery/runs/[id]/route.ts` | New GET — 503 when persistence unavailable, 404 on miss, 200 + DiscoveryRun on hit |
| `src/app/api/discovery/runs/route.ts` | New GET list endpoint — optional `?cohortId`, `?algorithmId`, `?limit` (1-200, default 50) |
| Two test files (20 cases) | Persistence service + GET endpoints, with a fluent fake Supabase client. Covers graceful degrade, successful insert, insert error, hit/miss/error paths, query-param validation |

## Why this matters for institutional pilots

The discovery API was previously stateless — every call computed a run and returned it; if the caller dropped the response, the run was gone. Audit trail was impossible. With persistence, an institutional pilot integrating their pipeline can:

1. POST a cohort → receive a DiscoveryRun id
2. Retrieve it later via GET /api/discovery/runs/<id> for audit
3. Compare runs across time via GET /api/discovery/runs?cohortId=...

This is the load-bearing step from "interesting prototype" to "can be embedded in a customer pipeline."

## Deployment note

The migration `supabase-discovery-runs.sql` must be run manually in the Supabase SQL editor before persistence becomes active in production. Until then, prod degrades cleanly: persist/get/list silently return `{persisted:false}` / null / [] without breaking the compute path. **Safe to merge before migration runs.**

## What's still ahead (separate PRs)

- API key auth on POST/GET endpoints (currently open API)
- Multi-tenant scoping (namespace runs by tenant)
- UI surface listing persisted runs (SPIRTES still reads static samples for the demo)

## Test plan

- [x] 605 vitest tests pass (20 new)
- [x] `tsc --noEmit` clean
- [x] `next build` with stub env vars completes through page-data collection
- [x] CI build-gate (PR #174) will run on this PR
- [ ] Vercel preview: existing platform behaviour unchanged; new endpoints return 503 (no Supabase migration in prod yet)
- [ ] After SQL migration runs: POST persists, GET retrieves, headers report `x-discovery-persisted: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)