### PR TITLE
polish(canvas+header): remove rendering-internals labels, declutter chrome

### DIFF
--- a/src/components/CDOmegaMonitor.tsx
+++ b/src/components/CDOmegaMonitor.tsx
@@ -209,15 +209,18 @@ export default function CDOmegaMonitor({
             );
           })}
         </div>
+        {/* Buffer bar caption row. The third cell used to repeat the
+            derived status (ELEVATED / CRITICAL / SAFE) which the Status
+            Badge to the right already shows in larger type — duplicate
+            text in tight header space, called out by the user as filler.
+            Dropped; the Ω marker + percentage are the non-redundant
+            pieces and stay. */}
         <div className="flex justify-between">
           <span className="text-[9px] font-mono" style={{ color: "var(--accent-red)" }}>
             &Omega;
           </span>
           <span className="text-[9px] font-mono" style={{ color: "var(--text-muted)" }}>
             {hasNodes ? `${omegaPct.toFixed(1)}%` : `${state.buffer.toFixed(1)}%`}
-          </span>
-          <span className="text-[9px] font-mono hidden sm:block" style={{ color: "var(--accent-green)" }}>
-            {derivedStatus.status === "NOMINAL" ? "SAFE" : derivedStatus.status}
           </span>
         </div>
       </div>

