### PR TITLE
feat(leads): notify admin via Resend on /request-access submit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react-dom": "19.2.3",
         "react-map-gl": "^8.1.0",
         "reactflow": "^11.11.4",
+        "resend": "^6.12.2",
         "three": "^0.183.1",
         "xlsx": "^0.18.5",
         "zustand": "^5.0.11"
@@ -2599,6 +2600,12 @@
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
@@ -6321,6 +6328,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -8837,6 +8850,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -9083,6 +9102,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.2.tgz",
+      "integrity": "sha512-xwgmU4b0OqoabJsIoK/x0Whk0Fcs3bpbK4i/DEWPiE5hYJHyHl0TbB6QbI3gIr+bLdLUJ1GYm/fe41aVFuHXgw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.90.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {
@@ -9642,6 +9682,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/stats-gl": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
@@ -9890,6 +9940,16 @@
       "license": "MIT",
       "peerDependencies": {
         "react": ">=17.0"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.90.0.tgz",
+      "integrity": "sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -10512,6 +10572,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-dom": "19.2.3",
     "react-map-gl": "^8.1.0",
     "reactflow": "^11.11.4",
+    "resend": "^6.12.2",
     "three": "^0.183.1",
     "xlsx": "^0.18.5",
     "zustand": "^5.0.11"

--- a/src/app/api/request-access/route.ts
+++ b/src/app/api/request-access/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient as createServiceClient } from "@supabase/supabase-js";
+import { Resend } from "resend";
 
 // Public lead-capture endpoint. Anonymous; rate-limiting and bot
 // protection are out of scope here — Vercel/middleware can layer on
@@ -11,6 +12,21 @@ const service = createServiceClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
   process.env.SUPABASE_SERVICE_ROLE_KEY!
 );
