### PR TITLE
feat(pareto): add Hall CGM as second public substrate — F doesn't generalise

### DIFF
--- a/public/discovery-runs/hall-csd-fit-hypo-calibration-v0-1-0.json
+++ b/public/discovery-runs/hall-csd-fit-hypo-calibration-v0-1-0.json
@@ -1,0 +1,238 @@
+{
+  "id": "651d9f61-aab0-4c4b-9d1a-0b2565ae33f5",
+  "cohortId": "hall-cgm-2018",
+  "cohortSourceHash": "903256ffb5977c770db355c798ac98a720e741a9af6b1e757f13e97b4fa1cca9",
+  "algorithm": {
+    "id": "csd-fit-hypo-calibration",
+    "version": "0.1.0"
+  },
+  "params": {
+    "cgmVariableId": "cgm_glucose_mgdl",
+    "hypoThresholdMgdl": 70,
+    "predictionHorizonMin": 30,
+    "gridSeconds": 300,
+    "windowSize": 24,
+    "minPointsPerSubject": 50,
+    "nReliabilityBins": 10,
+    "bootstrapSamples": 100,
+    "bootstrapLevel": 0.9,
+    "bootstrapSeed": 11134917
+  },
+  "startedAt": "2026-05-05T22:01:32.560Z",
+  "completedAt": "2026-05-05T22:01:33.035Z",
+  "status": "succeeded",
+  "result": {
+    "variables": [
+      "cgm_glucose_mgdl"
+    ],
+    "edges": [],
+    "diagnostics": {
+      "aurocFitHigh": 0.5029296551270095,
+      "aurocFitLow": 0.4970703448729905,
+      "brierScore": 0.09250722664126793,
+      "ece": 0.20025812739845758,
+      "meanCiHalfWidth": 0.11839192509231747,
+      "baseRate": 0.02729163777562058,
+      "nPairs": 36055,
+      "nSubjects": 19,
+      "reliabilityBins": [
+        {
+          "binLow": 0,
+          "binHigh": 0.1,
+          "predictedMean": 0.03131714172213645,
+          "observedRate": 0.028875865743207246,
+          "count": 9385
+        },
+        {
+          "binLow": 0.1,
+          "binHigh": 0.2,
+          "predictedMean": 0.152343370772795,
+          "observedRate": 0.02721291866028708,
+          "count": 6688
+        },
+        {
+          "binLow": 0.2,
+          "binHigh": 0.3,
+          "predictedMean": 0.24954672522414897,
+          "observedRate": 0.021065830721003136,
+          "count": 7975
+        },
+        {
+          "binLow": 0.3,
+          "binHigh": 0.4,
+          "predictedMean": 0.3472647042346392,
+          "observedRate": 0.02874453994645625,
+          "count": 7097
+        },
+        {
+          "binLow": 0.4,
+          "binHigh": 0.5,
+          "predictedMean": 0.4406257651292312,
+          "observedRate": 0.033137194177764014,
+          "count": 3229
+        },
+        {
+          "binLow": 0.5,
+          "binHigh": 0.6,
+          "predictedMean": 0.5406160964543638,
+          "observedRate": 0.028790786948176585,
+          "count": 1042
+        },
+        {
+          "binLow": 0.6,
+          "binHigh": 0.7,
+          "predictedMean": 0.6440569646564388,
+          "observedRate": 0.04,
+          "count": 400
+        },
+        {
+          "binLow": 0.7,
+          "binHigh": 0.8,
+          "predictedMean": 0.7416072327617025,
+          "observedRate": 0.026490066225165563,
+          "count": 151
+        },
+        {
+          "binLow": 0.8,
+          "binHigh": 0.9,
+          "predictedMean": 0.8387423324096309,
+          "observedRate": 0,
+          "count": 41
+        },
+        {
+          "binLow": 0.9,
+          "binHigh": 1,
+          "predictedMean": 0.9947600680582623,
+          "observedRate": 0.0425531914893617,
+          "count": 47
+        }
+      ],
+      "perSubject": [
+        {
+          "id": "hall-1636-69-001",
+          "nPairs": 1870,
+          "nEvents": 35,
+          "meanF": 0.21749703647092544
+        },
+        {
+          "id": "hall-1636-69-026",
+          "nPairs": 1830,
+          "nEvents": 0,
+          "meanF": 0.22143921405671285
+        },
+        {
+          "id": "hall-1636-69-032",
+          "nPairs": 1753,
+          "nEvents": 6,
+          "meanF": 0.2324452997359892
+        },
+        {
+          "id": "hall-1636-69-090",
+          "nPairs": 1939,
+          "nEvents": 26,
+          "meanF": 0.2264439206239661
+        },
+        {
+          "id": "hall-1636-69-091",
+          "nPairs": 1820,
+          "nEvents": 0,
+          "meanF": 0.22645634733062986
+        },
+        {
+          "id": "hall-1636-69-114",
+          "nPairs": 1782,
+          "nEvents": 0,
+          "meanF": 0.237529549845478
+        },
+        {
+          "id": "hall-1636-70-1005",
+          "nPairs": 1903,
+          "nEvents": 37,
+          "meanF": 0.22586691024731703
+        },
+        {
+          "id": "hall-1636-70-1010",
+          "nPairs": 1866,
+          "nEvents": 55,
+          "meanF": 0.23966025037938574
+        },
+        {
+          "id": "hall-2133-004",
+          "nPairs": 1752,
+          "nEvents": 26,
+          "meanF": 0.2467448999760408
+        },
+        {
+          "id": "hall-2133-015",
+          "nPairs": 1896,
+          "nEvents": 58,
+          "meanF": 0.22498177037968972
+        },
+        {
+          "id": "hall-2133-017",
+          "nPairs": 1819,
+          "nEvents": 6,
+          "meanF": 0.2253446346075719
+        },
+        {
+          "id": "hall-2133-018",
+          "nPairs": 1754,
+          "nEvents": 0,
+          "meanF": 0.24068333142646928
+        },
+        {
+          "id": "hall-2133-019",
+          "nPairs": 1828,
+          "nEvents": 44,
+          "meanF": 0.23562233947265476
+        },
+        {
+          "id": "hall-2133-021",
+          "nPairs": 1790,
+          "nEvents": 21,
+          "meanF": 0.23070550453645902
+        },
+        {
+          "id": "hall-2133-024",
+          "nPairs": 1830,
+          "nEvents": 164,
+          "meanF": 0.22961972824744548
+        },
+        {
+          "id": "hall-2133-027",
+          "nPairs": 2054,
+          "nEvents": 137,
+          "meanF": 0.2059280964547547
+        },
+        {
+          "id": "hall-2133-035",
+          "nPairs": 1935,
+          "nEvents": 16,
+          "meanF": 0.22584447252087908
+        },
+        {
+          "id": "hall-2133-036",
+          "nPairs": 2268,
+          "nEvents": 174,
+          "meanF": 0.21212375085535554
+        },
+        {
+          "id": "hall-2133-039",
+          "nPairs": 2366,
+          "nEvents": 179,
+          "meanF": 0.2271570772184304
+        }
+      ],
+      "validatedSubScores": [
+        "F",
+        "F-bootstrap-CI"
+      ],
+      "degenerateSubScores": [
+        "E",
+        "G-spectral",
+        "S-edges",
+        "M"
+      ]
+    }
+  }
+}

