### PR TITLE
feat(topo): replay animation — terrain morphs as cascade advances

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -354,9 +354,28 @@ The framework is fine — three.js / r3f is exactly what those reference platfor
 
 **Verification.** `tsc --noEmit` clean; lint clean on touched files; vitest 702/702 pass.
 
+### 2026-05-03 — Shipped: Topo replay animation — terrain morphs as the cascade runs
+
+**PR:** TBD (about to open).
+
+**Trigger.** User picked option 1 — turn TOPO from a static topology view into a scenario tool that morphs as the cascade replay advances. Bind the field input to `currentSnapshot.nodeStates[id].omegaComposite` so peaks rise / fall in sync with the replay scrubber.
+
+**What shipped.**
+- **Replay-aware field input.** `CausalDAGRelief` now reads `replayActive`, `activeTimeline`, `baselineEpochs` / `interventionEpochs`, and `currentEpoch` from the store. Derives a `currentSnapshot: EpochSnapshot | null` (clamped to range, like `CausalDAG2D` does). When non-null, builds a `fieldNodes` array that overrides each node's `omegaFragility.composite` with the snapshot's per-node ΩF. The fused / single field, the anchors, and the labels all read from `fieldNodes` — so the surface, the elevation, and the label Ω text all morph in lockstep as the user scrubs.
+- **Stable layout under scrub.** Switched the layout `useMemo` from `[graphData.nodes, graphData.edges]` (re-fires every scrub tick because `useTemporalGraph` allocates fresh arrays + node objects) to `[sig]` where `sig = graphSignature(nodes, edges)` (sorted node + edge id string). Topology changes still re-run the force-directed simulation; replay scrubs don't. Same pattern `CausalDAG2D` uses (`graphSignature` from `graph-layout-2d.ts`). Without this fix, scrubbing would also shuffle the canvas, which would compete with the field eval for the main thread and look terrible.
+- **REPLAY · EPOCH N / M pill** in the top-right. Amber-bordered, only renders when `currentSnapshot` is active. Tells users at a glance that the surface they're seeing is a replay frame, not the static graph.
+
+**Files.**
+- `src/components/CausalDAGRelief.tsx` — adds replay-state selectors, `currentSnapshot` derive, `fieldNodes` override, sig-keyed layout cache, REPLAY pill. Also adds imports: `graphSignature` from `graph-layout-2d`, `EpochSnapshot` type from `lib/types`.
+- `src/lib/__tests__/graph-relief-field.test.ts` — added 2 tests: `norms` length matches `positions/3` and ranges across [0,1]; replay contract — same nodes/layout, escalated ΩF → strictly higher peak.
+
+**Out of scope.** Throttling field recompute during fast scrubbing — at 128² × 169 samples × N domains the eval is ~100ms per frame, which is fine for click-stepping through epochs but would feel laggy for a real-time slider drag. If users actually scrub at 60fps, the right fix is either (a) lower-resolution preview during drag + full res on settle, or (b) port the kernel sum to a compute shader. Filed for later.
+
+**Verification.** `tsc --noEmit` clean; lint clean on touched files; vitest 704/704 pass (2 new in `graph-relief-field.test.ts`).
+
 ### 2026-05-03 — Next up
 