+
+// Resend is optional — if RESEND_API_KEY isn't set (dev environments,
+// preview deploys without the secret) we skip the notification email
+// and the lead still lands in public.leads. Admins fall back to
+// /admin/leads in that case.
+const resend = process.env.RESEND_API_KEY
+  ? new Resend(process.env.RESEND_API_KEY)
+  : null;
+
+const NOTIFY_TO =
+  process.env.RESEND_NOTIFY_TO ?? "info@apexanalytica.co";
+const NOTIFY_FROM =
+  process.env.RESEND_FROM ?? "Manifold <manifold@send.apexanalytica.co>";
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://manifold.apexanalytica.co";
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const MAX_FIELD = 500;
@@ -29,6 +45,55 @@ function asBoundedString(v: unknown, max: number): string | null {
   const trimmed = v.trim();
   if (!trimmed || trimmed.length > max) return null;
   return trimmed;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+interface NotificationLead {
+  name: string;
+  email: string;
+  organization: string;
+  useCase: string | null;
+  source: string;
+}
+
+function buildEmailHtml(lead: NotificationLead): string {
+  const useCaseBlock = lead.useCase
+    ? `<blockquote style="margin:8px 0;padding:8px 12px;border-left:3px solid #00e5ff;color:#444;white-space:pre-wrap">${escapeHtml(lead.useCase)}</blockquote>`
+    : `<p style="color:#888"><em>(no use case provided)</em></p>`;
+  return `
+    <div style="font-family:ui-monospace,Menlo,monospace;font-size:13px;line-height:1.6;color:#222">
+      <h2 style="margin:0 0 12px 0;font-size:14px;letter-spacing:0.1em;color:#0aa">NEW MANIFOLD ACCESS REQUEST</h2>
+      <p><strong>${escapeHtml(lead.name)}</strong> &lt;<a href="mailto:${encodeURIComponent(lead.email)}">${escapeHtml(lead.email)}</a>&gt; from <strong>${escapeHtml(lead.organization)}</strong> requested access.</p>
+      <p><strong>Source:</strong> ${escapeHtml(lead.source)}</p>
+      <p><strong>Use case:</strong></p>
+      ${useCaseBlock}
+      <p style="margin-top:20px"><a href="${SITE_URL}/admin/leads" style="color:#0aa">View in admin console &rarr;</a></p>
+    </div>
+  `;
+}
+
+function buildEmailText(lead: NotificationLead): string {
+  return [
+    `New Manifold access request`,
+    ``,
+    `Name:         ${lead.name}`,
+    `Email:        ${lead.email}`,
+    `Organization: ${lead.organization}`,
+    `Source:       ${lead.source}`,
+    ``,
+    `Use case:`,
+    lead.useCase ?? "(no use case provided)",
+    ``,
+    `Admin console: ${SITE_URL}/admin/leads`,
+  ].join("\n");
 }
 
 export async function POST(req: NextRequest) {
@@ -66,9 +131,11 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  const lowercaseEmail = email.toLowerCase();
+
   const { error } = await service.from("leads").insert({
     name,
-    email: email.toLowerCase(),
+    email: lowercaseEmail,
     organization,
     use_case: useCase,
     source,
@@ -82,5 +149,32 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  // Best-effort admin notification. The lead is already saved at this
+  // point; an email failure should not roll the request back. We
+  // await the send so Vercel doesn't kill the function before the
+  // request hits Resend, but catch any error and log it.
+  if (resend) {
+    const lead: NotificationLead = {
+      name,
+      email: lowercaseEmail,
+      organization,
+      useCase,
+      source,
+    };
+    try {
+      await resend.emails.send({
+        from: NOTIFY_FROM,
+        to: NOTIFY_TO,
+        replyTo: lowercaseEmail,
+        subject: `[Manifold] Access request: ${name} @ ${organization}`,
+        html: buildEmailHtml(lead),
+        text: buildEmailText(lead),
+      });
+    } catch (err) {
+      console.error("request-access notification failed:", err);
+    }
+  }
+
   return NextResponse.json({ success: true });
 }
+


### PR DESCRIPTION
## Summary

Wires up email notifications for new lead submissions so admins don't have to remember to check `/admin/leads`. Best-effort: notification is fire-and-forget after the lead is already saved, so a Resend outage never rolls back the user's request.

### Behavior
- `POST /api/request-access` inserts the lead, then sends email via Resend.
- **From:** `Manifold <manifold@send.apexanalytica.co>` (verified domain in Resend)
- **To:** `info@apexanalytica.co` (admin shared inbox)
- **Reply-To:** the lead's email — admin replies route directly to the prospect
- **Subject:** `[Manifold] Access request: <name> @ <org>`
- HTML + plain-text bodies; HTML-escapes user-supplied fields
- Direct link to `/admin/leads` for one-click triage

### Resilience
- Resend client constructed lazily — if `RESEND_API_KEY` is unset (dev / preview without secret), the route silently skips the notification and the lead still lands. Fallback: admin checks `/admin/leads` directly.
- Email send is awaited (Vercel kills serverless functions after response, so unawaited promises lose) but wrapped in try/catch — Resend failures are logged and don't fail the request.

### Env vars
| Name | Required | Default | Purpose |
|---|---|---|---|
| `RESEND_API_KEY` | yes (for sending) | — | Sensitive. Set in Vercel Production. |
| `RESEND_NOTIFY_TO` | no | `info@apexanalytica.co` | Recipient inbox. |
| `RESEND_FROM` | no | `Manifold <manifold@send.apexanalytica.co>` | Sender. Must match a verified Resend domain. |
| `NEXT_PUBLIC_SITE_URL` | no | `https://manifold.apexanalytica.co` | Used in the email's admin-console link. |

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Submit `/request-access` form on prod (after merge) with junk inputs
- [ ] Verify the lead row appears in `public.leads`
- [ ] Verify `info@apexanalytica.co` receives an email within ~30 seconds
- [ ] Click the "View in admin console" link in the email — lands on `/admin/leads`
- [ ] Try replying to the email — confirms Reply-To routes back to the lead's address

https://claude.ai/code/session_01Bk4PoJxdEhTNGrKbN5MHE3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bk4PoJxdEhTNGrKbN5MHE3)_