### PR TITLE
feat(topo): v5 — fragment shader for smooth gradients + crisp contours

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -334,9 +334,29 @@ The dominant-domain colour scheme from v3 read as patchwork. Users expect a topo
 
 **Verification.** `tsc --noEmit` clean; lint clean on touched files; vitest 702/702 pass.
 
+### 2026-05-03 — Shipped: Topo v5 — fragment shader, denser geometry, smooth contours
+
+**PR:** TBD (about to open).
+
+**Trigger.** v4 user feedback: *"this is better, but it's pixelated-looking. I've seen platforms that have a lot clearer terrain. Is there a different framework we can use?"*
+
+The framework is fine — three.js / r3f is exactly what those reference platforms use. The "pixelated" look came from two things stacking: (1) the geometry was 80×80 cells, so triangles were visible at silhouette, and (2) the iso-contour bands were baked into per-vertex RGB and linearly interpolated across triangles, so a band drawn at norm=0.5 only landed on triangles whose edges crossed 0.5 — apparent line width followed the triangle grid, not the screen. Pixel-rate fragment shading fixes both.
+
+**What shipped.**
+- **Fragment-shader topo material.** New `<shaderMaterial>` with custom GLSL inside `CausalDAGRelief.tsx`. The vertex shader passes a single per-vertex `aNorm` (normalised height) as a varying; the fragment shader reconstructs the elevation colour ramp + iso-contour lines + Lambert shading **per pixel**. Result: silky smooth gradients and crisp anti-aliased contour lines, regardless of geometry resolution. Iso-contour line is `1 - smoothstep(uLineWidth, uLineWidth + 0.008, distToBandEdge)`, mixed at 0.75 strength against `0.35× baseColor` for visible-but-not-busy ringing. 14 bands by default (was 12). Ambient floor 0.45 + 0.55 Lambert.
+- **Per-vertex `norms` attribute** on `FusedReliefField`. Same length as `positions/3`. The shader reads it; vertex `colors` stay populated as a fallback for any code path that doesn't bind the shader.
+- **Geometry resolution 80 → 128.** Triangles still get smaller for a smoother silhouette, but we don't need to crank further because the surface smoothness now comes from the fragment shader, not mesh density. ~16K vertices, ~100ms compute on 200-node graphs.
+- The single-domain path (1 unique domain) keeps using `meshStandardMaterial` with vertex colours — the shader is wired conditionally on the presence of `norms`.
+
+**Files.**
+- `src/lib/graph-relief-field.ts` — DEFAULTS resolution 80 → 128; `FusedReliefField` adds `norms: Float32Array`; `computeFusedReliefField` writes per-vertex norms in pass 2 (vertex colours stay populated minus the iso-contour modulation, which moved to the shader).
+- `src/components/CausalDAGRelief.tsx` — `TOPO_VERTEX_SHADER` + `TOPO_FRAGMENT_SHADER` GLSL strings, `<ReliefMesh>` accepts `norms?: Float32Array` and conditionally renders `<shaderMaterial>` vs `<meshStandardMaterial>` based on its presence. Fused-mesh call site passes `fusedField.norms`.
+
+**Verification.** `tsc --noEmit` clean; lint clean on touched files; vitest 702/702 pass.
+
 ### 2026-05-03 — Next up
 
-- Verify v4 on production: hard-refresh, click **TOPO**, expect (a) heatmap palette across the surface (cool valleys, hot peaks), (b) iso-contour rings, (c) up to 40 labels with sizes scaling by Ω and borders coloured by domain, (d) more dramatic peak/valley separation in silhouette. Remaining follow-ups: replay animation (bind field input to `currentSnapshot`), onboarding tooltip. Outside TOPO: deferred 3D `onPointerMove` throttle, map-view imperative-setData refactor.
+- Verify v5 on production: hard-refresh, click **TOPO**, expect (a) much smoother surface (no visible triangulation), (b) crisp anti-aliased contour rings (no more stair-stepped bands), (c) heatmap colour ramp pixel-perfect across the surface. Knobs to tune in shader uniforms if needed: `uBands` (default 14, controls ring density), `uLineWidth` (default 0.04, controls line thickness). Remaining follow-ups: replay animation (bind field input to `currentSnapshot`), onboarding tooltip. Outside TOPO: deferred 3D `onPointerMove` throttle, map-view imperative-setData refactor.
 
 ---
 

--- a/src/components/CausalDAGRelief.tsx
+++ b/src/components/CausalDAGRelief.tsx
@@ -16,6 +16,90 @@ import {
   type NodeAnchor,
   type ReliefField,
 } from "@/lib/graph-relief-field";