--- a/scripts/run-hall-csd-fit-calibration.ts
+++ b/scripts/run-hall-csd-fit-calibration.ts
@@ -1,0 +1,133 @@
+// Run CSD-fit-vs-hypoglycemia calibration on the Hall et al 2018 CGM
+// cohort — the second public CGM substrate in the validation suite.
+//
+// Hall is T2D + pre-diabetic, not T1D. Used here to test whether the
+// F sub-score validation generalises across populations and CGM
+// hardware. Hypoglycemia events are rarer here (~1.7% of timestamps
+// fall below 70 mg/dL on Hall, vs 11.85% on D1NAMO), which is part of
+// the test — does the calibrator stay well-behaved when the positive
+// class is sparse?
+//
+// Output:
+//   research/runs/hall-csd-fit-hypo-calibration-<ts>.json
+//   public/discovery-runs/hall-csd-fit-hypo-calibration-v0-1-0.json
+//
+// Usage: npx tsx scripts/run-hall-csd-fit-calibration.ts
+
+import * as fs from "fs/promises";
+import * as path from "path";
+import { randomUUID } from "crypto";
+
+import { hallCgmIngester } from "../src/lib/discovery/ingesters/hall-cgm";
+import {
+  calibrateCsdFitHypo,
+  DEFAULT_PARAMS,
+} from "../src/lib/discovery/calibration/csd-fit-hypo-calibrator";
+import { buildDiscoveryRun } from "../src/lib/discovery/run-types";
+
+async function main() {
+  const repoRoot = process.cwd();
+  const startedAt = new Date().toISOString();
+
+  console.log("[hall-fit] ingesting cohort...");
+  const cohort = await hallCgmIngester.ingest(repoRoot);
+  console.log(
+    `[hall-fit] cohort ${cohort.id}: ${cohort.subjects.length} subjects`,
+  );
+
+  console.log("[hall-fit] running CSD-fit hypo calibration...");
+  const cal = calibrateCsdFitHypo(cohort);
+  const completedAt = new Date().toISOString();
+
+  console.log("");
+  console.log(`AUROC (F → hypo):       ${cal.aurocFitHigh.toFixed(4)}`);
+  console.log(`AUROC (1−F → hypo):     ${cal.aurocFitLow.toFixed(4)}`);
+  console.log(`Brier (F as P(event)):  ${cal.brierScore.toFixed(4)}`);
+  console.log(`ECE:                    ${cal.ece.toFixed(4)}`);
+  console.log(`Mean CI half-width:     ${cal.meanCiHalfWidth.toFixed(4)}`);
+  console.log(`Base rate:              ${(cal.baseRate * 100).toFixed(2)}%`);
+  console.log(`N (window, label) pairs: ${cal.nPairs.toLocaleString()}`);
+  console.log(`Subjects used:          ${cal.nSubjects}`);
+  console.log("");
+  console.log("Per-subject:");
+  for (const s of cal.perSubject) {
+    const rate = s.nPairs === 0 ? 0 : (s.nEvents / s.nPairs) * 100;
+    console.log(
+      `  ${s.id}: ${s.nPairs.toString().padStart(4)} pairs, ` +
+        `${s.nEvents.toString().padStart(3)} events ` +
+        `(${rate.toFixed(1)}%), meanF=${s.meanF.toFixed(3)}`,
+    );
+  }
+  console.log("");
+  console.log("Reliability diagram (F vs label):");
+  for (const b of cal.reliabilityBins) {
+    if (b.count === 0) {
+      console.log(
+        `  [${b.binLow.toFixed(1)}-${b.binHigh.toFixed(1)})  empty`,
+      );
+      continue;
+    }
+    console.log(
+      `  [${b.binLow.toFixed(1)}-${b.binHigh.toFixed(1)})  ` +
+        `pred=${b.predictedMean.toFixed(3)}  obs=${b.observedRate.toFixed(3)}  ` +
+        `n=${b.count}`,
+    );
+  }
+  console.log("");
+  console.log(`Validates:  ${cal.validatedSubScores.join(", ")}`);
+  console.log(`Degenerate: ${cal.degenerateSubScores.join(", ")}`);
+
+  const run = buildDiscoveryRun({
+    id: randomUUID(),
+    cohort,
+    algorithm: { id: "csd-fit-hypo-calibration", version: "0.1.0" },
+    params: { ...DEFAULT_PARAMS } as Record<string, unknown>,
+    startedAt,
+    completedAt,
+    result: {
+      variables: [DEFAULT_PARAMS.cgmVariableId],
+      edges: [],
+      diagnostics: {
+        aurocFitHigh: cal.aurocFitHigh,
+        aurocFitLow: cal.aurocFitLow,
+        brierScore: cal.brierScore,
+        ece: cal.ece,
+        meanCiHalfWidth: cal.meanCiHalfWidth,
+        baseRate: cal.baseRate,
+        nPairs: cal.nPairs,
+        nSubjects: cal.nSubjects,
+        reliabilityBins: cal.reliabilityBins,
+        perSubject: cal.perSubject,
+        validatedSubScores: cal.validatedSubScores,
+        degenerateSubScores: cal.degenerateSubScores,
+      },
+    },
+  });
+
+  const outDir = path.join(repoRoot, "research", "runs");
+  await fs.mkdir(outDir, { recursive: true });
+  const ts = startedAt.replace(/[:.]/g, "-");
+  const outPath = path.join(
+    outDir,
+    `hall-csd-fit-hypo-calibration-${ts}.json`,
+  );
+  await fs.writeFile(outPath, JSON.stringify(run, null, 2));
+  console.log("");
+  console.log(`[hall-fit] wrote ${path.relative(repoRoot, outPath)}`);
+
+  const publicDir = path.join(repoRoot, "public", "discovery-runs");
+  await fs.mkdir(publicDir, { recursive: true });
+  const publicPath = path.join(
+    publicDir,
+    "hall-csd-fit-hypo-calibration-v0-1-0.json",
+  );
+  await fs.writeFile(publicPath, JSON.stringify(run, null, 2));
+  console.log(
+    `[hall-fit] wrote ${path.relative(repoRoot, publicPath)}`,
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/components/DiscoveryRunsPanel.tsx
+++ b/src/components/DiscoveryRunsPanel.tsx
@@ -45,7 +45,15 @@ const SAMPLE_RUN_URLS = [
   "/discovery-runs/d1namo-pcmci-linear-v0-1-0.json",
   "/discovery-runs/d1namo-bocpd-hypo-calibration-v0-1-0.json",
   "/discovery-runs/d1namo-csd-fit-hypo-calibration-v0-1-0.json",
+  "/discovery-runs/hall-csd-fit-hypo-calibration-v0-1-0.json",
 ];
+
+// Short cohort labels for tab rendering. Falls back to cohortId when
+// unknown — keeps adding new cohorts low-friction.
+const COHORT_SHORT_LABELS: Record<string, string> = {
+  "d1namo-2018": "D1NAMO",
+  "hall-cgm-2018": "HALL",
+};
 
 type LoadState =
   | { kind: "loading" }
@@ -85,38 +93,53 @@ export default function DiscoveryRunsPanel() {
   return (
     <div className="p-4 space-y-3">
       <div className="text-[8px] font-mono text-text-muted p-2 border border-border/50 rounded bg-surface-elevated">
-        Edges and calibration runs computed on a real observational
-        cohort (D1NAMO, Dubosson 2018), separate from the curated
-        CausalGraph above. The two structure-discovery tabs (lag /
-        pcmci) compare algorithms on the same data — common-cause
-        artefacts in the cheaper algorithm fail under proper
-        conditioning. The two calibration tabs (bocpd / csd-fit)
-        validate scores the platform ships against real labelled events.
+        Edges and calibration runs computed on real observational
+        cohorts, separate from the curated CausalGraph above. Two public
+        substrates today — D1NAMO (Dubosson 2018, 9 T1D subjects) and
+        Hall (Hall et al 2018, 19 T2D / pre-diabetic subjects). Tab
+        labels carry the cohort prefix; same algorithm across cohorts
+        is how cross-substrate generalisation gets tested.
       </div>
 
       {state.kind === "loading" && <LoadingTile />}
       {state.kind === "error" && <ErrorTile message={state.message} />}
       {state.kind === "ready" && (
         <>
-          {/* Algorithm tabs */}
-          <div className="flex gap-1.5">
-            {state.runs.map((r, i) => (
-              <button
-                key={r.id}
-                type="button"
-                onClick={() => setActiveIdx(i)}
-                className={`flex-1 text-[8px] font-[family-name:var(--font-michroma)] tracking-wider rounded px-2 py-1 border transition-colors ${
-                  i === activeIdx
-                    ? "text-[#40c4ff] border-[#40c4ff]/60 bg-[#40c4ff]/10"
-                    : "text-text-muted border-border bg-surface-elevated hover:border-foreground/40 hover:text-foreground"
-                }`}
-              >
-                {r.algorithm.id} v{r.algorithm.version}
-                <span className="block text-[7px] font-mono mt-0.5">
-                  {r.result.edges.length} edges
-                </span>
-              </button>
-            ))}
+          {/* Algorithm × cohort tabs. Cohort prefix only appears when
+              there's more than one cohort in the loaded set, so the
+              single-cohort case stays clean. */}
+          <div className="flex gap-1.5 flex-wrap">
+            {state.runs.map((r, i) => {
+              const distinctCohorts = new Set(
+                state.runs.map((x) => x.cohortId),
+              );
+              const showCohort = distinctCohorts.size > 1;
+              const cohortLabel =
+                COHORT_SHORT_LABELS[r.cohortId] ?? r.cohortId;
+              const isCal = CALIBRATION_ALGORITHM_IDS.has(r.algorithm.id);
+              return (
+                <button
+                  key={r.id}
+                  type="button"
+                  onClick={() => setActiveIdx(i)}
+                  className={`flex-1 min-w-[110px] text-[8px] font-[family-name:var(--font-michroma)] tracking-wider rounded px-2 py-1 border transition-colors ${
+                    i === activeIdx
+                      ? "text-[#40c4ff] border-[#40c4ff]/60 bg-[#40c4ff]/10"
+                      : "text-text-muted border-border bg-surface-elevated hover:border-foreground/40 hover:text-foreground"
+                  }`}
+                >
+                  {showCohort && (
+                    <span className="block text-[6.5px] font-mono opacity-70 -mb-0.5">
+                      {cohortLabel}
+                    </span>
+                  )}
+                  {r.algorithm.id} v{r.algorithm.version}
+                  <span className="block text-[7px] font-mono mt-0.5">
+                    {isCal ? "calibration" : `${r.result.edges.length} edges`}
+                  </span>
+                </button>
+              );
+            })}
           </div>
           <RunTile run={state.runs[activeIdx]} />
         </>
@@ -310,18 +333,29 @@ function RunTile({ run }: { run: DiscoveryRun }) {
         </div>
       )}
       {run.algorithm.id === "csd-fit-hypo-calibration" && (
-        <div className="text-[7px] font-mono text-accent-cyan/80 leading-relaxed border border-accent-cyan/20 bg-accent-cyan/5 rounded px-1.5 py-1">
-          <strong>F sub-score (CSD/AR(1) fit) vs hypoglycemia, 30-min
-          horizon.</strong> Validates the F sub-score and the bootstrap
-          CI shipped in the F·E·G·S·M relevance composite, on real
-          labelled D1NAMO data. <em>Not</em> a full F·E·G·S·M
-          validation: D1NAMO is single-subject CGM, so M (multi-node
-          consistency) and several other sub-scores are degenerate —
-          listed in the box above. Two AUROCs reported: high-F-predicts-
-          event (sanity) and (1−F)-predicts-event (the regime-shift
-          hypothesis: AR(1) fit collapses as the system approaches a
-          tipping point). The full F·E·G·S·M validation requires a
-          multi-subject-graph cohort like nPOD.
+        <div className="text-[7px] font-mono text-accent-cyan/80 leading-relaxed border border-accent-cyan/20 bg-accent-cyan/5 rounded px-1.5 py-1 space-y-1">
+          <div>
+            <strong>F sub-score (CSD/AR(1) fit) vs hypoglycemia, 30-min
+            horizon.</strong> Validates the F sub-score and the bootstrap
+            CI shipped in the F·E·G·S·M relevance composite, on real
+            labelled CGM data. <em>Not</em> a full F·E·G·S·M validation:
+            single-subject CGM has no multi-node graph, so M and
+            several other sub-scores are degenerate — listed above.
+            Two AUROCs reported: high-F-predicts-event (sanity) and
+            (1−F)-predicts-event (the regime-shift hypothesis: AR(1) fit
+            collapses as the system approaches a tipping point).
+          </div>
+          <div className="border-t border-accent-cyan/20 pt-1">
+            <strong>Cross-substrate finding (run on both cohorts):</strong>{" "}
+            On D1NAMO (T1D + insulin) F→hypo AUROC ≈ 0.59 — mildly
+            informative. On Hall (T2D / pre-diabetic, no insulin) the
+            same calibrator gives AUROC ≈ 0.50 — chance. F's apparent
+            predictive power on D1NAMO does not generalise to a
+            different population. The signal we saw on D1NAMO was
+            T1D-specific, not a universal claim about fit collapse.
+            Full F·E·G·S·M validation still requires a multi-subject-
+            graph cohort like nPOD.
+          </div>
         </div>
       )}
     </div>

--- a/src/lib/discovery/__tests__/hall-cgm-ingester.test.ts
+++ b/src/lib/discovery/__tests__/hall-cgm-ingester.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment node
+// Real fs / os / path access — happy-dom externalises Node built-ins
+// and breaks these in Vercel's build env. Override globally-defaulted
+// browser environment for this file only.
+import { describe, it, expect } from "vitest";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+
+import { hallCgmIngester } from "../ingesters/hall-cgm";
+
+// ─── Fixture ──────────────────────────────────────────────────────────
+//
+// Tiny synthetic-but-CSV-shape-correct fixture mirroring the Hall et al
+// 2018 schema. Used only to exercise the ingester's parsing and
+// validation logic; the production sample-run is computed from real
+// Hall CGM CSV (committed runner script reads it from
+// `research/datasets/hall/hall_cgm.csv`, gitignored).
+
+const FIXTURE_CSV = [
+  "id,time,gl,diagnosis",
+  "1636-69-001,2014-02-03 08:42:12,93.0,diabetic",
+  "1636-69-001,2014-02-03 08:47:12,95.0,diabetic",
+  "1636-69-001,2014-02-03 08:52:12,99.0,diabetic",
+  "2133-004,2015-04-10 12:00:00,140.0,pre-diabetic",
+  "2133-004,2015-04-10 12:05:00,148.0,pre-diabetic",
+  // Bad row — non-finite glucose, should be skipped silently.
+  "broken-001,2015-04-10 13:00:00,NaN,diabetic",
+].join("\n") + "\n";
+
+async function withCsv<T>(
+  csv: string,
+  fn: (root: string) => Promise<T>,
+): Promise<T> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "hall-cgm-ingester-"));
+  try {
+    const dataDir = path.join(dir, "research", "datasets", "hall");
+    await fs.mkdir(dataDir, { recursive: true });
+    await fs.writeFile(path.join(dataDir, "hall_cgm.csv"), csv);
+    return await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────
+
+describe("hallCgmIngester", () => {
+  it("parses the standard CSV shape and returns one Cohort", async () => {
+    await withCsv(FIXTURE_CSV, async (root) => {
+      const cohort = await hallCgmIngester.ingest(root);
+      expect(cohort.id).toBe("hall-cgm-2018");
+      expect(cohort.source.containsPHI).toBe(false);
+      expect(cohort.source.adapter).toBe("hall-cgm");
+      expect(cohort.variables).toHaveLength(1);
+      expect(cohort.variables[0].id).toBe("cgm_glucose_mgdl");
+      // 2 valid subjects (broken-001's only row is dropped → no subject).
+      expect(cohort.subjects).toHaveLength(2);
+      const s1 = cohort.subjects.find((s) => s.id === "hall-1636-69-001");
+      const s2 = cohort.subjects.find((s) => s.id === "hall-2133-004");
+      expect(s1?.measurements).toHaveLength(3);
+      expect(s2?.measurements).toHaveLength(2);
+    });
+  });
+
+  it("subject ids are prefixed and opaque (no PHI shape)", async () => {
+    await withCsv(FIXTURE_CSV, async (root) => {
+      const cohort = await hallCgmIngester.ingest(root);
+      for (const s of cohort.subjects) {
+        expect(s.id.startsWith("hall-")).toBe(true);
+        // No emails, no SSN-like sequences, no DOB shapes — source ids
+        // are already opaque, the prefix is just for cohort-namespacing.
+        expect(s.id).not.toMatch(/@/);
+        expect(s.id).not.toMatch(/\d{3}-\d{2}-\d{4}/);
+      }
+    });
+  });
+
+  it("measurement t starts at 0 for each subject (subject-session-start)", async () => {
+    await withCsv(FIXTURE_CSV, async (root) => {
+      const cohort = await hallCgmIngester.ingest(root);
+      for (const s of cohort.subjects) {
+        if (s.measurements.length === 0) continue;
+        // Sorted ascending → first t === 0.
+        expect(s.measurements[0].t).toBe(0);
+      }
+      expect(cohort.timeAxis.zeroConvention).toBe("subject-session-start");
+    });
+  });
+
+  it("respects diagnosisFilter to keep only diabetic subjects", async () => {
+    await withCsv(FIXTURE_CSV, async (root) => {
+      const cohort = await hallCgmIngester.ingest(root, {
+        diagnosisFilter: "diabetic",
+      });
+      expect(cohort.subjects).toHaveLength(1);
+      expect(cohort.subjects[0].id).toBe("hall-1636-69-001");
+      expect(cohort.subjects[0].demographics?.diagnosis).toBe("diabetic");
+    });
+  });
+
+  it("respects maxSubjects and cohortIdOverride", async () => {
+    await withCsv(FIXTURE_CSV, async (root) => {
+      const cohort = await hallCgmIngester.ingest(root, {
+        maxSubjects: 1,
+        cohortIdOverride: "hall-cgm-test",
+      });
+      expect(cohort.subjects).toHaveLength(1);
+      expect(cohort.id).toBe("hall-cgm-test");
+    });
+  });
+
+  it("populates a stable sourceHash that changes with the CSV content", async () => {
+    const a = await withCsv(FIXTURE_CSV, async (root) =>
+      hallCgmIngester.ingest(root),
+    );
+    const variant = FIXTURE_CSV.replace("93.0", "94.5");
+    const b = await withCsv(variant, async (root) =>
+      hallCgmIngester.ingest(root),
+    );
+    expect(a.source.sourceHash).toBeDefined();
+    expect(a.source.sourceHash).not.toBe(b.source.sourceHash);
+  });
+
+  it("rejects a totally empty CSV with a useful error", async () => {
+    await withCsv("id,time,gl,diagnosis\n", async (root) => {
+      await expect(hallCgmIngester.ingest(root)).rejects.toThrow(/zero rows/);
+    });
+  });
+
+  it("returns a meaningful error when the CSV is missing", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "hall-empty-"));
+    try {
+      await expect(hallCgmIngester.ingest(dir)).rejects.toThrow(
+        /fetch_hall_cgm\.py/,
+      );
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/lib/discovery/ingesters/hall-cgm.ts
+++ b/src/lib/discovery/ingesters/hall-cgm.ts
@@ -1,0 +1,207 @@
+// ─── Hall CGM Ingester ────────────────────────────────────────────────
+//
+// Reads the Hall et al 2018 CGM CSV (Stanford "Glucotypes" study,
+// PLoS Biology) into a normalised Cohort. Used as the second public
+// CGM substrate for validation runs alongside D1NAMO.
+//
+// PRIVACY: Hall et al published the data publicly through the iglu R
+// package. Subject ids are already opaque (`1636-69-001`,
+// `2133-004`, etc.) — there is no PHI. The adapter still asserts
+// containsPHI=false on the way out.
+//
+// SCOPE: Hall is T2D + pre-diabetic, not T1D. We use it as a publicly-
+// available real CGM substrate to test whether validation findings
+// (e.g. F sub-score behaviour from PR #200's csd-fit-hypo-calibrator)
+// generalise across populations and CGM hardware. Hypoglycemic events
+// are rarer here than in D1NAMO (~1.7% vs 11.85% of timestamps), which
+// is part of the test — does the calibrator stay well-behaved on a
+// substrate where the positive class is sparse?
+//
+// CSV shape (one row per CGM reading):
+//   id,time,gl,diagnosis
+//   1636-69-001,2014-02-03 08:42:12,93.0,diabetic
+//
+// Time is parsed as a UTC ISO timestamp; we emit measurements with
+// `t` = seconds-since-subject-session-start so each subject's
+// timeline starts at 0 (matches d1namoIngester semantics).
+
+import * as crypto from "crypto";
+import * as fs from "fs/promises";
+import * as path from "path";
+import type { CohortIngester, IngestOptions } from "../ingester-interface";
+import type {
+  Cohort,
+  Measurement,
+  Subject,
+  Variable,
+} from "../cohort-types";
+
+const ADAPTER_ID = "hall-cgm";
+const ADAPTER_VERSION = "0.1.0";
+
+const DEFAULT_CSV_PATH = "research/datasets/hall/hall_cgm.csv";
+
+const VAR_GLUCOSE: Variable = {
+  id: "cgm_glucose_mgdl",
+  label: "CGM glucose",
+  kind: "continuous",
+  cadenceSeconds: 300,
+  conceptCode: { system: "LOINC", code: "2345-7" }, // Glucose [Mass/volume] in Serum or Plasma
+};
+
+export interface HallCgmIngestOptions extends IngestOptions {
+  /** Override of the default CSV path (relative to cwd). */
+  csvPath?: string;
+  /** Filter to a specific diagnosis ("diabetic" / "pre-diabetic"). */
+  diagnosisFilter?: "diabetic" | "pre-diabetic";
+}
+
+interface RawRow {
+  id: string;
+  time: string;
+  gl: number;
+  diagnosis: string;
+}
+
+function parseCsv(text: string): RawRow[] {
+  const lines = text.split(/\r?\n/);
+  if (lines.length === 0) return [];
+  const header = lines[0].split(",");
+  const idIdx = header.indexOf("id");
+  const timeIdx = header.indexOf("time");
+  const glIdx = header.indexOf("gl");
+  const dxIdx = header.indexOf("diagnosis");
+  if (idIdx < 0 || timeIdx < 0 || glIdx < 0) {
+    throw new Error(
+      `hall-cgm: CSV missing required columns. Got: ${header.join(",")}`,
+    );
+  }
+  const rows: RawRow[] = [];
+  for (let li = 1; li < lines.length; li++) {
+    const line = lines[li];
+    if (!line) continue;
+    const cells = line.split(",");
+    if (cells.length < 3) continue;
+    const gl = Number(cells[glIdx]);
+    if (!Number.isFinite(gl)) continue;
+    rows.push({
+      id: cells[idIdx],
+      time: cells[timeIdx],
+      gl,
+      diagnosis: dxIdx >= 0 ? cells[dxIdx] : "",
+    });
+  }
+  return rows;
+}
+
+function buildCohortFromRows(
+  rows: RawRow[],
+  options: HallCgmIngestOptions | undefined,
+  rawText: string,
+): Cohort {
+  const filtered = options?.diagnosisFilter
+    ? rows.filter((r) => r.diagnosis === options.diagnosisFilter)
+    : rows;
+
+  const bySubject = new Map<string, RawRow[]>();
+  for (const r of filtered) {
+    const arr = bySubject.get(r.id);
+    if (arr) arr.push(r);
+    else bySubject.set(r.id, [r]);
+  }
+
+  const subjectIds = Array.from(bySubject.keys()).sort();
+  const subjects: Subject[] = [];
+  for (const sid of subjectIds) {
+    const subjRows = bySubject.get(sid)!;
+    subjRows.sort((a, b) => a.time.localeCompare(b.time));
+    const t0 = Date.parse(subjRows[0].time);
+    if (!Number.isFinite(t0)) continue;
+    const measurements: Measurement[] = [];
+    for (const r of subjRows) {
+      const tMs = Date.parse(r.time);
+      if (!Number.isFinite(tMs)) continue;
+      measurements.push({
+        variableId: VAR_GLUCOSE.id,
+        t: Math.round((tMs - t0) / 1000), // seconds since subject t0
+        value: r.gl,
+      });
+    }
+    if (measurements.length === 0) continue;
+    subjects.push({
+      id: `hall-${sid}`,
+      measurements,
+      // No private demographics in the CSV; record the diagnosis tag
+      // since it's already public in the source dataset.
+      demographics: { diagnosis: subjRows[0].diagnosis },
+    });
+  }
+
+  if (options?.maxSubjects && subjects.length > options.maxSubjects) {
+    subjects.length = options.maxSubjects;
+  }
+
+  const sourceHash = crypto
+    .createHash("sha256")
+    .update(rawText)
+    .digest("hex");
+
+  return {
+    id: options?.cohortIdOverride ?? "hall-cgm-2018",
+    label:
+      "Hall et al 2018 — 19 T2D / pre-diabetic subjects, ~5-min CGM (PLoS Biology)",
+    source: {
+      adapter: ADAPTER_ID,
+      adapterVersion: ADAPTER_VERSION,
+      sourceHash,
+      ingestedAt: options?.ingestedAt ?? new Date().toISOString(),
+      containsPHI: false,
+    },
+    variables: [VAR_GLUCOSE],
+    subjects,
+    timeAxis: {
+      zeroConvention: "subject-session-start",
+      displayUnit: "seconds",
+    },
+    metadata: {
+      description:
+        "Hall et al 2018 'Glucotypes reveal new patterns of glucose " +
+        "dysregulation' (PLoS Biology). 19 T2D + pre-diabetic subjects, " +
+        "~1800 CGM samples each at 5-min cadence. Public dataset shipped " +
+        "via the iglu R package; see " +
+        "https://raw.githubusercontent.com/irinagain/iglu/master/data/example_data_hall.rda. " +
+        "Used here as a second public CGM substrate for validation runs.",
+      accessTier: "public",
+    },
+  };
+}
+
+export const hallCgmIngester: CohortIngester<HallCgmIngestOptions> = {
+  id: ADAPTER_ID,
+  version: ADAPTER_VERSION,
+  description:
+    "Hall et al 2018 (Stanford Glucotypes) — 19 T2D / pre-diabetic " +
+    "subjects, ~5-min CGM. CSV-backed; subject ids already opaque in source.",
+  conceptSystems: ["LOINC"],
+
+  async ingest(sourcePath: string, options?: HallCgmIngestOptions): Promise<Cohort> {
+    const csvPath =
+      options?.csvPath ?? path.join(sourcePath || ".", DEFAULT_CSV_PATH);
+
+    let raw: string;
+    try {
+      raw = await fs.readFile(csvPath, "utf8");
+    } catch (e) {
+      throw new Error(
+        `hall-cgm: cannot read ${csvPath}. Did you run ` +
+          `\`python research/scripts/fetch_hall_cgm.py\` first? ` +
+          `Underlying error: ${(e as Error).message}`,
+      );
+    }
+    const rows = parseCsv(raw);
+    if (rows.length === 0) {
+      throw new Error(`hall-cgm: ${csvPath} parsed to zero rows`);
+    }
+    return buildCohortFromRows(rows, options, raw);
+  },
+};


### PR DESCRIPTION
## Summary

Second public CGM substrate behind the F-sub-score calibrator from PR #200. Adds Hall et al 2018 (Stanford "Glucotypes", PLoS Biology — 19 T2D + pre-diabetic subjects, ~5-min CGM, public via the iglu R package). The same `csd-fit-hypo-calibration` algorithm now runs on two populations, and the cross-substrate comparison ships visibly in the UI.

## The actual finding

| | D1NAMO (T1D + insulin) | Hall (T2D / pre-D, no insulin) |
|---|---|---|
| AUROC (F → hypo) | 0.589 | **0.503** (chance) |
| Base rate | 11.85% | 2.73% |
| Mean bootstrap CI half-width | 0.075 | 0.118 |
| Top-bin observed event rate | 0.681 | 0.043 |

**F's apparent predictive power on D1NAMO does not generalise to Hall.** The signal we saw was T1D-specific — a population on insulin where AR(1) fit-quality on the CGM trace tracks something real about imminent hypo — not a universal "fit collapse predicts hypo" claim. This is exactly the value of running on two substrates: cross-cohort heterogeneity gets surfaced as a finding rather than hidden in a single number.

The csd-fit caveat block in the SPIRTES UI now explains this in plain text below the metrics.

## Why Hall (and not JAEB Replace-BG yet)

Hall is publicly downloadable from a GitHub URL (no DUA, no registration). JAEB datasets (Replace-BG, DCLP3, etc.) require JAEB Public Datasets registration — that path stays open as a follow-up; Hall lets us land the cross-substrate machinery now using only public data.

Hall is T2D / pre-diabetic, not T1D. That's a feature for this PR (tests population generalisation) and a limit for future T1D-specific claims (a third T1D substrate beyond D1NAMO is still desirable).

## Files

| File | Change |
|------|--------|
| `src/lib/discovery/ingesters/hall-cgm.ts` | New TS ingester. Reads the iglu CSV (`id,time,gl,diagnosis`), de-identifies (Hall ids are already opaque; prefixes `hall-` for cohort-namespacing), maps to the same `cgm_glucose_mgdl` variable id D1NAMO uses so the calibrator runs unchanged. Supports `diagnosisFilter` (diabetic / pre-diabetic), `maxSubjects`, `cohortIdOverride`. |
| `src/lib/discovery/__tests__/hall-cgm-ingester.test.ts` | 8 tests: CSV parsing, opaque ids, t-from-zero per subject, diagnosis filter, maxSubjects + cohortIdOverride, sourceHash stability under content change, missing-CSV error message. |
| `scripts/run-hall-csd-fit-calibration.ts` | Run script (mirrors PR #200's d1namo runner). Writes both `research/runs/...json` and `public/discovery-runs/hall-csd-fit-hypo-calibration-v0-1-0.json`. |
| `public/discovery-runs/hall-csd-fit-hypo-calibration-v0-1-0.json` | The real artefact, end-to-end on real Hall data. |
| `src/components/DiscoveryRunsPanel.tsx` | Adds the Hall run to `SAMPLE_RUN_URLS`, introduces a `COHORT_SHORT_LABELS` map for tab prefixing, shows cohort labels on tabs only when ≥ 2 distinct cohorts are present (single-cohort views stay clean), updates the csd-fit caveat block with the cross-substrate finding. |

## Backwards compat

- Hall CSV is gitignored at `research/datasets/hall/hall_cgm.csv` (matches d1namo + existing dataset patterns). Only the post-run artefact ships.
- D1NAMO tabs unchanged. The cohort-prefix UI tweak only kicks in when more than one cohort is loaded — which is starting now.
- The csd-fit caveat block carries an updated cross-substrate finding paragraph; the original "what F-on-D1NAMO validated" content is preserved.

## Test plan

- [x] 8 new ingester tests pass
- [x] Full vitest suite green: 724 / 724
- [x] `npm run build` passes locally with placeholder envs (after `.next` cache clear; the new `@next/bundle-analyzer` dep added on main needed the cache invalidation)
- [x] Real run end-to-end on Hall produces the committed artefact (numbers above)
- [ ] PR-validate workflow green
- [ ] Vercel preview eyeball: confirm fifth tab `HALL csd-fit-hypo-calibration v0.1.0` shows on the SPIRTES module, cohort prefix appears on each tab, csd-fit caveat block shows the new cross-substrate paragraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)
