### PR TITLE
chore(scenarios): drop Saudi/Gulf preset shock library — empty by default

### DIFF
--- a/src/app/api/copilot/route.ts
+++ b/src/app/api/copilot/route.ts
@@ -34,7 +34,7 @@ Available actions:
 - <<<ACTION:set_truth_filter:raw|verified>>> — Toggle Tarski truth filter
 - <<<ACTION:set_domains:domain1,domain2>>> — Filter to specific domains
 
-You can include multiple actions in a single response. Always explain what you're doing alongside the action. Available shock IDs: hormuz_closure, abqaiq_strike, lng_train_failure, fertilizer_export_ban, phosphate_contamination, gas_grid_overload, food_price_shock.`;
+You can include multiple actions in a single response. Always explain what you're doing alongside the action. The preset shock library is empty by default — only emit add_shock when the user has supplied a custom scenario set or the active profile registers preset IDs.`;
 
 // ─── Anthropic streaming ────────────────────────────────────────
 

--- a/src/components/ShockPanel.tsx
+++ b/src/components/ShockPanel.tsx
@@ -74,44 +74,50 @@ export default function ShockPanel({
         <div className="text-[9px] text-text-muted font-mono tracking-wider mb-2">
           SCENARIOS
         </div>
-        {presets.map((shock) => {
-          const isActive = activeShocks.some((s) => s.id === shock.id);
-          return (
-            <button
-              key={shock.id}
-              onClick={() => !isActive && onShockAdd(shock)}
-              disabled={isActive}
-              className="w-full text-left mb-1.5 p-2 rounded border transition-all"
-              style={{
-                borderColor: isActive ? "var(--border-bright)" : "var(--border)",
-                opacity: isActive ? 0.4 : 1,
-                backgroundColor: isActive ? "transparent" : "var(--surface-elevated)",
-              }}
-            >
-              <div className="flex items-center gap-2">
-                <span
-                  className="text-[10px]"
-                  style={{
-                    color: getCategoryColor(shock.category),
-                  }}
-                >
-                  {getCategoryIcon(shock.category)}
-                </span>
-                <span className="text-[10px] font-mono text-foreground truncate">
-                  {shock.name}
-                </span>
-              </div>
-              <div className="text-[9px] text-text-muted mt-0.5 ml-5 truncate">
-                {shock.description}
-              </div>
-              {shock.physicalConstraint && (
-                <div className="text-[9px] text-accent-amber/60 mt-0.5 ml-5 truncate">
-                  &laquo; {shock.physicalConstraint} &raquo;
+        {presets.length === 0 ? (
+          <div className="text-[9px] text-text-muted/80 font-mono leading-relaxed">
+            No preset scenarios loaded. Click any node on the canvas to inject a shock at that vertex, or supply your own scenario set via the API or import path.
+          </div>
+        ) : (
+          presets.map((shock) => {
+            const isActive = activeShocks.some((s) => s.id === shock.id);
+            return (
+              <button
+                key={shock.id}
+                onClick={() => !isActive && onShockAdd(shock)}
+                disabled={isActive}
+                className="w-full text-left mb-1.5 p-2 rounded border transition-all"
+                style={{
+                  borderColor: isActive ? "var(--border-bright)" : "var(--border)",
+                  opacity: isActive ? 0.4 : 1,
+                  backgroundColor: isActive ? "transparent" : "var(--surface-elevated)",
+                }}
+              >
+                <div className="flex items-center gap-2">
+                  <span
+                    className="text-[10px]"
+                    style={{
+                      color: getCategoryColor(shock.category),
+                    }}
+                  >
+                    {getCategoryIcon(shock.category)}
+                  </span>
+                  <span className="text-[10px] font-mono text-foreground truncate">
+                    {shock.name}
+                  </span>
                 </div>
-              )}
-            </button>
-          );
-        })}
+                <div className="text-[9px] text-text-muted mt-0.5 ml-5 truncate">
+                  {shock.description}
+                </div>
+                {shock.physicalConstraint && (
+                  <div className="text-[9px] text-accent-amber/60 mt-0.5 ml-5 truncate">
+                    &laquo; {shock.physicalConstraint} &raquo;
+                  </div>
+                )}
+              </button>
+            );
+          })
+        )}
       </div>
     </div>
   );

--- a/src/lib/__tests__/omega-engine.test.ts
+++ b/src/lib/__tests__/omega-engine.test.ts
@@ -304,11 +304,11 @@ describe("computeCascadeAnalysis", () => {
 // ─── getPresetShocks ────────────────────────────────────────────
 
 describe("getPresetShocks", () => {
-  it("returns 7 preset shocks", () => {
-    expect(getPresetShocks()).toHaveLength(7);
+  it("returns an empty array by default (preset library cleared)", () => {
+    expect(getPresetShocks()).toEqual([]);
   });
 
-  it("all shocks have severity in (0, 1]", () => {
+  it("never returns a preset with invalid severity (contract holds for any future entries)", () => {
     for (const s of getPresetShocks()) {
       expect(s.severity).toBeGreaterThan(0);
       expect(s.severity).toBeLessThanOrEqual(1);

--- a/src/lib/omega-engine.ts
+++ b/src/lib/omega-engine.ts
@@ -8,64 +8,21 @@ import {
   CausalGraph,
 } from "./types";
 
-const PRESET_SHOCKS: CausalShock[] = [
-  {
-    id: "hormuz_closure",
-    name: "STRAIT OF HORMUZ CLOSURE",
-    severity: 0.50,
-    category: "geopolitical",
-    description: "Naval blockade shuts Strait of Hormuz — 21M bpd crude + 25% global LNG transit halted",
-    physicalConstraint: "Only bypass: East-West Pipeline (5M bpd max vs 21M bpd transit volume)",
-  },
-  {
-    id: "abqaiq_strike",
-    name: "ABQAIQ PROCESSING ATTACK",
-    severity: 0.45,
-    category: "energy",
-    description: "Drone/missile strike disables Abqaiq — 5.7M bpd processing capacity offline",
-    physicalConstraint: "Single-site concentration: 50% of Saudi processing capacity",
-  },
-  {
-    id: "lng_train_failure",
-    name: "RAS LAFFAN LNG TRAIN OUTAGE",
-    severity: 0.35,
-    category: "energy",
-    description: "Unplanned shutdown of 2 LNG mega-trains at Ras Laffan — 16 Mtpa capacity loss",
-    physicalConstraint: "Cryogenic heat exchanger replacement: 12-18 month lead time",
-  },
-  {
-    id: "fertilizer_export_ban",
-    name: "UREA EXPORT RESTRICTION",
-    severity: 0.30,
-    category: "supply",
-    description: "Emergency export controls on urea/ammonia — QAFCO output diverted to domestic",
-    physicalConstraint: "Food security override: Qatar domestic demand priority clause",
-  },
-  {
-    id: "phosphate_contamination",
-    name: "PHOSPHATE ORE CONTAMINATION",
-    severity: 0.25,
-    category: "supply",
-    description: "Cadmium contamination in Al Jalamid ore body — Ma'aden P3 output suspended",
-    physicalConstraint: "EU cadmium limit: 60mg/kg P2O5 — contaminated ore exceeds threshold",
-  },
-  {
-    id: "gas_grid_overload",
-    name: "MASTER GAS SYSTEM OVERLOAD",
-    severity: 0.40,
-    category: "energy",
-    description: "Summer peak demand exceeds MGS pipeline capacity — industrial curtailment",
-    physicalConstraint: "Pipeline hydraulic limit: 9.6 Bcf/d throughput ceiling",
-  },
-  {
-    id: "food_price_shock",
-    name: "GLOBAL FOOD PRICE SPIKE",
-    severity: 0.35,
-    category: "geopolitical",
-    description: "DAP/urea price surge >200% — importing nations face procurement crisis",
-    physicalConstraint: "Haber-Bosch economics: natural gas = 70-90% of ammonia production cost",
-  },
-];
+// Preset shock library — intentionally empty.
+//
+// The previous list was a domain-specific Saudi/Gulf scenario set
+// (Strait of Hormuz, Abqaiq, Ras Laffan, QAFCO, Ma'aden, MGS, food
+// price spike) that read as clutter to most users and tied the demo
+// to one geopolitical narrative. The platform's value is the engines
+// (causal discovery, criticality, interdiction), not a curated catalog
+// of scenarios — when a customer wants scenario presets they should
+// supply their own through the API, the import path, or a profile-
+// scoped catalog we add per-engagement.
+//
+// Active shocks injected by the user via direct node selection still
+// flow through the same `addShock` / cascade pipeline; only the
+// pre-baked SCENARIOS strip in the right rail is now empty by default.
+const PRESET_SHOCKS: CausalShock[] = [];
 
 export function getPresetShocks(): CausalShock[] {
   return PRESET_SHOCKS;

--- a/src/lib/tour-steps.ts
+++ b/src/lib/tour-steps.ts
@@ -314,7 +314,7 @@ const DEEP_DIVE_STEPS: TourStep[] = [
     copy: {
       title: "SHOCK / STRESSOR INJECTION",
       description:
-        "Under the criticality cards, the Scenario Injector loads preset shocks calibrated for your active domain. Geopolitical examples: Strait of Hormuz closure, Abqaiq attack, LNG train outage, sovereign default. Life Sciences examples: insulin supply disruption, β-cell antigen exposure spike, HLA-mismatch graft rejection. Each shock depletes the buffer according to severity and propagates through the cascade.",
+        "Under the criticality cards, the Scenario Injector lets you depress the buffer by injecting shocks at any node. Click a vertex on the canvas to inject at that point — the shock depletes the buffer according to severity and propagates through the cascade. The preset library is empty by default; supply your own scenario set via the API, the import path, or a profile-scoped catalog when you need recurring stressors.",
     },
     onEnter: () => useApexStore.getState().setActiveModule("pareto"),
   },


### PR DESCRIPTION
## Summary

Drops the 7 baked-in Saudi/Gulf scenarios from the Scenario Injector right rail. User feedback: domain-specific clutter, ties the demo to one geopolitical narrative, reads as noise to clients without that focus area.

## What goes away

| Old preset | Reason |
|---|---|
| Strait of Hormuz closure | Saudi/Gulf-specific |
| Abqaiq processing attack | Saudi/Gulf-specific |
| Ras Laffan LNG train outage | Qatar-specific |
| Urea export restriction (QAFCO) | Qatar-specific |
| Phosphate ore contamination (Ma'aden) | Saudi-specific |
| Master Gas System overload | Saudi-specific |
| Global food price spike | Tied to Haber-Bosch / Qatar gas economics |

These were specific *examples* of the cascade engine's capability, not core platform machinery. The underlying `CausalShock` type, `addShock` store action, and cascade simulator are unchanged — customers / APIs / future profile-scoped catalogs that push shocks programmatically continue to work.

## What stays

- Click-to-inject on any canvas vertex.
- Active shocks list + remove buttons in the right rail.
- The cascade simulator and the Pareto module's downstream relevance scoring.
- Type / store action surface (`CausalShock`, `addShock`, etc.).

## Files

| File | Change |
|------|--------|
| `src/lib/omega-engine.ts` | `PRESET_SHOCKS = []`. Comment block explains why and how customers can layer their own catalog back in. |
| `src/components/ShockPanel.tsx` | Empty-state copy when `presets.length === 0` — points users at click-to-inject and at supplying their own scenario set via API / import / profile catalog. |
| `src/lib/__tests__/omega-engine.test.ts` | Length-7 assertion → empty array. Severity contract test kept for any future entries. |
| `src/app/api/copilot/route.ts` | Strips hardcoded shock-ID list from the copilot system prompt; replaces with a line saying the preset library is empty by default and only emit `add_shock` when the user has supplied a scenario set. |
| `src/lib/tour-steps.ts` | Tour copy under "SHOCK / STRESSOR INJECTION" drops the Hormuz / Abqaiq / LNG / antigen-exposure examples; describes the panel by behavior instead of a fixed catalog. |

## Backwards compat

- `CausalShock` type unchanged.
- `addShock` / `removeShock` / cascade pipeline unchanged.
- Programmatic shock injection (e.g. via the copilot's `add_shock` action) still resolves IDs through `getPresetShocks`; with the array empty it returns "Unknown shock" until presets are populated through whatever future channel we wire (per-engagement profile-scoped catalog being the most likely shape).

## Test plan

- [x] Full vitest suite: 729 / 729
- [x] `npm run build` passes locally
- [ ] PR-validate workflow green
- [ ] Vercel preview eyeball: confirm the right-rail SCENARIOS strip shows the empty-state copy on the analyst view, no stale Hormuz/Abqaiq buttons, click-to-inject still works on canvas vertices

🤖 Generated with [Claude Code](https://claude.com/claude-code)
