### PR TITLE
feat(relief): v3 — fused mesh + iso-contours + picking

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -290,9 +290,30 @@ Remaining map-view perf opportunity if ever needed: the per-frame particle updat
 
 **Verification.** `tsc --noEmit` clean; lint clean on touched files; vitest 696/696 pass (4 new tests).
 
+### 2026-05-03 — Shipped: Relief v3 — fused mesh, iso-contours, picking
+
+**PR:** TBD (about to open).
+
+**Trigger.** User feedback on the v2 multilayer was direct: *"the peaks are not really well differentiated. it's not really good… can't select any of these nodes."* They sent a Reddit reference (r/SideProject — "topographic map of 10 million research papers") showing how a real topographic map should look: discrete mountain ridges, iso-contour rings, dense labels, all clickable. The v2 additive multilayer fundamentally couldn't get there because every domain contributed everywhere, smearing peaks into haze.
+
+**What shipped (v3 — bigger rework).**
+- **Fused single mesh** replaces additive multilayer. New `computeFusedReliefField(nodes, layout, params)` builds ONE BufferGeometry by summing every domain's Gaussians into a total height field, but tracks the *dominant* domain at each grid cell. Vertex color = `dominantDomainColor × elevationTint × isoContourBand`. Each peak now reads as a discrete ridge with a single colour identity ("this peak is mostly Energy"), not the previous translucent pile-up. Returns a populated `legend` field — replaces the old per-layer legend rendering.
+- **Iso-contour bands** baked into the vertex colour. `(cos(norm × BANDS × 2π) + 1) / 2` modulates each vertex's intensity; bands at edge centres are bright, valleys between bands are 0.6× dimmer. 12 bands gives the topographic-map ringed look the user asked for, without needing a custom shader. Sat on top of the elevation tint so darker valleys ringfade gracefully.
+- **Picking.** New `pickNearestNode(clickX, clickZ, nodes, layout, field, params, maxDistance)` does a nearest-node search over mesh-local layout positions, capped at ~1.5 × sigma so a click on flat ground doesn't pick a far-away node. The mesh now has an `onClick` handler that takes the r3f hit point, calls picker, and dispatches `setSelectedNode(id)` into the store. Same selection signal the rest of the app already listens to (3D pillars, ModulePanel, RiskPropagationFlow). Plus a brief "SELECTED: {label}" hint at the bottom of the canvas for 1.4s so the user gets a visible confirmation.
+- **Beefier labels.** Top-K bumped 8 → 12, switched to high-contrast white-on-black-with-shadow cards (the previous bg-surface-elevated/80 read as washed-out against bright peaks), thicker ticks (0.5r × 18h vs 0.6r × 14h), distance factor tuned tighter so labels stay legible at common camera distances.
+
+**Files.**
+- `src/lib/graph-relief-field.ts` — new `computeFusedReliefField` + `FusedReliefField` + `FusedReliefLegendEntry` exports, new `pickNearestNode` exporter. Existing `computeReliefField` / `computeReliefLayers` / `computeNodeAnchors` unchanged for back-compat with tests and any future re-use.
+- `src/components/CausalDAGRelief.tsx` — drops `<ReliefLayerMesh>` from the render path entirely (the type stays imported only by tests). New `<ReliefMesh>` accepts `onPick` and routes click events. Pick hint UI element added. Lighting bumped (ambient 0.35→0.45, directional 0.7→0.85) so iso-contours read clearly against the now-tinted vertex colours.
+- `src/lib/__tests__/graph-relief-field.test.ts` — 6 new tests: `computeFusedReliefField` shape + legend ordering, dominant-domain colouring at distant clusters, empty-graph handling; `pickNearestNode` happy path, cap radius, empty field.
+
+**Out of scope.** Replay animation (bind field input to `currentSnapshot`), per-layer Y-stacking (option B from the original choice — moot now that the fused mesh reads cleanly), onboarding tooltip. Filed.
+
+**Verification.** `tsc --noEmit` clean; lint clean on touched files; vitest 702/702 pass (6 new in `graph-relief-field.test.ts`).
+
 ### 2026-05-03 — Next up
 
-- Verify the readability pass on production (hard-refresh, click RELIEF, expect tilted camera, top-8 node labels above peaks, grid floor, sharper ridges). If labels are too dense or sparse on real data, the `topK` constant in `CausalDAGReliefInner` is one number to tune. Remaining Relief follow-ups: picking (raycast → select node), replay animation (bind field input to `currentSnapshot`), iso-contour lines, onboarding tooltip, per-layer Y-stacking (option B). Outside Relief: deferred 3D `onPointerMove` throttle, map-view imperative-setData refactor.
+- Verify v3 on production: hard-refresh, click RELIEF, expect (a) discrete mountain ridges with single-domain colours, (b) ringed iso-contour bands, (c) clicking on a peak selects that node and lights up downstream UI (top-Ω list, ModulePanel, etc.), (d) 12 readable labels on the dominant peaks. If the iso-band density is wrong (too busy on small graphs / too sparse on large), `BANDS` constant in `computeFusedReliefField` is one number to tune. Remaining Relief follow-ups: replay animation, onboarding tooltip. Outside Relief: deferred 3D `onPointerMove` throttle, map-view imperative-setData refactor.
 
 ---
 

--- a/src/components/CausalDAGRelief.tsx
+++ b/src/components/CausalDAGRelief.tsx
@@ -1,29 +1,24 @@
 "use client";
 