+
+/* ─── Topo shader ──────────────────────────────────────────────────
+ *
+ * The earlier path baked elevation colour + iso-contour rings into per-vertex
+ * RGB and let meshStandardMaterial linearly interpolate them across triangles.
+ * That's why the surface looked pixelated: a contour band drawn at norm=0.5
+ * would only land *exactly* on triangle interiors that crossed 0.5, so its
+ * apparent width followed the triangle grid, not the screen.
+ *
+ * Moving the colour + band math to the fragment shader fixes that — the
+ * varying `vNorm` is interpolated across each triangle, then every pixel
+ * computes its own colour and its own distance-to-band-edge. Result is
+ * pixel-smooth gradients and crisp anti-aliased contour lines, regardless
+ * of geometry resolution.
+ */
+const TOPO_VERTEX_SHADER = /* glsl */ `
+  attribute float aNorm;
+  varying float vNorm;
+  varying vec3 vNormal;
+
+  void main() {
+    vNorm = aNorm;
+    vNormal = normalize(normalMatrix * normal);
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`;
+
+const TOPO_FRAGMENT_SHADER = /* glsl */ `
+  precision highp float;
+
+  varying float vNorm;
+  varying vec3 vNormal;
+
+  uniform vec3 uLightDir;
+  uniform float uBands;
+  uniform float uLineWidth;
+
+  // Mirror of elevationColor() in graph-relief-field.ts. Keep in sync.
+  vec3 elevationColor(float t) {
+    float n = clamp(t, 0.0, 1.0);
+    if (n < 0.25) {
+      float k = n / 0.25;
+      return vec3(
+        mix(0.04, 0.0, k),
+        mix(0.05, 0.9, k),
+        mix(0.18, 1.0, k)
+      );
+    }
+    if (n < 0.55) {
+      float k = (n - 0.25) / 0.30;
+      return vec3(
+        mix(0.0, 1.0, k),
+        mix(0.9, 0.67, k),
+        mix(1.0, 0.0, k)
+      );
+    }
+    float k = clamp((n - 0.55) / 0.45, 0.0, 1.0);
+    return vec3(
+      1.0,
+      mix(0.67, 0.09, k),
+      mix(0.0, 0.27, k)
+    );
+  }
+
+  void main() {
+    float n = clamp(vNorm, 0.0, 1.0);
+    vec3 baseColor = elevationColor(n);
+
+    // Iso-contour lines. Distance from band-edge in [0, 0.5]; smooth-step
+    // across uLineWidth gives an anti-aliased dark line at every band edge.
+    float band = fract(n * uBands);
+    float distToEdge = min(band, 1.0 - band);
+    float line = 1.0 - smoothstep(uLineWidth, uLineWidth + 0.008, distToEdge);
+    vec3 surface = mix(baseColor, baseColor * 0.35, line * 0.75);
+
+    // Lambert shading with a fill so back-facing slopes aren't black.
+    vec3 N = normalize(vNormal);
+    vec3 L = normalize(uLightDir);
+    float lambert = max(dot(N, L), 0.0);
+    float light = 0.45 + 0.55 * lambert;
+
+    gl_FragColor = vec4(surface * light, 1.0);
+  }
+`;
 import CanvasWatermark from "./CanvasWatermark";
 import DAGOverlay from "./dag3d/DAGOverlay";
 
@@ -62,11 +146,17 @@ class ReliefErrorBoundary extends Component<
 
 function ReliefMesh({
   field,
+  norms,
   onPick,
 }: {
   field: ReliefField;
+  /** Per-vertex normalised height. Present for fused-mode renders; the
+   *  single-domain path falls back to vertex-colour rendering. */
+  norms?: Float32Array;
   onPick?: (clickX: number, clickZ: number) => void;
 }) {
+  const useShader = !!(norms && norms.length === field.positions.length / 3);
+
   const geometry = useMemo(() => {
     const geom = new THREE.BufferGeometry();
     if (field.positions.length === 0) return geom;
@@ -74,16 +164,33 @@ function ReliefMesh({
       "position",
       new THREE.BufferAttribute(field.positions, 3),
     );
-    geom.setAttribute(
-      "color",
-      new THREE.BufferAttribute(field.colors, 3),
-    );
+    if (useShader && norms) {
+      geom.setAttribute(
+        "aNorm",
+        new THREE.BufferAttribute(norms, 1),
+      );
+    } else {
+      geom.setAttribute(
+        "color",
+        new THREE.BufferAttribute(field.colors, 3),
+      );
+    }
     geom.setIndex(new THREE.BufferAttribute(field.indices, 1));
     geom.computeVertexNormals();
     return geom;
-  }, [field]);
+  }, [field, norms, useShader]);
 
   useEffect(() => () => geometry.dispose(), [geometry]);
