### PR TITLE
feat(onboarding-tour): TTS speaker + language pill on every step

### DIFF
--- a/src/components/SpotlightTour.tsx
+++ b/src/components/SpotlightTour.tsx
@@ -14,6 +14,7 @@ import {
   type TourStep,
   type DeepDiveTrack,
 } from "@/lib/tour-steps";
+import TTSControls from "@/components/TTSControls";
 
 // ─── Constants ──────────────────────────────────────────────────────────
 
@@ -706,12 +707,15 @@ function TooltipCard({
     mode === "first-run"
       ? "FIRST RUN"
       : mode === "engines"
-        ? "DEEP DIVE · ENGINES"
+        ? "ENGINES"
         : mode === "loop"
-          ? "DEEP DIVE · LOOP"
+          ? "LOOP"
           : mode === "customization"
-            ? "DEEP DIVE · CUSTOMIZATION"
+            ? "CUSTOM"
             : "";
+  // Speaker reads the title and body together so users hear the full
+  // step in context, not just the body without the heading.
+  const ttsText = `${copy.title}. ${copy.description}`;
 
   return (
     <motion.div
@@ -731,18 +735,27 @@ function TooltipCard({
       transition={{ duration: 0.2 }}
       onClick={(e) => e.stopPropagation()}
     >
-      <div className="text-[9px] font-mono tracking-wider text-text-muted mb-2 flex items-center justify-between">
-        <span>
+      {/* Header row: phase + step counter on the left, TTS controls + the
+          optional return-to-menu button on the right. TTS lives here on
+          every step so users can read or switch language at any point in
+          the tour, not just from the modal. */}
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <span className="text-[9px] font-mono tracking-wider text-text-muted truncate">
           {phaseLabel} · {tourStep + 1} OF {totalSteps}
         </span>
-        {onReturnToMenu && (
-          <button
-            onClick={onReturnToMenu}
-            className="text-text-muted hover:text-foreground transition-colors"
-          >
-            ◂ MENU
-          </button>
-        )}
+        <div className="flex items-center gap-1.5 shrink-0">
+          <TTSControls text={ttsText} ariaLabel="Read this step aloud" />
+          {onReturnToMenu && (
+            <button
+              onClick={onReturnToMenu}
+              className="text-[9px] font-mono tracking-wider text-text-muted hover:text-foreground transition-colors"
+              title="Back to deep-dive menu"
+              aria-label="Back to deep-dive menu"
+            >
+              ◂
+            </button>
+          )}
+        </div>
       </div>
 
       <h3 className="font-[family-name:var(--font-michroma)] text-sm tracking-wider text-accent-cyan mb-2">
@@ -832,8 +845,14 @@ function DeepDiveMenu({
       exit={{ opacity: 0, scale: 0.95 }}
       transition={{ duration: 0.2 }}
     >
-      <div className="text-[9px] font-mono tracking-wider text-text-muted mb-2">
-        DEEP DIVE · OPT-IN
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <span className="text-[9px] font-mono tracking-wider text-text-muted">
+          DEEP DIVE · OPT-IN
+        </span>
+        <TTSControls
+          text="Pick a deeper look. First run done. Pick a track for a deeper walkthrough, or close out and explore on your own. You can always relaunch this from the question mark in the top right."
+          ariaLabel="Read this menu aloud"
+        />
       </div>
       <h3 className="font-[family-name:var(--font-michroma)] text-sm tracking-wider text-accent-cyan mb-3">
         PICK A DEEPER LOOK


### PR DESCRIPTION
## Summary

Adds the TTS speaker and language pill to every tour tooltip and the deep-dive menu, not just the Domain Workspace modal. Read-aloud and language switching now follow the user across every step of the tour.

## Why

You flagged that the speaker icon "disappears in pretty much every other part of this tutorial" — only on the welcome modal. The affordance should be reachable across the board, not just at the entry point.

## Changes

- `TTSControls` lands in the `TooltipCard` header row, present on every tour step. Reads `${title}. ${description}` together so users hear the full step in context.
- Same controls added to the `DeepDiveMenu` header.
- Shortened phase labels so the header row fits the new controls cleanly within the 320px tooltip:
  - `DEEP DIVE · ENGINES` → `ENGINES`
  - `DEEP DIVE · LOOP` → `LOOP`
  - `DEEP DIVE · CUSTOMIZATION` → `CUSTOM`
- `◂ MENU` button collapses to `◂` (it's only rendered inside a deep-dive track, so its purpose is unambiguous).

## Multi-instance coordination

The modal and tooltip can both render `TTSControls` simultaneously. Each `useTTS` hook subscribes to `window.speechSynthesis` independently. Clicking speaker on instance B always calls `cancel()` first, which fires the first instance's `onend`/`onerror` — its "speaking" state self-clears. The selected voice persists in `localStorage`, so a language picked on the modal carries through into the in-tour speaker without prop-drilling.

## Test plan

- [ ] Hard refresh, clear `manifold:tour-seen`, reload
- [ ] Welcome step (modal): speaker + language pill present in modal header AND in tour tooltip header
- [ ] Click speaker in tour tooltip → reads title + body in selected voice
- [ ] Switch language pill in tour tooltip → next speaker click uses new voice
- [ ] Choice persists across step changes (BACK / NEXT)
- [ ] Walk through to first-run finish → deep-dive menu also has speaker + language pill
- [ ] Pick ENGINES → header reads `ENGINES · 1 OF 4 [🔊][EN▼][◂]`, fits cleanly
- [ ] `◂` returns to menu; speaker still works there
- [ ] Modal speaker and tour speaker don't fight: clicking one stops the other (verify with a long step body and a quick switch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
