### PR TITLE
feat(pareto): BOCPD live as a fourth criticality estimator

### DIFF
--- a/src/components/ModulePanel.tsx
+++ b/src/components/ModulePanel.tsx
@@ -11,6 +11,7 @@ import { getEstimatorMeta } from "@/lib/criticality-registry";
 import { moransI } from "@/lib/estimators/moran";
 import { extractT1DSeries, T1D_NODE_IDS } from "@/lib/t1d-estimator-inputs";
 import {
+  bocpdRegimeGate,
   csdRegimeGate,
   lpplsRegimeGate,
   phRegimeGate,
@@ -1096,6 +1097,59 @@ function ParetoPanel({
     };
   }, [scopedOmegaSeries, graphData.nodes, shocks, csdEpochs]);
 
+  // ── BOCPD: Bayesian online change-point detection on the same Ω trajectory ──
+  // Runs the run-length posterior over `scopedOmegaSeries` and exposes the
+  // per-step new-run probability as the criticality readout. Same Adams &
+  // MacKay (2007) implementation the discovery / calibration paths use —
+  // imported lazily so this module's bundle stays sane.
+  const bocpdData = useMemo(() => {
+    const observed = scopedOmegaSeries;
+    const n = observed.length;
+    if (n < 6) {
+      return {
+        timeSeries: observed,
+        modelSeries: undefined as number[] | undefined,
+        observedSeries: observed.length > 0 ? observed : undefined,
+        newRunProb: [] as number[],
+        confidence: 0,
+        sampleSize: n,
+        peakRecent: 0,
+        cv: 0,
+      };
+    }
+    // Lazy import keeps bocpd out of the initial chunk if BOCPD is gated
+    // off via the active profile's estimator list.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { bocpd } = require("@/lib/estimators/bocpd") as typeof import("@/lib/estimators/bocpd");
+    const result = bocpd(observed, { hazard: 1 / 50 });
+    const modelSeries = Array.from(result.predictiveMean);
+    const newRunProb = Array.from(result.newRunProb);
+    // Recent-window peak (matches bocpdRegimeGate semantics).
+    const windowStart = Math.max(0, n - 10);
+    let peakRecent = 0;
+    for (let t = windowStart; t < n; t++) {
+      if (newRunProb[t] > peakRecent) peakRecent = newRunProb[t];
+    }
+    // Coefficient of variation (variability over full posterior).
+    let mean = 0;
+    for (const v of newRunProb) mean += v;
+    mean /= n;
+    let varSum = 0;
+    for (const v of newRunProb) varSum += (v - mean) ** 2;
+    const std = Math.sqrt(varSum / n);
+    const cv = mean > 0 ? std / mean : 0;
+    return {
+      timeSeries: observed,
+      modelSeries,
+      observedSeries: observed,
+      newRunProb,
+      confidence: Math.max(0, Math.min(0.99, peakRecent)),
+      sampleSize: n,
+      peakRecent,
+      cv,
+    };
+  }, [scopedOmegaSeries]);
+
   // ── Relevance breakdown per model (F · E · G · S, smoothed via EMA) ──
   // Each ready estimator contributes an input. The composite replaces the
   // legacy per-model "confidence" badge and is broken out in the card UI so
@@ -1144,6 +1198,22 @@ function ParetoPanel({
           nodeCount,
         }),
         sufficiency: topologySufficiency(nodeCount),
+      });
+    }
+
+    // BOCPD — only included when the active profile actually requests it.
+    // Same scoped Ω trajectory as CSD/LPPLS; F sub-score scores BOCPD's
+    // posterior-predictive mean against the observed series.
+    if (activeProfile.criticalityEstimators.includes("bocpd")) {
+      const bocpdObserved = bocpdData.observedSeries ?? bocpdData.timeSeries ?? [];
+      inputs.push({
+        key: "bocpd",
+        observed: bocpdObserved,
+        modelSeries: bocpdData.modelSeries ?? [],
+        // BOCPD effective parameter count: 4 NIG hyperparameters + 1 hazard.
+        freeParams: 5,
+        gate: bocpdRegimeGate({ newRunProb: bocpdData.newRunProb }),
+        sufficiency: trajectorySufficiency(bocpdData.sampleSize, edgeCount),
       });
     }
 