-import { Component, useEffect, useMemo, useRef, type ReactNode } from "react";
-import { Canvas, useThree } from "@react-three/fiber";
+import { Component, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { Canvas, useThree, type ThreeEvent } from "@react-three/fiber";
 import { Html, OrbitControls } from "@react-three/drei";
 import * as THREE from "three";
 import { useFilteredGraph } from "@/hooks/useFilteredGraph";
 import { useApexStore } from "@/stores/useApexStore";
 import { compute2DForceLayout } from "@/lib/graph-layout-2d";
 import {
+  computeFusedReliefField,
   computeNodeAnchors,
   computeReliefField,
-  computeReliefLayers,
+  pickNearestNode,
+  type FusedReliefField,
   type NodeAnchor,
   type ReliefField,
-  type ReliefLayer,
 } from "@/lib/graph-relief-field";
 import CanvasWatermark from "./CanvasWatermark";
 import DAGOverlay from "./dag3d/DAGOverlay";
 
-/**
- * Class-based error boundary — keeps a render error inside the Relief view
- * from tearing down the whole app to Next.js's generic "Application error"
- * fallback. We log to the console (visible in DevTools / Vercel logs) and
- * show a small in-pane fallback so the rest of the UI stays interactive.
- */
 class ReliefErrorBoundary extends Component<
   { children: ReactNode },
   { error: Error | null }
@@ -58,14 +53,20 @@ class ReliefErrorBoundary extends Component<
  * high-ΩF nodes cluster, valleys where it's quiet.
  *
  * Single-domain graphs render with the elevation ramp (deep blue → red).
- * Multi-domain graphs split into per-domain meshes with additive blending —
- * each domain tinted by its color, peaks add together where domains overlap
- * (e.g. red + cyan = magenta where both are critical at the same spot).
+ * Multi-domain graphs use a single fused mesh: each vertex is colored by
+ * the dominant domain at that grid cell × elevation tint × iso-contour
+ * banding. This gives discrete, recognisable peaks (each ridge belongs to
+ * one domain by colour) instead of the blurry haze the additive multilayer
+ * produced.
  */
 
-function ReliefMesh({ field }: { field: ReliefField }) {
-  // BufferGeometry rebuilt only when the field changes — graph topology /
-  // ΩF value change. Hover and orbit don't trigger recompute.
+function ReliefMesh({
+  field,
+  onPick,
+}: {
+  field: ReliefField;
+  onPick?: (clickX: number, clickZ: number) => void;
+}) {
   const geometry = useMemo(() => {
     const geom = new THREE.BufferGeometry();
     if (field.positions.length === 0) return geom;
@@ -86,11 +87,22 @@ function ReliefMesh({ field }: { field: ReliefField }) {
 
   if (field.positions.length === 0) return null;
 
+  const handleClick = (e: ThreeEvent<MouseEvent>) => {
+    if (!onPick) return;
+    e.stopPropagation();
+    onPick(e.point.x, e.point.z);
+  };
+
   return (
-    <mesh geometry={geometry} castShadow={false} receiveShadow={false}>
+    <mesh
+      geometry={geometry}
+      castShadow={false}
+      receiveShadow={false}
+      onClick={handleClick}
+    >
       <meshStandardMaterial
         vertexColors
-        roughness={0.65}
+        roughness={0.55}
         metalness={0.05}
         side={THREE.DoubleSide}
         flatShading={false}
@@ -100,50 +112,8 @@ function ReliefMesh({ field }: { field: ReliefField }) {
 }
 
 /**
- * Per-domain mesh used in multilayer mode. Vertex colors are pre-tinted by
- * domain color × elevation gamma, and the material uses additive blending so
- * overlapping peaks color-mix on the GPU. Lighting is intentionally bypassed
- * (`emissive`-style additive read) — we want the colors to be unambiguous
- * domain reads, not modulated by surface normals.
- */
-function ReliefLayerMesh({ layer }: { layer: ReliefLayer }) {
-  const geometry = useMemo(() => {
-    const geom = new THREE.BufferGeometry();
-    if (layer.field.positions.length === 0) return geom;
-    geom.setAttribute(
-      "position",
-      new THREE.BufferAttribute(layer.field.positions, 3),
-    );
-    geom.setAttribute(
-      "color",
-      new THREE.BufferAttribute(layer.field.colors, 3),
-    );
-    geom.setIndex(new THREE.BufferAttribute(layer.field.indices, 1));
-    return geom;
-  }, [layer.field]);
-
-  useEffect(() => () => geometry.dispose(), [geometry]);
-
-  if (layer.field.positions.length === 0) return null;
-
-  return (
-    <mesh geometry={geometry} castShadow={false} receiveShadow={false}>
-      <meshBasicMaterial
-        vertexColors
-        side={THREE.DoubleSide}
-        transparent
-        depthWrite={false}
-        blending={THREE.AdditiveBlending}
-        toneMapped={false}
-      />
-    </mesh>
-  );
-}
-
-/**
  * Sets the camera to a sensible initial framing the first time a non-empty
- * field is rendered, then leaves it to OrbitControls. Subsequent graph
- * changes don't re-frame so the user's manual orbit is preserved.
+ * field is rendered, then leaves it to OrbitControls.
  */
 function CameraSetup({
   width,
@@ -160,10 +130,6 @@ function CameraSetup({
   useEffect(() => {
     if (framedRef.current) return;
     if (!enabled) return;
-    // Lower Y multiplier (0.35 vs 0.55) drops the camera closer to the
-    // horizon, giving the mesh actual relief silhouette instead of a
-    // top-down "smudge". Keep X/Z symmetric so the initial frame is a
-    // 45° azimuth.
     const dist = Math.max(width, height, 200) * 0.7;
     camera.position.set(dist * 0.95, dist * 0.35, dist * 0.95);
     camera.lookAt(0, 0, 0);
@@ -173,16 +139,8 @@ function CameraSetup({
   return null;
 }
 
-/**
- * Reference grid laid flat at y=−2, sized to the field bounds. Without it the
- * mesh floats in featureless black and there's no sense of scale or which
- * direction is which. The slight Y-offset keeps it from z-fighting the mesh
- * valleys.
- */
 function ReliefGrid({ width, height }: { width: number; height: number }) {
   const size = Math.max(width, height) * 1.2;
-  // Aim for ~16 visible cells across the larger dimension regardless of
-  // graph size — same density read at 200-unit graphs and 2000-unit graphs.
   const divisions = 16;
   return (
     <gridHelper
@@ -197,28 +155,28 @@ function NodeLabels({ anchors }: { anchors: NodeAnchor[] }) {
   return (
     <>
       {anchors.map((a) => (
-        <group key={a.id} position={[a.x, a.y + 14, a.z]}>
-          {/* Vertical tick from peak surface to label so the label has a
-              clear visual anchor — without this the labels float and you
-              can't tell which peak owns which name. */}
-          <mesh position={[0, -7, 0]}>
-            <cylinderGeometry args={[0.6, 0.6, 14, 6]} />
-            <meshBasicMaterial color="#ffffff" transparent opacity={0.35} />
+        <group key={a.id} position={[a.x, a.y + 18, a.z]}>
+          {/* Vertical tick from peak surface to label so each label has a
+              clear visual anchor — without this they float and you can't
+              tell which peak owns which name. */}
+          <mesh position={[0, -9, 0]}>
+            <cylinderGeometry args={[0.5, 0.5, 18, 6]} />
+            <meshBasicMaterial color="#ffffff" transparent opacity={0.55} />
           </mesh>
           <Html
             center
-            distanceFactor={420}
+            distanceFactor={380}
             zIndexRange={[10, 0]}
             style={{ pointerEvents: "none" }}
           >
             <div
-              className="px-1.5 py-0.5 rounded bg-surface-elevated/90 border border-border whitespace-nowrap"
+              className="px-1.5 py-0.5 rounded bg-black/85 border border-white/30 whitespace-nowrap shadow-[0_0_6px_rgba(0,0,0,0.6)]"
               style={{ transform: "translateY(-50%)" }}
             >
-              <div className="text-[8px] font-mono text-foreground leading-tight">
+              <div className="text-[8.5px] font-mono text-white leading-tight">
                 {a.label}
               </div>
-              <div className="text-[7px] font-mono text-text-muted leading-tight">
+              <div className="text-[7px] font-mono text-white/60 leading-tight">
                 Ω {a.composite.toFixed(1)}
               </div>
             </div>
@@ -229,14 +187,14 @@ function NodeLabels({ anchors }: { anchors: NodeAnchor[] }) {
   );
 }
 
-function DomainLegend({ layers }: { layers: ReliefLayer[] }) {
-  if (layers.length < 2) return null;
+function DomainLegend({ field }: { field: FusedReliefField }) {
+  if (field.legend.length < 2) return null;
   return (
     <div className="absolute top-4 left-4 z-10 flex flex-col gap-1 px-3 py-2 rounded border border-border bg-surface-elevated/80 backdrop-blur-sm pointer-events-none">
       <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted mb-1">
-        DOMAIN LAYERS · {layers.length}
+        DOMAIN LAYERS · {field.legend.length}
       </div>
-      {layers.map((l) => (
+      {field.legend.map((l) => (
         <div key={l.domain} className="flex items-center gap-2">
           <span
             className="inline-block h-2 w-2 rounded-full"
@@ -254,91 +212,46 @@ function DomainLegend({ layers }: { layers: ReliefLayer[] }) {
   );
 }
 
-export default function CausalDAGRelief() {
-  return (
-    <ReliefErrorBoundary>
-      <CausalDAGReliefInner />
-    </ReliefErrorBoundary>
-  );
-}
-
-/**
- * Cyan markers at selected node positions.
- *
- * The Relief view is a continuous heightfield, not discrete node renders, so
- * neither the singular `selectedNode` nor the multi-select array
- * (`selectedNodes`, written by the domain legend / shift-drag marquee) was
- * visible here at all. This component renders a tall cyan pillar + glowing
- * top sphere at each selected node's (x, y) layout position so users get the
- * same "where is my selection" reading they get in the 3D / 2D / Map views.
- *
- * Pillar height (110) is intentionally taller than the relief's max
- * heightScale (70) so markers always poke through the surface regardless of
- * where the underlying field happens to peak.
- */
 function SelectionMarkers({
   layout,
+  field,
 }: {
   layout: Map<string, { x: number; y: number }>;
+  field: ReliefField | null | undefined;
 }) {
   const selectedNode = useApexStore((s) => s.selectedNode);
   const selectedNodes = useApexStore((s) => s.selectedNodes);
 
   const markers = useMemo(() => {
-    if (layout.size === 0) return [];
-    // Mirror the bounds + padding the relief uses so marker world coords
-    // line up with the heightfield. See computeReliefField in
-    // src/lib/graph-relief-field.ts — keep the padding constant in sync.
-    const PADDING = 80;
-    let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
-    for (const p of layout.values()) {
-      if (!Number.isFinite(p.x) || !Number.isFinite(p.y)) continue;
-      if (p.x < minX) minX = p.x;
-      if (p.x > maxX) maxX = p.x;
-      if (p.y < minY) minY = p.y;
-      if (p.y > maxY) maxY = p.y;
-    }
-    if (!Number.isFinite(minX)) return [];
-    minX -= PADDING; maxX += PADDING;
-    minY -= PADDING; maxY += PADDING;
-    const cx = (minX + maxX) / 2;
-    const cy = (minY + maxY) / 2;
-
-    // Multi-select takes priority but still surface the singular selection
-    // when nothing else is selected (e.g. user clicked a top-Ω node).
+    if (!field || layout.size === 0) return [];
     const ids = new Set<string>(selectedNodes);
     if (selectedNode) ids.add(selectedNode);
-
     const out: { id: string; x: number; z: number }[] = [];
     for (const id of ids) {
       const p = layout.get(id);
       if (!p || !Number.isFinite(p.x) || !Number.isFinite(p.y)) continue;
-      out.push({ id, x: p.x - cx, z: p.y - cy });
+      out.push({ id, x: p.x - field.cx, z: p.y - field.cy });
     }
     return out;
-  }, [layout, selectedNode, selectedNodes]);
+  }, [layout, field, selectedNode, selectedNodes]);
 
-  if (markers.length === 0) return null;
+  if (markers.length === 0 || !field) return null;
 
-  const PILLAR_HEIGHT = 110;
+  const PILLAR_HEIGHT = 140;
   const PILLAR_RADIUS = 1.4;
 
   return (
     <group>
       {markers.map((m) => (
         <group key={m.id} position={[m.x, 0, m.z]}>
-          {/* Pillar: thin cyan cylinder rising from y=0 through the surface. */}
           <mesh position={[0, PILLAR_HEIGHT / 2, 0]}>
             <cylinderGeometry args={[PILLAR_RADIUS, PILLAR_RADIUS, PILLAR_HEIGHT, 10]} />
             <meshBasicMaterial color="#00e5ff" transparent opacity={0.65} />
           </mesh>
-          {/* Outer pillar halo for a soft glow. */}
           <mesh position={[0, PILLAR_HEIGHT / 2, 0]}>
             <cylinderGeometry args={[PILLAR_RADIUS * 2.2, PILLAR_RADIUS * 2.2, PILLAR_HEIGHT, 10]} />
             <meshBasicMaterial color="#00e5ff" transparent opacity={0.12} />
           </mesh>
-          {/* Cap: glowing sphere at the top so the marker reads from above
-              even when camera is high enough to see straight down. */}
           <mesh position={[0, PILLAR_HEIGHT, 0]}>
             <sphereGeometry args={[3.2, 14, 14]} />
             <meshBasicMaterial color="#00e5ff" />
@@ -353,8 +266,18 @@ function SelectionMarkers({
   );
 }
 
+export default function CausalDAGRelief() {
+  return (
+    <ReliefErrorBoundary>
+      <CausalDAGReliefInner />
+    </ReliefErrorBoundary>
+  );
+}
+
 function CausalDAGReliefInner() {
   const graphData = useFilteredGraph();
+  const setSelectedNode = useApexStore((s) => s.setSelectedNode);
+  const [pickHint, setPickHint] = useState<string | null>(null);
 
   // Reuse the existing 2D force layout so peaks land exactly where nodes
   // sit on the 2D canvas — switching between views feels coherent.
@@ -363,9 +286,6 @@ function CausalDAGReliefInner() {
     [graphData.nodes, graphData.edges],
   );
 
-  // Decide the rendering mode from the unique-domain count. Multilayer kicks
-  // in at ≥2 distinct domains; otherwise the elevation-ramp single mesh reads
-  // more naturally for a single subgraph.
   const uniqueDomains = useMemo(() => {
     const set = new Set<string>();
     for (const n of graphData.nodes) set.add(n.domain);
@@ -382,32 +302,44 @@ function CausalDAGReliefInner() {
     [multilayer, graphData.nodes, layout],
   );
 
-  const layers = useMemo(
+  // Fused mesh path — replaces the v2 additive multilayer. One single
+  // BufferGeometry, dominant-domain coloring, iso-contour bands.
+  const fusedField = useMemo(
     () =>
       multilayer
-        ? computeReliefLayers(graphData.nodes, layout)
-        : [],
+        ? computeFusedReliefField(graphData.nodes, layout)
+        : null,
     [multilayer, graphData.nodes, layout],
   );
 
-  const isEmpty = multilayer
-    ? layers.length === 0
-    : !singleField || singleField.positions.length === 0;
+  const activeField: ReliefField | null =
+    (multilayer ? fusedField : singleField) ?? null;
+  const isEmpty = !activeField || activeField.positions.length === 0;
 
-  // Use the first layer (or the single field) for camera framing dimensions.
-  const frameDims = multilayer
-    ? layers[0]?.field
-    : singleField ?? undefined;
-
-  // Top-K node anchors for floating labels above the most fragile peaks. We
-  // sample against the highest-peak layer in multilayer mode (or the single
-  // field) so the heights align with the dominant terrain the user sees.
   const anchors = useMemo<NodeAnchor[]>(() => {
-    if (isEmpty) return [];
-    const anchorField = multilayer ? layers[0]?.field : singleField;
-    if (!anchorField) return [];
-    return computeNodeAnchors(graphData.nodes, layout, anchorField, {}, 8);
-  }, [isEmpty, multilayer, layers, singleField, graphData.nodes, layout]);
+    if (!activeField || isEmpty) return [];
+    return computeNodeAnchors(graphData.nodes, layout, activeField, {}, 12);
+  }, [activeField, isEmpty, graphData.nodes, layout]);
+
+  // Click handler — convert the mesh-local hit point to nearest node id
+  // and dispatch into the store. Same selection signal the rest of the app
+  // already listens to (3D pillars, 2D React Flow, ModulePanel, etc.).
+  const handlePick = (clickX: number, clickZ: number) => {
+    if (!activeField) return;
+    const id = pickNearestNode(
+      clickX,
+      clickZ,
+      graphData.nodes,
+      layout,
+      activeField,
+    );
+    if (id) {
+      setSelectedNode(id);
+      const node = graphData.nodes.find((n) => n.id === id);
+      setPickHint(node?.label ?? id);
+      window.setTimeout(() => setPickHint(null), 1400);
+    }
+  };
 
   return (
     <div style={{ position: "absolute", inset: 0 }}>
@@ -423,10 +355,10 @@ function CausalDAGReliefInner() {
         }}
         gl={{ antialias: true, powerPreference: "high-performance" }}
       >
-        <ambientLight intensity={0.35} />
+        <ambientLight intensity={0.45} />
         <directionalLight
           position={[200, 300, 200]}
-          intensity={0.7}
+          intensity={0.85}
           color="#ffffff"
         />
         <pointLight
@@ -440,21 +372,20 @@ function CausalDAGReliefInner() {
           color="#00e5ff"
         />
 
-        {!isEmpty && frameDims && (
-          <ReliefGrid width={frameDims.width} height={frameDims.height} />
+        {!isEmpty && activeField && (
+          <ReliefGrid width={activeField.width} height={activeField.height} />
         )}
-        {!isEmpty && !multilayer && singleField && (
-          <ReliefMesh field={singleField} />
+        {!isEmpty && activeField && (
+          <ReliefMesh field={activeField} onPick={handlePick} />
         )}
-        {!isEmpty && multilayer && layers.map((l) => (
-          <ReliefLayerMesh key={l.domain} layer={l} />
-        ))}
-        {!isEmpty && <SelectionMarkers layout={layout} />}
+        {!isEmpty && (
+          <SelectionMarkers layout={layout} field={activeField} />
+        )}
         {!isEmpty && <NodeLabels anchors={anchors} />}
-        {!isEmpty && frameDims && (
+        {!isEmpty && activeField && (
           <CameraSetup
-            width={frameDims.width}
-            height={frameDims.height}
+            width={activeField.width}
+            height={activeField.height}
             enabled
           />
         )}
@@ -470,7 +401,16 @@ function CausalDAGReliefInner() {
           maxPolarAngle={Math.PI * 0.49}
         />
       </Canvas>
-      {!isEmpty && multilayer && <DomainLegend layers={layers} />}
+      {!isEmpty && multilayer && fusedField && (
+        <DomainLegend field={fusedField} />
+      )}
+      {pickHint && (
+        <div className="absolute bottom-6 left-1/2 -translate-x-1/2 z-10 px-3 py-1.5 rounded border border-accent-cyan/60 bg-surface-elevated/90 backdrop-blur-sm pointer-events-none">
+          <div className="text-[9px] font-mono text-accent-cyan">
+            SELECTED: {pickHint}
+          </div>
+        </div>
+      )}
       {isEmpty && (
         <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
           <div className="text-[10px] font-mono text-text-muted">

--- a/src/lib/__tests__/graph-relief-field.test.ts
+++ b/src/lib/__tests__/graph-relief-field.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from "vitest";
 import {
+  computeFusedReliefField,
   computeNodeAnchors,
   computeReliefField,
   computeReliefLayers,
+  pickNearestNode,
 } from "../graph-relief-field";
 import type { CausalNode } from "../types";
 
@@ -213,5 +215,129 @@ describe("computeNodeAnchors", () => {
     const field = computeReliefField(nodes, empty);
     const anchors = computeNodeAnchors(nodes, empty, field);
     expect(anchors).toEqual([]);
+  });
+});
+
+describe("computeFusedReliefField", () => {
+  it("produces a single mesh with N×N vertices and a populated legend", () => {
+    const nodes = [
+      makeNode("a", "Saudi Aramco Energy", 8),
+      makeNode("b", "Sovereign Risk", 7),
+      makeNode("c", "Saudi Aramco Energy", 6),
+    ];
+    const layout = new Map([
+      ["a", { x: 0, y: 0 }],
+      ["b", { x: 200, y: 200 }],
+      ["c", { x: 50, y: 50 }],
+    ]);
+    const field = computeFusedReliefField(nodes, layout, { resolution: 16 });
+    expect(field.positions.length).toBe(16 * 16 * 3);
+    expect(field.indices.length).toBe(15 * 15 * 6);
+    expect(field.peak).toBeGreaterThan(0);
+    // Legend: 2 distinct domains, biggest first.
+    expect(field.legend.length).toBe(2);
+    expect(field.legend[0].domain).toBe("Saudi Aramco Energy");
+    expect(field.legend[0].nodeCount).toBe(2);
+  });
+
+  it("each peak takes its dominant domain's tint (no haze)", () => {
+    // Two distant clusters — the vertex closest to cluster A should be
+    // tinted with A's domain colour, the one near cluster B with B's.
+    const nodes = [
+      // Cluster A at (0,0), domain X (#00e676 → very green)
+      makeNode("a1", "Saudi Aramco Energy", 10),
+      makeNode("a2", "Saudi Aramco Energy", 10),
+      // Cluster B far away, domain Y (#ff1744 → very red)
+      makeNode("b1", "Kill Chain", 10),
+      makeNode("b2", "Kill Chain", 10),
+    ];
+    const layout = new Map([
+      ["a1", { x: 0, y: 0 }],
+      ["a2", { x: 20, y: 20 }],
+      ["b1", { x: 1000, y: 1000 }],
+      ["b2", { x: 1020, y: 1020 }],
+    ]);
+    const field = computeFusedReliefField(nodes, layout, { resolution: 32 });
+    // Find vertex closest to cluster A peak (mesh origin minus midpoint).
+    // Easier — just sample a vertex near the corner where A clusters.
+    // A is at (0,0) in layout, recentered to (0 - cx, 0 - cy).
+    // Find vertex closest to that mesh-local point.
+    const targetX = 0 - field.cx;
+    const targetZ = 0 - field.cy;
+    let bestIdx = 0;
+    let bestD2 = Infinity;
+    for (let i = 0; i < field.positions.length; i += 3) {
+      const dx = field.positions[i] - targetX;
+      const dz = field.positions[i + 2] - targetZ;
+      const d2 = dx * dx + dz * dz;
+      if (d2 < bestD2) {
+        bestD2 = d2;
+        bestIdx = i;
+      }
+    }
+    // Domain Saudi Aramco (#00e676) → green channel dominates.
+    const r = field.colors[bestIdx];
+    const g = field.colors[bestIdx + 1];
+    const b = field.colors[bestIdx + 2];
+    expect(g).toBeGreaterThan(r);
+    expect(g).toBeGreaterThan(b);
+  });
+
+  it("returns empty + legend=[] for graphs with no layout entries", () => {
+    const nodes = [makeNode("a", "X", 5)];
+    const empty = new Map<string, { x: number; y: number }>();
+    const field = computeFusedReliefField(nodes, empty);
+    expect(field.positions.length).toBe(0);
+    expect(field.legend).toEqual([]);
+  });
+});
+
+describe("pickNearestNode", () => {
+  it("returns the node id closest to a click in mesh-local coords", () => {
+    const nodes = [
+      makeNode("a", "X", 5),
+      makeNode("b", "X", 5),
+      makeNode("c", "X", 5),
+    ];
+    const layout = new Map([
+      ["a", { x: 0, y: 0 }],
+      ["b", { x: 300, y: 0 }],
+      ["c", { x: 0, y: 300 }],
+    ]);
+    const field = computeReliefField(nodes, layout, { resolution: 16 });
+    // Click near where node "b" sits in mesh-local coords.
+    const bLocal = { x: 300 - field.cx, z: 0 - field.cy };
+    const id = pickNearestNode(
+      bLocal.x,
+      bLocal.z,
+      nodes,
+      layout,
+      field,
+    );
+    expect(id).toBe("b");
+  });
+
+  it("returns null when the click is outside the cap radius", () => {
+    const nodes = [makeNode("a", "X", 5)];
+    const layout = new Map([["a", { x: 0, y: 0 }]]);
+    const field = computeReliefField(nodes, layout, { resolution: 16 });
+    // Click 100,000 units away — well outside any cap.
+    const id = pickNearestNode(
+      100_000,
+      100_000,
+      nodes,
+      layout,
+      field,
+      {},
+      50,
+    );
+    expect(id).toBeNull();
+  });
+
+  it("returns null on an empty field", () => {
+    const nodes = [makeNode("a", "X", 5)];
+    const empty = new Map<string, { x: number; y: number }>();
+    const field = computeReliefField(nodes, empty);
+    expect(pickNearestNode(0, 0, nodes, empty, field)).toBeNull();
   });
 });

--- a/src/lib/graph-relief-field.ts
+++ b/src/lib/graph-relief-field.ts
@@ -563,3 +563,245 @@ function hexToLinearRGB(hex: string): [number, number, number] {
   const b = parseInt(m.slice(4, 6), 16) / 255;
   return [r, g, b];
 }
+
+// ─── Fused relief — single mesh colored by dominant domain ────────
+
+export interface FusedReliefLegendEntry {
+  domain: string;
+  colorHex: string;
+  /** Number of nodes in this domain — drives legend ordering. */
+  nodeCount: number;
+}
+
+export interface FusedReliefField extends ReliefField {
+  legend: FusedReliefLegendEntry[];
+}
+
+/**
+ * Build ONE heightfield mesh for the whole graph (sum of every domain's
+ * Gaussians) and color each vertex by the *dominant* domain at that grid
+ * cell × elevation tint × iso-contour banding.
+ *
+ * Why this beats the additive multilayer:
+ *  - Real silhouette. Each peak is a single 3D ridge, not 7 transparent
+ *    sheets stacked on top of each other smearing into a haze.
+ *  - Domain identity is still readable — the dominant-domain choice paints
+ *    each peak with one color, so the user can see "this ridge is mostly
+ *    Energy" vs "this one is mostly Macro Inflation".
+ *  - Iso-contours add the topographic-map character (the rings around
+ *    peaks) the user explicitly asked for.
+ *  - Only one geometry to raycast, so click-to-select picking works.
+ */
+export function computeFusedReliefField(
+  nodes: Pick<CausalNode, "id" | "domain" | "omegaFragility">[],
+  layout: Map<string, { x: number; y: number }>,
+  params: ReliefFieldParams = {},
+): FusedReliefField {
+  const { resolution, heightScale, padding, sigmaFraction, heightGamma } = {
+    ...DEFAULTS,
+    ...params,
+  };
+
+  // Group samples by domain — same as multilayer — but we'll fuse the
+  // fields into a single mesh.
+  type Sample = { x: number; y: number; w: number };
+  const byDomain = new Map<string, Sample[]>();
+  const domainNodeCount = new Map<string, number>();
+  let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+  for (const n of nodes) {
+    const p = layout.get(n.id);
+    if (!p) continue;
+    if (!Number.isFinite(p.x) || !Number.isFinite(p.y)) continue;
+    const composite = n.omegaFragility?.composite ?? 0;
+    const domain = typeof n.domain === "string" && n.domain.length > 0
+      ? n.domain
+      : "Unknown";
+    const sample: Sample = { x: p.x, y: p.y, w: nodeWeight(composite) };
+    const arr = byDomain.get(domain);
+    if (arr) arr.push(sample);
+    else byDomain.set(domain, [sample]);
+    domainNodeCount.set(domain, (domainNodeCount.get(domain) ?? 0) + 1);
+    if (p.x < minX) minX = p.x;
+    if (p.x > maxX) maxX = p.x;
+    if (p.y < minY) minY = p.y;
+    if (p.y > maxY) maxY = p.y;
+  }
+  if (byDomain.size === 0 || !Number.isFinite(minX)) {
+    return { ...EMPTY_FIELD, legend: [] };
+  }
+
+  minX -= padding; maxX += padding;
+  minY -= padding; maxY += padding;
+  const width = maxX - minX;
+  const height = maxY - minY;
+  const cx = (minX + maxX) / 2;
+  const cy = (minY + maxY) / 2;
+  const sigma = Math.max(60, Math.min(width, height) * sigmaFraction);
+  const sigma2 = sigma * sigma;
+  const N = resolution;
+  const vertCount = N * N;
+  const positions = new Float32Array(vertCount * 3);
+  const colors = new Float32Array(vertCount * 3);
+
+  // Pre-cache the domain order and per-domain RGB so the inner loop reuses
+  // tiny indexed tuples instead of Map lookups.
+  const domains = Array.from(byDomain.keys());
+  const domainSamples = domains.map((d) => byDomain.get(d)!);
+  const domainRGB = domains.map((d) => hexToLinearRGB(reliefDomainColor(d)));
+
+  // Pass 1 — for every grid cell, evaluate per-domain heights, sum to the
+  // total height, and remember which domain dominated.
+  const totalHeights = new Float32Array(vertCount);
+  const dominantDomain = new Uint8Array(vertCount);
+  let peak = 0;
+  for (let j = 0; j < N; j++) {
+    const y = minY + (j / (N - 1)) * height;
+    for (let i = 0; i < N; i++) {
+      const x = minX + (i / (N - 1)) * width;
+      let total = 0;
+      let bestH = -1;
+      let bestDom = 0;
+      for (let d = 0; d < domains.length; d++) {
+        const samples = domainSamples[d];
+        let h = 0;
+        for (const s of samples) {
+          const dx = x - s.x;
+          const dy = y - s.y;
+          h += s.w * Math.exp(-(dx * dx + dy * dy) / sigma2);
+        }
+        total += h;
+        if (h > bestH) {
+          bestH = h;
+          bestDom = d;
+        }
+      }
+      const idx = j * N + i;
+      totalHeights[idx] = total;
+      dominantDomain[idx] = bestDom;
+      if (total > peak) peak = total;
+    }
+  }
+
+  // Pass 2 — emit positions + colors. Vertex color = domainColor *
+  // elevation tint * iso-contour modulation. The iso-contour band is a
+  // soft sinusoidal pulse on the normalised elevation: bright at band
+  // centres, slightly darker at edges. Reads as the "ringed" topographic
+  // look from the reference image without needing a custom shader.
+  const inv = peak > 0 ? 1 / peak : 0;
+  // Number of elevation bands — each ring spans ~1/BANDS of [0, 1].
+  // 12 reads as crisp without becoming busy on small graphs.
+  const BANDS = 12;
+  for (let j = 0; j < N; j++) {
+    const yWorld = minY + (j / (N - 1)) * height;
+    for (let i = 0; i < N; i++) {
+      const xWorld = minX + (i / (N - 1)) * width;
+      const idx = j * N + i;
+      const rawNorm = totalHeights[idx] * inv;
+      const norm = Number.isFinite(rawNorm)
+        ? Math.max(0, Math.min(1, rawNorm))
+        : 0;
+      const shaped = Math.pow(norm, heightGamma);
+      const z = shaped * heightScale;
+
+      positions[idx * 3 + 0] = xWorld - cx;
+      positions[idx * 3 + 1] = z;
+      positions[idx * 3 + 2] = yWorld - cy;
+
+      const rgb = domainRGB[dominantDomain[idx]];
+      // Fade towards a near-black valley colour so deep regions read as
+      // background. Without this, low elevations still take the dominant
+      // domain colour and the whole mesh looks uniformly bright.
+      const tint = 0.15 + 0.85 * Math.pow(norm, 0.85);
+      // Iso-contour modulation. cos goes 1 at band centre, -1 at the
+      // band edge — we want a gentle dark ring on edges, so map
+      // (1 + cos) / 2 → [0..1] and lerp colour to 0.6× at edges. The
+      // multiplier of 2π × BANDS gives BANDS rings between 0 and 1.
+      const ring = (Math.cos(norm * BANDS * Math.PI * 2) + 1) * 0.5;
+      const ringFactor = 0.6 + 0.4 * ring;
+
+      colors[idx * 3 + 0] = rgb[0] * tint * ringFactor;
+      colors[idx * 3 + 1] = rgb[1] * tint * ringFactor;
+      colors[idx * 3 + 2] = rgb[2] * tint * ringFactor;
+    }
+  }
+
+  // Triangle indices.
+  const cells = (N - 1) * (N - 1);
+  const indices = new Uint32Array(cells * 6);
+  let k = 0;
+  for (let j = 0; j < N - 1; j++) {
+    for (let i = 0; i < N - 1; i++) {
+      const a = j * N + i;
+      const b = j * N + i + 1;
+      const c = (j + 1) * N + i;
+      const d = (j + 1) * N + i + 1;
+      indices[k++] = a; indices[k++] = c; indices[k++] = b;
+      indices[k++] = b; indices[k++] = c; indices[k++] = d;
+    }
+  }
+
+  // Legend ordered by node count desc — biggest contributors first.
+  const legend: FusedReliefLegendEntry[] = domains.map((domain) => ({
+    domain,
+    colorHex: reliefDomainColor(domain),
+    nodeCount: domainNodeCount.get(domain) ?? 0,
+  }));
+  legend.sort((a, b) => b.nodeCount - a.nodeCount);
+
+  return {
+    positions,
+    colors,
+    indices,
+    width,
+    height,
+    resolution: N,
+    peak,
+    cx,
+    cy,
+    legend,
+  };
+}
+
+// ─── Picking — click point → nearest node ────────────────────────────
+
+/**
+ * Given a click point in mesh-local coordinates (X, Z — the same space
+ * positions live in after recentering by `field.cx/cy`), return the node
+ * id whose layout position is closest. Returns null if no candidate is
+ * within `maxDistance` (defaults to roughly half the Gaussian sigma so a
+ * click on flat ground doesn't pick a far-away node).
+ */
+export function pickNearestNode(
+  clickX: number,
+  clickZ: number,
+  nodes: Pick<CausalNode, "id" | "omegaFragility">[],
+  layout: Map<string, { x: number; y: number }>,
+  field: ReliefField,
+  params: ReliefFieldParams = {},
+  maxDistance?: number,
+): string | null {
+  if (field.positions.length === 0) return null;
+
+  const { sigmaFraction } = { ...DEFAULTS, ...params };
+  const sigma = Math.max(60, Math.min(field.width, field.height) * sigmaFraction);
+  const cap = maxDistance ?? sigma * 1.5;
+  const cap2 = cap * cap;
+
+  let bestId: string | null = null;
+  let bestD2 = Infinity;
+  for (const n of nodes) {
+    const p = layout.get(n.id);
+    if (!p) continue;
+    if (!Number.isFinite(p.x) || !Number.isFinite(p.y)) continue;
+    const localX = p.x - field.cx;
+    const localZ = p.y - field.cy;
+    const dx = clickX - localX;
+    const dz = clickZ - localZ;
+    const d2 = dx * dx + dz * dz;
+    if (d2 < bestD2 && d2 <= cap2) {
+      bestD2 = d2;
+      bestId = n.id;
+    }
+  }
+  return bestId;
+}


### PR DESCRIPTION
## Summary

User feedback on the v2 multilayer was direct: *"peaks are not really well differentiated… can't select any of these nodes."* They sent a Reddit reference (r/SideProject — "topographic map of 10 million research papers") showing what a real topographic map should look like — discrete mountain ridges, iso-contour rings, clickable points scattered throughout.

The v2 additive multilayer fundamentally couldn't get there: every domain contributed to every grid cell, so the rendered surface was always a hazy lump regardless of how peaky each individual layer was. This is a bigger rework that drops additive multilayer entirely in favour of a single fused mesh.

### What changed

- **`computeFusedReliefField`** — single `BufferGeometry`. Sums all domains' Gaussians into one total height field, but tracks the *dominant* domain at each grid cell. Vertex color = `dominantDomainColor × elevationTint × isoContourBand`. Each peak now reads as a discrete ridge with a single colour identity ("this peak is mostly Energy") instead of the previous translucent pile-up.
- **Iso-contour bands** baked into the vertex colour. `(cos(norm × 12 × 2π) + 1) / 2` modulates each vertex — bright at band centres, 0.6× dimmer at edges. Gives the topographic ringed look from the reference image without a custom shader. 12 bands by default.
- **Picking.** New `pickNearestNode(clickX, clickZ, ...)` does a nearest-node search over mesh-local layout positions, capped at ~1.5 × sigma so a click on flat ground doesn't grab a far-away node. The mesh now has an `onClick` handler that takes the r3f hit point, runs picker, and dispatches `setSelectedNode(id)` into the store — same signal the rest of the app already listens to (3D pillars, ModulePanel, RiskPropagationFlow, top-Ω list). Brief "SELECTED: {label}" hint at the bottom of the canvas for 1.4s as visual confirmation.
- **Beefier labels.** Top-K bumped 8 → 12, switched to high-contrast white-on-black-with-shadow cards (the previous `bg-surface-elevated/80` read as washed-out against bright peaks), thicker ticks (0.5r × 18h vs 0.6r × 14h), distance factor tightened so labels stay legible at common camera distances.
- Lighting tuned (ambient 0.35→0.45, directional 0.7→0.85) so iso-contours read clearly against the now-tinted vertex colours.

### Out of scope

Replay animation (bind field input to `currentSnapshot`), per-layer Y-stacking (option B from the original choice — moot now that the fused mesh reads cleanly), onboarding tooltip. Filed.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Lint clean on touched files
- [x] vitest 702/702 pass (6 new in `graph-relief-field.test.ts`: fused field shape + legend, dominant-domain colouring at distant clusters, fused empty-graph handling; `pickNearestNode` happy path, cap radius, empty field)
- [ ] Visual: hard-refresh production, click RELIEF — expect (a) discrete coloured ridges instead of haze, (b) iso-contour rings around peaks, (c) clicking a peak selects that node and lights up downstream UI (ModulePanel, top-Ω list, etc.), (d) 12 readable labels on dominant peaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_