-- Verify v5 on production: hard-refresh, click **TOPO**, expect (a) much smoother surface (no visible triangulation), (b) crisp anti-aliased contour rings (no more stair-stepped bands), (c) heatmap colour ramp pixel-perfect across the surface. Knobs to tune in shader uniforms if needed: `uBands` (default 14, controls ring density), `uLineWidth` (default 0.04, controls line thickness). Remaining follow-ups: replay animation (bind field input to `currentSnapshot`), onboarding tooltip. Outside TOPO: deferred 3D `onPointerMove` throttle, map-view imperative-setData refactor.
+- Verify replay animation on production: load any demo flow → hit play → watch the topo surface morph as epochs advance. Expect the REPLAY · EPOCH N pill in the top-right and label Ω values updating in sync. Remaining follow-ups: onboarding tooltip (most users still won't intuit the topographic mental model on first glance), real-time scrub perf (preview-resolution-during-drag or compute-shader port). Outside TOPO: deferred 3D `onPointerMove` throttle, map-view imperative-setData refactor, real bundle-analyzer perf sweep using PR #222's tooling.
 
 ---
 

--- a/src/components/CausalDAGRelief.tsx
+++ b/src/components/CausalDAGRelief.tsx
@@ -6,7 +6,8 @@ import { Html, OrbitControls } from "@react-three/drei";
 import * as THREE from "three";
 import { useFilteredGraph } from "@/hooks/useFilteredGraph";
 import { useApexStore } from "@/stores/useApexStore";
-import { compute2DForceLayout } from "@/lib/graph-layout-2d";
+import { compute2DForceLayout, graphSignature } from "@/lib/graph-layout-2d";
+import type { EpochSnapshot } from "@/lib/types";
 import {
   computeFusedReliefField,
   computeNodeAnchors,
@@ -461,12 +462,61 @@ function CausalDAGReliefInner() {
   const setSelectedNode = useApexStore((s) => s.setSelectedNode);
   const [pickHint, setPickHint] = useState<string | null>(null);
 
-  // Reuse the existing 2D force layout so peaks land exactly where nodes
-  // sit on the 2D canvas — switching between views feels coherent.
-  const layout = useMemo(
-    () => compute2DForceLayout(graphData.nodes, graphData.edges),
+  // Replay state — when a cascade is being scrubbed, the current epoch's
+  // snapshot drives the topo's height field instead of the static node
+  // ΩF. This is what turns the view from "one frame of the network" into
+  // "watch the system fail in slow motion".
+  const replayActive = useApexStore((s) => s.replayActive);
+  const activeTimeline = useApexStore((s) => s.activeTimeline);
+  const baselineEpochs = useApexStore((s) => s.baselineEpochs);
+  const interventionEpochs = useApexStore((s) => s.interventionEpochs);
+  const currentEpoch = useApexStore((s) => s.currentEpoch);
+
+  const currentSnapshot: EpochSnapshot | null = useMemo(() => {
+    const epochs = activeTimeline === "baseline" ? baselineEpochs : interventionEpochs;
+    if (!replayActive || epochs.length === 0) return null;
+    const idx = Math.min(currentEpoch, Math.max(0, epochs.length - 1));
+    return epochs[idx] ?? null;
+  }, [replayActive, activeTimeline, baselineEpochs, interventionEpochs, currentEpoch]);
+
+  // Stable layout key. `useFilteredGraph` returns NEW node + edge object
+  // references whenever the temporal hook re-runs (every scrub tick), so
+  // a naive useMemo on `[graphData.nodes, graphData.edges]` would re-run
+  // the force-directed simulation each tick — the canvas would reshuffle
+  // mid-replay, and the field eval below would compete for the main
+  // thread. Keying off the structural signature (sorted node + edge ids)
+  // pins layout to topology only — exhaustive-deps disabled for the
+  // memo body because reading the latest references is intentional only
+  // when sig changes.
+  const sig = useMemo(
+    () => graphSignature(graphData.nodes, graphData.edges),
     [graphData.nodes, graphData.edges],
   );
+  const layout = useMemo(
+    () => compute2DForceLayout(graphData.nodes, graphData.edges),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [sig],
+  );
+
+  // Field-input nodes. When a replay snapshot is active, override each
+  // node's `omegaFragility.composite` with the snapshot's per-node
+  // ΩF — the mountain at node N now grows / shrinks as the cascade
+  // propagates. When no snapshot is active, fall through to graphData
+  // unchanged so the static view stays cheap.
+  const fieldNodes = useMemo(() => {
+    if (!currentSnapshot) return graphData.nodes;
+    return graphData.nodes.map((n) => {
+      const state = currentSnapshot.nodeStates[n.id];
+      if (!state) return n;
+      return {
+        ...n,
+        omegaFragility: {
+          ...n.omegaFragility,
+          composite: state.omegaComposite,
+        },
+      };
+    });
+  }, [graphData.nodes, currentSnapshot]);
 
   const uniqueDomains = useMemo(() => {
     const set = new Set<string>();
@@ -480,18 +530,16 @@ function CausalDAGReliefInner() {
     () =>
       multilayer
         ? null
-        : computeReliefField(graphData.nodes, layout),
-    [multilayer, graphData.nodes, layout],
+        : computeReliefField(fieldNodes, layout),
+    [multilayer, fieldNodes, layout],
   );
 
-  // Fused mesh path — replaces the v2 additive multilayer. One single
-  // BufferGeometry, dominant-domain coloring, iso-contour bands.
   const fusedField = useMemo(
     () =>
       multilayer
-        ? computeFusedReliefField(graphData.nodes, layout)
+        ? computeFusedReliefField(fieldNodes, layout)
         : null,
-    [multilayer, graphData.nodes, layout],
+    [multilayer, fieldNodes, layout],
   );
 
   const activeField: ReliefField | null =
@@ -500,12 +548,10 @@ function CausalDAGReliefInner() {
 
   const anchors = useMemo<NodeAnchor[]>(() => {
     if (!activeField || isEmpty) return [];
-    // 40 is enough to see most nodes on a typical 100–200-node graph
-    // without the canvas turning into a wall of overlapping labels.
-    // Each label's font + tick scales with composite so low-Ω entries
-    // stay visually subordinate to peaks.
-    return computeNodeAnchors(graphData.nodes, layout, activeField, {}, 40);
-  }, [activeField, isEmpty, graphData.nodes, layout]);
+    // Use fieldNodes (replay-aware) so label Ω values match what the
+    // surface is actually showing during a replay.
+    return computeNodeAnchors(fieldNodes, layout, activeField, {}, 40);
+  }, [activeField, isEmpty, fieldNodes, layout]);
 
   // Click handler — convert the mesh-local hit point to nearest node id
   // and dispatch into the store. Same selection signal the rest of the app
@@ -593,6 +639,17 @@ function CausalDAGReliefInner() {
       </Canvas>
       {!isEmpty && multilayer && fusedField && (
         <DomainLegend field={fusedField} />
+      )}
+      {currentSnapshot && (
+        <div className="absolute top-4 right-4 z-10 px-3 py-1.5 rounded border border-accent-amber/60 bg-surface-elevated/90 backdrop-blur-sm pointer-events-none">
+          <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-accent-amber">
+            REPLAY · EPOCH {currentEpoch + 1}
+            {(() => {
+              const epochs = activeTimeline === "baseline" ? baselineEpochs : interventionEpochs;
+              return epochs.length ? ` / ${epochs.length}` : "";
+            })()}
+          </div>
+        </div>
       )}
       {pickHint && (
         <div className="absolute bottom-6 left-1/2 -translate-x-1/2 z-10 px-3 py-1.5 rounded border border-accent-cyan/60 bg-surface-elevated/90 backdrop-blur-sm pointer-events-none">

--- a/src/lib/__tests__/graph-relief-field.test.ts
+++ b/src/lib/__tests__/graph-relief-field.test.ts
@@ -272,6 +272,52 @@ describe("computeFusedReliefField", () => {
     expect(field.positions.length).toBe(0);
     expect(field.legend).toEqual([]);
   });
+
+  it("emits per-vertex norms aligned with positions length", () => {
+    const nodes = [
+      makeNode("a", "Saudi Aramco Energy", 8),
+      makeNode("b", "Sovereign Risk", 5),
+    ];
+    const layout = new Map([
+      ["a", { x: 0, y: 0 }],
+      ["b", { x: 100, y: 0 }],
+    ]);
+    const field = computeFusedReliefField(nodes, layout, { resolution: 16 });
+    expect(field.norms.length).toBe(field.positions.length / 3);
+    // norms should range across [0, 1] — the peak vertex hits 1, valley
+    // vertices stay ≈ 0.
+    let max = -Infinity, min = Infinity;
+    for (let i = 0; i < field.norms.length; i++) {
+      if (field.norms[i] > max) max = field.norms[i];
+      if (field.norms[i] < min) min = field.norms[i];
+    }
+    expect(max).toBeGreaterThan(0.5);
+    expect(min).toBeLessThanOrEqual(max);
+    expect(min).toBeGreaterThanOrEqual(0);
+    expect(max).toBeLessThanOrEqual(1);
+  });
+
+  it("field reacts to ΩF changes (replay-aware input → different peak)", () => {
+    // Two nodes at the same positions, but different omega values across
+    // two compute calls — the computed peak should track the input. This
+    // is the contract the replay path relies on: when an EpochSnapshot
+    // overrides composite, the field morphs.
+    const layout = new Map([
+      ["a", { x: 0, y: 0 }],
+      ["b", { x: 80, y: 80 }],
+    ]);
+    const baseline = computeFusedReliefField(
+      [makeNode("a", "X", 4), makeNode("b", "Y", 3)],
+      layout,
+      { resolution: 16 },
+    );
+    const escalated = computeFusedReliefField(
+      [makeNode("a", "X", 9), makeNode("b", "Y", 8)],
+      layout,
+      { resolution: 16 },
+    );
+    expect(escalated.peak).toBeGreaterThan(baseline.peak);
+  });
 });
 
 describe("pickNearestNode", () => {


### PR DESCRIPTION
## Summary

Turns TOPO from a static topology view into a scenario tool. When a cascade replay is active, the topo's height field reads from the current `EpochSnapshot`'s per-node `omegaComposite` instead of static node ΩF — peaks rise and fall as epochs advance.

### What changed

- **Replay-aware field input.** Reads `replayActive`, `activeTimeline`, `baselineEpochs`/`interventionEpochs`, `currentEpoch` from the store. Derives `currentSnapshot: EpochSnapshot | null` (clamped to range, same way `CausalDAG2D` does). When non-null, builds a `fieldNodes` array that overrides each node's `omegaFragility.composite` with `snapshot.nodeStates[id].omegaComposite`. The fused / single field, the anchors, and the labels all read from `fieldNodes` — surface, elevation, and label Ω text all morph in lockstep as the user steps through epochs.
- **Stable layout under scrub.** Switched layout `useMemo` from `[graphData.nodes, graphData.edges]` (re-fires every scrub tick — `useTemporalGraph` allocates fresh arrays + node objects) to `[sig]` where `sig = graphSignature(nodes, edges)`. Topology changes still re-run the force-directed simulation; replay scrubs don't. Same pattern `CausalDAG2D` already uses. Without this fix, scrubbing would also reshuffle the canvas and compete with field eval for the main thread.
- **REPLAY · EPOCH N / M pill** in the top-right when `currentSnapshot` is active. Amber-bordered, font-michroma. Tells users at a glance the surface is a replay frame, not the static graph.

### Out of scope

Throttling field recompute during fast scrubbing — at 128² × ~169 samples × N domains, the eval is ~100ms per frame, which is fine for click-stepping through epochs but would lag for a real-time slider drag. If users actually scrub at 60fps, the right fix is either (a) lower-resolution preview during drag + full res on settle, or (b) compute-shader port. Filed.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Lint clean on touched files
- [x] vitest 704/704 pass (2 new in `graph-relief-field.test.ts`: `norms` length matches `positions/3` and ranges across [0,1]; replay contract — same nodes/layout, escalated ΩF → strictly higher peak)
- [ ] Visual: load a demo flow → hit play → expect terrain to morph as epochs advance, REPLAY pill in top-right, label Ω values updating in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_