### PR TITLE
fix(relief): hotfix production crash on RELIEF tab-switch

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -241,9 +241,34 @@ Remaining map-view perf opportunity if ever needed: the per-frame particle updat
 
 **Verification.** `tsc --noEmit` clean; lint clean on touched files; vitest 666/666 pass (9 new in `graph-relief-field.test.ts`).
 
+### 2026-05-03 — Hotfix: Relief production crash on tab-switch
+
+**Trigger.** Right after PR #210 merged, user reported a Next.js "Application error: a client-side exception has occurred" on clicking RELIEF in production. Generic top-level error fallback — no console access from this session, so the diagnosis was forced to be remote.
+
+**Working theory (most-to-least likely).**
+1. **Static import of `getDomainColor` from `graph-data.ts`** in `graph-relief-field.ts`. `graph-data.ts` is the 2,920-line MAIN_GRAPH module and is intentionally split out via the `import("@/lib/graph-data")` dynamic import in `page.tsx` (item #6 in the bundle plan). My static import pulled it into the Relief chunk, defeating the split and creating two competing init paths for the same constant. Production chunk loaders handle this less gracefully than dev's webpack runtime.
+2. **NaN/Infinity propagation through the heightfield.** A single non-finite `composite` (or non-finite `p.x`/`p.y` from a degenerate layout) corrupts `peak`, then `inv = 1/peak`, then every `norm`, and finally every Float32 in the colors/positions buffers. WebGL upload of a buffer full of NaN doesn't always throw cleanly — sometimes it's "INVALID_OPERATION" on first draw, sometimes silent black, sometimes a renderer abort.
+3. **No error boundary** around the Relief Canvas, so any render-time throw inside r3f surfaces as a top-level Next.js fault and tears down the whole app instead of just the Relief pane.
+
+**Fix shipped.**
+- **Inlined `DOMAIN_COLOR_MAP`** in `graph-relief-field.ts`. Removed the static import of `getDomainColor` from `graph-data.ts` entirely. The map is now a local constant; the Relief chunk no longer depends on `graph-data.ts`. Note left in the file: keep in sync with `getDomainColor` if either changes.
+- **Defensive guards in both field functions.** Skip nodes whose layout position is non-finite. Coerce a non-finite `omegaFragility?.composite` to 0. Coerce a missing/empty `domain` string to `"Unknown"`. In the second pass, clamp `norm` to `[0, 1]` and bail to 0 on non-finite — so the GPU upload is always sane Float32.
+- **Empty-buffer guard in mesh components.** `<ReliefMesh>` and `<ReliefLayerMesh>` now early-return `null` when `field.positions.length === 0` and skip the `setAttribute`/`setIndex` calls — `THREE.BufferAttribute(empty, 3)` was the most plausible direct throw point.
+- **Removed `computeVertexNormals()`** from `<ReliefLayerMesh>` — `meshBasicMaterial` doesn't use lighting, so normals were wasted work and one less thing to fail on.
+- **`<ReliefErrorBoundary>` class component** wraps the whole Relief view. A render error inside now logs to the console and shows a small in-pane "RELIEF VIEW UNAVAILABLE" fallback; the rest of the app stays interactive. Cheap belt-and-braces — should be the last line of defence regardless of which of the above was the actual culprit.
+
+**Out of scope (deliberate).** Changing chunking config in `next.config.ts` to force the desired split — too broad. The inline copy of the color map is sufficient and decouples Relief from graph-data forever.
+
+**Verification.** `tsc --noEmit` clean; lint clean on touched files; vitest 673/673 pass.
+
+**Files touched.**
+- `src/lib/graph-relief-field.ts` (+ ~50 / − 4) — inlined color map, defensive sample/norm guards.
+- `src/components/CausalDAGRelief.tsx` (+ ~50 / − 5) — error boundary, empty-buffer guards, removed redundant normal compute.
+- `docs/sessions/rendering-perf.md` — this entry.
+
 ### 2026-05-03 — Next up
 
-- TBD — open for direction. Remaining Relief follow-ups: picking (raycast → select node), replay animation (bind field input to `currentSnapshot`), iso-contour lines, onboarding tooltip. Outside Relief: deferred 3D `onPointerMove` throttle, map-view imperative-setData refactor.
+- Verify hotfix lands the Relief view in production. If still broken, the user's browser console output will localise it (the new Error Boundary prints `[Relief view] render error: ...` instead of a top-level fault). If verified, remaining Relief follow-ups: picking (raycast → select node), replay animation (bind field input to `currentSnapshot`), iso-contour lines, onboarding tooltip. Outside Relief: deferred 3D `onPointerMove` throttle, map-view imperative-setData refactor.
 
 ---
 

--- a/src/components/CausalDAGRelief.tsx
+++ b/src/components/CausalDAGRelief.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef } from "react";
+import { Component, useEffect, useMemo, useRef, type ReactNode } from "react";
 import { Canvas, useThree } from "@react-three/fiber";
 import { OrbitControls } from "@react-three/drei";
 import * as THREE from "three";