+
+  // Uniforms — recreated only on first mount; values are stable.
+  const uniforms = useMemo(
+    () => ({
+      uLightDir: { value: new THREE.Vector3(0.45, 1.0, 0.6).normalize() },
+      uBands: { value: 14 },
+      uLineWidth: { value: 0.04 },
+    }),
+    [],
+  );
 
   if (field.positions.length === 0) return null;
 
@@ -100,13 +207,23 @@ function ReliefMesh({
       receiveShadow={false}
       onClick={handleClick}
     >
-      <meshStandardMaterial
-        vertexColors
-        roughness={0.55}
-        metalness={0.05}
-        side={THREE.DoubleSide}
-        flatShading={false}
-      />
+      {useShader ? (
+        <shaderMaterial
+          vertexShader={TOPO_VERTEX_SHADER}
+          fragmentShader={TOPO_FRAGMENT_SHADER}
+          uniforms={uniforms}
+          side={THREE.DoubleSide}
+          transparent={false}
+        />
+      ) : (
+        <meshStandardMaterial
+          vertexColors
+          roughness={0.55}
+          metalness={0.05}
+          side={THREE.DoubleSide}
+          flatShading={false}
+        />
+      )}
     </mesh>
   );
 }
@@ -445,7 +562,11 @@ function CausalDAGReliefInner() {
           <ReliefGrid width={activeField.width} height={activeField.height} />
         )}
         {!isEmpty && activeField && (
-          <ReliefMesh field={activeField} onPick={handlePick} />
+          <ReliefMesh
+            field={activeField}
+            norms={fusedField?.norms}
+            onPick={handlePick}
+          />
         )}
         {!isEmpty && (
           <SelectionMarkers layout={layout} field={activeField} />

--- a/src/lib/graph-relief-field.ts
+++ b/src/lib/graph-relief-field.ts
@@ -86,16 +86,15 @@ export interface ReliefField {
 }
 
 const DEFAULTS: Required<ReliefFieldParams> = {
-  resolution: 80,
-  // Bigger height scale than v3 — the user wanted real vertical drama,
-  // not just colour. Combined with heightGamma 1.6, peaks now stand
-  // visibly above valleys in silhouette, not just in colour.
+  // Bumped from 80 to 128 — at 80 cells, triangles were visible at the
+  // silhouette and contour-band stripes looked stepped. 128² = 16,384
+  // verts ≈ 100ms compute on a 200-node graph. The shader-side iso-contour
+  // pass means we don't need to crank resolution any further; smoothness
+  // now comes from the pixel-rate fragment shader, not the mesh density.
+  resolution: 128,
   heightScale: 140,
   padding: 80,
-  // Tightened from 0.06 to 0.05 — even narrower Gaussian per node, so
-  // adjacent peaks stay separable rather than blending into a ridge.
   sigmaFraction: 0.05,
-  // Higher gamma → more aggressive valley-flattening + peak-rising.
   heightGamma: 1.6,
 };
 
@@ -572,6 +571,13 @@ export interface FusedReliefLegendEntry {
 
 export interface FusedReliefField extends ReliefField {
   legend: FusedReliefLegendEntry[];
+  /**
+   * Per-vertex normalised height in [0, 1] — same length as
+   * `positions.length / 3`. Fed to the topo shader as a per-vertex
+   * attribute so the fragment shader can compute pixel-perfect heatmap
+   * colour + iso-contour lines, regardless of how coarse the geometry is.
+   */
+  norms: Float32Array;
 }
 
 /**
@@ -624,7 +630,7 @@ export function computeFusedReliefField(
     if (p.y > maxY) maxY = p.y;
   }
   if (byDomain.size === 0 || !Number.isFinite(minX)) {
-    return { ...EMPTY_FIELD, legend: [] };
+    return { ...EMPTY_FIELD, legend: [], norms: new Float32Array(0) };
   }
 
   minX -= padding; maxX += padding;
@@ -679,15 +685,14 @@ export function computeFusedReliefField(
     }
   }
 
-  // Pass 2 — emit positions + colors. Vertex color = elevation heatmap
-  // (deep blue → cyan → amber → red) × iso-contour modulation. v3
-  // tinted by dominant domain at each cell, which read as a patchwork
-  // and lost the "brighter = higher" intuition users expect from a
-  // topographic / heatmap visualisation. v4 uses the elevation ramp
-  // for the surface and tints labels by domain instead.
+  // Pass 2 — emit positions + per-vertex norms. Vertex colours stay populated
+  // (used by the meshStandardMaterial fallback) but the *primary* topo
+  // shader path consumes `norms` and computes heatmap colour + iso-contour
+  // lines per fragment, which is why the surface looks crisp instead of
+  // pixelated regardless of how coarse the geometry is.
   void domainRGB; void dominantDomain; // retained for legend; not used in colour pass.
+  const norms = new Float32Array(vertCount);
   const inv = peak > 0 ? 1 / peak : 0;
-  const BANDS = 12;
   for (let j = 0; j < N; j++) {
     const yWorld = minY + (j / (N - 1)) * height;
     for (let i = 0; i < N; i++) {
@@ -704,18 +709,14 @@ export function computeFusedReliefField(
       positions[idx * 3 + 1] = z;
       positions[idx * 3 + 2] = yWorld - cy;
 
-      // Elevation heatmap. The same ramp the single-domain path uses, so
-      // both modes read identically — brighter / hotter = higher peak.
-      const [rR, gG, bB] = elevationColor(norm);
-      // Iso-contour modulation. cos goes 1 at band centre, -1 at edge —
-      // map (1 + cos) / 2 → [0..1] and darken edges to 0.55× for the
-      // ringed topographic look.
-      const ring = (Math.cos(norm * BANDS * Math.PI * 2) + 1) * 0.5;
-      const ringFactor = 0.55 + 0.45 * ring;
+      norms[idx] = norm;
 
-      colors[idx * 3 + 0] = rR * ringFactor;
-      colors[idx * 3 + 1] = gG * ringFactor;
-      colors[idx * 3 + 2] = bB * ringFactor;
+      // Vertex colour fallback (when the shaderMaterial isn't used).
+      // No iso-contour modulation here — the shader does that per pixel.
+      const [rR, gG, bB] = elevationColor(norm);
+      colors[idx * 3 + 0] = rR;
+      colors[idx * 3 + 1] = gG;
+      colors[idx * 3 + 2] = bB;
     }
   }
 
@@ -753,6 +754,7 @@ export function computeFusedReliefField(
     cx,
     cy,
     legend,
+    norms,
   };
 }
 


### PR DESCRIPTION
## Summary

User feedback on v4: *"this is better, but it's pixelated-looking. I've seen platforms that have a lot clearer terrain. Is there a different framework we can use?"*

The framework is fine — three.js / r3f is exactly what those reference platforms use. The "pixelated" look came from two things stacking:
1. Geometry was 80×80 cells, so triangles were visible at silhouette.
2. Iso-contour bands were baked into per-vertex RGB and **linearly interpolated** across triangles. A band drawn at norm=0.5 only landed on triangles whose edges crossed 0.5 — apparent line width followed the triangle grid, not the screen.

Pixel-rate fragment shading fixes both.

### What changed

- **Custom GLSL `<shaderMaterial>`.** The vertex shader passes a single per-vertex `aNorm` (normalised height) as a varying; the fragment shader reconstructs the elevation colour ramp + iso-contour lines + Lambert shading **per pixel**. Iso-contour line: `1 - smoothstep(uLineWidth, uLineWidth + 0.008, distToBandEdge)` — anti-aliased dark line at every band edge. Result: silky smooth gradients and crisp anti-aliased contour lines, regardless of geometry resolution. 14 bands by default.
- **Per-vertex `norms` attribute** added to `FusedReliefField`. Same length as `positions/3`. Shader reads it; vertex `colors` stay populated as a fallback for the single-domain path.
- **Geometry resolution 80 → 128** for a smoother silhouette. ~16K verts, ~100ms compute on 200-node graphs. We don't need to crank further — surface smoothness now comes from the shader, not mesh density.
- Single-domain path stays on `meshStandardMaterial`; shader is wired conditionally on presence of `norms`.

### Knobs to tune

If contour density or line thickness needs adjustment after visual sign-off, the uniforms `uBands` (default 14) and `uLineWidth` (default 0.04) in `CausalDAGRelief.tsx` are the only numbers to touch.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Lint clean on touched files
- [x] vitest 702/702 pass
- [ ] Visual: hard-refresh production, click **TOPO** — expect (a) noticeably smoother surface (no visible triangulation), (b) crisp anti-aliased contour rings on each peak (no more stair-stepped bands), (c) heatmap colour ramp pixel-perfect across the surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_