### PR TITLE
perf(dag3d): cached orb position + leaner sphere tessellation

### DIFF
--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -106,7 +106,8 @@ Append a row each time a perf-relevant change ships. Keep entries terse; cite PR
 
 | Date | PR | Action | Outcome / notes |
 |---|---|---|---|
-| 2026-05-01 | (this PR) | Wired `@vercel/speed-insights` into root layout + `@next/bundle-analyzer` into `next.config.ts`. Removed dead `@react-three/postprocessing` (zero source references). | Establishes baseline. Speed Insights data starts accumulating on next prod deploy. Bundle analyzer runs locally only via `ANALYZE=true npm run build`. |
+| 2026-05-01 | #222 | Wired `@vercel/speed-insights` into root layout + `@next/bundle-analyzer` into `next.config.ts`. Removed dead `@react-three/postprocessing` (zero source references). | Establishes baseline. Speed Insights data starts accumulating on next prod deploy. Bundle analyzer runs locally only via `ANALYZE=true npm run build`. |
+| 2026-05-06 | (this PR) | `DAGEdge3D` orb animation: replaced per-frame `curve.getPoint(t)` (allocates Vector3 + bezier eval) with O(1) lookup into the existing 32-point `curvePoints` cache. Dropped invisible-hitbox sphere tessellation 8×8→4×4 and orb tessellation 8×8→6×6. | No measurement run; based on code inspection. Expected savings: ~6k Vector3 allocations/sec at ~100 animating edges + lower raycast cost on hover. Visual diff at 0.25 orb radius is imperceptible. Re-measure during next perf audit; if still slow during cascade replay, the next ladder rung is `<instancedMesh>` for orbs. |
 
 Future entries: copy the row template above.
 

--- a/src/components/dag3d/DAGEdge3D.tsx
+++ b/src/components/dag3d/DAGEdge3D.tsx
@@ -135,12 +135,19 @@ function DAGEdge3DInner({
     (isTemporalFlow || propSignal > 0.3);
   const animSpeed = isTemporalFlow ? 0.4 : 0.3 + propSignal * 0.5;
 
-  // Animate particle along curve for temporal/causal edges
+  // Animate particle along curve for temporal/causal edges.
+  // Reads from the pre-cached curvePoints array (allocated once per
+  // posKey change) instead of re-evaluating the bezier each frame —
+  // saves ~one Vector3 allocation + a sqrt per animating edge per
+  // frame. With ~100 animating edges at 60fps that's ~6k fewer
+  // allocations/sec and noticeably less GC pressure during replay.
   useFrame((_, delta) => {
     if (!particleRef.current || !shouldAnimate) return;
     particleT.current = (particleT.current + delta * animSpeed) % 1;
-    const pos = curve.getPoint(particleT.current);
-    particleRef.current.position.set(pos.x, pos.y, pos.z);
+    const samples = curvePoints.length;
+    const i = Math.min(samples - 1, Math.floor(particleT.current * samples));
+    const [x, y, z] = curvePoints[i];
+    particleRef.current.position.set(x, y, z);
   });
 
   return (
@@ -169,7 +176,10 @@ function DAGEdge3DInner({
           }
         }}
       >
-        <sphereGeometry args={[scissorsMode || ablationMode ? 3.5 : 2, 8, 8]} />
+        {/* Invisible hitbox — raycast cost scales with triangle count,
+            so keep the tessellation low. 4×4 segments = 8 triangles
+            vs 8×8 = 64 with no visual difference (it's transparent). */}
+        <sphereGeometry args={[scissorsMode || ablationMode ? 3.5 : 2, 4, 4]} />
         <meshBasicMaterial transparent opacity={0} depthWrite={false} />
       </mesh>
 
@@ -193,7 +203,10 @@ function DAGEdge3DInner({
           small glowing sphere that travels source → target along the curve */}
       {shouldAnimate && (
         <mesh ref={particleRef}>
-          <sphereGeometry args={[0.25, 8, 8]} />
+          {/* 6×6 segments = 36 triangles, indistinguishable from 8×8
+              (64 tri) at this radius (0.25). Saves vertex work
+              proportional to active orb count. */}
+          <sphereGeometry args={[0.25, 6, 6]} />
           <meshBasicMaterial
             color={color}
             transparent


### PR DESCRIPTION
## Summary

User-reported slowness on the cascade-replay orb animation. Two targeted, low-risk changes in `DAGEdge3D.tsx`. No engine code touched.

### 1. Per-frame Vector3 allocation removed

The orb's `useFrame` was calling `curve.getPoint(particleT.current)` every animated frame, which allocates a fresh `Vector3` and runs the quadratic bezier formula. There's already a 32-point cached `curvePoints` array (computed once per `posKey`/`curveOffset` for line rendering). Switched the animation to read from that array via O(1) lookup.

With ~100 animating edges at 60fps that's **~6k fewer Vector3 allocations per second** and proportional GC relief during replay.

```diff
-  const pos = curve.getPoint(particleT.current);
-  particleRef.current.position.set(pos.x, pos.y, pos.z);
+  const samples = curvePoints.length;
+  const i = Math.min(samples - 1, Math.floor(particleT.current * samples));
+  const [x, y, z] = curvePoints[i];
+  particleRef.current.position.set(x, y, z);
```

### 2. Sphere geometries tessellated lighter

- **Invisible hitbox**: `8×8` → `4×4` segments. Hitboxes never render (transparent + `depthWrite={false}`) but still participate in raycast intersection on every hover tick. **8 triangles vs 64** with zero visual difference.
- **Orb sphere**: `8×8` → `6×6` segments. **36 vs 64 triangles.** At the 0.25-unit radius the difference is imperceptible.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run` — 722/722 passing
- [ ] Visual smoke on Vercel preview / production: cascade replay → orbs flow continuously, no visible stepping; hover edges to confirm hitbox raycast still works
- [ ] Compare frame budget against pre-PR Speed Insights data (data still accumulating from #222 baseline)

## What's next if this isn't enough

The next ladder rung is converting orbs to `<instancedMesh>` (single draw call across all orbs instead of N). Flagged in the audit-log entry. Will require a slightly bigger refactor — moving orb data into a parent component — so saving for after we have measurement data.

Audit-log row appended to `docs/PERFORMANCE.md` per the §5 convention.

https://claude.ai/code/session_01Bk4PoJxdEhTNGrKbN5MHE3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bk4PoJxdEhTNGrKbN5MHE3)_