@@ -1205,7 +1275,7 @@ function ParetoPanel({
       prevCompositesRef.current.set(key, breakdown.composite);
     }
     return result;
-  }, [csdData, phData, lpplsData, graphData.edges, graphData.nodes, scopeLabel]);
+  }, [csdData, phData, lpplsData, bocpdData, graphData.edges, graphData.nodes, scopeLabel, activeProfile]);
 
   const paretoSectionExpanded = expandedChart === "pareto";
 
@@ -1319,40 +1389,36 @@ function ParetoPanel({
                 : `LPPLS fit R\u00B2 = ${(lpplsData.rSquared * 100).toFixed(1)}% on n=${lpplsData.sampleSize} (${lpplsData.evaluations} grid evaluations). ${lpplsData.rSquared > 0.6 ? "Trajectory exhibits super-exponential growth with log-periodic structure \u2014 bubble-like dynamics detected." : lpplsData.rSquared > 0.3 ? "Partial LPPLS pattern; system may be entering the pre-critical regime." : "Weak LPPLS signature \u2014 trajectory does not yet match super-exponential growth."} Fit tc = ${lpplsData.tc.toFixed(3)} (fraction of window), \u03C9 = ${lpplsData.omega.toFixed(2)} rad, m = ${lpplsData.m.toFixed(3)}.`,
             };
           }
