### PR TITLE
feat(3d): readability — labels-on-demand, brighter orbs, size-metric toggle

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -424,14 +424,29 @@ This was the work deferred in PR #198 with the note *"would need a custom edge c
 
 **Verification.** `tsc --noEmit` clean; lint clean on touched files; vitest 723/723 pass.
 
+### 2026-05-03 — Shipped: 3D readability — labels-on-demand, brighter orbs, size-metric toggle
+
+**PR:** TBD (about to open).
+
+**Trigger.** User feedback on the 3D diagram: *"looks busy / hard to track. Rather than every node labeled, only show labels when I select one. The orbs themselves are near invisible — make them easier to identify. Should we link the orb size to a network feature shown on the right? Maybe a toggle?"*
+
+**What shipped.**
+- **Labels on demand only.** `DAGNode3D` previously rendered every node's label permanently (hidden only during active orbit). Now the label only shows when the node is hovered, single-selected, or a neighbour of the selected node. The hover detail card (full ΩF profile + radar + network metrics) still surfaces full info on demand. Removes the "hodgepodge of overlapping text" the user flagged.
+- **Brighter orbs.** Three changes in concert: (a) base radius range 0.20–0.75 → 0.45–1.05 (≈ 2× across the board, lifts the floor so peripheral nodes still read as orbs not dots); (b) idle emissive intensity floor 0.4 → 0.7 (and hover 0.8 → 0.95); (c) outer glow-sphere opacity 0.06 / 0.12 → 0.16 / 0.32; (d) ΩF colour ring opacity 0.15 / 0.35 → 0.32 / 0.55. Orbs now have visible presence at idle, not just when hovered.
+- **`nodeSizeMetric` toggle.** New `NodeSizeMetric = "omega" | "eigenvector" | "betweenness"` type added to `lib/types.ts`. Store carries `nodeSizeMetric` (default `"eigenvector"` — same as before, just now selectable) + `setNodeSizeMetric` action. `DAGOverlay` exposes a small `SIZE: ΩF / EIG / BTW` button trio in the top-right control strip, only visible in 3D view. `DAGNode3D` reads the store value and computes radius from the chosen metric — `omega` maps `composite/10` to the unit interval; the centralities are passed through directly. Hover-card footer reflects the active metric ("size ∝ ΩF composite", etc.).
+
+**Files.**
+- `src/lib/types.ts` — new `NodeSizeMetric` type.
+- `src/stores/useApexStore.ts` — `nodeSizeMetric` slot + setter, default `"eigenvector"`.
+- `src/components/dag3d/DAGOverlay.tsx` — 3D-only `SIZE:` toggle wired to the store.
+- `src/components/dag3d/DAGNode3D.tsx` — radius formula honours the toggle, label conditional gate, glow / emissive intensity bumps, hover-card footer text.
+
+**Verification.** `tsc --noEmit` clean; lint clean on touched files; vitest 729/729 pass. (Three pre-existing lint warnings outside the diff.)
+
 ### 2026-05-03 — Next up
 
