### PR TITLE
fix(pareto): include BOCPD in geopolitical profile estimators (follow-up #234)

### DIFF
--- a/src/lib/domain-profiles.ts
+++ b/src/lib/domain-profiles.ts
@@ -157,7 +157,11 @@ export const GEOPOLITICAL_PROFILE: DomainProfile = {
   pillarLabels: GEOPOLITICAL_PILLARS,
   pillarDetails: GEOPOLITICAL_PILLAR_DETAILS,
   compositeMethodology: GEOPOLITICAL_METHODOLOGY,
-  criticalityEstimators: ["csd", "ph", "lppls"],
+  // BOCPD is now live as a fourth criticality estimator (PR #234) — it
+  // runs on the same scoped Ω trajectory CSD/LPPLS already use and produces
+  // a regular F·E·G·S·M breakdown. Including it here makes the analyst
+  // Pareto card show all four tabs by default.
+  criticalityEstimators: ["csd", "ph", "lppls", "bocpd"],
 };
 
 // ─── Medical / T1D beta-cell restoration ────────────────────────────


### PR DESCRIPTION
## Summary

Follow-up fix to PR #234. The runtime for BOCPD-as-criticality landed in #234 (live on `scopedOmegaSeries`, new `bocpdRegimeGate`, full F·E·G·S·M breakdown) but I forgot to add `"bocpd"` to the analyst profile's `criticalityEstimators` array. Result: production still rendered the old three tabs (CSD / PH / LPPLS) instead of four.

This is a one-line array entry: `["csd", "ph", "lppls"]` → `["csd", "ph", "lppls", "bocpd"]` on `GEOPOLITICAL_PROFILE`.

## Why this slipped through #234

The T1D profile already listed `"bocpd"`, so the new live runtime hit the `bocpd` branch under that profile end-to-end and looked correct in dev. The geopolitical profile is what ships on prod for analyst users, and it never picked up the entry.

Lesson: profile lists need a per-PR review when a new estimator goes from gated → ready. Adding a test to the registry that flags any `defaultAvailability: "ready"` estimator missing from at least one production profile would close this gap mechanically; not in scope here but worth queuing.

## Test plan

- [x] No code logic changes — pure config update. Existing 729 tests still pass.
- [x] Build passes locally with placeholder envs.
- [ ] Vercel preview eyeball: confirm Pareto card on geopolitical view shows 4 tabs (CSD, PH, LPPLS, BOCPD), each with the standard 5-row F·E·G·S·M breakdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
