### PR TITLE
perf(dag3d): custom memo comparators on DAGNode3D + DAGEdge3D

### DIFF
--- a/src/components/dag3d/DAGEdge3D.tsx
+++ b/src/components/dag3d/DAGEdge3D.tsx
@@ -233,5 +233,51 @@ function DAGEdge3DInner({
   );
 }
 
-const DAGEdge3D = React.memo(DAGEdge3DInner);
+/**
+ * Custom equality check for the React.memo wrap below. Same problem as in
+ * DAGNode3D — sourcePos / targetPos rebuild fresh `[x, y, z]` tuples each
+ * parent render, epochState is sometimes a fresh object literal, and the
+ * onClick / onScissorsClick / onAblationClick closures are inline. That
+ * defeated default shallow equality and re-rendered all ~323 edges on
+ * every selection change, costing frame budget that the per-frame
+ * particle animations needed.
+ *
+ * Compares value props by content and ignores callback identity (closures
+ * are pure functions of stable bound `edge.id` + store actions).
+ */
+function arePropsEqual(prev: DAGEdge3DProps, next: DAGEdge3DProps) {
+  if (prev.edge !== next.edge) return false;
+  if (
+    prev.sourcePos[0] !== next.sourcePos[0] ||
+    prev.sourcePos[1] !== next.sourcePos[1] ||
+    prev.sourcePos[2] !== next.sourcePos[2]
+  ) return false;
+  if (
+    prev.targetPos[0] !== next.targetPos[0] ||
+    prev.targetPos[1] !== next.targetPos[1] ||
+    prev.targetPos[2] !== next.targetPos[2]
+  ) return false;
+  if (prev.isHighlighted !== next.isHighlighted) return false;
+  if (prev.isDimmed !== next.isDimmed) return false;
+  if (prev.isVerifiedInconsistent !== next.isVerifiedInconsistent) return false;
+  if (prev.isCrossDomain !== next.isCrossDomain) return false;
+  if (prev.isConnectedToSelected !== next.isConnectedToSelected) return false;
+  if (prev.anyNodeSelected !== next.anyNodeSelected) return false;
+  if (prev.isSevered !== next.isSevered) return false;
+  if (prev.isConsequenceEdge !== next.isConsequenceEdge) return false;
+  if (prev.scissorsMode !== next.scissorsMode) return false;
+  if (prev.isAblated !== next.isAblated) return false;
+  if (prev.ablationMode !== next.ablationMode) return false;
+  // epochState — only `propagationSignal` is read (drives shouldAnimate).
+  const pe = prev.epochState;
+  const ne = next.epochState;
+  if (pe !== ne) {
+    if (!pe || !ne) return false;
+    if (pe.propagationSignal !== ne.propagationSignal) return false;
+  }
+  // Intentionally not comparing onScissorsClick / onAblationClick / onEdgeClick.
+  return true;
+}
+
+const DAGEdge3D = React.memo(DAGEdge3DInner, arePropsEqual);
 export default DAGEdge3D;

--- a/src/components/dag3d/DAGNode3D.tsx
+++ b/src/components/dag3d/DAGNode3D.tsx
@@ -423,5 +423,58 @@ function DAGNode3DInner({
   );
 }
 
