### PR TITLE
fix(pricing): brand mark goes to new website, not legacy apexanalytica.co

### DIFF
--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -24,11 +24,18 @@ export default function PricingPage() {
 
       <header className="relative border-b border-border">
         <div className="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
-          {/* Brand mark on /pricing routes back to the marketing home
-              (apexanalytica.co), NOT to the platform root — visitors
-              landing here are evaluating the product, so "home" means
-              the public marketing site, not the platform dashboard. */}
-          <a href="https://apexanalytica.co/" className="flex items-center gap-3">
+          {/* Brand mark on /pricing routes back to the new marketing
+              site (apex-analytica-website.vercel.app), NOT to the
+              platform root or the legacy apexanalytica.co Vite SPA.
+              Visitors landing here are evaluating the product, so
+              "home" means the new public marketing site we're
+              building, not the platform dashboard.
+
+              TODO when DNS for apexanalytica.co cuts over to this
+              new website (the Vercel project apex-analytica-website),
+              swap this href to https://apexanalytica.co/ so the
+              brand mark uses the canonical domain. */}
+          <a href="https://apex-analytica-website.vercel.app/" className="flex items-center gap-3">
             <Image src="/logo.png" alt="Apex Analytica" width={36} height={36} />
             <div className="leading-tight">
               <div className="text-[12px] font-[family-name:var(--font-michroma)] tracking-[0.25em] text-accent-cyan">


### PR DESCRIPTION
## Summary

Follow-up to #231. The earlier fix pointed the `/pricing` brand mark at `apexanalytica.co/`, but that domain currently serves the **legacy Vite SPA on Netlify**, not the new Next.js marketing site we're building (PR #224, branch `claude/angry-kare-9bd8f1`). Visitors clicking the brand mark were landing on the old site.

Repoints to **`https://apex-analytica-website.vercel.app/`** — the stable Vercel alias for the newly-deployed website project. The alias auto-updates on every prod deploy.

## Vercel project setup (one-time, just done)

Spun up a new Vercel project `apex-analytica-website` pointing at the `website/` subdirectory of this repo. Stable URL: https://apex-analytica-website.vercel.app — verified `/`, `/access`, `/domains`, `/team` all return 200 with the expected new-site content.

## Future TODO

When DNS for `apexanalytica.co` cuts over to this new Vercel project (away from the existing Netlify Vite SPA), the brand mark `href` should be swapped back to `https://apexanalytica.co/` so the canonical domain is used. Inline TODO comment marks the spot.

## Test plan

- [x] `apex-analytica-website.vercel.app` returns 200 on `/`, `/access`, `/domains`, `/team`
- [x] Page title matches: `Apex Analytica — Causal Intelligence for Critical Systems`
- [x] After merge: brand mark on `manifold.apexanalytica.co/pricing` routes to the new Vercel deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)