@@ -14,6 +14,40 @@ import {
 } from "@/lib/graph-relief-field";
 import CanvasWatermark from "./CanvasWatermark";
 import DAGOverlay from "./dag3d/DAGOverlay";
+
+/**
+ * Class-based error boundary — keeps a render error inside the Relief view
+ * from tearing down the whole app to Next.js's generic "Application error"
+ * fallback. We log to the console (visible in DevTools / Vercel logs) and
+ * show a small in-pane fallback so the rest of the UI stays interactive.
+ */
+class ReliefErrorBoundary extends Component<
+  { children: ReactNode },
+  { error: Error | null }
+> {
+  state = { error: null as Error | null };
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+  componentDidCatch(error: Error, info: { componentStack?: string }) {
+    console.error("[Relief view] render error:", error, info.componentStack);
+  }
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="absolute inset-0 flex items-center justify-center bg-background pointer-events-none">
+          <div className="text-[10px] font-mono text-text-muted text-center px-6">
+            RELIEF VIEW UNAVAILABLE
+            <div className="mt-1 text-[9px] opacity-60">
+              {this.state.error.message || "Renderer failed to initialise"}
+            </div>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
 
 /**
  * Topographic / "Relief" view — 4th rendering mode. Reads the network as a
@@ -31,6 +65,7 @@ function ReliefMesh({ field }: { field: ReliefField }) {
   // ΩF value change. Hover and orbit don't trigger recompute.
   const geometry = useMemo(() => {
     const geom = new THREE.BufferGeometry();
+    if (field.positions.length === 0) return geom;
     geom.setAttribute(
       "position",
       new THREE.BufferAttribute(field.positions, 3),
@@ -45,6 +80,8 @@ function ReliefMesh({ field }: { field: ReliefField }) {
   }, [field]);
 
   useEffect(() => () => geometry.dispose(), [geometry]);
+
+  if (field.positions.length === 0) return null;
 
   return (
     <mesh geometry={geometry} castShadow={false} receiveShadow={false}>
@@ -69,6 +106,7 @@ function ReliefMesh({ field }: { field: ReliefField }) {
 function ReliefLayerMesh({ layer }: { layer: ReliefLayer }) {
   const geometry = useMemo(() => {
     const geom = new THREE.BufferGeometry();
+    if (layer.field.positions.length === 0) return geom;
     geom.setAttribute(
       "position",
       new THREE.BufferAttribute(layer.field.positions, 3),
@@ -78,11 +116,12 @@ function ReliefLayerMesh({ layer }: { layer: ReliefLayer }) {
       new THREE.BufferAttribute(layer.field.colors, 3),
     );
     geom.setIndex(new THREE.BufferAttribute(layer.field.indices, 1));
-    geom.computeVertexNormals();
     return geom;
   }, [layer.field]);
 
   useEffect(() => () => geometry.dispose(), [geometry]);
+
+  if (layer.field.positions.length === 0) return null;
 
   return (
     <mesh geometry={geometry} castShadow={false} receiveShadow={false}>
@@ -153,6 +192,14 @@ function DomainLegend({ layers }: { layers: ReliefLayer[] }) {
 }
 
 export default function CausalDAGRelief() {
+  return (
+    <ReliefErrorBoundary>
+      <CausalDAGReliefInner />
+    </ReliefErrorBoundary>
+  );
+}
+
+function CausalDAGReliefInner() {
   const graphData = useFilteredGraph();
 
   // Reuse the existing 2D force layout so peaks land exactly where nodes

--- a/src/lib/graph-relief-field.ts
+++ b/src/lib/graph-relief-field.ts
@@ -1,5 +1,42 @@
 import type { CausalNode } from "./types";
-import { getDomainColor } from "./graph-data";
+
+/**
+ * Per-domain color map for the multilayer Relief view. Inlined here (rather
+ * than importing `getDomainColor` from `graph-data.ts`) so this module never
+ * pulls the 2,920-line graph-data module into the Relief chunk — that module
+ * is dynamically imported elsewhere (see `page.tsx`) and a static import
+ * here would defeat the chunk split. Keep these in sync with
+ * `graph-data.ts:getDomainColor` if either changes.
+ */
+const DOMAIN_COLOR_MAP: Record<string, string> = {
+  "Saudi Aramco Energy": "#00e676",
+  "QatarEnergy LNG": "#00e5ff",
+  "QAFCO Fertilizer": "#76ff03",
+  "Ma'aden Phosphate": "#ffab00",
+  "Financial Contagion": "#ff6d00",
+  "Sovereign Risk": "#ffab00",
+  "Supply Chain Food Security": "#00e5ff",
+  "Undersea Cable Infrastructure": "#7c4dff",
+  "Macro Impact: Labor, Growth & Housing": "#40c4ff",
+  "Macro Impact: Inflation & Policy": "#ff80ab",
+  "Drone Swarms": "#ff4081",
+  "SATCOM": "#448aff",
+  "ISR Fusion": "#ea80fc",
+  "Chip Embargo": "#ff9100",
+  "Secure Compute": "#69f0ae",
+  "Kill Chain": "#ff1744",
+  "T1D Autoimmune": "#ff80ab",
+  "T1D β-cell Biology": "#40c4ff",
+  "T1D Metabolic": "#69f0ae",
+  "T1D Intervention": "#ffab00",
+  "T1D Complications": "#ff6d00",
+  "T1D VX-880": "#40c4ff",
+};
+const DEFAULT_DOMAIN_COLOR = "#5a5e72";
+
+function reliefDomainColor(domain: string): string {
+  return DOMAIN_COLOR_MAP[domain] ?? DEFAULT_DOMAIN_COLOR;
+}
 
 /**
  * Build a 2D scalar criticality field from a node layout. Each node contributes
@@ -67,7 +104,10 @@ export function computeReliefField(
   for (const n of nodes) {
     const p = layout.get(n.id);
     if (!p) continue;
-    samples.push({ x: p.x, y: p.y, w: n.omegaFragility.composite });
+    if (!Number.isFinite(p.x) || !Number.isFinite(p.y)) continue;
+    const composite = n.omegaFragility?.composite;
+    const w = Number.isFinite(composite) ? composite : 0;
+    samples.push({ x: p.x, y: p.y, w });
     if (p.x < minX) minX = p.x;
     if (p.x > maxX) maxX = p.x;
     if (p.y < minY) minY = p.y;
@@ -119,7 +159,10 @@ export function computeReliefField(
     for (let i = 0; i < N; i++) {
       const xWorld = minX + (i / (N - 1)) * width;
       const idx = j * N + i;
-      const norm = heights[idx] * inv;
+      const rawNorm = heights[idx] * inv;
+      const norm = Number.isFinite(rawNorm)
+        ? Math.max(0, Math.min(1, rawNorm))
+        : 0;
       const z = norm * heightScale;
 
       positions[idx * 3 + 0] = xWorld - cx;
@@ -228,10 +271,16 @@ export function computeReliefLayers(
   for (const n of nodes) {
     const p = layout.get(n.id);
     if (!p) continue;
-    const sample: Sample = { x: p.x, y: p.y, w: n.omegaFragility.composite };
-    const arr = byDomain.get(n.domain);
+    if (!Number.isFinite(p.x) || !Number.isFinite(p.y)) continue;
+    const composite = n.omegaFragility?.composite;
+    const w = Number.isFinite(composite) ? composite : 0;
+    const domain = typeof n.domain === "string" && n.domain.length > 0
+      ? n.domain
+      : "Unknown";
+    const sample: Sample = { x: p.x, y: p.y, w };
+    const arr = byDomain.get(domain);
     if (arr) arr.push(sample);
-    else byDomain.set(n.domain, [sample]);
+    else byDomain.set(domain, [sample]);
     if (p.x < minX) minX = p.x;
     if (p.x > maxX) maxX = p.x;
     if (p.y < minY) minY = p.y;
@@ -296,7 +345,7 @@ export function computeReliefLayers(
       }
     }
 
-    const colorHex = getDomainColor(domain);
+    const colorHex = reliefDomainColor(domain);
     const colorRGB = hexToLinearRGB(colorHex);
     const inv = peak > 0 ? 1 / peak : 0;
 
@@ -305,15 +354,19 @@ export function computeReliefLayers(
       for (let i = 0; i < N; i++) {
         const xWorld = gx[i];
         const idx = j * N + i;
-        const norm = heights[idx] * inv;
+        // Clamp defensively — a NaN/Infinity in `composite` propagates to
+        // `peak`/`inv`/`norm` and corrupts the GPU upload, which can crash
+        // the renderer on first draw.
+        const rawNorm = heights[idx] * inv;
+        const norm = Number.isFinite(rawNorm)
+          ? Math.max(0, Math.min(1, rawNorm))
+          : 0;
         const z = norm * heightScale;
 
         positions[idx * 3 + 0] = xWorld - cx;
         positions[idx * 3 + 1] = z;
         positions[idx * 3 + 2] = yWorld - cy;
 
-        // Gamma=1.5 keeps valleys dark (≈black under additive blending) and
-        // makes peaks pop with full domain saturation.
         const tint = Math.pow(norm, 1.5);
         colors[idx * 3 + 0] = colorRGB[0] * tint;
         colors[idx * 3 + 1] = colorRGB[1] * tint;


### PR DESCRIPTION
## Summary

User reported a Next.js top-level "Application error: a client-side exception" when switching to **RELIEF** in production. No browser console access from this session, so this is a defensive triage of the three most likely production-only failure modes — fixing each one independently so whichever was the actual cause is now resolved, and the boundary catches anything I missed.

### Working theory (most-to-least likely)

1. **Static import of `getDomainColor` from `graph-data.ts`** in `graph-relief-field.ts`. `graph-data.ts` is the 2,920-line `MAIN_GRAPH` module and is intentionally split out via the `import("@/lib/graph-data")` dynamic import in `page.tsx` (item #6 in the bundle plan). My static import dragged it back into the Relief chunk, defeating the split and creating two competing init paths for the same constant. Production chunk loaders handle this less gracefully than dev's webpack runtime.
2. **NaN/Infinity propagation through the heightfield.** A single non-finite `composite` (or non-finite layout position) corrupts `peak`, then `inv = 1/peak`, then every `norm`, and finally every Float32 in the buffer. WebGL upload of a NaN-laden buffer doesn't throw cleanly — sometimes `INVALID_OPERATION` on first draw, sometimes silent black, sometimes a renderer abort.
3. **No error boundary** around the Relief Canvas, so any render-time throw inside r3f surfaces as a top-level Next.js fault.

### Fix shipped

- **Inlined `DOMAIN_COLOR_MAP`** in `graph-relief-field.ts`. Removed the static import of `getDomainColor`. The Relief chunk no longer depends on `graph-data.ts`. Note left to keep the two color maps in sync.
- **Defensive guards in both compute functions.** Skip nodes whose layout position is non-finite. Coerce non-finite `omegaFragility?.composite` to 0. Coerce missing/empty `domain` to `"Unknown"`. Clamp `norm` to `[0, 1]` and bail to 0 on non-finite — GPU upload is always sane Float32.
- **Empty-buffer guard** in `<ReliefMesh>` / `<ReliefLayerMesh>` — early-return `null` and skip `setAttribute`/`setIndex` when `field.positions.length === 0`. `THREE.BufferAttribute(empty, 3)` was the most plausible direct throw point.
- **Removed `computeVertexNormals()`** from `<ReliefLayerMesh>` — `meshBasicMaterial` doesn't use lighting, so normals were wasted work and one less thing to fail on.
- **`<ReliefErrorBoundary>`** wraps the whole Relief view. A render error inside now logs `[Relief view] render error: ...` to the console and shows an in-pane "RELIEF VIEW UNAVAILABLE" fallback; the rest of the UI stays interactive.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Lint clean on touched files
- [x] vitest 673/673 pass
- [ ] Verify in production: click RELIEF — should now render the topographic mesh. If it still fails, the new Error Boundary will surface a localised error in the console (no more top-level "Application error" fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_