### PR TITLE
perf(baseline): Speed Insights + bundle analyzer + audit-log doc

### DIFF
--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,119 @@
+# Performance — instrumentation, runbook, audit log
+
+> **Audience:** Apex Analytica engineers and operations.
+> **Status:** Living document. The audit-log section ([§5](#5-audit-log)) is appended to whenever a meaningful perf change ships.
+> **Scope:** What perf instrumentation is wired into Manifold, how to read the data, what to watch for, and a chronological log of past audits + actions so we don't redo work.
+
+The platform doesn't have a dedicated perf engineer. This doc is the substitute — a discoverable, persistent process so that any session (Claude or human) can:
+
+1. Look up what's instrumented today.
+2. Know which thresholds matter.
+3. See what was already audited and what was deliberately left alone.
+
+**If you're about to do a perf audit, append your findings + actions to the audit log at the bottom.** Future you will thank present you.
+
+---
+
+## 1. What's instrumented
+
+### 1.1 `@vercel/speed-insights` — real-user Web Vitals
+
+Wired into `src/app/layout.tsx`. Reports per-route Core Web Vitals (LCP, INP, CLS, FCP, TTFB) from real users back to Vercel.
+
+- **Where to read the data:** `vercel.com/junaidapexs-projects/manifold/observability/speed-insights`
+- **What it costs:** $0 on Hobby, included in Pro. No code changes required to see the data — it accumulates passively as users visit.
+- **First useful results:** ~24 hours of real traffic. Don't expect signal until then.
+
+### 1.2 `@next/bundle-analyzer` — client + server bundle treemap
+
+Wrapped around `next.config.ts`'s export. **Inert by default**; only active when `ANALYZE=true` is set at build time. This means production builds on Vercel are not affected.
+
+- **How to run locally:**
+  ```bash
+  ANALYZE=true npm run build
+  ```
+  The build opens a browser tab with an interactive treemap of every JS chunk shipped to the client (and a separate one for the server). Hover any rectangle to see its byte size and what it contains.
+- **What to look for:**
+  - Single packages > 100 KB minified+gzipped (red flag — should be dynamic-imported).
+  - Duplicate-looking trees (e.g., two copies of `react-three-fiber` from different transitive paths — fix via `npm dedupe` or version pinning).
+  - Anything in the *initial* (entry) bundle that only one route uses (move to that route's page or `dynamic()`).
+
+### 1.3 `prebuild` test gate
+
+Defined in `package.json`:
+```json
+"prebuild": "vitest run"
+```
+
+Every Vercel build runs the full unit-test suite before `next build`. A failing test blocks the deploy. This is intentional and is the project's only quality gate.
+
+- **Side effect on perf:** Adds ~15s to every build. Acceptable.
+- **If a test starts breaking deploys:** `CI=1 npm run build` locally to reproduce. **Never disable `prebuild` to ship.** Fix the test.
+
+### 1.4 What is *not* instrumented (deliberate gaps)
+
+- **No Sentry / error-tracking SDK.** Vercel function logs are the catch-all. Add Sentry only if reproducing production errors becomes painful.
+- **No synthetic monitoring** (uptime pings). Vercel's own deployment health is the substitute.
+- **No React DevTools Profiler integration in production.** If a re-render perf issue is reported, profile locally with the user's exact path.
+
+---
+
+## 2. Thresholds — what counts as "slow"
+
+Use these as the line for "we should investigate":
+
+| Metric | Green | Yellow | Red |
+|---|---|---|---|
+| **LCP** (Largest Contentful Paint) | ≤ 2.5 s | 2.5 – 4 s | > 4 s |
+| **INP** (Interaction to Next Paint) | ≤ 200 ms | 200 – 500 ms | > 500 ms |
+| **CLS** (Cumulative Layout Shift) | ≤ 0.1 | 0.1 – 0.25 | > 0.25 |
+| **First-load JS** (per route, gzipped) | ≤ 250 KB | 250 – 500 KB | > 500 KB |
+| **TTFB** (Time to First Byte, p75) | ≤ 600 ms | 600 ms – 1.5 s | > 1.5 s |
+
+These mirror Google's Core Web Vitals defaults. Don't chase green on every metric — chase "no red" on the high-traffic routes (`/`, `/pricing`, `/login`, `/request-access`) and accept yellow on the heavy workspace pages (`/`, the 3D causal graph) where interactivity > paint speed.
+
+---
+
+## 3. Recurring review cadence
+
+Suggested rhythm:
+
+- **Monthly** (calendar reminder): open Speed Insights, look at the worst route by INP. If it moved into red, file an issue.
+- **After any large dependency change** (`npm install <new-package>`, major version bumps): run `ANALYZE=true npm run build` and confirm no chunk gained more than ~30 KB unexpectedly.
+- **Before adding a heavy SDK** (anything > 50 KB minified): consider dynamic import + a feature flag rather than a static import.
+
+If the monthly cadence slips, no penalty. The instrumentation runs on its own; the data is there when you want it.
+
+---
+
+## 4. Common interventions, ranked by leverage
+
+When the audit finds a problem, this is the menu of fixes, ordered by typical impact:
+
+1. **Convert a static import to `dynamic()` with `ssr: false`** — biggest win for client-heavy components. Already done for `CausalDAG3D`, `CausalDAGMap`, `CausalDAGRelief`, the Trinity graphs. If a new heavy component lands, follow the same pattern.
+2. **Remove a dependency you no longer use.** `grep -rln "from ['\"]<pkg>" src/` to confirm zero usage; then `npm uninstall <pkg>`.
+3. **Inline-defer below-the-fold UI.** Wrap with `React.lazy()` + `<Suspense>`. Saves initial JS at the cost of a brief skeleton.
+4. **`next/image` with explicit width/height + `priority` only on the LCP image.** Cuts CLS and unblocks LCP.
+5. **Server Components for read-only data fetches.** Already doing this for `/admin/*` pages.
+6. **Memoize expensive Zustand selectors.** Profile first; don't memoize speculatively.
+7. **Cache LLM responses where the input is identical** (compute, copilot). Out of scope for v1; consider when latency complaints arrive.
+
+---
+
+## 5. Audit log
+
+Append a row each time a perf-relevant change ships. Keep entries terse; cite PR numbers, not lines.
+
+| Date | PR | Action | Outcome / notes |
+|---|---|---|---|
+| 2026-05-01 | (this PR) | Wired `@vercel/speed-insights` into root layout + `@next/bundle-analyzer` into `next.config.ts`. Removed dead `@react-three/postprocessing` (zero source references). | Establishes baseline. Speed Insights data starts accumulating on next prod deploy. Bundle analyzer runs locally only via `ANALYZE=true npm run build`. |
+
+Future entries: copy the row template above.
+
+---
+
+## 6. See also
+
+- [`DEPLOYMENT.md`](./DEPLOYMENT.md) — Vercel build pipeline, env vars, runbook.
+- [`ARCHITECTURE.md`](./ARCHITECTURE.md) — request lifecycle and runtime split (client / Edge / Node).
+- [`BILLING.md`](./BILLING.md) — for context on which routes are public vs admin-only (different perf SLAs apply).

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ This `docs/` folder is the canonical reference for how those pieces fit together
 | [`DATA_MODEL.md`](./DATA_MODEL.md) | The causal graphs (`MAIN_GRAPH`, `ATHENA_GRAPH`, `BRIDGE_EDGES`), domain selector, in-memory store. | You are adding a new domain, node, or cross-domain edge. |
 | [`ENGINES.md`](./ENGINES.md) | The four causal-inference modules (Spirtes, Tarski, Pearl, Pareto) plus the Omega, Cascade, Intervention, Ablation, and Monte-Carlo engines. | You are touching simulation, scoring, or interpretation logic. |
 | [`DEPLOYMENT.md`](./DEPLOYMENT.md) | Vercel project, custom domain, environment variables, CLI deploy + alias pattern, runbook for common failures. | You are shipping a release or recovering from an incident. |
+| [`PERFORMANCE.md`](./PERFORMANCE.md) | Speed Insights + bundle-analyzer wiring, threshold guidance, recurring review cadence, audit log of past changes. | You are auditing perf, adding a heavy dependency, or reading the audit log before optimizing. |
 
 The legacy `.docx` files in this folder (`apex-terminal-spirtes-engine.docx`, `apex-terminal-system-architecture.docx`, `apex-terminal-tarski-engine.docx`) are kept for historical reference only and are superseded by the markdown files above.
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,14 @@
 import type { NextConfig } from "next";
+import bundleAnalyzer from "@next/bundle-analyzer";
+
+// Wrap the export with the bundle analyzer. It's a no-op unless
+// ANALYZE=true is set at build time, so production builds on Vercel
+// are unaffected.
+//   ANALYZE=true npm run build   → opens treemap of client + server
+//                                  bundles in the default browser.
+const withBundleAnalyzer = bundleAnalyzer({
+  enabled: process.env.ANALYZE === "true",
+});
 
 const nextConfig: NextConfig = {
   // Enable gzip/brotli compression for served assets
@@ -17,4 +27,4 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+export default withBundleAnalyzer(nextConfig);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,12 @@
         "@mozilla/readability": "^0.6.0",
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",
-        "@react-three/postprocessing": "^3.0.4",
         "@reactflow/background": "^11.3.14",
         "@reactflow/controls": "^11.2.14",
         "@reactflow/core": "^11.11.4",
         "@supabase/ssr": "^0.10.2",
         "@supabase/supabase-js": "^2.103.0",
+        "@vercel/speed-insights": "^2.0.0",
         "@vis.gl/react-maplibre": "^8.1.0",
         "d3-force-3d": "^3.0.6",
         "framer-motion": "^12.34.3",
@@ -34,6 +34,7 @@
         "zustand": "^5.0.11"
       },
       "devDependencies": {
+        "@next/bundle-analyzer": "^16.2.4",
         "@tailwindcss/postcss": "^4",
         "@types/jsdom": "^28.0.1",
         "@types/node": "^20",
@@ -571,6 +572,16 @@
       "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.9.0",
@@ -1717,6 +1728,16 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@next/bundle-analyzer": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-16.2.4.tgz",
+      "integrity": "sha512-EAA9xTDv0P1IiUcZaASJJPkNDjRvL7OMTha6XN8MBzALYGfn7I52Mn7vRiyjVfNrtUPi2qiacY+eFVXe3lKCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webpack-bundle-analyzer": "4.10.1"
+      }
+    },
     "node_modules/@next/env": {
       "version": "16.1.6",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
@@ -1929,6 +1950,13 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@react-three/drei": {
       "version": "10.7.7",
       "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.7.7.tgz",
@@ -2015,32 +2043,6 @@
         "react-native": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@react-three/postprocessing": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@react-three/postprocessing/-/postprocessing-3.0.4.tgz",
-      "integrity": "sha512-e4+F5xtudDYvhxx3y0NtWXpZbwvQ0x1zdOXWTbXMK6fFLVDd4qucN90YaaStanZGS4Bd5siQm0lGL/5ogf8iDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "maath": "^0.6.0",
-        "n8ao": "^1.9.4",
-        "postprocessing": "^6.36.6"
-      },
-      "peerDependencies": {
-        "@react-three/fiber": "^9.0.0",
-        "react": "^19.0",
-        "three": ">= 0.156.0"
-      }
-    },
-    "node_modules/@react-three/postprocessing/node_modules/maath": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/maath/-/maath-0.6.0.tgz",
-      "integrity": "sha512-dSb2xQuP7vDnaYqfoKzlApeRcR2xtN8/f7WV/TMAkBC8552TwTLtOO0JTcSygkYMjNDPoo6V01jTw/aPi4JrMw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/three": ">=0.144.0",
-        "three": ">=0.144.0"
       }
     },
     "node_modules/@reactflow/background": {
@@ -3466,6 +3468,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4131,6 +4134,44 @@
         "react": ">= 16.8.0"
       }
     },
