### PR TITLE
feat(canvas): domain-legend selection now visibly highlights in 3D / 2D / Relief

### DIFF
--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -422,12 +422,34 @@ function CausalDAG2DInner() {
     rafRef.current = requestAnimationFrame(tick);
   }, []);
 
-  // Emphasis target: hover wins over selection. Empty when nothing is hovered
-  // or selected — that's the default "no dimming" state.
+  // Emphasis target: hover wins over single selection. Empty when nothing is
+  // hovered or selected — that's the default "no dimming" state.
   const emphasisTarget = hoveredNodeId ?? selectedNode ?? null;
 
   const emphasisMap = useMemo(() => {
     const map = new Map<string, NodeEmphasis>();
+
+    // Multi-selection (domain legend, shift-drag marquee): every selected
+    // node gets focus, everything else dims. Takes effect even when no
+    // single node is selected — previously this state was invisible
+    // unless the user separately turned on isolation.
+    if (multiSelectedNodes.length > 0) {
+      const sel = new Set(multiSelectedNodes);
+      for (const n of graphData.nodes) {
+        map.set(n.id, sel.has(n.id) ? "focus" : "dim");
+      }
+      // If a singular hover/select coexists, let it upgrade its target to
+      // focus and surface its neighbors as "neighbor" (over the dim base).
+      if (emphasisTarget) {
+        map.set(emphasisTarget, "focus");
+        const neighbors = adjacency.get(emphasisTarget) ?? [];
+        for (const id of neighbors) {
+          if (!sel.has(id)) map.set(id, "neighbor");
+        }
+      }
+      return map;
+    }
+
     if (!emphasisTarget) return map;
     const neighbors = new Set(adjacency.get(emphasisTarget) ?? []);
     for (const n of graphData.nodes) {
@@ -436,7 +458,7 @@ function CausalDAG2DInner() {
       else map.set(n.id, "dim");
     }
     return map;
-  }, [emphasisTarget, graphData.nodes, adjacency]);
+  }, [emphasisTarget, graphData.nodes, adjacency, multiSelectedNodes]);
 
   const nodes: Node[] = useMemo(() => {
     return graphData.nodes.map((n) => {

--- a/src/components/CausalDAG3D.tsx
+++ b/src/components/CausalDAG3D.tsx
@@ -1027,7 +1027,11 @@ export default function CausalDAG3D() {
             const isMultiSelected = multiSelectedSet.has(node.id);
             const isSelected = selectedNode === node.id || isMultiSelected;
             const isNeighborOfSelected = selectedNeighborNodes.has(node.id);
-            const anyNodeSelected = selectedNode !== null;
+            // Dim non-selected nodes whenever ANYTHING is selected — single OR
+            // multi. Previously only the singular selection drove the dim
+            // pass, so domain-legend / shift-drag selections silently pushed
+            // multiple cyan rings into a sea of equally-bright neighbors.
+            const anyNodeSelected = selectedNode !== null || multiSelectedSet.size > 0;
 
             return (
               <DAGNode3D

--- a/src/components/CausalDAGRelief.tsx
+++ b/src/components/CausalDAGRelief.tsx
@@ -5,6 +5,7 @@ import { Canvas, useThree } from "@react-three/fiber";
 import { OrbitControls } from "@react-three/drei";
 import * as THREE from "three";
 import { useFilteredGraph } from "@/hooks/useFilteredGraph";
+import { useApexStore } from "@/stores/useApexStore";
 import { compute2DForceLayout } from "@/lib/graph-layout-2d";
 import {
   computeReliefField,
@@ -199,6 +200,97 @@ export default function CausalDAGRelief() {
   );
 }
 
+/**
+ * Cyan markers at selected node positions.
+ *
+ * The Relief view is a continuous heightfield, not discrete node renders, so
+ * neither the singular `selectedNode` nor the multi-select array
+ * (`selectedNodes`, written by the domain legend / shift-drag marquee) was
+ * visible here at all. This component renders a tall cyan pillar + glowing
+ * top sphere at each selected node's (x, y) layout position so users get the
+ * same "where is my selection" reading they get in the 3D / 2D / Map views.
+ *
+ * Pillar height (110) is intentionally taller than the relief's max
+ * heightScale (70) so markers always poke through the surface regardless of
+ * where the underlying field happens to peak.
+ */
+function SelectionMarkers({
+  layout,
+}: {
+  layout: Map<string, { x: number; y: number }>;
+}) {
+  const selectedNode = useApexStore((s) => s.selectedNode);
+  const selectedNodes = useApexStore((s) => s.selectedNodes);
+
+  const markers = useMemo(() => {
+    if (layout.size === 0) return [];
+    // Mirror the bounds + padding the relief uses so marker world coords
+    // line up with the heightfield. See computeReliefField in
+    // src/lib/graph-relief-field.ts — keep the padding constant in sync.
+    const PADDING = 80;
+    let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+    for (const p of layout.values()) {
+      if (!Number.isFinite(p.x) || !Number.isFinite(p.y)) continue;
+      if (p.x < minX) minX = p.x;
+      if (p.x > maxX) maxX = p.x;
+      if (p.y < minY) minY = p.y;
+      if (p.y > maxY) maxY = p.y;
+    }
+    if (!Number.isFinite(minX)) return [];
+    minX -= PADDING; maxX += PADDING;
+    minY -= PADDING; maxY += PADDING;
+    const cx = (minX + maxX) / 2;
+    const cy = (minY + maxY) / 2;
+
+    // Multi-select takes priority but still surface the singular selection
+    // when nothing else is selected (e.g. user clicked a top-Ω node).
+    const ids = new Set<string>(selectedNodes);
+    if (selectedNode) ids.add(selectedNode);
+
+    const out: { id: string; x: number; z: number }[] = [];
+    for (const id of ids) {
+      const p = layout.get(id);
+      if (!p || !Number.isFinite(p.x) || !Number.isFinite(p.y)) continue;
+      out.push({ id, x: p.x - cx, z: p.y - cy });
+    }
+    return out;
+  }, [layout, selectedNode, selectedNodes]);
+
+  if (markers.length === 0) return null;
+
+  const PILLAR_HEIGHT = 110;
+  const PILLAR_RADIUS = 1.4;
+
+  return (
+    <group>
+      {markers.map((m) => (
+        <group key={m.id} position={[m.x, 0, m.z]}>
+          {/* Pillar: thin cyan cylinder rising from y=0 through the surface. */}
+          <mesh position={[0, PILLAR_HEIGHT / 2, 0]}>
+            <cylinderGeometry args={[PILLAR_RADIUS, PILLAR_RADIUS, PILLAR_HEIGHT, 10]} />
+            <meshBasicMaterial color="#00e5ff" transparent opacity={0.65} />
+          </mesh>
+          {/* Outer pillar halo for a soft glow. */}
+          <mesh position={[0, PILLAR_HEIGHT / 2, 0]}>
+            <cylinderGeometry args={[PILLAR_RADIUS * 2.2, PILLAR_RADIUS * 2.2, PILLAR_HEIGHT, 10]} />
+            <meshBasicMaterial color="#00e5ff" transparent opacity={0.12} />
+          </mesh>
+          {/* Cap: glowing sphere at the top so the marker reads from above
+              even when camera is high enough to see straight down. */}
+          <mesh position={[0, PILLAR_HEIGHT, 0]}>
+            <sphereGeometry args={[3.2, 14, 14]} />
+            <meshBasicMaterial color="#00e5ff" />
+          </mesh>
+          <mesh position={[0, PILLAR_HEIGHT, 0]}>
+            <sphereGeometry args={[5.5, 14, 14]} />
+            <meshBasicMaterial color="#00e5ff" transparent opacity={0.25} />
+          </mesh>
+        </group>
+      ))}
+    </group>
+  );
+}
+
 function CausalDAGReliefInner() {
   const graphData = useFilteredGraph();
 
@@ -282,6 +374,7 @@ function CausalDAGReliefInner() {
         {!isEmpty && multilayer && layers.map((l) => (
           <ReliefLayerMesh key={l.domain} layer={l} />
         ))}
+        {!isEmpty && <SelectionMarkers layout={layout} />}
         {!isEmpty && frameDims && (
           <CameraSetup
             width={frameDims.width}


### PR DESCRIPTION
## Summary

Picking a domain in the canvas DOMAINS legend (or the shift-drag marquee) was already writing the right IDs into the store's `selectedNodes`, but each canvas renderer ignored or under-rendered that signal in a slightly different way. Click "Macro Impact: Inflation & Policy" → 27 IDs in the store → essentially identical canvas. This PR catches all three canvas renderers up.

| View | Bug | Fix |
|------|-----|-----|
| **3D** | `anyNodeSelected` (the flag that dims non-selected nodes) only watched the singular `selectedNode`. So the cyan ring + scale-up *did* fire on each multi-selected node, but with no dimming background, it disappeared into the equally-bright neighbors. | Expand to `selectedNode !== null \|\| multiSelectedSet.size > 0`. |
| **2D** | The `emphasisMap` only built dim/focus/neighbor entries off a single hover/select target. Multi-selection was invisible unless the user separately toggled Isolation on. | Extended map: when `multiSelectedNodes.length > 0`, every selected node gets `focus`, others get `dim`. A coexisting hover or single-select upgrades its target to focus and surfaces neighbors over the dim base — domain selection + node hover compose cleanly. |
| **Relief** | The heightfield is continuous — no discrete node renders to highlight. Selection state had nowhere to live visually. | New `SelectionMarkers` component: tall cyan pillar (110 world units, taller than the 70-unit max heightScale so it always pokes through) plus glowing top sphere at each selected node's (x, y) layout position. Mirrors the relief's bounds + padding offsets exactly so markers line up. Works on single-domain and multilayer. |

## Test plan

- [ ] Hard refresh, RELIEF view, multi-domain workspace (e.g. the FINANCIAL persona's full set)
- [ ] Click "Macro Impact: Inflation & Policy" in the DOMAINS legend → cyan obelisks rise across the surface where those nodes sit; click same entry again to clear
- [ ] Switch to **2D** → same selection still active, those nodes glow + others dim; toggle a different domain → switches highlight
- [ ] Switch to **3D** → selection visible (no isolation needed); cyan rings + scale-up + dim background
- [ ] Shift-drag marquee in 3D and 2D → same visual result
- [ ] Hover a node while a domain is selected (2D) → that node's neighbors come out of `dim` to `neighbor`, selected stays focused
- [ ] Map view (already worked) → unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
