### PR TITLE
polish(pricing): brand link + lifted access CTA + network background

### DIFF
--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -13,8 +13,12 @@ export default function PricingPage() {
     <div className="min-h-screen bg-background text-foreground">
       <header className="border-b border-border">
         <div className="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
-          <Link href="/" className="flex items-center gap-3">
-            <Image src="/logo.png" alt="Manifold" width={36} height={36} />
+          {/* Brand mark on /pricing routes back to the marketing home
+              (apexanalytica.co), NOT to the platform root — visitors
+              landing here are evaluating the product, so "home" means
+              the public marketing site, not the platform dashboard. */}
+          <a href="https://apexanalytica.co/" className="flex items-center gap-3">
+            <Image src="/logo.png" alt="Apex Analytica" width={36} height={36} />
             <div className="leading-tight">
               <div className="text-[12px] font-[family-name:var(--font-michroma)] tracking-[0.25em] text-accent-cyan">
                 MANIFOLD
@@ -23,7 +27,7 @@ export default function PricingPage() {
                 by APEX ANALYTICA
               </div>
             </div>
-          </Link>
+          </a>
           <nav className="flex items-center gap-5 text-[10px] font-mono text-text-muted">
             <Link href="/login" className="hover:text-foreground">
               SIGN IN

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import { PRICING_PLANS } from "@/lib/billing";
+import PricingBackground from "@/components/visuals/PricingBackground";
 
 export const metadata = {
   title: "Pricing — Manifold by Apex Analytica",
@@ -10,8 +11,18 @@ export const metadata = {
 
 export default function PricingPage() {
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <header className="border-b border-border">
+    <div className="relative min-h-screen bg-background text-foreground">
+      {/* Ambient causal-graph background — sits behind every section
+          on the page. Fixed so it doesn't scroll, low opacity so it
+          coexists with the price grid and CTA blocks. */}
+      <div
+        aria-hidden
+        className="fixed inset-0 -z-10 pointer-events-none opacity-[0.28]"
+      >
+        <PricingBackground />
+      </div>
+
+      <header className="relative border-b border-border">
         <div className="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
           {/* Brand mark on /pricing routes back to the marketing home
               (apexanalytica.co), NOT to the platform root — visitors
@@ -42,8 +53,8 @@ export default function PricingPage() {
         </div>
       </header>
 
-      <main className="max-w-6xl mx-auto px-6 py-16">
-        <div className="text-center mb-14 space-y-3">
+      <main className="relative max-w-6xl mx-auto px-6 py-16">
+        <div className="text-center mb-10 space-y-3">
           <div className="text-[10px] font-[family-name:var(--font-michroma)] tracking-[0.3em] text-text-muted">
             INSTITUTIONAL ACCESS
           </div>
@@ -55,6 +66,30 @@ export default function PricingPage() {
             Every deployment starts with a sales conversation and a
             48-hour pilot scoped to your evaluation use case.
           </p>
+        </div>
+
+        {/* "Evaluating Manifold? Pilot first" CTA above the price
+            grid — visitors see the access path before scrolling
+            through the tiers, so the prices feel like a follow-up
+            to the pilot conversation, not a paywall. */}
+        <div className="mb-12 rounded-lg border border-accent-cyan/30 bg-accent-cyan/[0.04] p-5 md:p-6 flex flex-col md:flex-row md:items-center justify-between gap-5">
+          <div className="space-y-1.5 max-w-2xl">
+            <div className="text-[10px] font-[family-name:var(--font-michroma)] tracking-[0.25em] text-accent-cyan">
+              EVALUATING MANIFOLD?
+            </div>
+            <p className="text-[12.5px] font-mono text-foreground/85 leading-relaxed">
+              Start with a 48-hour pilot before talking pricing. We
+              provision against your real use case and reply within
+              one business day.
+            </p>
+          </div>
+          <Link
+            href="/request-access"
+            className="inline-flex items-center justify-center gap-2 px-5 py-2.5 bg-accent-cyan/15 border border-accent-cyan/60 rounded text-[11px] font-[family-name:var(--font-michroma)] tracking-[0.25em] text-accent-cyan hover:bg-accent-cyan/25 transition-colors shrink-0"
+          >
+            <span>REQUEST ACCESS</span>
+            <span aria-hidden>›</span>
+          </Link>
         </div>
 
         <div className="grid md:grid-cols-3 gap-5">
@@ -108,28 +143,22 @@ export default function PricingPage() {
           ))}
         </div>
 
-        <div className="mt-16 border-t border-border pt-10 text-center space-y-3">
-          <div className="text-[10px] font-[family-name:var(--font-michroma)] tracking-[0.25em] text-text-muted">
-            EVALUATING MANIFOLD
-          </div>
-          <p className="text-[12px] font-mono text-text-muted max-w-2xl mx-auto leading-relaxed">
-            We provision a 48-hour pilot for qualified institutional
-            buyers — funds, banks, defense primes, sovereign offices,
-            and research institutions. Tell us who you are and what
-            you&apos;re evaluating; we&apos;ll respond within one business day.
+        <div className="mt-14 border-t border-border pt-8 flex flex-col md:flex-row items-center justify-between gap-4">
+          <p className="text-[11.5px] font-mono text-text-muted leading-relaxed">
+            Funds, banks, defense primes, sovereign offices, research
+            institutions. Pilot first, paperwork second.
           </p>
-          <div className="pt-2">
-            <Link
-              href="/request-access"
-              className="inline-block px-5 py-2.5 bg-accent-cyan/10 border border-accent-cyan/40 rounded text-[11px] font-[family-name:var(--font-michroma)] tracking-wider text-accent-cyan hover:bg-accent-cyan/20"
-            >
-              REQUEST ACCESS
-            </Link>
-          </div>
+          <Link
+            href="/request-access"
+            className="inline-flex items-center justify-center gap-2 px-4 py-2 border border-border rounded text-[10px] font-[family-name:var(--font-michroma)] tracking-[0.25em] text-text-muted hover:text-accent-cyan hover:border-accent-cyan/60 transition-colors"
+          >
+            <span>REQUEST ACCESS</span>
+            <span aria-hidden>›</span>
+          </Link>
         </div>
       </main>
 
-      <footer className="border-t border-border mt-16 py-8 text-center text-[9px] font-mono text-text-muted">
+      <footer className="relative border-t border-border mt-16 py-8 text-center text-[9px] font-mono text-text-muted">
         © Apex Analytica · Manifold is an institutional research terminal
       </footer>
     </div>

--- a/src/components/visuals/PricingBackground.tsx
+++ b/src/components/visuals/PricingBackground.tsx
@@ -1,0 +1,179 @@
+/**
+ * PricingBackground — animated full-bleed causal graph for the
+ * /pricing page, matching the visual language of the public
+ * marketing site.
+ *
+ * Renders a diffuse network of nodes + edges with traveling dash
+ * pulses along each edge, masked with a soft radial fade so it
+ * dissolves into the page edges. Topology is generated
+ * deterministically from a fixed seed so SSR matches CSR and the
+ * visual is stable across re-renders.
+ *
+ * Self-contained: includes its own keyframes via a <style> tag so
+ * we don't have to touch the platform's globals.css. Mount this
+ * inside a fixed-positioned wrapper on the page that wants the
+ * effect.
+ */
+
+import React from "react";
+
+type Node = { x: number; y: number; r: number; pulseDelay: number; accent: boolean };
+type Edge = { a: number; b: number; flowDelay: number; flowDuration: number };
+
+// Deterministic PRNG so SSR == CSR == every render.
+function mulberry32(seed: number) {
+  let t = seed >>> 0;
+  return () => {
+    t = (t + 0x6d2b79f5) >>> 0;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r = (r + Math.imul(r ^ (r >>> 7), 61 | r)) ^ r;
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function buildGraph(width: number, height: number, seed = 42): {
+  nodes: Node[];
+  edges: Edge[];
+} {
+  const rng = mulberry32(seed);
+  const nodes: Node[] = [];
+  const cols = 9;
+  const rows = 5;
+  const cellW = width / cols;
+  const cellH = height / rows;
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      const jitterX = (rng() - 0.5) * cellW * 0.55;
+      const jitterY = (rng() - 0.5) * cellH * 0.55;
+      const x = (c + 0.5) * cellW + jitterX;
+      const y = (r + 0.5) * cellH + jitterY;
+      const radius = 1.4 + rng() * 1.6;
+      const accent = rng() < 0.18;
+      const pulseDelay = rng() * 4;
+      nodes.push({ x, y, r: radius, pulseDelay, accent });
+    }
+  }
+
+  const edges: Edge[] = [];
+  for (let i = 0; i < nodes.length; i++) {
+    const n = nodes[i];
+    const candidates = nodes
+      .map((other, j) => ({
+        j,
+        d: Math.hypot(other.x - n.x, other.y - n.y),
+      }))
+      .filter((c) => c.j !== i)
+      .sort((a, b) => a.d - b.d)
+      .slice(0, 3 + Math.floor(rng() * 2));
+
+    for (const c of candidates) {
+      if (rng() < 0.45 && c.j > i) {
+        edges.push({
+          a: i,
+          b: c.j,
+          flowDelay: rng() * 4,
+          flowDuration: 2.6 + rng() * 4,
+        });
+      }
+    }
+  }
+
+  return { nodes, edges };
+}
+
+const VIEW_W = 1440;
+const VIEW_H = 720;
+const { nodes: NODES, edges: EDGES } = buildGraph(VIEW_W, VIEW_H);
+
+export default function PricingBackground() {
+  return (
+    <>
+      <style>{`
+        @keyframes pricing-bg-edge-flow {
+          0%   { stroke-dashoffset: 200; }
+          100% { stroke-dashoffset: 0; }
+        }
+        @keyframes pricing-bg-node-pulse {
+          0%   { transform: scale(1);   opacity: 0.5; }
+          50%  { transform: scale(2.6); opacity: 0;   }
+          100% { transform: scale(1);   opacity: 0;   }
+        }
+      `}</style>
+      <svg
+        viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+        preserveAspectRatio="xMidYMid slice"
+        className="absolute inset-0 w-full h-full pointer-events-none"
+        aria-hidden
+      >
+        <defs>
+          <radialGradient id="pricing-bg-fade" cx="50%" cy="50%" r="60%">
+            <stop offset="0%" stopColor="#000" stopOpacity="0" />
+            <stop offset="60%" stopColor="#000" stopOpacity="0" />
+            <stop offset="100%" stopColor="#000" stopOpacity="1" />
+          </radialGradient>
+          <mask id="pricing-bg-mask">
+            <rect width={VIEW_W} height={VIEW_H} fill="white" />
+            <rect width={VIEW_W} height={VIEW_H} fill="url(#pricing-bg-fade)" />
+          </mask>
+        </defs>
+
+        <g mask="url(#pricing-bg-mask)">
+          {EDGES.map((e, i) => {
+            const a = NODES[e.a];
+            const b = NODES[e.b];
+            const isAccent = a.accent || b.accent;
+            const stroke = isAccent ? "var(--accent-amber)" : "var(--accent-cyan)";
+            return (
+              <g key={`edge-${i}`}>
+                <line
+                  x1={a.x}
+                  y1={a.y}
+                  x2={b.x}
+                  y2={b.y}
+                  stroke={stroke}
+                  strokeOpacity={0.12}
+                  strokeWidth={0.8}
+                />
+                <line
+                  x1={a.x}
+                  y1={a.y}
+                  x2={b.x}
+                  y2={b.y}
+                  stroke={stroke}
+                  strokeOpacity={0.55}
+                  strokeWidth={0.9}
+                  strokeDasharray="2 18"
+                  style={{
+                    animation: `pricing-bg-edge-flow ${e.flowDuration}s linear ${e.flowDelay}s infinite`,
+                  }}
+                />
+              </g>
+            );
+          })}
+
+          {NODES.map((n, i) => {
+            const fill = n.accent ? "var(--accent-amber)" : "var(--accent-cyan)";
+            return (
+              <g key={`node-${i}`}>
+                <circle cx={n.x} cy={n.y} r={n.r} fill={fill} fillOpacity={0.6} />
+                <circle
+                  cx={n.x}
+                  cy={n.y}
+                  r={n.r}
+                  fill="none"
+                  stroke={fill}
+                  strokeWidth={0.8}
+                  strokeOpacity={0.5}
+                  style={{
+                    animation: `pricing-bg-node-pulse 4s cubic-bezier(0.215, 0.61, 0.355, 1) ${n.pulseDelay}s infinite`,
+                    transformOrigin: `${n.x}px ${n.y}px`,
+                  }}
+                />
+              </g>
+            );
+          })}
+        </g>
+      </svg>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Three polish items on `manifold.apexanalytica.co/pricing` flagged
together. All public-facing — visitors evaluating Manifold land here,
not signed-in platform users.

### 1. Brand mark links to marketing home, not platform root (`b9306e0`)

The `<Link href="/">` wrapping the MANIFOLD / APEX ANALYTICA mark
routed to `/` on the same origin (`manifold.apexanalytica.co/`) — i.e.,
the platform login / dashboard. For someone evaluating from outside,
"home" means the marketing site. Changed to
`<a href="https://apexanalytica.co/">`. Other links in the same header
(`SIGN IN`, `REQUEST ACCESS`) intentionally stay as `next/link`.

### 2. Access CTA lifted above the price grid (`eb1cac7`)

User: *"if you saw all these prices, you might kinda get scared away."*
Added a prominent `EVALUATING MANIFOLD? Start with a 48-hour pilot
before talking pricing.` block between the page hero and the price
tiles, with a `REQUEST ACCESS ›` button. The previous bottom-of-page
"EVALUATING MANIFOLD" block is slimmed to a one-line nudge so we
keep a closing action without duplicating the message.

### 3. Network-graph background to match other public pages (`eb1cac7`)

`/pricing` was the only public-facing surface without the ambient
causal-graph backdrop the marketing site uses. New self-contained
component `src/components/visuals/PricingBackground.tsx` — SVG nodes
and edges, traveling dash pulses, soft radial-fade mask. Mounted as a
`fixed inset-0 -z-10` layer behind everything on the pricing page.
Animations are inlined inside the component via a `<style>` tag, so
this PR doesn't touch `globals.css`. Topology is deterministic from a
fixed seed so SSR matches CSR.

## Test plan

- [x] Brand mark on `/pricing` → routes to `https://apexanalytica.co/`
- [x] `SIGN IN` still routes to `/login` on the platform
- [x] `REQUEST ACCESS` still routes to `/request-access` on the platform
- [x] `EVALUATING MANIFOLD?` CTA visible without scrolling past the tiles
- [x] Bottom of the page has a slim closing nudge (not duplicated copy)
- [x] Causal-graph network visible behind the page content, low opacity
- [x] `tsc --noEmit` clean for the modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
