### PR TITLE
fix(2d): defensive nodePositions selector — no more stack-at-origin empty canvas

### DIFF
--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -380,7 +380,31 @@ function CausalDAG2DInner() {
     setCachedLayout(compute2DForceLayout(graphData.nodes, graphData.edges));
     setLivePositions(null);
   }
-  const nodePositions = livePositions ?? cachedLayout;
+  // Defensive selector. The simple `livePositions ?? cachedLayout` was
+  // vulnerable to two edge cases that left every node rendered at
+  // (0, 0) — a stack-of-169-nodes-at-origin which reads as "empty
+  // canvas" because they all overlap (0,0 is also outside the default
+  // viewport):
+  //
+  //  (a) Empty live positions — `livePositions = new Map()` is non-null
+  //      and shadows the cachedLayout fallback, but `.get(n.id)` always
+  //      misses, so every node falls to `{ x: 0, y: 0 }`.
+  //  (b) Stale live positions — when the graph swaps (persona / domain
+  //      change), the rAF tick from the *old* simulation can fire after
+  //      the new graph loads and call `setLivePositions(staleMap)`. The
+  //      stale map's keys are the OLD graph's node IDs; new graph nodes
+  //      miss the lookup and stack at the origin.
+  //
+  // Falling back to cachedLayout in either case keeps the canvas
+  // populated until the new live sim catches up (which it will, since
+  // the useEffect below rebuilds it from the freshly-computed
+  // cachedLayout for the new graph).
+  const nodePositions = useMemo(() => {
+    if (!livePositions || livePositions.size === 0) return cachedLayout;
+    if (graphData.nodes.length === 0) return cachedLayout;
+    if (!livePositions.has(graphData.nodes[0].id)) return cachedLayout;
+    return livePositions;
+  }, [livePositions, cachedLayout, graphData.nodes]);
 
   // Build the live (perturbable) simulation whenever the cached layout swaps.
   // No setState here — only ref + rAF management.


### PR DESCRIPTION
## Summary

Fixes the 2D canvas going blank — status bar shows the right node/edge counts but the viewport is empty.

## Root cause

The `nodePositions` selector was `livePositions ?? cachedLayout`. When the graph swaps (persona / domain change), the rAF tick from the *old* live simulation can fire after the new graph loads and call `setLivePositions(staleMap)` — keys are the OLD graph's node IDs. New-graph nodes miss the lookup and fall back to `{ x: 0, y: 0 }` (line 465). 169 markers stacked at the origin reads as "empty canvas" because (0, 0) sits outside the default React Flow viewport.

There's also a similar failure mode for an empty `livePositions` (`new Map()` is non-null and shadows the cachedLayout fallback).

## Fix

Replace `??` with a defensive `useMemo` that explicitly:
- falls back to cachedLayout when livePositions is empty
- falls back to cachedLayout when livePositions doesn't contain the current graph's first node ID (= stale)
- otherwise uses livePositions as before

The useEffect that rebuilds the live sim already runs against the new graph's cachedLayout, so this just skips the stale frame.

## What's not in this PR

The user also reported the ΩF-series tiles in the bottom strip showing `LIVE — building` indefinitely. That's a separate symptom (live-feed history not accumulating past the first poll) and needs network-tab data to diagnose. Will follow up.

## Test plan

- [ ] Hard refresh, switch personas a few times, switch domains a few times — canvas should always show nodes after a moment, never empty
- [ ] Drag a node — drag-perturb still works (livePositions during drag are always fresh, so no regression)
- [ ] Cascade replay still pulls stressed nodes toward stressed neighbors as before
- [ ] Switch from 3D → 2D → 3D → 2D rapidly — viewport always populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
