### PR TITLE
fix(demo): load graph data on flow mount so canvas isn't empty

### DIFF
--- a/src/components/DemoFlowPlayer.tsx
+++ b/src/components/DemoFlowPlayer.tsx
@@ -4,16 +4,18 @@
  * DemoFlowPlayer — guided cause-and-effect tour through the causal graph.
  *
  * Steps a user through a scripted DemoFlow (see src/lib/demo-flows.ts):
- * sets the relevant domains, injects shocks in sequence, and shows
- * narrative overlays. Restores prior store state on exit.
+ * sets the relevant domains, loads the graph, injects shocks in
+ * sequence, and shows narrative overlays. Restores prior store state
+ * on exit.
  *
  * Mounted at the app root level so it overlays the existing canvas.
  * Visibility is driven by zustand state (`activeDemoFlowId`).
  */
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import { buildGraphFromDomains } from "@/components/DomainSelector";
 import { FLOWS, getFlowById, type DemoFlow } from "@/lib/demo-flows";
-import type { CausalShock } from "@/lib/types";
+import type { CausalGraph, CausalShock } from "@/lib/types";
 import { useApexStore } from "@/stores/useApexStore";
 
 interface PlayerProps {
@@ -21,31 +23,47 @@ interface PlayerProps {
   onClose: () => void;
 }
 
+interface PriorState {
+  selectedDomains: string[];
+  graphData: CausalGraph;
+}
+
 function Player({ flowId, onClose }: PlayerProps) {
   const flow = useMemo(() => getFlowById(flowId), [flowId]);
   const addShock = useApexStore((s) => s.addShock);
   const removeShock = useApexStore((s) => s.removeShock);
   const setSelectedDomains = useApexStore((s) => s.setSelectedDomains);
-  const priorDomainsRef = useRef<string[] | null>(null);
+  const setGraphData = useApexStore((s) => s.setGraphData);
+  const priorRef = useRef<PriorState | null>(null);
   const injectedShockIdsRef = useRef<string[]>([]);
   const [stepIdx, setStepIdx] = useState(0);
   const [paused, setPaused] = useState(false);
 
-  // ── On mount: capture prior state, force the flow's domains ──
+  // ── On mount: capture prior state, load the flow's graph + domains ──
   useEffect(() => {
     if (!flow) return;
     const store = useApexStore.getState();
-    priorDomainsRef.current = [...store.selectedDomains];
+    priorRef.current = {
+      selectedDomains: [...store.selectedDomains],
+      graphData: store.graphData,
+    };
+    // Load the graph data so useFilteredGraph has nodes/edges to filter
+    // (the canvas was empty without this — DomainSelector's "Initialize"
+    // button does the same; we replicate it here so the demo works
+    // before the user has committed to a domain selection).
+    const merged = buildGraphFromDomains(flow.domainIds);
+    setGraphData(merged);
     setSelectedDomains(flow.domainIds);
     return () => {
-      // Cleanup on unmount: clear injected shocks, restore domains.
+      // Cleanup on unmount: clear injected shocks, restore graph state.
       for (const id of injectedShockIdsRef.current) removeShock(id);
       injectedShockIdsRef.current = [];
-      if (priorDomainsRef.current) {
-        setSelectedDomains(priorDomainsRef.current);
+      if (priorRef.current) {
+        setGraphData(priorRef.current.graphData);
+        setSelectedDomains(priorRef.current.selectedDomains);
       }
     };
-  }, [flow, setSelectedDomains, removeShock]);
+  }, [flow, setSelectedDomains, setGraphData, removeShock]);
 
   // ── Inject the step's shock when the step becomes active ──
   useEffect(() => {


### PR DESCRIPTION
## Summary

Bug fix on top of #203 (demo flows). When you clicked a demo, it ran through its narrative steps but the canvas stayed empty — nothing visually populated.

**Root cause:** The demo player set `selectedDomains` but never touched `graphData`. `useFilteredGraph` filters `graphData` against `selectedDomains`, so with `graphData` empty there was nothing to filter. The DomainSelector's "Initialize" button does the right thing (`buildGraphFromDomains` then `setGraphData`); the demo player skipped that step.

**Fix:** Player now calls `buildGraphFromDomains(flow.domainIds)` on mount and stores the result in `graphData`. Prior `graphData` is captured alongside prior `selectedDomains` in the same ref and restored on unmount, so exiting the demo cleanly returns the user to whatever they had loaded before.

One file touched (`DemoFlowPlayer.tsx`). Uses the existing exported `buildGraphFromDomains` from DomainSelector — no refactor.

## Test plan

- [x] `npm test` — 600/600 passing
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: click each of the 3 demo flows, verify canvas now populates with the relevant nodes/edges
- [ ] Manual: exit demo, verify prior domain selection + graph data is restored

https://claude.ai/code/session_014AELhRkzeHMphQeQLwTGZF

---
_Generated by [Claude Code](https://claude.ai/code/session_014AELhRkzeHMphQeQLwTGZF)_