-3D diagram cleanup (user clarified after this PR was scoped):
-- Remove permanent labels on every orb; show label only on hover/select. Currently looks like a hodgepodge of overlapping text.
-- Make orbs more visible (current style is "near invisible").
-- Toggle to map orb size to a network metric (eigenvector / betweenness centrality) rather than a fixed size — currently size is constant. The right-panel network analysis already exposes the metrics; surface them visually.
-
-Outside this: deferred 3D `onPointerMove` throttle (PR #199), map-view imperative-setData refactor, real bundle-analyzer perf sweep using PR #222's tooling.
+- Verify 3D readability on production: hard-refresh, switch to 3D — expect (a) no labels at idle, only on hover or selection, (b) orbs visibly larger and brighter, (c) `SIZE: ΩF / EIG / BTW` toggle in the top-right strip switches the orb-radius metric live.
+- Outside this: deferred 3D `onPointerMove` throttle (PR #199), map-view imperative-setData refactor, real bundle-analyzer perf sweep using PR #222's tooling.
 
 ---
 

--- a/src/components/dag3d/DAGNode3D.tsx
+++ b/src/components/dag3d/DAGNode3D.tsx
@@ -87,6 +87,7 @@ function DAGNode3DInner({
 }: DAGNode3DProps) {
   const isOrbiting = useOrbitActive();
   const selectedDomains = useApexStore((s) => s.selectedDomains);
+  const nodeSizeMetric = useApexStore((s) => s.nodeSizeMetric);
   const profile = resolveDomainProfile(selectedDomains);
   const pillarLabels = profile.pillarLabels;
   const meshRef = useRef<THREE.Mesh>(null);
@@ -98,10 +99,22 @@ function DAGNode3DInner({
   const color = isGreyedOut ? "#3a3d50" : isConsequence ? "#ff6d00" : baseColor;
   const composite = epochState ? epochState.omegaComposite : node.omegaFragility.composite;
 
-  // Node size driven by EIGENVECTOR CENTRALITY (network importance)
-  // Higher centrality = larger node (more influential in the network)
+  // Node radius driven by the user-selected metric. v1 was hardwired to
+  // eigenvector centrality at 0.2 → 0.75; users complained the orbs were
+  // "near invisible" at the low end. New range 0.45 → 1.05 (≈ 2× bigger
+  // across the board) keeps small/large differentiation but lifts the
+  // floor enough that even peripheral nodes read as orbs, not dots.
   const ec = metrics?.eigenvectorCentrality ?? 0.5;
-  const size = 0.2 + ec * 0.55; // range 0.2–0.75
+  const bc = metrics?.betweennessCentrality ?? 0.5;
+  // Map composite (0..10) → 0..1 for the omega path.
+  const omegaUnit = Math.max(0, Math.min(1, composite / 10));
+  const sizeUnit =
+    nodeSizeMetric === "omega"
+      ? omegaUnit
+      : nodeSizeMetric === "betweenness"
+        ? Math.max(0, Math.min(1, bc))
+        : Math.max(0, Math.min(1, ec));
+  const size = 0.45 + sizeUnit * 0.6;
 
   const glowColor = isConsequence ? "#ff6d00" : getOmegaGlowColor(composite);
   const shockGlow = epochState ? epochState.shockIntensity : 0;
@@ -178,24 +191,27 @@ function DAGNode3DInner({
         </mesh>
       )}
 
-      {/* Omega glow ring */}
+      {/* Omega glow ring — opacity floor lifted so the ΩF colour signal
+           reads at idle (was 0.15 / 0.35; now 0.32 / 0.55). */}
       <mesh rotation={[Math.PI / 2, 0, 0]}>
         <ringGeometry args={[size * 1.3, size * 1.5, 32]} />
         <meshBasicMaterial
           color={glowColor}
           transparent
-          opacity={(hovered ? 0.35 : 0.15) * (dimmed ? 0.3 : 1)}
+          opacity={(hovered ? 0.55 : 0.32) * (dimmed ? 0.3 : 1)}
           side={THREE.DoubleSide}
         />
       </mesh>
 
-      {/* Glow sphere (outer) */}
+      {/* Glow sphere (outer) — bumped from 0.06/0.12 to 0.16/0.32 so the
+           orb has visible presence at idle, not just on hover. v1 was
+           "near invisible" against the dark background. */}
       <mesh>
         <sphereGeometry args={[size * 1.6, 16, 16]} />
         <meshBasicMaterial
           color={color}
           transparent
-          opacity={(hovered ? 0.12 : 0.06) * (dimmed ? 0.3 : 1)}
+          opacity={(hovered ? 0.32 : 0.16) * (dimmed ? 0.3 : 1)}
         />
       </mesh>
 
@@ -219,7 +235,9 @@ function DAGNode3DInner({
         <meshStandardMaterial
           color={color}
           emissive={isGreyedOut ? "#1a1a2e" : isSelected ? "#00e5ff" : color}
-          emissiveIntensity={isGreyedOut ? 0.02 : isSelected ? 1.0 : hovered ? 0.8 : (0.4 + (composite / 10) * 0.3 + shockGlow * 0.6)}
+          // Idle floor lifted from 0.4 to 0.7 so orbs are clearly emissive
+          // out of the box, not just when hovered.
+          emissiveIntensity={isGreyedOut ? 0.02 : isSelected ? 1.0 : hovered ? 0.95 : (0.7 + (composite / 10) * 0.3 + shockGlow * 0.6)}
           transparent
           opacity={nodeOpacity}
         />
@@ -241,9 +259,11 @@ function DAGNode3DInner({
         </mesh>
       )}
 
-      {/* Label — hidden during active orbit rotation to prevent DOM overhead
-           that causes GPU timeout with 100+ nodes */}
-      {!dimmed && !isOrbiting && (
+      {/* Label — only visible on hover, single-select, or multi-select.
+           v1 painted a label on every orb permanently and dense graphs read
+           as a hodgepodge of overlapping text. The hover detail card below
+           still surfaces full info on demand. */}
+      {!dimmed && !isOrbiting && (hovered || isSelected || isNeighborOfSelected) && (
         <Html
           position={[0, size * 1.6 + 0.6, 0]}
           center
@@ -394,7 +414,12 @@ function DAGNode3DInner({
                   </div>
                 </div>
                 <div style={{ fontSize: "8px", color: "#5a5e72", marginTop: "5px", fontStyle: "italic" }}>
-                  {getCentralityLabel(ec)} — size ∝ eigenvector centrality
+                  {getCentralityLabel(ec)} — size ∝{" "}
+                  {nodeSizeMetric === "omega"
+                    ? "ΩF composite"
+                    : nodeSizeMetric === "betweenness"
+                      ? "betweenness centrality"
+                      : "eigenvector centrality"}
                 </div>
               </div>
             )}

--- a/src/components/dag3d/DAGOverlay.tsx
+++ b/src/components/dag3d/DAGOverlay.tsx
@@ -12,6 +12,8 @@ export default function DAGOverlay() {
   const activeModule = useApexStore((s) => s.activeModule);
   const viewMode = useApexStore((s) => s.viewMode);
   const setViewMode = useApexStore((s) => s.setViewMode);
+  const nodeSizeMetric = useApexStore((s) => s.nodeSizeMetric);
+  const setNodeSizeMetric = useApexStore((s) => s.setNodeSizeMetric);
   const truthFilter = useApexStore((s) => s.truthFilter);
   const selectedNode = useApexStore((s) => s.selectedNode);
   const setSelectedNode = useApexStore((s) => s.setSelectedNode);
@@ -89,6 +91,35 @@ export default function DAGOverlay() {
           the corner stays clean. View labels still say which view is
           active via the highlighted button. */}
       <div className="absolute top-3 right-3 flex items-center gap-2 pointer-events-auto">
+        {/* 3D-only: orb-size metric toggle. ΩF reads as "criticality"; the
+            two centralities reveal structure (eigenvector → influence
+            hubs; betweenness → bridges). Hidden in other views since the
+            orbs only exist in 3D. */}
+        {viewMode === "3d" && (
+          <span className="flex items-center gap-1 px-1.5 py-0.5 rounded border border-border bg-surface-elevated">
+            <span className="text-[8px] font-mono text-text-muted pr-0.5">SIZE:</span>
+            {(
+              [
+                { id: "omega", label: "ΩF" },
+                { id: "eigenvector", label: "EIG" },
+                { id: "betweenness", label: "BTW" },
+              ] as const
+            ).map((opt) => (
+              <button
+                key={opt.id}
+                onClick={() => setNodeSizeMetric(opt.id)}
+                className={`text-[8px] font-mono px-1.5 py-0.5 rounded transition-colors ${
+                  nodeSizeMetric === opt.id
+                    ? "text-accent-cyan bg-accent-cyan/15"
+                    : "text-text-muted hover:text-accent-cyan"
+                }`}
+                title={`Map orb size to ${opt.label}`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </span>
+        )}
         {/* View mode cycle buttons. Internal id stays "relief" so existing
             store / type machinery keeps working; the user-facing label is
             "TOPO" (more recognisable than "RELIEF" for a topographic map). */}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -331,6 +331,13 @@ export interface RiskPropagationCard {
 // ─── View State ──────────────────────────────────────────────────
 export type ViewMode = "2d" | "3d" | "map" | "relief";
 export type TruthFilter = "raw" | "verified";
+/**
+ * Which signal the 3D orbs encode in their radius. `omega` reads as
+ * "criticality" (the most actionable signal for typical users), the two
+ * centrality options reveal network structure (which nodes are influence
+ * hubs vs. bridges).
+ */
+export type NodeSizeMetric = "omega" | "eigenvector" | "betweenness";
 
 // ─── Regime & Doomsday ──────────────────────────────────────────
 export type RegimeType = "STABLE" | "MELT_UP" | "CRASH" | "PHASE_TRANSITION" | "STAGNATION";

--- a/src/stores/useApexStore.ts
+++ b/src/stores/useApexStore.ts
@@ -5,6 +5,7 @@ import {
   CausalEdge,
   ModuleId,
   ViewMode,
+  NodeSizeMetric,
   TruthFilter,
   CopilotMessage,
   CausalGraph,
@@ -109,6 +110,17 @@ interface ApexState {
   // View
   viewMode: ViewMode;
   setViewMode: (mode: ViewMode) => void;
+
+  /**
+   * Drives 3D orb size. The 3D view can map the radius to either the
+   * static ΩF composite or to one of the live network-analysis metrics
+   * (eigenvector / betweenness centrality). Both centrality metrics are
+   * already computed during layout and surfaced in the right-side
+   * Network Analysis panel; this toggle lets the user swap which signal
+   * the orbs encode without leaving the canvas.
+   */
+  nodeSizeMetric: NodeSizeMetric;
+  setNodeSizeMetric: (metric: NodeSizeMetric) => void;
 
   // Truth filter
   truthFilter: TruthFilter;
@@ -366,6 +378,12 @@ export const useApexStore = create<ApexState>((set, get) => ({
   // View
   viewMode: "3d",
   setViewMode: (mode) => set({ viewMode: mode }),
+
+  // Default to eigenvector — that's what the 3D view shipped with before
+  // the toggle. Surfacing the choice as a visible UI control is the
+  // change; the existing read stays the default.
+  nodeSizeMetric: "eigenvector",
+  setNodeSizeMetric: (metric) => set({ nodeSizeMetric: metric }),
 
   // Truth filter
   truthFilter: "raw",


### PR DESCRIPTION
## Summary

User feedback on the 3D diagram: *"looks busy / hard to track. Rather than every node labeled, only show labels when I select one. The orbs themselves are near invisible — make them easier to identify. Should we link the orb size to a network feature shown on the right? Maybe a toggle?"*

Three coordinated changes.

### Labels on demand

`DAGNode3D` previously rendered every node's label permanently (hidden only during active orbit). Now the label only shows when the node is **hovered**, **single-selected**, or a **neighbour of the selected node**. The hover detail card still surfaces full info on demand. Removes the "hodgepodge of overlapping text" the user flagged.

### Brighter orbs

Four bumps in concert:
- Base radius range `0.20–0.75` → **`0.45–1.05`** (≈ 2× across the board, lifts the floor so peripheral nodes still read as orbs not dots).
- Idle emissive intensity floor `0.4` → **`0.7`**.
- Outer glow-sphere opacity `0.06 / 0.12` → **`0.16 / 0.32`**.
- ΩF colour ring opacity `0.15 / 0.35` → **`0.32 / 0.55`**.

Orbs now have visible presence at idle, not just when hovered.

### Size-metric toggle

- New `NodeSizeMetric = "omega" | "eigenvector" | "betweenness"` type in `lib/types.ts`.
- Store carries `nodeSizeMetric` + `setNodeSizeMetric`, default `"eigenvector"` (matches the v1 hardcoded behaviour, just now selectable).
- `DAGOverlay` exposes a small **`SIZE: ΩF / EIG / BTW`** button trio in the top-right control strip, only visible in 3D view.
- `DAGNode3D` reads the store value: `omega` maps `composite/10` to unit interval, centralities pass through. Hover-card footer reflects the active metric ("size ∝ ΩF composite", etc.).

## Test plan

- [x] `tsc --noEmit` clean
- [x] Lint clean on touched files
- [x] vitest 729/729 pass
- [ ] Visual: hard-refresh production, switch to 3D — expect (a) no labels at idle; only on hover or selection, (b) orbs visibly larger and brighter than before, (c) `SIZE: ΩF / EIG / BTW` toggle in the top-right strip switches the orb-radius metric live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_