-const DAGNode3D = React.memo(DAGNode3DInner);
+/**
+ * Custom equality check for the React.memo wrap below. The default shallow
+ * comparator was being defeated for every node on every parent re-render
+ * because three props rebuild fresh refs each time:
+ *
+ *   - `position`: a new `[x, y, z]` tuple from posMap[node.id]
+ *   - `epochState`: a fresh object literal in the non-snapshot fallback path
+ *     (see CausalDAG3D.tsx, where the parent maps the nodes)
+ *   - `onClick` / `onDoubleClick`: inline closures
+ *
+ * That meant ~169 nodes re-rendering on every parent update — each with its
+ * own framer-motion / R3F work — which competed with the per-frame edge
+ * particle animations and made the orbs glitch when domain selection
+ * touched many nodes at once.
+ *
+ * This comparator compares the value-bearing props by content (not by ref)
+ * and ignores callback identity. Closures are functionally pure (they close
+ * over `node.id` + stable store actions), so re-render isn't required when
+ * only their reference flips.
+ */
+function arePropsEqual(prev: DAGNode3DProps, next: DAGNode3DProps) {
+  if (prev.node !== next.node) return false;
+  // position is a tuple — compare element-wise
+  if (
+    prev.position[0] !== next.position[0] ||
+    prev.position[1] !== next.position[1] ||
+    prev.position[2] !== next.position[2]
+  ) return false;
+  if (prev.isInterventionTarget !== next.isInterventionTarget) return false;
+  if (prev.isVerifiedRestricted !== next.isVerifiedRestricted) return false;
+  if (prev.isSelected !== next.isSelected) return false;
+  if (prev.isNeighborOfSelected !== next.isNeighborOfSelected) return false;
+  if (prev.anyNodeSelected !== next.anyNodeSelected) return false;
+  if (prev.isConsequence !== next.isConsequence) return false;
+  if (prev.isGreyedOut !== next.isGreyedOut) return false;
+  if (prev.isAblated !== next.isAblated) return false;
+  if (prev.ablationMode !== next.ablationMode) return false;
+  if (prev.metrics !== next.metrics) return false;
+  // epochState fields actually read by the component (omegaComposite +
+  // shockIntensity). The object reference often changes per render even when
+  // the contents don't, so reference compare would always invalidate.
+  const pe = prev.epochState;
+  const ne = next.epochState;
+  if (pe !== ne) {
+    if (!pe || !ne) return false;
+    if (pe.omegaComposite !== ne.omegaComposite) return false;
+    if (pe.shockIntensity !== ne.shockIntensity) return false;
+  }
+  // Intentionally not comparing onClick / onDoubleClick — closures rebuild
+  // every parent render but their behavior is stable per node.id.
+  return true;
+}
+
+const DAGNode3D = React.memo(DAGNode3DInner, arePropsEqual);
 export default DAGNode3D;


### PR DESCRIPTION
## Summary

Fixes the edge-particle stutter you reported when picking a domain in the legend that selects many nodes at once. Camera fit is preserved.

## Diagnosis

Both `DAGNode3D` and `DAGEdge3D` were already wrapped in `React.memo`, but the default shallow comparator was being defeated by three classes of fresh refs on every parent render:

| Prop | Why it changed every render |
|------|----------------------------|
| `position` / `sourcePos` / `targetPos` | `[x, y, z]` tuples spread fresh in the parent |
| `epochState` | `epochState ?? { … }` fallback path produced a new object literal |
| `onClick` / `onDoubleClick` / `onScissorsClick` / `onAblationClick` / `onEdgeClick` | inline closures rebuilt each render |

So when you'd pick a domain → 30 nodes flip to selected → parent re-renders the whole map → **all 169 nodes + all 323 edges** re-rendered, even ones whose state didn't change. The per-frame `useFrame` particle animations got starved for budget; the orbs glitched.

## Fix

Replace the default comparator with custom `arePropsEqual` on each component:

- **Element-wise** position tuple compare.
- **Field-wise** epochState compare (only `omegaComposite` + `shockIntensity` for nodes, `propagationSignal` for edges — those are the only fields the components actually read).
- **Ignore callback identity.** The closures close over `node.id`/`edge.id` (stable) + store actions (stable), so re-render isn't required when only their reference flips.
- All other primitives compared directly.

Result: only the nodes/edges whose visible state actually flipped re-render. The other 200+ skip work.

## What's not changed

- `CameraRig` fit-animation — kept (you said you like it).
- Multi-select dim pass from PR #218 — kept.
- All visual behavior — unchanged.

## Test plan

- [ ] Hard refresh, pick a domain in the DOMAINS legend in 3D view that has 20+ nodes (e.g. "Macro Impact: Inflation & Policy")
- [ ] Camera fit-animation still runs
- [ ] **Edge particle orbs continue moving smoothly during the camera animation** — this is the regression that prompted the fix
- [ ] After the camera settles, orbs continue at normal speed; no stutter when switching domains
- [ ] Single-node click + shift-drag marquee still highlight correctly (no over-aggressive memo)
- [ ] Cascade replay (after a shock) still plays — node opacity transitions still fire (epochState's read fields trigger re-render)
- [ ] Hover behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
