### PR TITLE
feat(relief): multilayer per-domain additive stacks

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -185,9 +185,65 @@ Also cleared two warnings while the file was open: removed the unused `NodeMetri
 
 **Verification.** `tsc --noEmit` clean; lint clean on changed file; vitest 622/622 pass.
 
+### 2026-05-03 — Map orb "batching" was already live
+
+User asked about map orb batching (item #3 of the original perf split). Audit of `CausalDAGMap.tsx` confirms the orbs are already optimally batched: every rAF tick builds a single `FeatureCollection` containing all particles for all temporal edges and calls `setParticleGeoJSON(...)` once; the map renders all of them through a single `<Source id="particles" type="geojson">` with two layers (`particle-glow`, `particle-dots`). One buffer upload per frame regardless of edge count. No work to do under the "batching" framing.
+
+Remaining map-view perf opportunity if ever needed: the per-frame particle update goes through React (`setParticleGeoJSON` → re-render → react-map-gl diffs → `setData`). Cutting React out of the per-frame loop and hitting `map.getSource('particles').setData(...)` imperatively would skip ~60 React renders/sec when temporal edges are visible. Not "batching" — different fix; not pursued this round.
+
+### 2026-05-03 — Shipped: 4th view mode "Relief" — topographic criticality heightfield
+
+**PR:** [#204 — feat(relief): 4th view mode — topographic criticality heightfield](https://github.com/ApexAnalytica/apex-terminal/pull/204) — merged `fe80279`. (Backfilled here — the original PR's doc update only carried the PR #199 entry through.)
+
+**Trigger.** User asked for a 4th display method as a topological heatmap with peaks where criticality is higher, and asked how multilayer (per-domain) overlapping topo maps would look in the same format.
+
+**What shipped (v1).** Single-domain Relief view: takes the existing 2D force layout, treats each node as a Gaussian source with weight = ΩF composite, evaluates the field on an 80×80 grid, renders as an r3f heightfield mesh with elevation-driven color ramp (deep blue → cyan → amber → red). Same 2D layout drives all four views, so peaks land exactly where nodes sit on the 2D canvas — view switching feels coherent.
+
+**Files.**
+- `src/lib/graph-relief-field.ts` (new) — `computeReliefField(nodes, layout)` returns interleaved Float32 buffers (positions, colors, indices) ready for `THREE.BufferGeometry`. Two-pass: evaluate field (per-vertex Gaussian sum), then write vertex buffers + per-vertex colors via the elevation ramp.
+- `src/components/CausalDAGRelief.tsx` (new) — r3f Canvas + mesh + ambient/directional/2 colored point lights, OrbitControls capped at the horizon (`maxPolarAngle ≈ π/2`) so users can't flip under the terrain. One-shot camera framing on first non-empty field; manual orbit preserved across graph swaps.
+- `src/lib/types.ts` — adds `"relief"` to `ViewMode`.
+- `src/app/page.tsx` — dynamic import (separate chunk), conditional mount under `viewMode === "relief"`.
+- `src/components/dag3d/DAGOverlay.tsx` — RELIEF added to the view-switcher buttons; rendering badge shows WEBGL_RELIEF.
+
+**Cost.** Field evaluation is ~30ms on 100 nodes (6,400 cells × 100 samples × `exp()`). Memoized on graph identity, so hover / scrub / orbit / selection don't trigger recompute.
+
+**Verification.** `tsc --noEmit` clean; lint clean on touched files; vitest 622/622 pass.
+
+### 2026-05-03 — Shipped: Relief multilayer — per-domain additive stacks
+
+**PR:** TBD (about to open after this entry).
+
+**Trigger.** Direct follow-up to PR #204 — the user's original feature request explicitly asked about multilayer ("multiple color overlaps topologizal maps"). v1 was single-domain elevation ramp; v2 is per-domain additive stacks.
+
+**What shipped.**
+- `computeReliefLayers(nodes, layout, params?)` in `graph-relief-field.ts` — groups nodes by `node.domain`, evaluates each domain's Gaussian field over a **shared world-space grid** (global bounds across all nodes; bandwidth/sigma identical per layer). Each layer's vertex colors are pre-tinted by `getDomainColor(domain) × pow(norm, 1.5)` so valleys go to black (additive zero) and peaks saturate at the domain color. Triangle indices are shared across layers — same buffer reference, no duplication.
+- New `<ReliefLayerMesh>` in `CausalDAGRelief.tsx` uses `meshBasicMaterial` + `THREE.AdditiveBlending` + `depthWrite: false` + `toneMapped: false`. Lighting is intentionally bypassed — domain colors must be unambiguous, not normal-modulated. Where two domain peaks coincide spatially, GPU adds the tints (red + cyan = magenta) — exactly the "color overlap" reading the user asked for.
+- Auto-mode-switch: 1 unique domain → original single-mesh elevation ramp (preserves v1 read for single-vertical graphs); ≥2 unique domains → multilayer. No new toggle to learn.
+- `<DomainLegend>` overlay in the top-left when multilayer is active: bullet + domain name + node count, sorted by peak descending.
+
+**Design decisions captured.**
+- *Shared layout vs per-domain layout.* Shared. Peaks across layers line up by node, so an overlap reads as "this region is critical across multiple domains" — analytically meaningful. Per-domain layouts would read as separate continents — visually pretty, analytically useless. Rejected.
+- *Additive vs alpha-blended.* Additive. Order-independent on GPU; color mixing emerges naturally; valleys disappear without depth-sorting headaches.
+- *Shared triangle index buffer.* All layers share one `Uint32Array` index buffer reference — N×N grids with identical topology. Saves N² × 6 × 4 bytes per extra layer.
+
+**Files.**
+- `src/lib/graph-relief-field.ts` — new export `computeReliefLayers` + `ReliefLayer` type + `hexToLinearRGB` helper. Existing `computeReliefField` unchanged for the single-domain path.
+- `src/components/CausalDAGRelief.tsx` — multilayer branch with `<ReliefLayerMesh>`, legend overlay, mode-switch driven by unique-domain count.
+- `src/lib/__tests__/graph-relief-field.test.ts` (new) — vitest covering: empty input, layer count = unique domains, shared bounds across layers, nodeCount per layer, peak-descending order, valley vertices = additive black, re-centering invariant.
+
+**Cost.** O(layers × cells × samples_per_layer × `exp()`) — same total work as the single-pass since `Σ samples_per_layer = total samples`. On a 4-domain × 100-node graph at 80×80 the field eval is still ~30ms. Memoized on `[graphData.nodes, layout]` — hover/scrub/orbit don't recompute.
+
+**Out of scope (deliberately).**
+- *Per-layer Y-stacking.* Not needed: additive blending with `depthWrite: false` makes every fragment additive into the framebuffer regardless of depth, so two layers at the same Y read correctly.
+- *Picking through additive layers.* Multilayer is informational; selection still happens in 2D/3D.
+- *Per-domain visibility toggles in the legend.* The existing DomainSelector card-checks already control which domains feed the field (via `useFilteredGraph`), so a second toggle would be redundant.
+
+**Verification.** `tsc --noEmit` clean; lint clean on touched files; vitest 666/666 pass (9 new in `graph-relief-field.test.ts`).
+
 ### 2026-05-03 — Next up
 
-- TBD — open for direction. Two remaining of the original three-way split: map orb batching (#3), or the deferred 3D follow-ups (Canvas onPointerMove throttle / hoist).
+- TBD — open for direction. Remaining Relief follow-ups: picking (raycast → select node), replay animation (bind field input to `currentSnapshot`), iso-contour lines, onboarding tooltip. Outside Relief: deferred 3D `onPointerMove` throttle, map-view imperative-setData refactor.
 
 ---
 

--- a/src/components/CausalDAGRelief.tsx
+++ b/src/components/CausalDAGRelief.tsx
@@ -6,16 +6,24 @@ import { OrbitControls } from "@react-three/drei";
 import * as THREE from "three";
 import { useFilteredGraph } from "@/hooks/useFilteredGraph";
 import { compute2DForceLayout } from "@/lib/graph-layout-2d";
-import { computeReliefField, type ReliefField } from "@/lib/graph-relief-field";
+import {
+  computeReliefField,
+  computeReliefLayers,
+  type ReliefField,
+  type ReliefLayer,
+} from "@/lib/graph-relief-field";
 import CanvasWatermark from "./CanvasWatermark";
 import DAGOverlay from "./dag3d/DAGOverlay";
 
 /**
  * Topographic / "Relief" view — 4th rendering mode. Reads the network as a
  * scalar criticality field over the existing 2D force layout: peaks where
- * high-ΩF nodes cluster, valleys where it's quiet. v1 is single-domain
- * (uses ΩF composite). Multilayer with per-domain colored stacks is a
- * future extension and would render multiple translucent meshes.
+ * high-ΩF nodes cluster, valleys where it's quiet.
+ *
+ * Single-domain graphs render with the elevation ramp (deep blue → red).
+ * Multi-domain graphs split into per-domain meshes with additive blending —
+ * each domain tinted by its color, peaks add together where domains overlap
+ * (e.g. red + cyan = magenta where both are critical at the same spot).
  */
 
 function ReliefMesh({ field }: { field: ReliefField }) {
@@ -36,8 +44,6 @@ function ReliefMesh({ field }: { field: ReliefField }) {
     return geom;
   }, [field]);
 
-  // Dispose the geometry when this component unmounts or field swaps so we
-  // don't leak GPU buffers across graph imports.
   useEffect(() => () => geometry.dispose(), [geometry]);
 
   return (
@@ -54,24 +60,96 @@ function ReliefMesh({ field }: { field: ReliefField }) {
 }
 
 /**
+ * Per-domain mesh used in multilayer mode. Vertex colors are pre-tinted by
+ * domain color × elevation gamma, and the material uses additive blending so
+ * overlapping peaks color-mix on the GPU. Lighting is intentionally bypassed
+ * (`emissive`-style additive read) — we want the colors to be unambiguous
+ * domain reads, not modulated by surface normals.
+ */
+function ReliefLayerMesh({ layer }: { layer: ReliefLayer }) {
+  const geometry = useMemo(() => {
+    const geom = new THREE.BufferGeometry();
+    geom.setAttribute(
+      "position",
+      new THREE.BufferAttribute(layer.field.positions, 3),
+    );
+    geom.setAttribute(
+      "color",
+      new THREE.BufferAttribute(layer.field.colors, 3),
+    );
+    geom.setIndex(new THREE.BufferAttribute(layer.field.indices, 1));
+    geom.computeVertexNormals();
+    return geom;
+  }, [layer.field]);
+
+  useEffect(() => () => geometry.dispose(), [geometry]);
+
+  return (
+    <mesh geometry={geometry} castShadow={false} receiveShadow={false}>
+      <meshBasicMaterial
+        vertexColors
+        side={THREE.DoubleSide}
+        transparent
+        depthWrite={false}
+        blending={THREE.AdditiveBlending}
+        toneMapped={false}
+      />
+    </mesh>
+  );
+}
+
+/**
  * Sets the camera to a sensible initial framing the first time a non-empty
  * field is rendered, then leaves it to OrbitControls. Subsequent graph
  * changes don't re-frame so the user's manual orbit is preserved.
  */
-function CameraSetup({ field }: { field: ReliefField }) {
+function CameraSetup({
+  width,
+  height,
+  enabled,
+}: {
+  width: number;
+  height: number;
+  enabled: boolean;
+}) {
   const { camera } = useThree();
   const framedRef = useRef(false);
 
   useEffect(() => {
     if (framedRef.current) return;
-    if (field.positions.length === 0) return;
-    const dist = Math.max(field.width, field.height, 200) * 0.65;
+    if (!enabled) return;
+    const dist = Math.max(width, height, 200) * 0.65;
     camera.position.set(dist * 0.85, dist * 0.55, dist * 0.85);
     camera.lookAt(0, 0, 0);
     framedRef.current = true;
-  }, [camera, field]);
+  }, [camera, width, height, enabled]);
 
   return null;
+}
+
+function DomainLegend({ layers }: { layers: ReliefLayer[] }) {
+  if (layers.length < 2) return null;
+  return (
+    <div className="absolute top-4 left-4 z-10 flex flex-col gap-1 px-3 py-2 rounded border border-border bg-surface-elevated/80 backdrop-blur-sm pointer-events-none">
+      <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted mb-1">
+        DOMAIN LAYERS · {layers.length}
+      </div>
+      {layers.map((l) => (
+        <div key={l.domain} className="flex items-center gap-2">
+          <span
+            className="inline-block h-2 w-2 rounded-full"
+            style={{ backgroundColor: l.colorHex }}
+          />
+          <span className="text-[9px] font-mono text-foreground">
+            {l.domain}
+          </span>
+          <span className="text-[8px] font-mono text-text-muted ml-auto">
+            {l.nodeCount}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
 }
 
 export default function CausalDAGRelief() {
@@ -84,12 +162,41 @@ export default function CausalDAGRelief() {
     [graphData.nodes, graphData.edges],
   );
 
-  const field = useMemo(
-    () => computeReliefField(graphData.nodes, layout),
-    [graphData.nodes, layout],
+  // Decide the rendering mode from the unique-domain count. Multilayer kicks
+  // in at ≥2 distinct domains; otherwise the elevation-ramp single mesh reads
+  // more naturally for a single subgraph.
+  const uniqueDomains = useMemo(() => {
+    const set = new Set<string>();
+    for (const n of graphData.nodes) set.add(n.domain);
+    return set.size;
+  }, [graphData.nodes]);
+
+  const multilayer = uniqueDomains >= 2;
+
+  const singleField = useMemo(
+    () =>
+      multilayer
+        ? null
+        : computeReliefField(graphData.nodes, layout),
+    [multilayer, graphData.nodes, layout],
   );
 
-  const isEmpty = field.positions.length === 0;
+  const layers = useMemo(
+    () =>
+      multilayer
+        ? computeReliefLayers(graphData.nodes, layout)
+        : [],
+    [multilayer, graphData.nodes, layout],
+  );
+
+  const isEmpty = multilayer
+    ? layers.length === 0
+    : !singleField || singleField.positions.length === 0;
+
+  // Use the first layer (or the single field) for camera framing dimensions.
+  const frameDims = multilayer
+    ? layers[0]?.field
+    : singleField ?? undefined;
 
   return (
     <div style={{ position: "absolute", inset: 0 }}>
@@ -122,11 +229,18 @@ export default function CausalDAGRelief() {
           color="#00e5ff"
         />
 
-        {!isEmpty && (
-          <>
-            <ReliefMesh field={field} />
-            <CameraSetup field={field} />
-          </>
+        {!isEmpty && !multilayer && singleField && (
+          <ReliefMesh field={singleField} />
+        )}
+        {!isEmpty && multilayer && layers.map((l) => (
+          <ReliefLayerMesh key={l.domain} layer={l} />
+        ))}
+        {!isEmpty && frameDims && (
+          <CameraSetup
+            width={frameDims.width}
+            height={frameDims.height}
+            enabled
+          />
         )}
 
         <OrbitControls
@@ -140,6 +254,7 @@ export default function CausalDAGRelief() {
           maxPolarAngle={Math.PI * 0.49}
         />
       </Canvas>
+      {!isEmpty && multilayer && <DomainLegend layers={layers} />}
       {isEmpty && (
         <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
           <div className="text-[10px] font-mono text-text-muted">

--- a/src/lib/__tests__/graph-relief-field.test.ts
+++ b/src/lib/__tests__/graph-relief-field.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeReliefField,
+  computeReliefLayers,
+} from "../graph-relief-field";
+import type { CausalNode } from "../types";
+
+function makeNode(id: string, domain: string, omega: number): CausalNode {
+  return {
+    id,
+    label: id,
+    description: "",
+    category: "geopolitical",
+    domain,
+    omegaFragility: {
+      institutionalRot: omega,
+      regulatoryFog: omega,
+      jurisdictionalHazard: omega,
+      cascadeLoad: omega,
+      tailRisk: omega,
+      composite: omega,
+    },
+    discoverySource: "manual",
+  } as unknown as CausalNode;
+}
+
+describe("computeReliefField", () => {
+  it("returns empty field for nodes with no layout entries", () => {
+    const nodes = [makeNode("a", "X", 5)];
+    const empty = new Map<string, { x: number; y: number }>();
+    const field = computeReliefField(nodes, empty);
+    expect(field.positions.length).toBe(0);
+    expect(field.indices.length).toBe(0);
+    expect(field.peak).toBe(0);
+  });
+
+  it("produces a non-empty heightfield with vertices count = N×N", () => {
+    const nodes = [makeNode("a", "X", 8), makeNode("b", "X", 4)];
+    const layout = new Map([
+      ["a", { x: 0, y: 0 }],
+      ["b", { x: 100, y: 50 }],
+    ]);
+    const field = computeReliefField(nodes, layout, { resolution: 16 });
+    expect(field.resolution).toBe(16);
+    expect(field.positions.length).toBe(16 * 16 * 3);
+    expect(field.indices.length).toBe(15 * 15 * 6);
+    expect(field.peak).toBeGreaterThan(0);
+  });
+
+  it("re-centers world bounds around the origin", () => {
+    const nodes = [makeNode("a", "X", 5)];
+    const layout = new Map([["a", { x: 1000, y: 1000 }]]);
+    const field = computeReliefField(nodes, layout, { resolution: 8 });
+    let xSum = 0, zSum = 0;
+    for (let i = 0; i < field.positions.length; i += 3) {
+      xSum += field.positions[i];
+      zSum += field.positions[i + 2];
+    }
+    const meanX = xSum / (field.positions.length / 3);
+    const meanZ = zSum / (field.positions.length / 3);
+    expect(Math.abs(meanX)).toBeLessThan(0.01);
+    expect(Math.abs(meanZ)).toBeLessThan(0.01);
+  });
+});
+
+describe("computeReliefLayers", () => {
+  it("returns one layer per unique domain", () => {
+    const nodes = [
+      makeNode("a", "Saudi Aramco Energy", 8),
+      makeNode("b", "Saudi Aramco Energy", 6),
+      makeNode("c", "Sovereign Risk", 7),
+    ];
+    const layout = new Map([
+      ["a", { x: 0, y: 0 }],
+      ["b", { x: 50, y: 0 }],
+      ["c", { x: 0, y: 100 }],
+    ]);
+    const layers = computeReliefLayers(nodes, layout, { resolution: 8 });
+    expect(layers.length).toBe(2);
+    const domains = layers.map((l) => l.domain).sort();
+    expect(domains).toEqual(["Saudi Aramco Energy", "Sovereign Risk"]);
+  });
+
+  it("all layers share the same world-space dimensions", () => {
+    const nodes = [
+      makeNode("a", "X", 8),
+      makeNode("b", "Y", 6),
+      makeNode("c", "Z", 4),
+    ];
+    const layout = new Map([
+      ["a", { x: 0, y: 0 }],
+      ["b", { x: 200, y: 0 }],
+      ["c", { x: 100, y: 200 }],
+    ]);
+    const layers = computeReliefLayers(nodes, layout, { resolution: 8 });
+    expect(layers.length).toBe(3);
+    const w = layers[0].field.width;
+    const h = layers[0].field.height;
+    for (const l of layers) {
+      expect(l.field.width).toBe(w);
+      expect(l.field.height).toBe(h);
+      expect(l.field.resolution).toBe(8);
+    }
+  });
+
+  it("nodeCount matches per-domain node populations", () => {
+    const nodes = [
+      makeNode("a", "X", 5),
+      makeNode("b", "X", 5),
+      makeNode("c", "X", 5),
+      makeNode("d", "Y", 5),
+    ];
+    const layout = new Map([
+      ["a", { x: 0, y: 0 }],
+      ["b", { x: 50, y: 0 }],
+      ["c", { x: 0, y: 50 }],
+      ["d", { x: 100, y: 100 }],
+    ]);
+    const layers = computeReliefLayers(nodes, layout, { resolution: 8 });
+    const xLayer = layers.find((l) => l.domain === "X")!;
+    const yLayer = layers.find((l) => l.domain === "Y")!;
+    expect(xLayer.nodeCount).toBe(3);
+    expect(yLayer.nodeCount).toBe(1);
+  });
+
+  it("layer ordering is stable: highest peak first", () => {
+    const nodes = [
+      makeNode("a", "Strong", 10),
+      makeNode("b", "Strong", 10),
+      makeNode("c", "Weak", 1),
+    ];
+    const layout = new Map([
+      ["a", { x: 0, y: 0 }],
+      ["b", { x: 30, y: 30 }],
+      ["c", { x: 200, y: 200 }],
+    ]);
+    const layers = computeReliefLayers(nodes, layout, { resolution: 8 });
+    expect(layers[0].domain).toBe("Strong");
+    expect(layers[0].field.peak).toBeGreaterThan(layers[1].field.peak);
+  });
+
+  it("vertex valleys are dark (additive black)", () => {
+    const nodes = [makeNode("a", "X", 10)];
+    const layout = new Map([["a", { x: 0, y: 0 }]]);
+    const layers = computeReliefLayers(nodes, layout, { resolution: 16 });
+    const field = layers[0].field;
+    // The corner vertex should be far from the (0,0) source — color tint ≈ 0.
+    const cornerR = field.colors[0];
+    const cornerG = field.colors[1];
+    const cornerB = field.colors[2];
+    expect(cornerR + cornerG + cornerB).toBeLessThan(0.05);
+  });
+
+  it("returns empty array for graphs with no layout entries", () => {
+    const nodes = [makeNode("a", "X", 5)];
+    const empty = new Map<string, { x: number; y: number }>();
+    const layers = computeReliefLayers(nodes, empty);
+    expect(layers).toEqual([]);
+  });
+});

--- a/src/lib/graph-relief-field.ts
+++ b/src/lib/graph-relief-field.ts
@@ -1,4 +1,5 @@
 import type { CausalNode } from "./types";
+import { getDomainColor } from "./graph-data";
 
 /**
  * Build a 2D scalar criticality field from a node layout. Each node contributes
@@ -182,4 +183,172 @@ function elevationColor(t: number): [number, number, number] {
 
 function lerp(a: number, b: number, t: number): number {
   return a + (b - a) * t;
+}
+
+// ─── Multilayer (per-domain) ───────────────────────────────────────
+
+export interface ReliefLayer {
+  domain: string;
+  /** Hex string from getDomainColor — passthrough so the legend can render. */
+  colorHex: string;
+  /** Linear RGB tuple (0–1) used to tint vertex colors in the mesh. */
+  colorRGB: [number, number, number];
+  field: ReliefField;
+  /** Node count contributing to this layer — drives legend ordering. */
+  nodeCount: number;
+}
+
+/**
+ * Group nodes by `node.domain` and build one ReliefField per domain over a
+ * shared world-space grid. Shared bounds are critical: per-domain bounds would
+ * scatter the meshes into separate continents, defeating the "where do
+ * domains overlap" reading. With shared bounds, peaks across layers line up
+ * by node — a dense red+green region tells you that domain reads as
+ * critical across both vocabularies.
+ *
+ * Each layer's vertex colors are pre-tinted by domain color (multiplied by
+ * the elevation gamma) so the consumer can render with additive blending and
+ * get color-mixing where peaks overlap.
+ */
+export function computeReliefLayers(
+  nodes: Pick<CausalNode, "id" | "domain" | "omegaFragility">[],
+  layout: Map<string, { x: number; y: number }>,
+  params: ReliefFieldParams = {},
+): ReliefLayer[] {
+  const { resolution, heightScale, padding, sigmaFraction } = {
+    ...DEFAULTS,
+    ...params,
+  };
+
+  // Pre-extract usable samples and group by domain. Compute global bounds
+  // across ALL samples so every layer evaluates over the same grid.
+  type Sample = { x: number; y: number; w: number };
+  const byDomain = new Map<string, Sample[]>();
+  let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+  for (const n of nodes) {
+    const p = layout.get(n.id);
+    if (!p) continue;
+    const sample: Sample = { x: p.x, y: p.y, w: n.omegaFragility.composite };
+    const arr = byDomain.get(n.domain);
+    if (arr) arr.push(sample);
+    else byDomain.set(n.domain, [sample]);
+    if (p.x < minX) minX = p.x;
+    if (p.x > maxX) maxX = p.x;
+    if (p.y < minY) minY = p.y;
+    if (p.y > maxY) maxY = p.y;
+  }
+  if (byDomain.size === 0 || !Number.isFinite(minX)) return [];
+
+  minX -= padding; maxX += padding;
+  minY -= padding; maxY += padding;
+  const width = maxX - minX;
+  const height = maxY - minY;
+  const cx = (minX + maxX) / 2;
+  const cy = (minY + maxY) / 2;
+  const sigma = Math.max(60, Math.min(width, height) * sigmaFraction);
+  const sigma2 = sigma * sigma;
+  const N = resolution;
+  const vertCount = N * N;
+
+  // Triangle indices are identical across layers — share the buffer.
+  const cells = (N - 1) * (N - 1);
+  const indices = new Uint32Array(cells * 6);
+  {
+    let k = 0;
+    for (let j = 0; j < N - 1; j++) {
+      for (let i = 0; i < N - 1; i++) {
+        const a = j * N + i;
+        const b = j * N + i + 1;
+        const c = (j + 1) * N + i;
+        const d = (j + 1) * N + i + 1;
+        indices[k++] = a; indices[k++] = c; indices[k++] = b;
+        indices[k++] = b; indices[k++] = c; indices[k++] = d;
+      }
+    }
+  }
+
+  // Cache the X/Y grid coordinates — same for every layer.
+  const gx = new Float32Array(N);
+  const gy = new Float32Array(N);
+  for (let i = 0; i < N; i++) gx[i] = minX + (i / (N - 1)) * width;
+  for (let j = 0; j < N; j++) gy[j] = minY + (j / (N - 1)) * height;
+
+  const layers: ReliefLayer[] = [];
+  for (const [domain, samples] of byDomain) {
+    const positions = new Float32Array(vertCount * 3);
+    const colors = new Float32Array(vertCount * 3);
+    const heights = new Float32Array(vertCount);
+
+    let peak = 0;
+    for (let j = 0; j < N; j++) {
+      const y = gy[j];
+      for (let i = 0; i < N; i++) {
+        const x = gx[i];
+        let h = 0;
+        for (const s of samples) {
+          const dx = x - s.x;
+          const dy = y - s.y;
+          h += s.w * Math.exp(-(dx * dx + dy * dy) / sigma2);
+        }
+        const idx = j * N + i;
+        heights[idx] = h;
+        if (h > peak) peak = h;
+      }
+    }
+
+    const colorHex = getDomainColor(domain);
+    const colorRGB = hexToLinearRGB(colorHex);
+    const inv = peak > 0 ? 1 / peak : 0;
+
+    for (let j = 0; j < N; j++) {
+      const yWorld = gy[j];
+      for (let i = 0; i < N; i++) {
+        const xWorld = gx[i];
+        const idx = j * N + i;
+        const norm = heights[idx] * inv;
+        const z = norm * heightScale;
+
+        positions[idx * 3 + 0] = xWorld - cx;
+        positions[idx * 3 + 1] = z;
+        positions[idx * 3 + 2] = yWorld - cy;
+
+        // Gamma=1.5 keeps valleys dark (≈black under additive blending) and
+        // makes peaks pop with full domain saturation.
+        const tint = Math.pow(norm, 1.5);
+        colors[idx * 3 + 0] = colorRGB[0] * tint;
+        colors[idx * 3 + 1] = colorRGB[1] * tint;
+        colors[idx * 3 + 2] = colorRGB[2] * tint;
+      }
+    }
+
+    layers.push({
+      domain,
+      colorHex,
+      colorRGB,
+      field: {
+        positions,
+        colors,
+        indices,
+        width,
+        height,
+        resolution: N,
+        peak,
+      },
+      nodeCount: samples.length,
+    });
+  }
+
+  // Render order: lowest peak first, highest last. With additive blending the
+  // order is mathematically irrelevant, but a stable, peak-driven order keeps
+  // the legend meaningful.
+  layers.sort((a, b) => b.field.peak - a.field.peak);
+  return layers;
+}
+
+function hexToLinearRGB(hex: string): [number, number, number] {
+  const m = hex.replace("#", "");
+  const r = parseInt(m.slice(0, 2), 16) / 255;
+  const g = parseInt(m.slice(2, 4), 16) / 255;
+  const b = parseInt(m.slice(4, 6), 16) / 255;
+  return [r, g, b];
 }


### PR DESCRIPTION
## Summary

Direct follow-up to #204 — the user's original feature request explicitly asked about multilayer ("multiple color overlaps topologizal maps"). v1 was the single-domain elevation ramp; v2 is per-domain colored stacks with additive blending.

- **`computeReliefLayers(nodes, layout, params?)`** in `graph-relief-field.ts` — groups nodes by `node.domain`, evaluates each domain's Gaussian field over a **shared world-space grid** (global bounds; identical bandwidth/sigma per layer). Each layer's vertex colors are pre-tinted by `getDomainColor(domain) × pow(norm, 1.5)` so valleys → black (additive zero) and peaks saturate at the domain color. Triangle indices are shared across layers — same `Uint32Array` reference, no duplication.
- **`<ReliefLayerMesh>`** uses `meshBasicMaterial` + `THREE.AdditiveBlending` + `depthWrite: false` + `toneMapped: false`. Lighting is intentionally bypassed — domain colors must be unambiguous, not normal-modulated. Where two domain peaks coincide spatially, GPU adds the tints (red + cyan = magenta) — exactly the "color overlap" reading the user asked for.
- **Auto mode-switch:** 1 unique domain → original elevation-ramp single mesh (preserves v1 read for single-vertical graphs); ≥2 unique domains → multilayer. No new toggle.
- **`<DomainLegend>`** overlay (top-left): bullet + domain name + node count, sorted by peak descending.

### Design decisions

- **Shared layout vs per-domain layout** → shared. Peaks line up by node so an overlap reads as "this region is critical across multiple domains" — analytically meaningful. Per-domain layouts would scatter into separate continents.
- **Additive vs alpha blend** → additive. Order-independent on GPU; color mixing emerges naturally; no depth-sort headaches.
- **Shared triangle index buffer** across layers — saves N²×6×4 bytes per extra layer.

### Cost

Same total work as the single-pass since `Σ samples_per_layer = total samples`. ~30ms field eval on a 4-domain × 100-node graph at 80×80. Memoized on `[graphData.nodes, layout]` — hover/scrub/orbit don't recompute.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Lint clean on touched files
- [x] vitest 666/666 pass (9 new in `graph-relief-field.test.ts` — empty input, layer count = unique domains, shared bounds, nodeCount, peak ordering, valley = additive black, re-centering invariant)
- [ ] Visual check on Vercel preview / production: select multiple domains in DomainSelector → switch to RELIEF tab → verify per-domain colored peaks with overlap mixing
- [ ] Visual check on a single-domain graph (e.g. only T1D VX-880) → confirm v1 elevation ramp still active, no legend shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_