--- a/src/components/dag3d/DAGOverlay.tsx
+++ b/src/components/dag3d/DAGOverlay.tsx
@@ -83,19 +83,12 @@ export default function DAGOverlay() {
         </div>
       </div>
 
-      {/* Top Right: Method badges + controls */}
+      {/* Top Right: View-mode cycle buttons. The previous RENDERING /
+          METHOD info badges (WEBGL_3D / REACTFLOW_2D / DCD / NOTEARS) were
+          internal stack details that didn't help end users — removed so
+          the corner stays clean. View labels still say which view is
+          active via the highlighted button. */}
       <div className="absolute top-3 right-3 flex items-center gap-2 pointer-events-auto">
-        <span className="text-[8px] font-mono px-2 py-0.5 rounded border border-border text-text-muted bg-surface-elevated">
-          RENDERING: {
-            viewMode === "3d" ? "WEBGL_3D"
-            : viewMode === "2d" ? "REACTFLOW_2D"
-            : viewMode === "map" ? "MAPLIBRE_GEO"
-            : "WEBGL_TOPO"
-          }
-        </span>
-        <span className="text-[8px] font-mono px-2 py-0.5 rounded border border-border text-text-muted bg-surface-elevated">
-          METHOD: DCD / NOTEARS
-        </span>
         {/* View mode cycle buttons. Internal id stays "relief" so existing
             store / type machinery keeps working; the user-facing label is
             "TOPO" (more recognisable than "RELIEF" for a topographic map). */}
@@ -309,7 +302,23 @@ export default function DAGOverlay() {
         </div>
       </div>
 
-      {/* Bottom Left (lower): Structural metrics */}
+      {/* Bottom Left: Control hints (above) + structural metrics (below).
+          Previously the hints sat at bottom-3 right-3, which the CLIENT
+          DEPLOYMENT CTA on the same edge clipped over. Moved to the
+          opposite corner and stacked above the metrics so neither
+          overlaps the deploy link.
+          The "NODE SIZE = EIGENVECTOR CENTRALITY | DISTANCE = EDGE WEIGHT"
+          sub-text was removed — too cryptic to help end users, and most
+          of that meaning is conveyed by the visual itself. */}
+      {(viewMode === "3d" || viewMode === "map") && (
+        <div className="absolute bottom-9 left-3 pointer-events-none">
+          <div className="text-[8px] font-mono text-text-muted/50">
+            {viewMode === "3d"
+              ? "DRAG: ORBIT | SCROLL: ZOOM | RIGHT-CLICK: PAN | SHIFT+DRAG: SELECT | DOUBLE-CLICK: FOCUS | ESC: DESELECT"
+              : "DRAG: PAN | SCROLL: ZOOM | CLICK: SELECT | SHIFT+CLICK: MULTI-SELECT | HOVER: INSPECT"}
+          </div>
+        </div>
+      )}
       <div className="absolute bottom-3 left-3">
         <div className="flex gap-4 text-[9px] font-mono text-text-muted">
           <span>NODES: {meta.totalNodes}</span>
@@ -318,27 +327,6 @@ export default function DAGOverlay() {
           <span>CONSTRAINT: {meta.constraintType.split("+")[0].trim()}</span>
         </div>
       </div>
-
-      {/* Bottom Right: Control hints + layout legend */}
-      {viewMode === "3d" && (
-        <div className="absolute bottom-3 right-3 flex flex-col items-end gap-1">
-          <div className="text-[8px] font-mono text-text-muted/40 flex gap-3">
-            <span>NODE SIZE = EIGENVECTOR CENTRALITY</span>
-            <span>|</span>
-            <span>DISTANCE = EDGE WEIGHT (CORRELATION)</span>
-          </div>
-          <div className="text-[8px] font-mono text-text-muted/50">
-            DRAG: ORBIT | SCROLL: ZOOM | RIGHT-CLICK: PAN | SHIFT+DRAG: SELECT | DOUBLE-CLICK: FOCUS | ESC: DESELECT
-          </div>
-        </div>
-      )}
-      {viewMode === "map" && (
-        <div className="absolute bottom-3 right-3">
-          <div className="text-[8px] font-mono text-text-muted/50">
-            DRAG: PAN | SCROLL: ZOOM | CLICK: SELECT | SHIFT+CLICK: MULTI-SELECT | HOVER: INSPECT
-          </div>
-        </div>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Three small UX cleanups on the main canvas + header chrome that you flagged.

| Where | What was wrong | Fix |
|-------|----------------|-----|
| Canvas top-right | `RENDERING: WEBGL_3D` / `REACTFLOW_2D` / `MAPLIBRE_GEO` / `WEBGL_TOPO` and `METHOD: DCD / NOTEARS` info badges exposed internal rendering stack labels — not useful for end users, just noise next to the view-mode buttons. | Removed both badges. The active view is still obvious from the highlighted button. |
| Canvas bottom-right | The "DRAG: ORBIT \| SCROLL: ZOOM \| …" hints sat at `bottom-3 right-3`, same edge as the CLIENT DEPLOYMENT CTA link, which clipped over the right ~250px of the hint string. The "NODE SIZE = EIGENVECTOR CENTRALITY \| DISTANCE = EDGE WEIGHT" sub-text next to it was also cryptic. | Hints moved to `bottom-9 left-3` (above the structural-metrics row) — opposite corner from the deploy link, no overlap. NODE-SIZE legend dropped. |
| Header CDΩ monitor | Buffer-bar caption row showed `Ω` / `66.4%` / `ELEVATED`, with the Status Badge directly to its right *also* showing `ELEVATED` in larger type. Same word twice within ~120px. | Dropped the duplicate status from the caption row. Ω marker + percentage stay. |

No behavior changes — pure visual cleanup.

## Test plan

- [ ] 3D view: top-right shows only the 3D / 2D / MAP / TOPO buttons. No `RENDERING:` or `METHOD:` pills.
- [ ] 3D view: bottom-left shows control hints above the `NODES / EDGES / DENSITY / CONSTRAINT` row. CLIENT DEPLOYMENT link in bottom-right is unobstructed.
- [ ] Switch to MAP view: same hint behavior, with map-specific hint copy.
- [ ] Switch to 2D / TOPO view: no control hint (existing behavior, neither had hints before this PR).
- [ ] Header CDΩ region: buffer bar caption shows `Ω` and `XX.X%` only — no status word in the caption. Status Badge to the right still shows ELEVATED / CRITICAL / SAFE / etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
