### PR TITLE
perf(2d): adjacency-indexed contraction + nodeById/edgeById lookups

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -136,7 +136,32 @@ Also cleared two warnings while the file was open: removed the unused `NodeMetri
 
 **Verification.** `tsc --noEmit` clean; lint clean on `CausalDAG3D.tsx`; vitest 567/567 pass.
 
-### 2026-05-02 — Next up
+### 2026-05-03 — 2D canvas perf pass: adjacency-indexed contraction
+
+**Commit:** `84b8a18` on `claude/rendering-perf-manifold-UblqD` (pushed; PR not yet opened).
+
+**Trigger.** User picked option #1 from a three-way split (profile 2D canvas / audit 3D scene / batch map orbs). Goal: identify and fix the highest-ROI perf issues on the most-recently-rebuilt surface before the 2D Obsidian layout starts feeling its weight on dense graphs.
+
+**Hot spots found.**
+1. **`CausalDAG2D.tsx:428–438` — replay contraction was O(N×E) per tick.** The inner contraction loop walked all of `graphData.edges` for every node in the `nodes` useMemo. That useMemo rebuilds on every `currentSnapshot` change (i.e. every replay tick at ~30 Hz). On a 100-node / 200-edge graph that's 20K iters per tick, ~600K ops/sec sustained during replay.
+2. **`CausalDAG2D.tsx:404–407` — hover-emphasis neighbor lookup also walked `graphData.edges`** linearly on every hover. Same fix shape as (1).
+3. **`graphSignature` recomputed on every render** (`CausalDAG2D.tsx:341`) — sort+join over node+edge id sets. Cheap individually, but runs on hover, drag, replay tick.
+4. **`O(N)` / `O(E)` `find()` calls** in `onEdgeClick` and the `selectedSourceLabel` / `selectedTargetLabel` resolution.
+
+**Fixes.**
+- New memos: `nodeById`, `edgeById`, `adjacency` (`Map<id, neighborId[]>`), all keyed on the corresponding `graphData.nodes` / `graphData.edges` ref.
+- Replay contraction now walks `adjacency.get(n.id)` — O(degree) per shocked node instead of O(E). Per-tick cost scales with edge count, not (nodes × edges).
+- `emphasisMap` neighbor lookup reuses the same adjacency map.
+- `graphSignature` wrapped in `useMemo` against the same node/edge refs.
+- `onEdgeClick` uses `edgeById.get(rfEdge.id)`; label resolution uses `nodeById.get(...)`.
+
+**Out of scope (deliberately).** The `edges` useMemo (`:478–541`) still rebuilds on every hover because `emphasisTarget` is in its deps — that's structural to React Flow's prop-diff model. Splitting structural edge data from emphasis-derived style would need a custom edge component subscribing to `emphasisTarget` separately. Filed as a follow-up if dense-graph hover starts feeling heavy.
+
+**Files touched.** `src/components/CausalDAG2D.tsx` (+59 −31).
+
+**Verification.** `tsc --noEmit` clean; lint clean on changed file; vitest 600/600 pass. No behavior change — just lookup-shape refactoring.
+
+### 2026-05-03 — Next up
 
 - TBD — open for direction.
 

--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -338,7 +338,36 @@ function CausalDAG2DInner() {
   const selectedNode = useApexStore((s) => s.selectedNode);
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
 
-  const sig = graphSignature(graphData.nodes, graphData.edges);
+  // Indexed lookups — replace O(N)/O(E) find() calls in render and handlers.
+  const nodeById = useMemo(
+    () => new Map(graphData.nodes.map((n) => [n.id, n] as const)),
+    [graphData.nodes],
+  );
+  const edgeById = useMemo(
+    () => new Map(graphData.edges.map((e) => [e.id, e] as const)),
+    [graphData.edges],
+  );
+
+  // Undirected adjacency. Drives both replay contraction (O(degree) per node
+  // instead of O(E)) and hover-emphasis neighbor lookup. Built once per edge
+  // set; replay tick changes don't invalidate.
+  const adjacency = useMemo(() => {
+    const map = new Map<string, string[]>();
+    for (const e of graphData.edges) {
+      let s = map.get(e.source);
+      if (!s) { s = []; map.set(e.source, s); }
+      s.push(e.target);
+      let t = map.get(e.target);
+      if (!t) { t = []; map.set(e.target, t); }
+      t.push(e.source);
+    }
+    return map;
+  }, [graphData.edges]);
+
+  const sig = useMemo(
+    () => graphSignature(graphData.nodes, graphData.edges),
+    [graphData.nodes, graphData.edges],
+  );
   const [prevSig, setPrevSig] = useState<string>("");
   const [cachedLayout, setCachedLayout] = useState<Map<string, Position2D>>(
     () => new Map(),
@@ -400,18 +429,14 @@ function CausalDAG2DInner() {
   const emphasisMap = useMemo(() => {
     const map = new Map<string, NodeEmphasis>();
     if (!emphasisTarget) return map;
-    const neighbors = new Set<string>();
-    for (const e of graphData.edges) {
-      if (e.source === emphasisTarget) neighbors.add(e.target);
-      if (e.target === emphasisTarget) neighbors.add(e.source);
-    }
+    const neighbors = new Set(adjacency.get(emphasisTarget) ?? []);
     for (const n of graphData.nodes) {
       if (n.id === emphasisTarget) map.set(n.id, "focus");
       else if (neighbors.has(n.id)) map.set(n.id, "neighbor");
       else map.set(n.id, "dim");
     }
     return map;
-  }, [emphasisTarget, graphData.nodes, graphData.edges]);
+  }, [emphasisTarget, graphData.nodes, adjacency]);
 
   const nodes: Node[] = useMemo(() => {
     return graphData.nodes.map((n) => {
@@ -421,27 +446,30 @@ function CausalDAG2DInner() {
 
       // Replay contraction: pull stressed nodes toward stressed neighbors.
       // Applied as an offset over the dynamic layout so it doesn't fight drag.
+      // Walks the precomputed adjacency list — O(degree) per node instead of
+      // O(E), so per-tick cost scales with edge count rather than (nodes × edges).
       if (currentSnapshot) {
         const state = currentSnapshot.nodeStates[n.id];
         if (state && state.shockIntensity > 0.01) {
-          let cx = 0, cy = 0, totalWeight = 0;
-          for (const edge of graphData.edges) {
-            const nbId = edge.source === n.id ? edge.target : edge.target === n.id ? edge.source : null;
-            if (!nbId) continue;
-            const nbPos = nodePositions.get(nbId);
-            const nbState = currentSnapshot.nodeStates[nbId];
-            if (!nbPos) continue;
-            const w = nbState ? 0.3 + nbState.shockIntensity * 0.7 : 0.1;
-            cx += nbPos.x * w;
-            cy += nbPos.y * w;
-            totalWeight += w;
-          }
-          if (totalWeight > 0) {
-            cx /= totalWeight;
-            cy /= totalWeight;
-            const pull = state.shockIntensity * CONTRACTION;
-            posX = posX + (cx - posX) * pull;
-            posY = posY + (cy - posY) * pull;
+          const neighbors = adjacency.get(n.id);
+          if (neighbors && neighbors.length > 0) {
+            let cx = 0, cy = 0, totalWeight = 0;
+            for (const nbId of neighbors) {
+              const nbPos = nodePositions.get(nbId);
+              if (!nbPos) continue;
+              const nbState = currentSnapshot.nodeStates[nbId];
+              const w = nbState ? 0.3 + nbState.shockIntensity * 0.7 : 0.1;
+              cx += nbPos.x * w;
+              cy += nbPos.y * w;
+              totalWeight += w;
+            }
+            if (totalWeight > 0) {
+              cx /= totalWeight;
+              cy /= totalWeight;
+              const pull = state.shockIntensity * CONTRACTION;
+              posX = posX + (cx - posX) * pull;
+              posY = posY + (cy - posY) * pull;
+            }
           }
         }
       }
@@ -466,7 +494,7 @@ function CausalDAG2DInner() {
         },
       };
     });
-  }, [graphData, nodePositions, truthFilter, currentSnapshot, emphasisMap]);
+  }, [graphData, nodePositions, truthFilter, currentSnapshot, emphasisMap, adjacency]);
 
   // Filter nodes for isolation mode
   const visibleNodes = useMemo(() => {
@@ -559,12 +587,12 @@ function CausalDAG2DInner() {
 
   const onEdgeClick: EdgeMouseHandler = useCallback(
     (_event, rfEdge) => {
-      const causalEdge = graphData.edges.find((e) => e.id === rfEdge.id);
+      const causalEdge = edgeById.get(rfEdge.id);
       if (causalEdge) {
         setSelectedEdge((prev) => (prev?.id === causalEdge.id ? null : causalEdge));
       }
     },
-    [graphData.edges]
+    [edgeById]
   );
 
   const setSelectedNode = useApexStore((s) => s.setSelectedNode);
@@ -708,12 +736,12 @@ function CausalDAG2DInner() {
     sim.cool();
   }, []);
 
-  // Resolve labels for edge inspector
+  // Resolve labels for edge inspector — O(1) via nodeById Map.
   const selectedSourceLabel = selectedEdge
-    ? graphData.nodes.find((n) => n.id === selectedEdge.source)?.label ?? selectedEdge.source
+    ? nodeById.get(selectedEdge.source)?.label ?? selectedEdge.source
     : "";
   const selectedTargetLabel = selectedEdge
-    ? graphData.nodes.find((n) => n.id === selectedEdge.target)?.label ?? selectedEdge.target
+    ? nodeById.get(selectedEdge.target)?.label ?? selectedEdge.target
     : "";
 
   return (


### PR DESCRIPTION
## Summary

Profile pass on the 2D canvas (`CausalDAG2D.tsx`). Three hot spots, three fixes — no behavior change.

- **Replay contraction was O(N×E) per snapshot tick.** The inner loop walked all of `graphData.edges` for every node in the `nodes` useMemo, which rebuilds on every `currentSnapshot` change (~30 Hz during replay). On a 100-node / 200-edge graph that's 20K iters per tick, ~600K ops/sec sustained. Precomputed an undirected adjacency `Map<id, neighborId[]>` per edge set; the loop is now O(degree) per shocked node.
- **Hover-emphasis neighbor lookup also walked `graphData.edges` linearly** on every hover. Reuses the same adjacency map.
- **`find()` calls in `onEdgeClick` and `selectedSourceLabel` / `selectedTargetLabel` resolution** replaced with `nodeById` / `edgeById` Map lookups. Same pattern as the recent CausalDAG3D / DAGOverlay indexing work in #185.
- Bonus: `graphSignature` now memoized against `graphData.nodes` / `graphData.edges` refs so it doesn't re-sort+join on every hover/drag/tick.

## Out of scope (deliberately)

The `edges` useMemo still rebuilds on every hover because `emphasisTarget` is in its deps — that's structural to React Flow's prop-diff model. Splitting structural edge data from emphasis-derived style would need a custom edge component subscribing to `emphasisTarget` separately. Filed as a follow-up if dense-graph hover starts feeling heavy.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint --max-warnings 0` clean on `CausalDAG2D.tsx`
- [x] `vitest run` → 600/600 pass
- [ ] Visual smoke on Vercel preview: drag a node, hover a node, scrub timeline through a shock cascade, click an edge for the inspector — all should look identical to before


---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_