### PR TITLE
fix(topo): labels float at true peak height + Ω intensity legend

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -373,9 +373,37 @@ The framework is fine — three.js / r3f is exactly what those reference platfor
 
 **Verification.** `tsc --noEmit` clean; lint clean on touched files; vitest 704/704 pass (2 new in `graph-relief-field.test.ts`).
 
+### 2026-05-03 — Shipped: Topo label-on-peak fix + Ω intensity legend
+
+**PR:** TBD (about to open).
+
+**Trigger.** User feedback: *"the way nodes render on top of it is really hard to follow. Right now they seem to be sitting at the bottom on a flat map. Also could we have a vertical scale showing what each striation is in terms of Ω."*
+
+**The bug.** `computeNodeAnchors` was sampling each node's height with the raw `composite` value:
+```ts
+h += s.composite * Math.exp(-(...) / sigma2);
+```
+But the field eval uses `nodeWeight(composite) = composite ^ WEIGHT_EXPONENT (1.5)`. For composite=10, that's 10 vs 31.6 — the anchor's `h / field.peak` ratio was ~0.3 of the actual mesh-vertex norm at that point, so `pow(norm, heightGamma) * heightScale` came out at ~20 when the surface peak was at 140. Labels rendered close to y=0 — exactly the "sitting at the bottom" the user reported. One-line fix: anchor sampling now mirrors the field-eval kernel.
+
+**What shipped.**
+- **Anchor height fix.** `computeNodeAnchors` now uses `nodeWeight(s.composite)` to match the field eval. Labels now float at the true peak height.
+- **`<ElevationLegend>` component.** Vertical heatmap-gradient strip on the right edge of the canvas, ~180px tall, with five label stops (Ω peak / HIGH / MID / LOW / Ω 0). Uses 14 horizontal tick lines that mirror the shader's `uBands = 14`, so the strip's tick density visually maps to the iso-rings on the surface. Right-side rotated "Ω INTENSITY" text. Pulls `peakOmega` from `fieldNodes` (replay-aware), so the top label updates as ΩF changes during a replay.
+- **`elevationColorJS`** small helper in the component — JS mirror of the shader's GLSL elevationColor ramp, used to paint the CSS gradient stops so the legend visually matches the surface palette. Comment ties them together; keep in sync if the ramp ever changes.
+
+**Files.**
+- `src/lib/graph-relief-field.ts` — `computeNodeAnchors` height kernel uses `nodeWeight()` instead of raw `composite`. Comment explaining the contract.
+- `src/components/CausalDAGRelief.tsx` — adds `<ElevationLegend>`, `elevationColorJS()` helper, `peakOmega` useMemo, render call site below the domain legend.
+- `src/lib/__tests__/graph-relief-field.test.ts` — new regression test "anchor y matches the actual mesh-vertex height at the node position": for an isolated source the anchor should reach ≥ 95% of the global mesh-vertex max-Y (was previously sitting at <30% of it).
+
+**Verification.** `tsc --noEmit` clean; lint clean on touched files; vitest 711/711 pass.
+
 ### 2026-05-03 — Next up
 
-- Verify replay animation on production: load any demo flow → hit play → watch the topo surface morph as epochs advance. Expect the REPLAY · EPOCH N pill in the top-right and label Ω values updating in sync. Remaining follow-ups: onboarding tooltip (most users still won't intuit the topographic mental model on first glance), real-time scrub perf (preview-resolution-during-drag or compute-shader port). Outside TOPO: deferred 3D `onPointerMove` throttle, map-view imperative-setData refactor, real bundle-analyzer perf sweep using PR #222's tooling.
+User flagged three more issues in the same message:
+1. **2D map blinks on hover; map disappears briefly on selection.** Known item — deferred from PR #198 with the note *"the `edges` useMemo (`:478–541`) still rebuilds on every hover because `emphasisTarget` is in its deps. Splitting structural edge data from emphasis-derived style would need a custom edge component subscribing to `emphasisTarget` separately."* That's the fix. The "map disappears on select" piece is new info — could be `useEdgesState` or React Flow's internal remount on a different signal — needs a quick repro and a focused fix in the same PR.
+2. **3D diagram looks busy / hard to track.** User got cut off mid-sentence about the orbs — pending clarification on whether they want smaller orbs, simpler labels, fewer visible items, or all three.
+
+Outside TOPO: deferred 3D `onPointerMove` throttle, map-view imperative-setData refactor, real bundle-analyzer perf sweep using PR #222's tooling.
 
 ---
 

--- a/src/components/CausalDAGRelief.tsx
+++ b/src/components/CausalDAGRelief.tsx
@@ -395,6 +395,88 @@ function DomainLegend({ field }: { field: FusedReliefField }) {
   );
 }
 
