### PR TITLE
feat(relief): 4th view mode — topographic criticality heightfield

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -161,9 +161,33 @@ Also cleared two warnings while the file was open: removed the unused `NodeMetri
 
 **Verification.** `tsc --noEmit` clean; lint clean on changed file; vitest 600/600 pass. No behavior change — just lookup-shape refactoring.
 
+### 2026-05-03 — 3D scene audit: selection Sets + scrub-stable disconnected check
+
+**PR:** [#199 — perf(3d): selection Sets in render loop + scrub-stable disconnected check](https://github.com/ApexAnalytica/apex-terminal/pull/199) — merged `febc761`.
+
+**Trigger.** Continued the perf sweep with item #2 of the original three-way split (3D scene audit).
+
+**Hot spots found.**
+1. **Render loop `.includes()` checks were O(M) per node and per edge.** `CausalDAG3D.tsx` at `:996, :1000, :1017, :1051, :1089` calls `multiSelectedNodes.includes(...)` / `ablatedNodeIds.includes(...)` / `ablatedEdgeIds.includes(...)` inside the per-node and per-edge maps. With 50 selections on a 200-node graph that's ~20K ops per re-render across all four call sites.
+2. **`disconnectedNodes` was scrub-thrashing.** Memoed on the full `graphData` ref, so a V+E BFS re-ran on every replay tick — but connectivity is purely structural and scrubbing only bumps temporal omega. Same cost as `positions` rebuild every tick, just for the connected-component check.
+3. **Five separate invalidator effects** in `StoreInvalidator` (`:367–371`) — each `useEffect` has a one-element dep list, all calling `invalidate()`.
+
+**Fixes.**
+- New memos: `multiSelectedSet`, `ablatedNodeSet`, `ablatedEdgeSet`. Render-loop call sites switched to `.has()`. Same shape as the existing `selectedEdgeIds` / `selectedNeighborNodes` / `disconnectedNodes` Sets used elsewhere in the file.
+- `disconnectedNodes` re-keyed on `topologyKey + severedEdges` and reads graph data via `graphDataForLayoutRef` — same scrub-stable pattern as `positions` and `networkMetrics`.
+- Five invalidator effects collapsed to one with combined deps. Behaviorally identical (React fires on any-dep change), just less noise.
+
+**Out of scope (deliberately).**
+- The blanket `onPointerMove` invalidate on the Canvas (`:983`) — broad firehose on every pointer move, but it's the safety net for hover-driven node lighting under `frameloop="demand"`. Touching it risks visible regressions on hover. Filed as follow-up if a benchmark shows it as a real cost.
+- `downstreamNodes` / `greyedOutNodes` BFS still iterates `graphData.edges` linearly. Only fires on intervention click; not hot.
+
+**Files touched.** `src/components/CausalDAG3D.tsx` (+45 −18).
+
+**Verification.** `tsc --noEmit` clean; lint clean on changed file; vitest 622/622 pass.
+
 ### 2026-05-03 — Next up
 
-- TBD — open for direction.
+- TBD — open for direction. Two remaining of the original three-way split: map orb batching (#3), or the deferred 3D follow-ups (Canvas onPointerMove throttle / hoist).
 
 ---
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,6 +43,20 @@ const CausalDAGMap = dynamic(() => import("@/components/CausalDAGMap"), {
   ),
 });
 
+// Dynamic import for Relief view — r3f scene with a Gaussian heightfield.
+// Mount only when active; unlike 2D/3D it doesn't keep its own WebGL context
+// alive in the background.
+const CausalDAGRelief = dynamic(() => import("@/components/CausalDAGRelief"), {
+  ssr: false,
+  loading: () => (
+    <div className="w-full h-full flex items-center justify-center bg-background">
+      <div className="text-[10px] font-mono text-text-muted animate-pulse">
+        INITIALIZING RELIEF RENDERER...
+      </div>
+    </div>
+  ),
+});
+
 export default function Home() {
   const viewMode = useApexStore((s) => s.viewMode);
 
@@ -127,6 +141,11 @@ export default function Home() {
             {viewMode === "map" && (
               <div className="absolute inset-0" style={{ zIndex: 1 }}>
                 <CausalDAGMap />
+              </div>
+            )}
+            {viewMode === "relief" && (
+              <div className="absolute inset-0" style={{ zIndex: 1 }}>
+                <CausalDAGRelief />
               </div>
             )}
             {/* Client deployment CTA */}

--- a/src/components/CausalDAGRelief.tsx
+++ b/src/components/CausalDAGRelief.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+import { Canvas, useThree } from "@react-three/fiber";
+import { OrbitControls } from "@react-three/drei";
+import * as THREE from "three";
+import { useFilteredGraph } from "@/hooks/useFilteredGraph";
+import { compute2DForceLayout } from "@/lib/graph-layout-2d";
+import { computeReliefField, type ReliefField } from "@/lib/graph-relief-field";
+import CanvasWatermark from "./CanvasWatermark";
+import DAGOverlay from "./dag3d/DAGOverlay";
+
+/**
+ * Topographic / "Relief" view — 4th rendering mode. Reads the network as a
+ * scalar criticality field over the existing 2D force layout: peaks where
+ * high-ΩF nodes cluster, valleys where it's quiet. v1 is single-domain
+ * (uses ΩF composite). Multilayer with per-domain colored stacks is a
+ * future extension and would render multiple translucent meshes.
+ */
+
+function ReliefMesh({ field }: { field: ReliefField }) {
+  // BufferGeometry rebuilt only when the field changes — graph topology /
+  // ΩF value change. Hover and orbit don't trigger recompute.
+  const geometry = useMemo(() => {
+    const geom = new THREE.BufferGeometry();
+    geom.setAttribute(
+      "position",
+      new THREE.BufferAttribute(field.positions, 3),
+    );
+    geom.setAttribute(
+      "color",
+      new THREE.BufferAttribute(field.colors, 3),
+    );
+    geom.setIndex(new THREE.BufferAttribute(field.indices, 1));
+    geom.computeVertexNormals();
+    return geom;
+  }, [field]);
+
+  // Dispose the geometry when this component unmounts or field swaps so we
+  // don't leak GPU buffers across graph imports.
+  useEffect(() => () => geometry.dispose(), [geometry]);
+
+  return (
+    <mesh geometry={geometry} castShadow={false} receiveShadow={false}>
+      <meshStandardMaterial
+        vertexColors
+        roughness={0.65}
+        metalness={0.05}
+        side={THREE.DoubleSide}
+        flatShading={false}
+      />
+    </mesh>
+  );
+}
+
+/**
+ * Sets the camera to a sensible initial framing the first time a non-empty
+ * field is rendered, then leaves it to OrbitControls. Subsequent graph
+ * changes don't re-frame so the user's manual orbit is preserved.
+ */
+function CameraSetup({ field }: { field: ReliefField }) {
+  const { camera } = useThree();
+  const framedRef = useRef(false);
+
+  useEffect(() => {
+    if (framedRef.current) return;
+    if (field.positions.length === 0) return;
+    const dist = Math.max(field.width, field.height, 200) * 0.65;
+    camera.position.set(dist * 0.85, dist * 0.55, dist * 0.85);
+    camera.lookAt(0, 0, 0);
+    framedRef.current = true;
+  }, [camera, field]);
+
+  return null;
+}
+
+export default function CausalDAGRelief() {
+  const graphData = useFilteredGraph();
+
+  // Reuse the existing 2D force layout so peaks land exactly where nodes
+  // sit on the 2D canvas — switching between views feels coherent.
+  const layout = useMemo(
+    () => compute2DForceLayout(graphData.nodes, graphData.edges),
+    [graphData.nodes, graphData.edges],
+  );
+
+  const field = useMemo(
+    () => computeReliefField(graphData.nodes, layout),
+    [graphData.nodes, layout],
+  );
+
+  const isEmpty = field.positions.length === 0;
+
+  return (
+    <div style={{ position: "absolute", inset: 0 }}>
+      <CanvasWatermark />
+      <DAGOverlay />
+      <Canvas
+        camera={{ position: [400, 250, 400], fov: 50, near: 1, far: 5000 }}
+        style={{
+          background: "#050508",
+          position: "absolute",
+          inset: 0,
+          touchAction: "none",
+        }}
+        gl={{ antialias: true, powerPreference: "high-performance" }}
+      >
+        <ambientLight intensity={0.35} />
+        <directionalLight
+          position={[200, 300, 200]}
+          intensity={0.7}
+          color="#ffffff"
+        />
+        <pointLight
+          position={[-300, 200, -200]}
+          intensity={0.45}
+          color="#7c4dff"
+        />
+        <pointLight
+          position={[0, 100, 350]}
+          intensity={0.35}
+          color="#00e5ff"
+        />
+
+        {!isEmpty && (
+          <>
+            <ReliefMesh field={field} />
+            <CameraSetup field={field} />
+          </>
+        )}
+
+        <OrbitControls
+          makeDefault
+          enableDamping
+          dampingFactor={0.1}
+          rotateSpeed={0.5}
+          zoomSpeed={0.8}
+          minDistance={20}
+          maxDistance={3000}
+          maxPolarAngle={Math.PI * 0.49}
+        />
+      </Canvas>
+      {isEmpty && (
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+          <div className="text-[10px] font-mono text-text-muted">
+            NO LAYOUT — IMPORT A GRAPH
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/dag3d/DAGOverlay.tsx
+++ b/src/components/dag3d/DAGOverlay.tsx
@@ -86,13 +86,18 @@ export default function DAGOverlay() {
       {/* Top Right: Method badges + controls */}
       <div className="absolute top-3 right-3 flex items-center gap-2 pointer-events-auto">
         <span className="text-[8px] font-mono px-2 py-0.5 rounded border border-border text-text-muted bg-surface-elevated">
-          RENDERING: {viewMode === "3d" ? "WEBGL_3D" : viewMode === "2d" ? "REACTFLOW_2D" : "MAPLIBRE_GEO"}
+          RENDERING: {
+            viewMode === "3d" ? "WEBGL_3D"
+            : viewMode === "2d" ? "REACTFLOW_2D"
+            : viewMode === "map" ? "MAPLIBRE_GEO"
+            : "WEBGL_RELIEF"
+          }
         </span>
         <span className="text-[8px] font-mono px-2 py-0.5 rounded border border-border text-text-muted bg-surface-elevated">
           METHOD: DCD / NOTEARS
         </span>
         {/* View mode cycle buttons */}
-        {(["3d", "2d", "map"] as const).map((mode) => (
+        {(["3d", "2d", "map", "relief"] as const).map((mode) => (
           <button
             key={mode}
             onClick={() => setViewMode(mode)}
@@ -102,7 +107,7 @@ export default function DAGOverlay() {
                 : "border-border text-text-muted hover:text-accent-cyan hover:border-accent-cyan/40"
             }`}
           >