+    "node_modules/@vercel/speed-insights": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vis.gl/react-mapbox": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@vis.gl/react-mapbox/-/react-mapbox-8.1.0.tgz",
@@ -4362,6 +4403,19 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/adler-32": {
@@ -5009,6 +5063,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5124,6 +5188,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-binarytree": {
@@ -5353,6 +5418,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -5473,6 +5545,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/earcut": {
       "version": "3.0.2",
@@ -6659,6 +6738,22 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/happy-dom": {
       "version": "20.8.4",
@@ -8225,6 +8320,16 @@
       "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
       "license": "MIT"
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -8237,16 +8342,6 @@
       "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
       "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
       "license": "MIT"
-    },
-    "node_modules/n8ao": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/n8ao/-/n8ao-1.10.1.tgz",
-      "integrity": "sha512-hhI1pC+BfOZBV1KMwynBrVlIm8wqLxj/abAWhF2nZ0qQKyzTSQa1QtLVS2veRiuoBQXojxobcnp0oe+PUoxf/w==",
-      "license": "ISC",
-      "peerDependencies": {
-        "postprocessing": ">=6.30.0",
-        "three": ">=0.137"
-      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -8537,6 +8632,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -8759,15 +8864,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/postprocessing": {
-      "version": "6.38.3",
-      "resolved": "https://registry.npmjs.org/postprocessing/-/postprocessing-6.38.3.tgz",
-      "integrity": "sha512-5qCFp8j62nWL6sSVv/RKuHscQUIV+VMMgWeHLYZQEBpAk7G+r3jA3bSKON7gZjiuxdZ/F4PXj2Jc1oPh/7Eg+g==",
-      "license": "Zlib",
-      "peerDependencies": {
-        "three": ">= 0.157.0 < 0.184.0"
       }
     },
     "node_modules/potpack": {
@@ -9424,6 +9520,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/sort-asc": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.2.0.tgz",
@@ -9959,6 +10070,16 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tough-cookie": {
@@ -10886,6 +11007,66 @@
         "node": ">=20"
       }
     },
