### PR TITLE
fix(onboarding-tour): welcome NEXT must wait for LAUNCH WORKSPACE

### DIFF
--- a/src/components/SpotlightTour.tsx
+++ b/src/components/SpotlightTour.tsx
@@ -404,10 +404,25 @@ export default function SpotlightTour() {
   }, [setTourActive, setTourStep]);
 
   const next = useCallback(() => {
-    if (step?.id === "welcome-and-domain" && selectedDomains.length === 0) {
-      setShowDomainHint(true);
-      if (!domainSelectorOpen) setDomainSelectorOpen(true);
-      return;
+    if (step?.id === "welcome-and-domain") {
+      // Don't advance while the workspace modal is still on top of the
+      // canvas — the next step highlights the canvas and would render
+      // behind the modal. The user has to click LAUNCH WORKSPACE inside
+      // the modal (which writes selectedDomains into the store AND
+      // closes the modal). The auto-advance effect below picks it up
+      // from there.
+      if (domainSelectorOpen) {
+        setShowDomainHint(true);
+        return;
+      }
+      // Modal is closed but no domains made it into the store — user
+      // dismissed without launching. Reopen and surface the hint.
+      if (selectedDomains.length === 0) {
+        setShowDomainHint(true);
+        setDomainSelectorOpen(true);
+        return;
+      }
+      // Modal closed AND domains in store → normal advance below.
     }
     if (step?.id === "first-run-finish") {
       // First-run done → show the deep-dive menu instead of closing.
@@ -757,7 +772,7 @@ function TooltipCard({
 
       {showDomainHint && (
         <div className="mb-3 rounded border border-amber-400/40 bg-amber-400/10 px-2 py-1.5 text-[10px] font-mono tracking-wider text-amber-300">
-          Pick a domain in the workspace first — the platform can&apos;t render without one.
+          Pick at least one domain and click LAUNCH WORKSPACE in the modal to continue.
         </div>
       )}
 


### PR DESCRIPTION
## Summary

Fixes two related bugs in the onboarding tour's welcome step you flagged from the live deploy:

### Bug 1 — NEXT advances past the welcome step while the modal is still open

**Repro:** pick a domain → LAUNCH WORKSPACE → re-open the workspace modal from the header trigger → relaunch the tour from the modal `?` → click NEXT. The tour advances to the canvas step, highlight is rendered behind the modal, modal is still on top.

**Cause:** the welcome-step gate only checked `selectedDomains.length === 0`. With a previously-launched workspace it passes, even though `domainSelectorOpen` is still true.

**Fix:** NEXT now refuses to advance from welcome whenever `domainSelectorOpen === true`, regardless of store state. The modal has to close first — the only path that closes it is LAUNCH WORKSPACE (which also writes `selectedDomains`), and the existing auto-advance effect picks it up from there.

### Bug 2 — Hint says "pick a domain" when the user has already staged selections

**Repro (your screenshot):** open modal → pick GEOPOLITICAL persona → 3 domains show ACTIVE (footer: "3 domains selected · 168 nodes") → click NEXT in the tour → amber hint says "Pick a domain in the workspace first — the platform can't render without one."

**Cause:** the "ACTIVE" pills reflect a component-local `localSelected` in `DomainSelector`. Only LAUNCH WORKSPACE writes those into the store's `selectedDomains`, which is what the tour reads. So the user has visually staged selections but the store is still empty.

**Fix:** rewrote the hint to point at the actual action — "Pick at least one domain and click LAUNCH WORKSPACE in the modal to continue." — which is correct in both stuck-states (nothing staged OR staged-but-not-launched) without needing to plumb `localSelected` out of `DomainSelector`.

## Test plan

- [ ] First-visit flow: open Manifold in incognito → tour auto-launches → NEXT shows new amber hint pointing at LAUNCH WORKSPACE
- [ ] Stage selections without launching: pick GEOPOLITICAL → 3 cards go ACTIVE → click NEXT → amber hint reads correctly, modal stays in front
- [ ] Click LAUNCH WORKSPACE → modal closes, tour auto-advances to the canvas step
- [ ] Reopen scenario from Bug 1: pick + LAUNCH → reopen workspace from header → click `?` on modal → click NEXT → does NOT advance, hint shows; click LAUNCH → advances correctly
- [ ] Existing first-visit gating still works: pick zero domains, dismiss modal, NEXT reopens it
- [ ] No regression on the other 8 first-run steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)
