### PR TITLE
docs(billing): flag /pricing chrome as co-owned with website session

### DIFF
--- a/docs/BILLING.md
+++ b/docs/BILLING.md
@@ -47,6 +47,8 @@ There is no automated payment integration. The admin (currently Junaid) is the b
 | `/request-access` | `src/app/request-access/page.tsx` (server) + `RequestAccessForm.tsx` (client behind `<Suspense>`) | Lead capture form. Pre-fills the use-case textarea when arriving from a tier CTA. POSTs to `/api/request-access`. |
 | `/expired` | `src/app/expired/page.tsx` (server) + `SignOutButton.tsx` (client) | Auth-aware upgrade wall. Loads the user's tier and copy adapts (trial vs paid lapsed vs admin-flipped expired). Primary CTA via [`UpgradeCTA`](#7-shared-components). |
 
+> ⚠ **`/pricing` visual chrome is co-owned with the website session.** The page imports `PricingBackground` from `src/components/visuals/` and the header / CTA cards have been polished by a parallel "website" Claude-Code session (see PR #231 for the canonical example). If you're modifying `src/app/pricing/page.tsx`, **stick to changes that route through `PRICING_PLANS` in `src/lib/billing.ts`** (tier names, prices, blurbs, features, CTA labels) — that's the safe, non-overlapping seam. Visual styling and layout may be touched by either session, so coordinate via `MEMORY.md` / session notes before bigger restructures. The form on `/request-access`, the API at `/api/request-access`, and the `leads` table are billing-session-only and not touched by the website work.
+
 The middleware allowlist for these routes lives in `src/lib/supabase/middleware.ts`:
 
 ```ts


### PR DESCRIPTION
## Summary

One-liner callout in `docs/BILLING.md` flagging that `src/app/pricing/page.tsx` is co-owned by two parallel Claude-Code sessions (billing + website). The website session shipped PR #231 polishing the pricing page with `PricingBackground` and a lifted access CTA above the price grid; without a note like this, the next billing session that touches the same file could clobber that work or vice-versa.

The note documents the safe seam: **content edits route through `PRICING_PLANS` in `src/lib/billing.ts`**, visual styling is shared territory and needs coordination via `MEMORY.md` / session notes.

It also explicitly states what is **not** co-owned (form on `/request-access`, the API route, the `leads` table) so future sessions don't apply the same concern there.

## Test plan
- [x] Markdown renders cleanly
- [x] No code changes — docs-only

https://claude.ai/code/session_01Bk4PoJxdEhTNGrKbN5MHE3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bk4PoJxdEhTNGrKbN5MHE3)_