+    "node_modules/webpack-bundle-analyzer": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz",
+      "integrity": "sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "0.5.7",
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "commander": "^7.2.0",
+        "debounce": "^1.2.1",
+        "escape-string-regexp": "^4.0.0",
+        "gzip-size": "^6.0.0",
+        "html-escaper": "^2.0.2",
+        "is-plain-object": "^5.0.0",
+        "opener": "^1.5.2",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.3",
+        "ws": "^7.3.1"
+      },
+      "bin": {
+        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
@@ -11143,7 +11324,7 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     "@mozilla/readability": "^0.6.0",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.5.0",
-    "@react-three/postprocessing": "^3.0.4",
     "@reactflow/background": "^11.3.14",
     "@reactflow/controls": "^11.2.14",
     "@reactflow/core": "^11.11.4",
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.103.0",
+    "@vercel/speed-insights": "^2.0.0",
     "@vis.gl/react-maplibre": "^8.1.0",
     "d3-force-3d": "^3.0.6",
     "framer-motion": "^12.34.3",
@@ -39,6 +39,7 @@
     "zustand": "^5.0.11"
   },
   "devDependencies": {
+    "@next/bundle-analyzer": "^16.2.4",
     "@tailwindcss/postcss": "^4",
     "@types/jsdom": "^28.0.1",
     "@types/node": "^20",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Michroma, Geist_Mono } from "next/font/google";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import "./globals.css";
 
 const michroma = Michroma({
@@ -36,6 +37,7 @@ export default function RootLayout({
         className={`${michroma.variable} ${geistMono.variable} antialiased bg-background text-foreground`}
       >
         {children}
+        <SpeedInsights />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary

Establish a perf-measurement baseline before chasing optimizations. Three high-confidence changes, all additive or removing genuinely dead code.

### Wiring
- **`@vercel/speed-insights/next`** mounted in `src/app/layout.tsx`. Reports per-route Core Web Vitals (LCP, INP, CLS, FCP, TTFB) from real users back to Vercel. Free on Hobby. First useful signal after ~24 hours of prod traffic.
- **`@next/bundle-analyzer`** wrapped around `next.config.ts`'s export, gated on `ANALYZE=true` so production builds are unaffected. Local usage:
  ```
  ANALYZE=true npm run build
  ```
  Opens an interactive treemap of every client + server JS chunk. Useful before / after dependency changes.

### Cleanup
- Removed `@react-three/postprocessing` (zero `src/` references; verified via `grep -rln "@react-three/postprocessing"` including `.json` and `package-lock.json`). Shaves install time + transitive weight; production behavior unchanged.

### Documentation
- New **`docs/PERFORMANCE.md`** captures:
  - What's instrumented and where to read the data on Vercel
  - Threshold guidance (green/yellow/red for LCP/INP/CLS/first-load JS/TTFB)
  - Suggested monthly review cadence
  - Common interventions ranked by leverage
  - **A chronological audit log** so future sessions (Claude or human) don't redo work — this commit appends the first row.

The audit-log convention is the explicit answer to "make this an open process so we don't forget": every meaningful perf change going forward gets a one-line entry citing PR + outcome. The doc is registered in `docs/README.md` for discoverability.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 692/692 passing
- [ ] After merge + deploy: confirm Speed Insights starts reporting on `vercel.com/junaidapexs-projects/manifold/observability/speed-insights` within 24h
- [ ] Locally run `ANALYZE=true npm run build` and confirm treemap opens

https://claude.ai/code/session_01Bk4PoJxdEhTNGrKbN5MHE3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bk4PoJxdEhTNGrKbN5MHE3)_