-            {mode === "3d" ? "3D" : mode === "2d" ? "2D" : "MAP"}
+            {mode === "3d" ? "3D" : mode === "2d" ? "2D" : mode === "map" ? "MAP" : "RELIEF"}
           </button>
         ))}
       </div>

--- a/src/lib/graph-relief-field.ts
+++ b/src/lib/graph-relief-field.ts
@@ -1,0 +1,185 @@
+import type { CausalNode } from "./types";
+
+/**
+ * Build a 2D scalar criticality field from a node layout. Each node contributes
+ * a Gaussian "bump" at its position with weight = ΩF composite (0–10). The
+ * resulting heightfield reads as terrain — peaks where critical nodes cluster,
+ * valleys where the network is quiet.
+ *
+ * Returns interleaved buffers ready for THREE.BufferGeometry — `positions` is
+ * `(x, y_height, z)` with Y up so the mesh sits flat in the world. `colors`
+ * is per-vertex RGB, ramped by normalized elevation.
+ */
+
+export interface ReliefFieldParams {
+  /** Grid resolution in cells per side. 80 = 6,400 vertices ≈ 30ms on 100 nodes. */
+  resolution?: number;
+  /** Visual height scale applied to normalized elevation. */
+  heightScale?: number;
+  /** Outer padding in layout units around the node bounds. */
+  padding?: number;
+  /** Gaussian bandwidth as a fraction of the smaller bounds dimension. */
+  sigmaFraction?: number;
+}
+
+export interface ReliefField {
+  positions: Float32Array;
+  colors: Float32Array;
+  indices: Uint32Array;
+  width: number;
+  height: number;
+  resolution: number;
+  /** Maximum raw field value before normalization — useful for legends. */
+  peak: number;
+}
+
+const DEFAULTS: Required<ReliefFieldParams> = {
+  resolution: 80,
+  heightScale: 30,
+  padding: 80,
+  sigmaFraction: 0.12,
+};
+
+const EMPTY_FIELD: ReliefField = {
+  positions: new Float32Array(0),
+  colors: new Float32Array(0),
+  indices: new Uint32Array(0),
+  width: 0,
+  height: 0,
+  resolution: 0,
+  peak: 0,
+};
+
+export function computeReliefField(
+  nodes: Pick<CausalNode, "id" | "omegaFragility">[],
+  layout: Map<string, { x: number; y: number }>,
+  params: ReliefFieldParams = {},
+): ReliefField {
+  const { resolution, heightScale, padding, sigmaFraction } = {
+    ...DEFAULTS,
+    ...params,
+  };
+
+  // Pre-extract usable node samples (skip any without a layout entry).
+  const samples: { x: number; y: number; w: number }[] = [];
+  let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+  for (const n of nodes) {
+    const p = layout.get(n.id);
+    if (!p) continue;
+    samples.push({ x: p.x, y: p.y, w: n.omegaFragility.composite });
+    if (p.x < minX) minX = p.x;
+    if (p.x > maxX) maxX = p.x;
+    if (p.y < minY) minY = p.y;
+    if (p.y > maxY) maxY = p.y;
+  }
+  if (samples.length === 0 || !Number.isFinite(minX)) return EMPTY_FIELD;
+
+  minX -= padding; maxX += padding;
+  minY -= padding; maxY += padding;
+  const width = maxX - minX;
+  const height = maxY - minY;
+
+  // Bandwidth scales with the smaller extent so dense and sparse layouts both
+  // produce readable contour spread.
+  const sigma = Math.max(60, Math.min(width, height) * sigmaFraction);
+  const sigma2 = sigma * sigma;
+
+  const N = resolution;
+  const vertCount = N * N;
+  const positions = new Float32Array(vertCount * 3);
+  const colors = new Float32Array(vertCount * 3);
+  const heights = new Float32Array(vertCount);
+
+  // Pass 1 — evaluate the field on the grid.
+  let peak = 0;
+  for (let j = 0; j < N; j++) {
+    const y = minY + (j / (N - 1)) * height;
+    for (let i = 0; i < N; i++) {
+      const x = minX + (i / (N - 1)) * width;
+      let h = 0;
+      for (const s of samples) {
+        const dx = x - s.x;
+        const dy = y - s.y;
+        h += s.w * Math.exp(-(dx * dx + dy * dy) / sigma2);
+      }
+      const idx = j * N + i;
+      heights[idx] = h;
+      if (h > peak) peak = h;
+    }
+  }
+
+  // Pass 2 — write vertex (x, y_height, z) and per-vertex color, recentered
+  // around the origin so OrbitControls naturally pivots over the center.
+  const cx = (minX + maxX) / 2;
+  const cy = (minY + maxY) / 2;
+  const inv = peak > 0 ? 1 / peak : 0;
+  for (let j = 0; j < N; j++) {
+    const yWorld = minY + (j / (N - 1)) * height;
+    for (let i = 0; i < N; i++) {
+      const xWorld = minX + (i / (N - 1)) * width;
+      const idx = j * N + i;
+      const norm = heights[idx] * inv;
+      const z = norm * heightScale;
+
+      positions[idx * 3 + 0] = xWorld - cx;
+      positions[idx * 3 + 1] = z;
+      positions[idx * 3 + 2] = yWorld - cy;
+
+      const [r, g, b] = elevationColor(norm);
+      colors[idx * 3 + 0] = r;
+      colors[idx * 3 + 1] = g;
+      colors[idx * 3 + 2] = b;
+    }
+  }
+
+  // Triangle indices — two triangles per cell.
+  const cells = (N - 1) * (N - 1);
+  const indices = new Uint32Array(cells * 6);
+  let k = 0;
+  for (let j = 0; j < N - 1; j++) {
+    for (let i = 0; i < N - 1; i++) {
+      const a = j * N + i;
+      const b = j * N + i + 1;
+      const c = (j + 1) * N + i;
+      const d = (j + 1) * N + i + 1;
+      indices[k++] = a; indices[k++] = c; indices[k++] = b;
+      indices[k++] = b; indices[k++] = c; indices[k++] = d;
+    }
+  }
+
+  return { positions, colors, indices, width, height, resolution: N, peak };
+}
+
+/**
+ * Color ramp by normalized elevation: deep midnight blue → cyan → amber → red.
+ * Tuned to the Manifold palette (#00e5ff / #ffab00 / #ff1744).
+ */
+function elevationColor(t: number): [number, number, number] {
+  const n = Math.max(0, Math.min(1, t));
+  if (n < 0.25) {
+    const k = n / 0.25;
+    return [
+      lerp(0.04, 0.0, k),
+      lerp(0.05, 0.9, k),
+      lerp(0.18, 1.0, k),
+    ];
+  }
+  if (n < 0.55) {
+    const k = (n - 0.25) / 0.30;
+    return [
+      lerp(0.0, 1.0, k),
+      lerp(0.9, 0.67, k),
+      lerp(1.0, 0.0, k),
+    ];
+  }
+  const k = Math.min(1, (n - 0.55) / 0.45);
+  return [
+    1.0,
+    lerp(0.67, 0.09, k),
+    lerp(0.0, 0.27, k),
+  ];
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -272,7 +272,7 @@ export interface RiskPropagationCard {
 }
 
 // ─── View State ──────────────────────────────────────────────────
-export type ViewMode = "2d" | "3d" | "map";
+export type ViewMode = "2d" | "3d" | "map" | "relief";
 export type TruthFilter = "raw" | "verified";
 
 // ─── Regime & Doomsday ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a **Relief** rendering surface alongside 2D / 3D / Map. Reads the network as a scalar criticality field: take the existing 2D force layout, treat each node as a Gaussian source with weight = ΩF composite, evaluate the field on an 80×80 grid, render as a heightfield mesh in r3f. Peaks where high-Ω nodes cluster, valleys where it's quiet. Color ramps deep blue → cyan → amber → red by elevation.

The same 2D layout drives all four views, so peaks land exactly where nodes sit on the 2D canvas — switching between views feels coherent.

## What's in scope (v1)

- Single-domain: ΩF composite only.
- 80×80 grid heightfield.
- Color ramp by elevation.
- Damped OrbitControls capped at the horizon (`maxPolarAngle ≈ π/2`).
- One-shot camera framing on first non-empty field; manual orbit preserved across graph changes.

## Out of scope (deliberate, follow-up territory)

- **Multilayer** — per-domain colored stacks with additive blending (the "colored overlapping topo maps" idea). Same plumbing, just multiple meshes sharing one layout.
- **Interactive picking** — click a peak → select the underlying node. Doable via raycasting against the mesh + nearest-node lookup.
- **Animated criticality during replay** — bind the field input to `currentSnapshot.nodeStates[id].omegaComposite` instead of static node ΩF. Would need a per-tick recompute or a vertex-shader approach.
- **Iso-contour lines** — overlay thin lines at fixed elevations.

## Files

- `src/lib/graph-relief-field.ts` (new) — `computeReliefField(nodes, layout)` returns interleaved Float32 buffers (positions, colors, indices) ready for `THREE.BufferGeometry`.
- `src/components/CausalDAGRelief.tsx` (new) — r3f Canvas + mesh + lights + camera framing.
- `src/lib/types.ts` — adds `"relief"` to `ViewMode`.
- `src/app/page.tsx` — dynamic import, conditional mount.
- `src/components/dag3d/DAGOverlay.tsx` — RELIEF button + rendering badge.

## Cost

Field evaluation is ~30ms on 100 nodes (6,400 cells × 100 samples × `exp()`). Memoized on graph identity, so hover / scrub / orbit / selection don't trigger recompute. r3f `frameloop` is default (every frame) — fine for a static mesh with damped orbit; demand-mode would also work but adds complexity for v1.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint --max-warnings 0` clean on touched files
- [x] `vitest run` → 622/622 pass
- [ ] Visual smoke on Vercel preview: click RELIEF — heightfield renders, orbit feels natural, peaks correspond to high-Ω nodes; switch back to 2D/3D/Map and verify those still work


---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_