### PR TITLE
fix(demo): wire DemoFlow.highlightNodeIds into the canvas selection

### DIFF
--- a/src/components/DemoFlowPlayer.tsx
+++ b/src/components/DemoFlowPlayer.tsx
@@ -26,6 +26,7 @@ interface PlayerProps {
 interface PriorState {
   selectedDomains: string[];
   graphData: CausalGraph;
+  selectedNodes: string[];
 }
 
 function Player({ flowId, onClose }: PlayerProps) {
@@ -34,6 +35,7 @@ function Player({ flowId, onClose }: PlayerProps) {
   const removeShock = useApexStore((s) => s.removeShock);
   const setSelectedDomains = useApexStore((s) => s.setSelectedDomains);
   const setGraphData = useApexStore((s) => s.setGraphData);
+  const setSelectedNodes = useApexStore((s) => s.setSelectedNodes);
   const startReplay = useApexStore((s) => s.startReplay);
   const stopReplay = useApexStore((s) => s.stopReplay);
   const priorRef = useRef<PriorState | null>(null);
@@ -48,6 +50,7 @@ function Player({ flowId, onClose }: PlayerProps) {
     priorRef.current = {
       selectedDomains: [...store.selectedDomains],
       graphData: store.graphData,
+      selectedNodes: [...store.selectedNodes],
     };
     // Load the graph data so useFilteredGraph has nodes/edges to filter
     // (the canvas was empty without this — DomainSelector's "Initialize"
@@ -58,16 +61,32 @@ function Player({ flowId, onClose }: PlayerProps) {
     setSelectedDomains(flow.domainIds);
     return () => {
       // Cleanup on unmount: stop the cascade replay, clear injected
-      // shocks, restore graph state.
+      // shocks, restore graph state + prior canvas selection.
       stopReplay();
       for (const id of injectedShockIdsRef.current) removeShock(id);
       injectedShockIdsRef.current = [];
       if (priorRef.current) {
         setGraphData(priorRef.current.graphData);
         setSelectedDomains(priorRef.current.selectedDomains);
+        setSelectedNodes(priorRef.current.selectedNodes);
       }
     };
-  }, [flow, setSelectedDomains, setGraphData, removeShock, stopReplay]);
+  }, [flow, setSelectedDomains, setGraphData, setSelectedNodes, removeShock, stopReplay]);
+
+  // ── Drive the canvas highlight from the active step's highlightNodeIds ──
+  // Without this, clicking Next changed the narrative card text but the
+  // canvas itself sat inert (highlightNodeIds was rendered only as a
+  // "Watching:" comma list inside the narrative card). Now the same multi-
+  // select pipeline that the domain legend / shift-drag marquee use lights
+  // up the watched nodes — 3D rings + camera-fit, 2D dims everything else,
+  // RELIEF raises cyan obelisks. An empty / missing field clears the
+  // selection so narrative-only steps return the camera to the full-graph
+  // fit instead of holding on the previous step's nodes.
+  useEffect(() => {
+    if (!flow) return;
+    const step = flow.steps[stepIdx];
+    setSelectedNodes(step?.highlightNodeIds ?? []);
+  }, [flow, stepIdx, setSelectedNodes]);
 
   // ── Inject the step's shock when the step becomes active ──
   // After each shock fires we kick startReplay() so the cascade simulator


### PR DESCRIPTION
## Summary

You flagged that clicking **Next** through a demo flow only changes the narrative card — the canvas itself sits inert. Confirmed: each demo step has a `highlightNodeIds` array (`src/lib/demo-flows.ts`) telling the player which nodes to spotlight, but the player only rendered that array as a `Watching: …` comma list inside the narrative card. It never wrote those IDs into the canvas selection.

This wires it up. PR #218 just shipped multi-select highlighting in 3D / 2D / Relief, so we already have the right pipeline — just call `setSelectedNodes(step.highlightNodeIds ?? [])` on every step change.

## Effects

- **3D**: `CameraRig` already auto-fits to multi-selection — the camera smoothly tracks the relevant cluster as the demo advances.
- **2D**: highlighted nodes glow + scale up; everything else dims.
- **Relief**: cyan obelisks rise at the highlighted node positions.
- **Map**: was already wired and continues to work.
- **Narrative-only steps** (no `highlightNodeIds`) clear the selection — camera returns to the full-graph fit instead of holding on the previous step's nodes.

Prior-state restoration was extended to also save/restore the user's pre-demo `selectedNodes`, alongside the existing `selectedDomains` + `graphData`.

## What's NOT changed

No demo-flow data edits — the `highlightNodeIds` arrays that have been sitting unused since the demo shipped now just work. No new dependencies, no new components.

## Test plan

- [ ] Hard refresh, launch a demo flow (Hormuz Closure is the canonical one)
- [ ] Click **Next** through the steps in 3D view — camera should track to each step's highlighted cluster, those nodes get cyan rings, others dim
- [ ] Switch to **2D** mid-demo — same nodes glow, others dim
- [ ] Switch to **RELIEF** — cyan obelisks rise at the watched positions; advancing moves them
- [ ] Hit **Pause** + click **Back** — earlier step's highlights are reapplied
- [ ] Step into a narrative-only beat (no highlightNodeIds) → selection clears, camera returns to full-graph fit
- [ ] Click **Exit** mid-demo → graph + selection restored to whatever was active before launching the demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
