### PR TITLE
feat(relief): readability pass — peakier terrain, tilted camera, grid, node labels

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -266,9 +266,33 @@ Remaining map-view perf opportunity if ever needed: the per-frame particle updat
 - `src/components/CausalDAGRelief.tsx` (+ ~50 / − 5) — error boundary, empty-buffer guards, removed redundant normal compute.
 - `docs/sessions/rendering-perf.md` — this entry.
 
+### 2026-05-03 — Shipped: Relief readability pass — peakier terrain, tilted camera, grid, top-K node labels
+
+**PR:** TBD (about to open).
+
+**Trigger.** User said the live Relief view "kinda just looks like a flat map" — the multi-domain mesh was reading as one soft mound instead of distinguishable peaks, the camera was too top-down to see silhouette, and there was no way to identify *which* nodes the ridges belonged to. Asked for tilt + axes/grid + node labels.
+
+**What shipped.**
+- **Sharper terrain.** `heightScale 30 → 90`, `sigmaFraction 0.12 → 0.06` (tighter Gaussian — peaks no longer smear into one another), and a new `heightGamma: 1.35` knob that powers the normalised elevation before mapping to vertex Y. Combined with the upstream `nodeWeight()` power-1.5 boost (PR #218 territory), peaks now read as discrete ridges with flat valleys instead of a single dome. `elevationColor()` still keys off the linear `norm` so the legend ramp stays readable.
+- **Tilted initial camera.** `dist * 0.55` Y-multiplier dropped to `0.35`, giving a ~20° elevation angle instead of a half-overhead view. The mesh now has actual silhouette on first frame; OrbitControls take over from there.
+- **`<ReliefGrid>`.** Flat `gridHelper` at `y = -2`, sized to 1.2 × the bounds and divided into 16 cells. Two-tone colors (`#1a1d2b` / `#0e1018`) sit just-visible against the `#050508` background — the mesh is no longer floating in featureless black.
+- **Top-K node labels.** New `computeNodeAnchors(nodes, layout, field, params, K=8)` in `graph-relief-field.ts` samples the field at each top-K node's position and returns mesh-local `(x, z, y)` so the component can drop drei `<Html>` cards above the highest peaks. Each label shows `{node.label}` + `Ω X.X` and a thin vertical tick down to the peak surface so the visual anchor is unambiguous. Defaults to 8 labels — enough to identify the dominant ridges, not so many that the canvas turns into label soup.
+- **`ReliefField` exposes `cx, cy`.** The world-space recentring origin used by both compute functions. Lets `computeNodeAnchors` (and any future picking work) convert raw layout coords to mesh-local without re-deriving the bounds.
+
+**Files.**
+- `src/lib/graph-relief-field.ts` — `heightGamma` param + `cx/cy` field exports, height-gamma applied in both compute functions, new `computeNodeAnchors` + `NodeAnchor` exports.
+- `src/components/CausalDAGRelief.tsx` — `<ReliefGrid>`, `<NodeLabels>`, tilted `<CameraSetup>`, `Html` import from drei, anchors useMemo against the dominant peak field.
+- `src/lib/__tests__/graph-relief-field.test.ts` — added 4 tests: `cx/cy` exposed correctly; anchors top-K + sorted; anchors recentred to mesh-local; anchors empty on empty field.
+
+**Cost.** Anchor sampling is O(K × N) per recompute (K=8, N=node count). On a 200-node graph that's ~1,600 `exp()` calls — under 1ms. Memoised on `[graphData.nodes, layout]` so hover/scrub/orbit don't trigger.
+
+**Out of scope (deliberately).** Per-layer Y-stacking (option B in the user's pick) — the sharpened terrain alone already separates peaks readably, and stacking would compete with the additive color-mixing read. Picking through the mesh — still a future PR.
+
+**Verification.** `tsc --noEmit` clean; lint clean on touched files; vitest 696/696 pass (4 new tests).
+
 ### 2026-05-03 — Next up
 
-- Verify hotfix lands the Relief view in production. If still broken, the user's browser console output will localise it (the new Error Boundary prints `[Relief view] render error: ...` instead of a top-level fault). If verified, remaining Relief follow-ups: picking (raycast → select node), replay animation (bind field input to `currentSnapshot`), iso-contour lines, onboarding tooltip. Outside Relief: deferred 3D `onPointerMove` throttle, map-view imperative-setData refactor.
+- Verify the readability pass on production (hard-refresh, click RELIEF, expect tilted camera, top-8 node labels above peaks, grid floor, sharper ridges). If labels are too dense or sparse on real data, the `topK` constant in `CausalDAGReliefInner` is one number to tune. Remaining Relief follow-ups: picking (raycast → select node), replay animation (bind field input to `currentSnapshot`), iso-contour lines, onboarding tooltip, per-layer Y-stacking (option B). Outside Relief: deferred 3D `onPointerMove` throttle, map-view imperative-setData refactor.
 
 ---
 

--- a/src/components/CausalDAGRelief.tsx
+++ b/src/components/CausalDAGRelief.tsx
@@ -2,14 +2,16 @@
 
 import { Component, useEffect, useMemo, useRef, type ReactNode } from "react";
 import { Canvas, useThree } from "@react-three/fiber";
-import { OrbitControls } from "@react-three/drei";
+import { Html, OrbitControls } from "@react-three/drei";
 import * as THREE from "three";
 import { useFilteredGraph } from "@/hooks/useFilteredGraph";
 import { useApexStore } from "@/stores/useApexStore";
 import { compute2DForceLayout } from "@/lib/graph-layout-2d";
 import {
+  computeNodeAnchors,
   computeReliefField,
   computeReliefLayers,
+  type NodeAnchor,
   type ReliefField,
   type ReliefLayer,
 } from "@/lib/graph-relief-field";
@@ -158,13 +160,73 @@ function CameraSetup({
   useEffect(() => {
     if (framedRef.current) return;
     if (!enabled) return;
-    const dist = Math.max(width, height, 200) * 0.65;
-    camera.position.set(dist * 0.85, dist * 0.55, dist * 0.85);
+    // Lower Y multiplier (0.35 vs 0.55) drops the camera closer to the
+    // horizon, giving the mesh actual relief silhouette instead of a
+    // top-down "smudge". Keep X/Z symmetric so the initial frame is a
+    // 45° azimuth.
+    const dist = Math.max(width, height, 200) * 0.7;
+    camera.position.set(dist * 0.95, dist * 0.35, dist * 0.95);
     camera.lookAt(0, 0, 0);
     framedRef.current = true;
   }, [camera, width, height, enabled]);
 
   return null;
+}
+
+/**
+ * Reference grid laid flat at y=−2, sized to the field bounds. Without it the
+ * mesh floats in featureless black and there's no sense of scale or which
+ * direction is which. The slight Y-offset keeps it from z-fighting the mesh
+ * valleys.
+ */
+function ReliefGrid({ width, height }: { width: number; height: number }) {
+  const size = Math.max(width, height) * 1.2;
+  // Aim for ~16 visible cells across the larger dimension regardless of
+  // graph size — same density read at 200-unit graphs and 2000-unit graphs.
+  const divisions = 16;
+  return (
+    <gridHelper
+      args={[size, divisions, "#1a1d2b", "#0e1018"]}
+      position={[0, -2, 0]}
+    />
+  );
+}
+
+function NodeLabels({ anchors }: { anchors: NodeAnchor[] }) {
+  if (anchors.length === 0) return null;
+  return (
+    <>
+      {anchors.map((a) => (
+        <group key={a.id} position={[a.x, a.y + 14, a.z]}>
+          {/* Vertical tick from peak surface to label so the label has a
+              clear visual anchor — without this the labels float and you
+              can't tell which peak owns which name. */}
+          <mesh position={[0, -7, 0]}>
+            <cylinderGeometry args={[0.6, 0.6, 14, 6]} />
+            <meshBasicMaterial color="#ffffff" transparent opacity={0.35} />
+          </mesh>
+          <Html
+            center
+            distanceFactor={420}
+            zIndexRange={[10, 0]}
+            style={{ pointerEvents: "none" }}
+          >
+            <div
+              className="px-1.5 py-0.5 rounded bg-surface-elevated/90 border border-border whitespace-nowrap"
+              style={{ transform: "translateY(-50%)" }}
+            >
+              <div className="text-[8px] font-mono text-foreground leading-tight">
+                {a.label}
+              </div>
+              <div className="text-[7px] font-mono text-text-muted leading-tight">
+                Ω {a.composite.toFixed(1)}
+              </div>
+            </div>
+          </Html>
+        </group>
+      ))}
+    </>
+  );
 }
 
 function DomainLegend({ layers }: { layers: ReliefLayer[] }) {
@@ -337,6 +399,16 @@ function CausalDAGReliefInner() {
     ? layers[0]?.field
     : singleField ?? undefined;
 
+  // Top-K node anchors for floating labels above the most fragile peaks. We
+  // sample against the highest-peak layer in multilayer mode (or the single
+  // field) so the heights align with the dominant terrain the user sees.
+  const anchors = useMemo<NodeAnchor[]>(() => {
+    if (isEmpty) return [];
+    const anchorField = multilayer ? layers[0]?.field : singleField;
+    if (!anchorField) return [];
+    return computeNodeAnchors(graphData.nodes, layout, anchorField, {}, 8);
+  }, [isEmpty, multilayer, layers, singleField, graphData.nodes, layout]);
+
   return (
     <div style={{ position: "absolute", inset: 0 }}>
       <CanvasWatermark />
@@ -368,6 +440,9 @@ function CausalDAGReliefInner() {
           color="#00e5ff"
         />
 
+        {!isEmpty && frameDims && (
+          <ReliefGrid width={frameDims.width} height={frameDims.height} />
+        )}
         {!isEmpty && !multilayer && singleField && (
           <ReliefMesh field={singleField} />
         )}
@@ -375,6 +450,7 @@ function CausalDAGReliefInner() {
           <ReliefLayerMesh key={l.domain} layer={l} />
         ))}
         {!isEmpty && <SelectionMarkers layout={layout} />}
+        {!isEmpty && <NodeLabels anchors={anchors} />}
         {!isEmpty && frameDims && (
           <CameraSetup
             width={frameDims.width}

--- a/src/lib/__tests__/graph-relief-field.test.ts
+++ b/src/lib/__tests__/graph-relief-field.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  computeNodeAnchors,
   computeReliefField,
   computeReliefLayers,
 } from "../graph-relief-field";
@@ -156,5 +157,61 @@ describe("computeReliefLayers", () => {
     const empty = new Map<string, { x: number; y: number }>();
     const layers = computeReliefLayers(nodes, empty);
     expect(layers).toEqual([]);
+  });
+
+  it("ReliefField exposes the cx/cy world center used for recentering", () => {
+    const nodes = [
+      makeNode("a", "X", 5),
+      makeNode("b", "X", 5),
+    ];
+    const layout = new Map([
+      ["a", { x: 100, y: 200 }],
+      ["b", { x: 200, y: 400 }],
+    ]);
+    const field = computeReliefField(nodes, layout, { resolution: 8 });
+    // cx/cy should be the midpoint of the padded bounds — the same recentering
+    // origin the mesh uses, so labels can convert (layout x,y) → mesh-local.
+    expect(field.cx).toBeCloseTo(150, 0);
+    expect(field.cy).toBeCloseTo(300, 0);
+  });
+});
+
+describe("computeNodeAnchors", () => {
+  it("returns at most topK anchors, sorted by composite descending", () => {
+    const nodes = [
+      makeNode("low", "X", 1),
+      makeNode("mid", "X", 5),
+      makeNode("high", "X", 9),
+      makeNode("higher", "X", 9.5),
+    ];
+    const layout = new Map([
+      ["low", { x: 0, y: 0 }],
+      ["mid", { x: 100, y: 0 }],
+      ["high", { x: 0, y: 100 }],
+      ["higher", { x: 100, y: 100 }],
+    ]);
+    const field = computeReliefField(nodes, layout, { resolution: 16 });
+    const anchors = computeNodeAnchors(nodes, layout, field, {}, 2);
+    expect(anchors.length).toBe(2);
+    expect(anchors[0].id).toBe("higher");
+    expect(anchors[1].id).toBe("high");
+  });
+
+  it("anchors are recentered to mesh-local coords (matches field.cx/cy)", () => {
+    const nodes = [makeNode("a", "X", 8)];
+    const layout = new Map([["a", { x: 500, y: 300 }]]);
+    const field = computeReliefField(nodes, layout, { resolution: 16 });
+    const [anchor] = computeNodeAnchors(nodes, layout, field, {}, 1);
+    expect(anchor.x).toBeCloseTo(500 - field.cx, 1);
+    expect(anchor.z).toBeCloseTo(300 - field.cy, 1);
+    expect(anchor.y).toBeGreaterThan(0);
+  });
+
+  it("returns [] when the field is empty", () => {
+    const nodes = [makeNode("a", "X", 5)];
+    const empty = new Map<string, { x: number; y: number }>();
+    const field = computeReliefField(nodes, empty);
+    const anchors = computeNodeAnchors(nodes, empty, field);
+    expect(anchors).toEqual([]);
   });
 });

--- a/src/lib/graph-relief-field.ts
+++ b/src/lib/graph-relief-field.ts
@@ -58,6 +58,13 @@ export interface ReliefFieldParams {
   padding?: number;
   /** Gaussian bandwidth as a fraction of the smaller bounds dimension. */
   sigmaFraction?: number;
+  /**
+   * Power applied to normalized elevation before mapping to vertex Y.
+   * `> 1` flattens valleys and raises peaks (visually more "peaky"); `1` is
+   * linear; `< 1` lifts mid-elevations. Default 1.4 → distinct peaks instead
+   * of the soft-mound look the linear mapping produced on multi-domain graphs.
+   */
+  heightGamma?: number;
 }
 
 export interface ReliefField {
@@ -69,17 +76,30 @@ export interface ReliefField {
   resolution: number;
   /** Maximum raw field value before normalization — useful for legends. */
   peak: number;
+  /**
+   * World-space center the mesh was recentered around. Subtract these from a
+   * raw layout (x, y) to convert to mesh-local coordinates — needed by the
+   * component to place HTML labels above the right node peaks.
+   */
+  cx: number;
+  cy: number;
 }
 
 const DEFAULTS: Required<ReliefFieldParams> = {
   resolution: 80,
   // Tall enough to read as terrain rather than a pancake on a wide layout.
-  heightScale: 70,
+  // The combined effect of nodeWeight power-boost + heightGamma already
+  // makes peaks pop, so the linear scale stays modest.
+  heightScale: 90,
   padding: 80,
   // Tighter Gaussian than v1 — a quarter-extent bandwidth (0.12) smeared every
   // node's contribution and merged peaks into one broad lump. ~6% gives local,
   // legible mountains while still being smooth between adjacent nodes.
   sigmaFraction: 0.06,
+  // Power applied to normalised height. > 1 flattens valleys and sharpens
+  // peaks. Combined with the WEIGHT_EXPONENT below, makes the multi-domain
+  // mesh read as discrete ridges instead of one soft mound.
+  heightGamma: 1.35,
 };
 
 /** Power-law boost applied to each node's composite ΩF before kernel
@@ -101,6 +121,8 @@ const EMPTY_FIELD: ReliefField = {
   height: 0,
   resolution: 0,
   peak: 0,
+  cx: 0,
+  cy: 0,
 };
 
 export function computeReliefField(
@@ -108,7 +130,7 @@ export function computeReliefField(
   layout: Map<string, { x: number; y: number }>,
   params: ReliefFieldParams = {},
 ): ReliefField {
-  const { resolution, heightScale, padding, sigmaFraction } = {
+  const { resolution, heightScale, padding, sigmaFraction, heightGamma } = {
     ...DEFAULTS,
     ...params,
   };
@@ -177,12 +199,18 @@ export function computeReliefField(
       const norm = Number.isFinite(rawNorm)
         ? Math.max(0, Math.min(1, rawNorm))
         : 0;
-      const z = norm * heightScale;
+      // Gamma > 1 raises the contrast between peaks and valleys —
+      // peaks stay near 1, mid-elevations drop more aggressively, valleys
+      // flatten. Reads as ridges and basins instead of a soft mound.
+      const shaped = Math.pow(norm, heightGamma);
+      const z = shaped * heightScale;
 
       positions[idx * 3 + 0] = xWorld - cx;
       positions[idx * 3 + 1] = z;
       positions[idx * 3 + 2] = yWorld - cy;
 
+      // Color ramp still keys off the linear `norm` so the legend stays
+      // readable — only the geometry is gamma'd.
       const [r, g, b] = elevationColor(norm);
       colors[idx * 3 + 0] = r;
       colors[idx * 3 + 1] = g;
@@ -205,7 +233,7 @@ export function computeReliefField(
     }
   }
 
-  return { positions, colors, indices, width, height, resolution: N, peak };
+  return { positions, colors, indices, width, height, resolution: N, peak, cx, cy };
 }
 
 /**
@@ -272,7 +300,7 @@ export function computeReliefLayers(
   layout: Map<string, { x: number; y: number }>,
   params: ReliefFieldParams = {},
 ): ReliefLayer[] {
-  const { resolution, heightScale, padding, sigmaFraction } = {
+  const { resolution, heightScale, padding, sigmaFraction, heightGamma } = {
     ...DEFAULTS,
     ...params,
   };
@@ -385,14 +413,15 @@ export function computeReliefLayers(
       for (let i = 0; i < N; i++) {
         const xWorld = gx[i];
         const idx = j * N + i;
-        // Clamp defensively — a NaN/Infinity in `composite` propagates to
-        // `peak`/`inv`/`norm` and corrupts the GPU upload, which can crash
-        // the renderer on first draw.
         const rawNorm = heights[idx] * inv;
         const norm = Number.isFinite(rawNorm)
           ? Math.max(0, Math.min(1, rawNorm))
           : 0;
-        const z = norm * heightScale;
+        // Apply the same height-gamma as the single-domain path so the two
+        // modes have the same "peakiness" character. The color tint uses a
+        // slightly stronger gamma so valleys go to additive black faster.
+        const shaped = Math.pow(norm, heightGamma);
+        const z = shaped * heightScale;
 
         positions[idx * 3 + 0] = xWorld - cx;
         positions[idx * 3 + 1] = z;
@@ -417,6 +446,8 @@ export function computeReliefLayers(
         height,
         resolution: N,
         peak,
+        cx,
+        cy,
       },
       nodeCount: samples.length,
     });
@@ -427,6 +458,102 @@ export function computeReliefLayers(
   // the legend meaningful.
   layers.sort((a, b) => b.field.peak - a.field.peak);
   return layers;
+}
+
+// ─── Node anchors for HTML labels ──────────────────────────────────
+
+export interface NodeAnchor {
+  id: string;
+  label: string;
+  /** Mesh-local X (= layout x − cx). */
+  x: number;
+  /** Mesh-local Z (= layout y − cy). */
+  z: number;
+  /** Vertex Y the label should float above. */
+  y: number;
+  /** ΩF composite — drives top-K ordering and label coloring. */
+  composite: number;
+  /** Owning domain — drives label color. */
+  domain: string;
+}
+
+/**
+ * Compute world-space anchors for the top-K most-fragile nodes so the
+ * component can drop HTML labels above their peaks. Without these labels
+ * the relief mesh is just an abstract surface — labels are how a viewer
+ * recognises *which* nodes the mountain ridges are made of.
+ *
+ * Height is approximated by sampling the same Gaussian field at each node's
+ * (x, y) position. Cheap (O(K × N) where K is the cap) and exact enough for
+ * label placement.
+ */
+export function computeNodeAnchors(
+  nodes: Pick<CausalNode, "id" | "label" | "domain" | "omegaFragility">[],
+  layout: Map<string, { x: number; y: number }>,
+  field: ReliefField,
+  params: ReliefFieldParams = {},
+  topK = 8,
+): NodeAnchor[] {
+  if (field.positions.length === 0 || field.peak <= 0) return [];
+
+  const { padding, sigmaFraction, heightScale, heightGamma } = {
+    ...DEFAULTS,
+    ...params,
+  };
+  const sigma = Math.max(60, Math.min(field.width, field.height) * sigmaFraction);
+  const sigma2 = sigma * sigma;
+
+  // Gather every usable node-with-position once so we can reuse them as
+  // both label candidates and Gaussian sources.
+  type Source = { id: string; label: string; domain: string; composite: number; x: number; y: number };
+  const sources: Source[] = [];
+  for (const n of nodes) {
+    const p = layout.get(n.id);
+    if (!p) continue;
+    if (!Number.isFinite(p.x) || !Number.isFinite(p.y)) continue;
+    const composite = Number.isFinite(n.omegaFragility?.composite)
+      ? n.omegaFragility.composite
+      : 0;
+    sources.push({
+      id: n.id,
+      label: n.label,
+      domain: typeof n.domain === "string" ? n.domain : "Unknown",
+      composite,
+      x: p.x,
+      y: p.y,
+    });
+  }
+  if (sources.length === 0) return [];
+
+  // Top-K by composite. With K small (default 8), an n*log(n) sort is fine.
+  const sorted = [...sources].sort((a, b) => b.composite - a.composite);
+  const picks = sorted.slice(0, Math.min(topK, sorted.length));
+
+  // Sample the field at each pick's coordinates. Suppress padding parameter
+  // since `field.cx/cy` already encode the recentered origin.
+  void padding;
+
+  const anchors: NodeAnchor[] = [];
+  for (const pick of picks) {
+    let h = 0;
+    for (const s of sources) {
+      const dx = pick.x - s.x;
+      const dy = pick.y - s.y;
+      h += s.composite * Math.exp(-(dx * dx + dy * dy) / sigma2);
+    }
+    const norm = Math.max(0, Math.min(1, h / field.peak));
+    const shaped = Math.pow(norm, heightGamma);
+    anchors.push({
+      id: pick.id,
+      label: pick.label,
+      domain: pick.domain,
+      composite: pick.composite,
+      x: pick.x - field.cx,
+      z: pick.y - field.cy,
+      y: shaped * heightScale,
+    });
+  }
+  return anchors;
 }
 
 function hexToLinearRGB(hex: string): [number, number, number] {


### PR DESCRIPTION
## Summary

User said the live multi-domain Relief view "kinda just looks like a flat map" — the additive layers smeared into one soft mound, the camera was too top-down to read silhouette, and there was no way to identify *which* nodes the ridges represented. Asked for tilt + a grid/axes + node labels.

### What changed

- **Sharper terrain.** `sigmaFraction 0.12 → 0.06` (tighter Gaussian — neighbours no longer smear into one another), `heightScale 30 → 90`, plus a new `heightGamma: 1.35` knob that powers the normalised elevation before mapping to vertex Y. Stacks on top of the upstream `nodeWeight()` power-1.5 boost from #214/#218 — peaks now read as discrete ridges with flat valleys instead of a single dome. `elevationColor()` still keys off the linear `norm` so the legend ramp stays readable.
- **Tilted initial camera.** `dist * 0.55` Y-multiplier dropped to `0.35` (~20° elevation angle vs the half-overhead view). Real silhouette on first frame; OrbitControls take over from there.
- **`<ReliefGrid>`** — flat `gridHelper` at `y = -2`, sized to 1.2× the bounds, 16 cells wide, two-tone dark colors that just register against `#050508`. The mesh no longer floats in featureless black.
- **Top-K node labels.** New `computeNodeAnchors(nodes, layout, field, params, K=8)` samples the field at each top-K node and returns mesh-local `(x, z, y)`; `<NodeLabels>` drops drei `<Html>` cards above the dominant peaks with a thin vertical tick to the surface for a clear visual anchor. Each label shows `{label}` + `Ω X.X`. Defaults to 8 — enough to identify the ridges, not so many the canvas becomes label soup.
- **`ReliefField` exposes `cx, cy`** — the recentring origin used by both compute functions. Future picking / overlay work can convert raw layout coords to mesh-local without re-deriving bounds.

### Cost

Anchor sampling is O(K × N) per recompute (K=8, N≈200 → ~1,600 `exp()` calls, sub-ms). Memoised on `[graphData.nodes, layout]` so hover/scrub/orbit don't trigger.

### Out of scope

Per-layer Y-stacking (option B in the original pick) — the sharpened terrain alone already separates peaks readably and stacking would compete with the additive color-mixing read. Picking through the mesh — future PR.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Lint clean on touched files
- [x] vitest 696/696 pass (4 new tests: `cx/cy` exposed, anchors top-K + sorted, anchors recentred to mesh-local, anchors empty on empty field)
- [ ] Visual: hard-refresh production, click RELIEF — expect tilted camera (real silhouette on first frame), top-8 labels above the highest ΩF peaks, faint grid floor, sharper ridge structure than the previous "flat map"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_