-          // ── BOCPD ──────────────────────────────────────────────────
+          // ── BOCPD (live as a fourth criticality estimator on the
+          // scoped Ω trajectory — same series CSD/LPPLS use) ──────────
           if (id === "bocpd") {
-            const t1dSeries = extractT1DSeries(temporalData);
-            // Summarise data availability across all T1D nodes.
-            const seriesInfo = T1D_NODE_IDS.map((nid) => {
-              const s = t1dSeries.get(nid);
-              return s ? `${nid}: ${s.values.length}pt (${s.source})` : `${nid}: 0pt`;
-            });
-            const maxN = Math.max(
-              ...T1D_NODE_IDS.map((nid) => t1dSeries.get(nid)?.values.length ?? 0),
+            const rel = relevanceMap.get("bocpd");
+            const bocpdEpochs = Math.max(
+              0,
+              Math.round((1 - bocpdData.peakRecent) * 200),
             );
-            const bestEntry = T1D_NODE_IDS.map((nid) => t1dSeries.get(nid)).find(
-              (s) => s && s.values.length === maxN,
-            );
-            const inputs = `BOCPD requires ≥20 observations per series.\n` +
-              `Longest available series: ${maxN} point(s)` +
-              (bestEntry ? ` from ${bestEntry.source}` : "") + `.\n` +
-              `T1D node availability:\n${seriesInfo.join("\n")}`;
             return {
               key: "bocpd",
               abbrev: meta.abbrev,
               fullName: meta.fullName,
-              epochs: 0,
-              maxEpochs: 1,
-              color: meta.color,
-              confidence: 0,
-              timeSeries: [],
-              modelSeries: undefined,
+              epochs: bocpdEpochs,
+              maxEpochs: 200,
+              color: getCritColor(bocpdEpochs),
+              confidence: rel ? rel.composite : bocpdData.confidence,
+              relevance: rel,
+              timeSeries: bocpdData.timeSeries,
+              modelSeries: bocpdData.modelSeries,
               shortDesc: meta.shortDesc,
-              methodology: meta.methodology,
-              formula: `INSUFFICIENT DATA on curated graph nodes — need ≥20 points, have ${maxN}` +
-                (bestEntry ? ` (from ${bestEntry.source})` : ""),
-              assessment: `INSUFFICIENT DATA on curated graph nodes — BOCPD (Adams & MacKay 2007) requires ≥20 observations on each node to fit the run-length posterior. The 7 Tier-A T1D nodes currently carry 3–5 digitised trial time-points each (VX-880 FORWARD-101 has 3; TN-10 has 2–3; T1D Index has 5). Maximum available on this surface: ${maxN} point(s).\n\nNOTE: BOCPD is LIVE elsewhere in the platform — see the SPIRTES module's bocpd-hypo-calibration tab, which runs the same estimator on the D1NAMO public cohort (8,300+ CGM samples across 9 T1D subjects) and reports AUROC 0.679 / Brier 0.183 / ECE 0.175 against ground-truth hypoglycemic events. This Pareto card activates here when one of these curated graph nodes carries ≥20 longitudinal observations.`,
-              emptyState: { kind: "awaiting-data" as const, inputs },
+              methodology: [
+                `Adams & MacKay (2007) Bayesian Online Change-Point Detection on the same scoped mean-Ω trajectory as CSD / LPPLS (${scopeLabel}, n=${bocpdData.sampleSize}). Normal-Inverse-Gamma conjugate prior on (mean, variance) of Gaussian observations; tracks the run-length posterior P(r_t = k) at each step.`,
+                `Solid line: observed Ω trajectory. Dashed line: BOCPD's posterior-predictive mean E[x_{t+1} | x_{1:t}]. The criticality readout is `+
+                  `peakRecent — the maximum P(new run) over the trailing 10 steps — currently ${bocpdData.peakRecent.toFixed(3)}. CV of newRunProb across the full trace: ${bocpdData.cv.toFixed(3)}.`,
+                `Same kernel runs on D1NAMO CGM in the SPIRTES module's bocpd-hypo-calibration tab (8,300+ samples across 9 T1D subjects, AUROC 0.679 against hypoglycemic events). Here the same estimator scores Ω regime-shift activity on whatever trajectory the active scope produces.`,
+              ],
+              formula: `peakRecent = ${bocpdData.peakRecent.toFixed(3)} | CV = ${bocpdData.cv.toFixed(3)} | hazard = 1/50 | n = ${bocpdData.sampleSize}`,
+              assessment: bocpdData.sampleSize < 6
+                ? `INSUFFICIENT DATA — only ${bocpdData.sampleSize} observation(s) in the scoped Ω trajectory. BOCPD needs ≥6 to fit a meaningful posterior. Trigger a temporal replay or widen the selection.`
+                : `${bocpdData.peakRecent >= 0.5 ? "REGIME-CHANGE ACTIVE" : bocpdData.peakRecent >= 0.2 ? "Elevated regime-change probability" : "Stable regime"} — recent-window peak P(new run) = ${bocpdData.peakRecent.toFixed(3)} over the trailing 10 of n=${bocpdData.sampleSize} steps. Posterior variability CV = ${bocpdData.cv.toFixed(3)}; ${bocpdData.cv >= 0.5 ? "trace shows clear rises and falls — BOCPD has structure to detect." : "trace is flat — BOCPD is contributing little beyond its prior."}`,
             };
           }
           // ── TRANSFER ENTROPY ────────────────────────────────────────

--- a/src/lib/__tests__/pareto-relevance.test.ts
+++ b/src/lib/__tests__/pareto-relevance.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   outOfSampleFit,
   akaikeEvidenceWeights,
+  bocpdRegimeGate,
   csdRegimeGate,
   lpplsRegimeGate,
   phRegimeGate,
@@ -139,6 +140,43 @@ describe("lpplsRegimeGate", () => {
   it("returns 0 for series shorter than 6 points", () => {
     const r = lpplsRegimeGate({ observed: [1, 2, 3], modelSeries: [1, 2, 3] });
     expect(r.score).toBe(0);
+  });
+});
+
+describe("bocpdRegimeGate", () => {
+  it("returns 0 for series shorter than 6 points", () => {
+    const r = bocpdRegimeGate({ newRunProb: [0.1, 0.2, 0.3] });
+    expect(r.score).toBe(0);
+    expect(r.detail).toMatch(/n=3/);
+  });
+
+  it("scores high for a posterior with a recent peak above threshold", () => {
+    // Quiet then spikes recently — peak window catches the rise.
+    const newRunProb = [
+      0.02, 0.02, 0.03, 0.02, 0.02, 0.02, 0.02, 0.02,
+      0.7, 0.85, 0.9, 0.6,
+    ];
+    const r = bocpdRegimeGate({ newRunProb });
+    expect(r.score).toBeGreaterThan(0.4);
+  });
+
+  it("scores low for a flat-line posterior", () => {
+    const flat = Array.from({ length: 20 }, () => 0.02);
+    const r = bocpdRegimeGate({ newRunProb: flat });
+    expect(r.score).toBeLessThan(0.1);
+  });
+
+  it("scores higher with structure than without (ordering invariant)", () => {
+    const flat = Array.from({ length: 30 }, () => 0.02);
+    const structured = [
+      0.02, 0.02, 0.05, 0.4, 0.7, 0.5, 0.2, 0.05,
+      0.02, 0.02, 0.02, 0.05, 0.5, 0.85, 0.6, 0.2,
+      0.05, 0.02, 0.02, 0.02, 0.05, 0.4, 0.7, 0.55,
+      0.2, 0.05, 0.02, 0.5, 0.8, 0.6,
+    ];
+    expect(
+      bocpdRegimeGate({ newRunProb: structured }).score,
+    ).toBeGreaterThan(bocpdRegimeGate({ newRunProb: flat }).score);
   });
 });
 

--- a/src/lib/criticality-registry.ts
+++ b/src/lib/criticality-registry.ts
@@ -85,26 +85,27 @@ const REGISTRY: Record<EstimatorId, EstimatorMeta> = {
     defaultAvailability: "ready",
   },
 
-  // ── Medical estimators (TS-ported, awaiting real data wiring) ──────
+  // ── BOCPD: live on the scoped Ω trajectory (same source as CSD/LPPLS).
+  // Was previously gated to T1D-node series (rarely > 5 points each); now
+  // runs on whatever trajectory the active scope produces, which is the
+  // same substrate the rest of the criticality cards already use.
   bocpd: {
     id: "bocpd",
     abbrev: "BOCPD",
     fullName: "BAYESIAN ONLINE CHANGE-POINT DETECTION",
     shortDesc:
-      "Run-length posterior on a patient trace — flags regime shifts (honeymoon end, DKA onset)",
+      "Run-length posterior on the scoped Ω trajectory — flags regime shifts via P(new run)",
     color: "#00e5ff",
     methodology: [
       "Adams & MacKay (2007) run-length posterior with a Normal-Inverse-Gamma conjugate prior on a Gaussian observation model. For each time step we track P(r_t = k), the probability that the current run began k steps ago.",
-      "Signal of interest is P(r_t < cpWindow) — the probability that a change-point has occurred in the last `cpWindow` observations. Threshold this to flag regime shifts: honeymoon-phase termination, insulin-dose regime changes, DKA precursors, stress-induced excursions.",
-      "TS implementation lives at src/lib/estimators/bocpd.ts with a parity test against the Python reference. Awaiting a patient time-series source — CGM trace, C-peptide AUC sequence, or daily TIR — to be wired into the store before this card can run live.",
+      "Signal of interest is P(r_t < cpWindow) — the probability that a change-point has occurred in the last `cpWindow` observations. The Pareto card surfaces the trailing-window peak of this trace as the criticality readout; F·E·G·S·M's regime gate then weighs it against (1) recent peak above floor and (2) variability of the full posterior so a flat trace does not score as criticality.",
+      "TS implementation at src/lib/estimators/bocpd.ts with a parity test against the Python reference. Same kernel that runs on D1NAMO CGM in the SPIRTES bocpd-hypo-calibration tab (AUROC 0.679 vs hypoglycemic events).",
     ],
     formula:
       "P(r_t | x_{1:t}) ∝ Σ P(x_t | r_{t-1}, x_past) · P(r_t | r_{t-1}) · P(r_{t-1} | x_{1:t-1})",
     placeholderAssessment:
-      "AWAITING DATA — patient trace not yet wired. Once a CGM / C-peptide series is available, this card fits the run-length posterior online and surfaces the P(new run) trajectory with threshold crossings annotated.",
-    defaultAvailability: "awaiting-data",
-    requiredInputs:
-      "A scalar time series per patient — CGM glucose (5-min cadence), C-peptide AUC (per visit), or daily time-in-range. ~50+ observations for a stable posterior.",
+      "STABLE REGIME — posterior is concentrated on the current run; no recent change-point activity above floor.",
+    defaultAvailability: "ready",
   },
   "transfer-entropy": {
     id: "transfer-entropy",

--- a/src/lib/pareto-relevance.ts
+++ b/src/lib/pareto-relevance.ts
@@ -61,6 +61,19 @@ export const PARETO_RELEVANCE_CONSTANTS = {
   // PH gate
   PH_MID_FILTRATION_INDEX: 30, // midpoint of 60-step filtration
 
+  // BOCPD gate
+  // ----------------------------------------------------------------------
+  // Adams & MacKay (2007) BOCPD outputs `newRunProb[t]` ∈ [0,1], the
+  // probability of a change-point in the trailing window. The regime gate
+  // fires when there is *meaningful change-point activity* — either a
+  // recent peak above BOCPD_PEAK_THRESHOLD, or a non-degenerate run-length
+  // posterior (high entropy/uncertainty in run-length distribution). A
+  // flatline series (BOCPD output ≈ hazard everywhere) scores low, since
+  // BOCPD has nothing to say about that regime — exactly the contextual
+  // veto F·E·G·S·M's gates are designed to apply.
+  BOCPD_PEAK_THRESHOLD: 0.3, // newRunProb above this counts as a peak
+  BOCPD_PEAK_WINDOW: 10,     // recent window over which to scan for a peak
+
   // Likelihood floors (avoid −∞ when residuals are degenerate)
   MIN_RESIDUAL_VARIANCE: 1e-6,
 
@@ -387,6 +400,63 @@ export function lpplsRegimeGate(args: {
   return {
     score,
     detail: `accel ${accel01.toFixed(2)}, residual sign-changes ${signChanges} → ${oscillation01.toFixed(2)}.`,
+  };
+}
+
+/**
+ * G — BOCPD regime gate.
+ *
+ * BOCPD is meaningful when there's *something for it to detect* — a series
+ * with no detectable change-points just gives newRunProb ≈ hazard
+ * everywhere, and the model is contributing nothing beyond its prior.
+ *
+ * Score combines two signals:
+ *   (1) recent peak — max newRunProb in the trailing window above floor.
+ *       Maps any peak above BOCPD_PEAK_THRESHOLD to peak01 ∈ [0, 1].
+ *   (2) variability — coefficient of variation of newRunProb across the
+ *       full history. A flat trace (all values within a hazard-level band)
+ *       contributes near-zero; a trace that rises and falls contributes 1.
+ *
+ * Equal-weight average. Returns score=0 when the series is too short for
+ * BOCPD to produce a meaningful posterior (n < 6).
+ */
+export function bocpdRegimeGate(args: {
+  newRunProb: number[];
+}): SubScore {
+  const { newRunProb } = args;
+  const n = newRunProb.length;
+  if (n < 6) {
+    return { score: 0, detail: `n=${n}; need ≥6 for posterior.` };
+  }
+
+  // (1) Recent peak signal.
+  const windowStart = Math.max(0, n - C.BOCPD_PEAK_WINDOW);
+  let recentPeak = 0;
+  for (let t = windowStart; t < n; t++) {
+    if (newRunProb[t] > recentPeak) recentPeak = newRunProb[t];
+  }
+  const peak01 = clamp01(
+    Math.max(0, recentPeak - C.BOCPD_PEAK_THRESHOLD) /
+      Math.max(1e-6, 1 - C.BOCPD_PEAK_THRESHOLD),
+  );
+
+  // (2) Variability of the full posterior trace. Coefficient of variation
+  // (σ / μ) clamped — anything below ~10% CV reads as flatline.
+  let mean = 0;
+  for (const v of newRunProb) mean += v;
+  mean /= n;
+  let variance = 0;
+  for (const v of newRunProb) variance += (v - mean) ** 2;
+  variance /= n;
+  const std = Math.sqrt(variance);
+  const cv = mean > 0 ? std / mean : 0;
+  // CV ≈ 0 (flat) → 0; CV ≈ 1+ (rises and falls) → 1.
+  const variability01 = clamp01(cv);
+
+  const score = (peak01 + variability01) / 2;
+  return {
+    score,
+    detail: `peak ${recentPeak.toFixed(2)} → ${peak01.toFixed(2)}, CV ${cv.toFixed(2)} → ${variability01.toFixed(2)}.`,
   };
 }
 


### PR DESCRIPTION
## Summary

Wires BOCPD into the Pareto card alongside CSD / PH / LPPLS. Previously the BOCPD card hard-gated to per-T1D-node digitised series (typically 3–5 points → permanent INSUFFICIENT DATA), with the live BOCPD logic only existing in the SPIRTES calibration tab. Now BOCPD runs on the same `scopedOmegaSeries` CSD and LPPLS already use, so it's a peer member of the F·E·G·S·M relevance batch and gets Akaike-weighted against the other three.

## Why now

We just shipped a real-data calibration for BOCPD on D1NAMO (PR #139, AUROC 0.679 vs hypoglycemic events) and a real-data calibration for the F sub-score on both D1NAMO (#200) and Hall (#230). The kernel and the calibration are validated — the missing piece was wiring the live estimator into the criticality card itself, not just the validation tab.

## Architectural change

| | Before | After |
|---|---|---|
| Substrate | per-node T1D series (3–5 pts) | scoped Ω trajectory (same as CSD/LPPLS) |
| Default availability | `awaiting-data` | `ready` |
| Lives in relevance batch | no | yes — when profile requests it |
| Akaike-weighted vs siblings | no | yes |
| F·E·G·S·M breakdown | n/a (empty card) | full 5-row breakdown like CSD/LPPLS |

## Files

| File | Change |
|------|--------|
| `src/lib/pareto-relevance.ts` | New `bocpdRegimeGate` helper. G score = avg of (1) recent peak above `BOCPD_PEAK_THRESHOLD` over trailing 10 steps and (2) coefficient of variation of `newRunProb` across full posterior. Flat trace → low G; rises and falls → high G. New constants `BOCPD_PEAK_THRESHOLD = 0.3`, `BOCPD_PEAK_WINDOW = 10`. |
| `src/components/ModulePanel.tsx` | New `bocpdData` useMemo runs BOCPD via lazy require on `scopedOmegaSeries`. Pushes BOCPD into the relevance batch when `activeProfile.criticalityEstimators` includes `"bocpd"`. Replaces the old INSUFFICIENT-DATA descriptor branch with a live one that mirrors CSD's pattern. `freeParams = 5` (4 NIG hyperparams + hazard). |
| `src/lib/criticality-registry.ts` | bocpd `defaultAvailability: "awaiting-data" → "ready"`. methodology / shortDesc / placeholderAssessment rewritten for the live trajectory. `requiredInputs` removed. |
| `src/lib/__tests__/pareto-relevance.test.ts` | 4 new `bocpdRegimeGate` tests: short-input default, recent-peak scoring, flat-line low score, structured > flat ordering invariant. |

## Score shape recap

`G_bocpd = (peak01 + variability01) / 2`

- `peak01 = clamp01((max(newRunProb, last 10 steps) − 0.3) / 0.7)` — any peak above the 0.3 floor maps to [0, 1].
- `variability01 = clamp01(σ / μ)` of `newRunProb` across the full posterior — flat ≈ 0, oscillating ≈ 1.

The full F·E·G·S·M composite for BOCPD is then `S · G · M · (0.6·F + 0.4·E)` — same formula as the other three. F is computed via the same `outOfSampleFit` helper using BOCPD's posterior-predictive mean as the model series.

## Test plan

- [x] 4 new `bocpdRegimeGate` tests pass
- [x] Full vitest suite green: 722 / 722
- [x] `npm run build` passes locally with placeholder envs (after `.next` cache clear; needed because main has accumulated dep changes)
- [ ] PR-validate workflow green
- [ ] Vercel preview eyeball: confirm the BOCPD tab on the Pareto card now shows the 5-row F·E·G·S·M breakdown (not INSUFFICIENT DATA), the chart shows observed Ω trajectory + BOCPD predictiveMean dashed line, the headline pill carries `± N% rel`, and the assessment line reads with the live peakRecent / CV numbers

## Backwards compatibility

- Profiles that don't include `"bocpd"` in `criticalityEstimators` see zero behavioural change.
- BOCPD descriptor still falls back to "INSUFFICIENT DATA" when `sampleSize < 6` — same threshold style as CSD's n<5 fallback.
- The discovery-side BOCPD calibration (`bocpd-hypo-calibration` on D1NAMO) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
