### PR TITLE
fix(demo): reopen DomainSelector on demo finish/exit

### DIFF
--- a/src/components/DemoFlowPlayer.tsx
+++ b/src/components/DemoFlowPlayer.tsx
@@ -209,11 +209,19 @@ function Player({ flowId, onClose }: PlayerProps) {
 export function DemoFlowPlayerHost() {
   const activeDemoFlowId = useApexStore((s) => s.activeDemoFlowId);
   const setActiveDemoFlowId = useApexStore((s) => s.setActiveDemoFlowId);
+  const setDomainSelectorOpen = useApexStore((s) => s.setDomainSelectorOpen);
   if (!activeDemoFlowId) return null;
   return (
     <Player
       flowId={activeDemoFlowId}
-      onClose={() => setActiveDemoFlowId(null)}
+      onClose={() => {
+        setActiveDemoFlowId(null);
+        // Reopen the DomainSelector so the user lands back at the picker
+        // instead of an empty canvas. Without this the Player's cleanup
+        // restores to whatever state existed pre-demo — which is empty
+        // when the user entered straight from the picker.
+        setDomainSelectorOpen(true);
+      }}
     />
   );
 }


### PR DESCRIPTION
## Summary

Bug you reported: after clicking "Finish demo" you land on a blank canvas with nothing to do.

**Root cause:** when you enter a demo straight from the picker without first selecting any domains, the Player captures the empty pre-demo state (`selectedDomains=[]`, `graphData=EMPTY_GRAPH`). On exit it faithfully restores that empty state.

**Fix:** the host's `onClose` handler now also calls `setDomainSelectorOpen(true)` so the user lands back at the picker — same place they started. From there they can pick a domain to explore manually, run another demo, or close the modal explicitly.

One file touched (`DemoFlowPlayer.tsx`). Tests + tsc clean.

## Test plan

- [x] `npm test` — passing
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: run any demo → Finish → DomainSelector should reopen

https://claude.ai/code/session_014AELhRkzeHMphQeQLwTGZF

---
_Generated by [Claude Code](https://claude.ai/code/session_014AELhRkzeHMphQeQLwTGZF)_