+/**
+ * Vertical Ω-intensity legend on the right edge — answers "what does each
+ * iso-contour band represent?". Maps the same elevationColor() ramp the
+ * surface uses to a visible scale, with the maximum-composite contributor
+ * shown as the "PEAK Ω" reference. The mapping isn't strictly linear
+ * (kernel sums + heightGamma both bend it) but it's the right qualitative
+ * read: cooler colour = quieter region, hotter = more critical cluster.
+ */
+function ElevationLegend({ peakOmega }: { peakOmega: number }) {
+  // Ramp built from the JS elevationColor() at 21 stops — gives a smooth
+  // CSS gradient that matches what the shader paints.
+  const stops: string[] = [];
+  for (let i = 0; i <= 20; i++) {
+    const t = i / 20;
+    const [r, g, b] = elevationColorJS(t);
+    stops.push(
+      `rgb(${Math.round(r * 255)}, ${Math.round(g * 255)}, ${Math.round(b * 255)}) ${i * 5}%`,
+    );
+  }
+  // 14 ticks matches the shader's BANDS uniform (default 14) so the
+  // strip's tick density mirrors the rings on the surface.
+  const ticks = 14;
+  return (
+    <div className="absolute top-1/2 right-4 -translate-y-1/2 z-10 flex items-stretch gap-2 pointer-events-none">
+      <div className="flex flex-col justify-between text-[8px] font-mono text-text-muted py-0.5">
+        <span style={{ color: "#ff5566" }}>Ω {peakOmega.toFixed(1)}</span>
+        <span>HIGH</span>
+        <span>MID</span>
+        <span>LOW</span>
+        <span>Ω 0</span>
+      </div>
+      <div className="relative w-2 h-44 rounded overflow-hidden border border-border">
+        <div
+          className="absolute inset-0"
+          style={{
+            background: `linear-gradient(to top, ${stops.join(", ")})`,
+          }}
+        />
+        {/* Tick marks aligned with shader bands — the user can read
+            "this iso-ring on the surface = roughly this elevation". */}
+        {Array.from({ length: ticks - 1 }).map((_, i) => {
+          const top = ((i + 1) / ticks) * 100;
+          return (
+            <div
+              key={i}
+              className="absolute left-0 right-0 h-px"
+              style={{ top: `${top}%`, backgroundColor: "rgba(0,0,0,0.45)" }}
+            />
+          );
+        })}
+      </div>
+      <div className="flex items-end pb-0 pl-1">
+        <div
+          className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted"
+          style={{ writingMode: "vertical-rl", transform: "rotate(180deg)" }}
+        >
+          Ω INTENSITY
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** JS-side mirror of the shader's elevationColor — keep in lockstep with the
+ *  ramp baked into TOPO_FRAGMENT_SHADER and graph-relief-field's
+ *  elevationColor(). Used by the legend to paint a CSS gradient that visually
+ *  matches the surface. */
+function elevationColorJS(t: number): [number, number, number] {
+  const n = Math.max(0, Math.min(1, t));
+  const lerp = (a: number, b: number, k: number) => a + (b - a) * k;
+  if (n < 0.25) {
+    const k = n / 0.25;
+    return [lerp(0.04, 0.0, k), lerp(0.05, 0.9, k), lerp(0.18, 1.0, k)];
+  }
+  if (n < 0.55) {
+    const k = (n - 0.25) / 0.3;
+    return [lerp(0.0, 1.0, k), lerp(0.9, 0.67, k), lerp(1.0, 0.0, k)];
+  }
+  const k = Math.min(1, (n - 0.55) / 0.45);
+  return [1.0, lerp(0.67, 0.09, k), lerp(0.0, 0.27, k)];
+}
+
 function SelectionMarkers({
   layout,
   field,
@@ -546,6 +628,18 @@ function CausalDAGReliefInner() {
     (multilayer ? fusedField : singleField) ?? null;
   const isEmpty = !activeField || activeField.positions.length === 0;
 
+  // Max Ω composite across the visible (replay-aware) graph — drives
+  // the elevation legend's "PEAK Ω" label so users have a numeric
+  // anchor for the heatmap.
+  const peakOmega = useMemo(() => {
+    let max = 0;
+    for (const n of fieldNodes) {
+      const c = n.omegaFragility?.composite;
+      if (typeof c === "number" && Number.isFinite(c) && c > max) max = c;
+    }
+    return max;
+  }, [fieldNodes]);
+
   const anchors = useMemo<NodeAnchor[]>(() => {
     if (!activeField || isEmpty) return [];
     // Use fieldNodes (replay-aware) so label Ω values match what the
@@ -639,6 +733,9 @@ function CausalDAGReliefInner() {
       </Canvas>
       {!isEmpty && multilayer && fusedField && (
         <DomainLegend field={fusedField} />
+      )}
+      {!isEmpty && peakOmega > 0 && (
+        <ElevationLegend peakOmega={peakOmega} />
       )}
       {currentSnapshot && (
         <div className="absolute top-4 right-4 z-10 px-3 py-1.5 rounded border border-accent-amber/60 bg-surface-elevated/90 backdrop-blur-sm pointer-events-none">

--- a/src/lib/__tests__/graph-relief-field.test.ts
+++ b/src/lib/__tests__/graph-relief-field.test.ts
@@ -209,6 +209,26 @@ describe("computeNodeAnchors", () => {
     expect(anchor.y).toBeGreaterThan(0);
   });
 
+  it("anchor y matches the actual mesh-vertex height at the node position", () => {
+    // Regression for the "labels look like they sit on the floor" bug —
+    // computeNodeAnchors must use the same nodeWeight kernel as the field
+    // eval, otherwise the normalised height diverges from the surface.
+    // For a single isolated source, the anchor at the source position is
+    // the global peak, so its norm should be ~1 and y ≈ heightScale.
+    const nodes = [makeNode("a", "X", 9)];
+    const layout = new Map([["a", { x: 0, y: 0 }]]);
+    const field = computeReliefField(nodes, layout, { resolution: 32 });
+    const [anchor] = computeNodeAnchors(nodes, layout, field, {}, 1);
+    // Find the maximum vertex height in the field — anchor must reach
+    // at least 95% of it (small floor-level slop from the discrete grid).
+    let maxY = 0;
+    for (let i = 1; i < field.positions.length; i += 3) {
+      if (field.positions[i] > maxY) maxY = field.positions[i];
+    }
+    expect(maxY).toBeGreaterThan(0);
+    expect(anchor.y).toBeGreaterThan(maxY * 0.95);
+  });
+
   it("returns [] when the field is empty", () => {
     const nodes = [makeNode("a", "X", 5)];
     const empty = new Map<string, { x: number; y: number }>();

--- a/src/lib/graph-relief-field.ts
+++ b/src/lib/graph-relief-field.ts
@@ -531,11 +531,16 @@ export function computeNodeAnchors(
 
   const anchors: NodeAnchor[] = [];
   for (const pick of picks) {
+    // CRITICAL: use the same kernel weight the field eval uses
+    // (`nodeWeight = composite^WEIGHT_EXPONENT`). v1 used the raw
+    // composite here, so `h / field.peak` was a wildly different ratio
+    // from the actual mesh-vertex norm — labels rendered at ≤ 20% of
+    // their true peak height and looked like they sat on the floor.
     let h = 0;
     for (const s of sources) {
       const dx = pick.x - s.x;
       const dy = pick.y - s.y;
-      h += s.composite * Math.exp(-(dx * dx + dy * dy) / sigma2);
+      h += nodeWeight(s.composite) * Math.exp(-(dx * dx + dy * dy) / sigma2);
     }
     const norm = Math.max(0, Math.min(1, h / field.peak));
     const shaped = Math.pow(norm, heightGamma);


### PR DESCRIPTION
## Summary

User feedback: *"nodes render on top of it is hard to follow — right now they seem to be sitting at the bottom on a flat map. Could we have a vertical scale showing what each striation is in terms of Ω."*

Two fixes in one PR.

### Label height bug

`computeNodeAnchors` was sampling each node's height with raw `composite`, but the field eval uses `nodeWeight(composite) = composite^1.5`. For composite=10 that's 10 vs 31.6 — the anchor's `h / field.peak` ratio was ~0.3 of the actual mesh norm at that grid point, so `pow(norm, 1.6) * 140` came out at ~20 when the surface peak was at 140. Labels rendered near y=0 — exactly the "sitting at the bottom" complaint. One-line fix: anchor sampling now uses `nodeWeight(s.composite)`.

### Elevation / Ω intensity legend

New `<ElevationLegend>` component renders a vertical heatmap-gradient strip on the right edge of the canvas, ~180px tall, with five label stops (Ω peak / HIGH / MID / LOW / Ω 0). Uses 14 horizontal tick lines that mirror the shader's `uBands=14`, so the strip's tick density visually maps to the iso-rings on the surface. `peakOmega` is pulled from `fieldNodes` (replay-aware) so the top label updates as ΩF changes mid-replay. New `elevationColorJS` helper paints the CSS gradient to match the GLSL ramp the shader uses.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Lint clean on touched files
- [x] vitest 711/711 pass — added regression test "anchor y matches the actual mesh-vertex height at the node position": for an isolated source the anchor should reach ≥ 95% of the global mesh-vertex max-Y (was previously sitting at <30% of it)
- [ ] Visual: hard-refresh production, click TOPO — expect (a) node labels floating at the actual peak heights, not sitting on a flat plane, (b) vertical Ω-intensity legend strip on the right edge with peak Ω value at top

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_