### PR TITLE
feat(copilot): tool registry + isolate_nodes

### DIFF
--- a/src/lib/__tests__/copilot-tool-registry.test.ts
+++ b/src/lib/__tests__/copilot-tool-registry.test.ts
@@ -1,0 +1,373 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  defineTool,
+  parseActionTags,
+  parseKvPayload,
+  coerceAndValidate,
+  executeTag,
+  executeActions,
+  renderToolsForPrompt,
+  renderToolsAsJsonSchema,
+  __resetRegistryForTests,
+  type ToolContext,
+  type ParamShape,
+} from "@/lib/copilot/tool-registry";
+import type { ApexState } from "@/stores/useApexStore";
+import type { CausalGraph, CausalNode } from "@/lib/types";
+import { makeNode, makeEdge, makeGraph } from "./fixtures/graph-fixtures";
+
+// ─── Mock context ───────────────────────────────────────────────
+
+interface StoreSpy {
+  setSelectedNode: { calls: (string | null)[] };
+  setSelectedNodes: { calls: string[][] };
+  setIsolateSelection: { calls: boolean[] };
+  graph: CausalGraph;
+  selectedNodes: string[];
+  isolateSelection: boolean;
+}
+
+function makeMockContext(graph: CausalGraph): { ctx: ToolContext; spy: StoreSpy } {
+  const spy: StoreSpy = {
+    setSelectedNode: { calls: [] },
+    setSelectedNodes: { calls: [] },
+    setIsolateSelection: { calls: [] },
+    graph,
+    selectedNodes: [],
+    isolateSelection: false,
+  };
+
+  const fakeStore = {
+    graphData: graph,
+    selectedNodes: spy.selectedNodes,
+    isolateSelection: spy.isolateSelection,
+    setSelectedNode: (id: string | null) => spy.setSelectedNode.calls.push(id),
+    setSelectedNodes: (ids: string[]) => {
+      spy.setSelectedNodes.calls.push(ids);
+      spy.selectedNodes = ids;
+    },
+    setIsolateSelection: (on: boolean) => {
+      spy.setIsolateSelection.calls.push(on);
+      spy.isolateSelection = on;
+    },
+  } as unknown as ApexState;
+
+  return { ctx: { getStore: () => fakeStore }, spy };
+}
+
+// ─── Parser tests ───────────────────────────────────────────────
+
+describe("parseActionTags", () => {
+  it("extracts a single bare action tag", () => {
+    const tags = parseActionTags("Hello <<<ACTION:select_node:USA_GRID>>> world.");
+    expect(tags).toHaveLength(1);
+    expect(tags[0]).toMatchObject({ name: "select_node", payload: "USA_GRID" });
+  });
+
+  it("extracts multiple tags from one response", () => {
+    const tags = parseActionTags("<<<ACTION:add_shock:TAIWAN>>> then <<<ACTION:set_module:pearl>>>");
+    expect(tags).toHaveLength(2);
+    expect(tags.map((t) => t.name)).toEqual(["add_shock", "set_module"]);
+  });
+
+  it("handles a payload-less tag (nullary action)", () => {
+    const tags = parseActionTags("<<<ACTION:reset_severed>>>");
+    expect(tags).toHaveLength(1);
+    expect(tags[0]).toMatchObject({ name: "reset_severed", payload: "" });
+  });
+});
+
+describe("parseKvPayload", () => {
+  it("parses a single k=v pair", () => {
+    expect(parseKvPayload("budget=3")).toEqual({ budget: "3" });
+  });
+
+  it("parses multiple k=v pairs separated by commas", () => {
+    expect(parseKvPayload("budget=3,mode=edge")).toEqual({ budget: "3", mode: "edge" });
+  });
+
+  it("preserves a bare payload as _legacy for back-compat", () => {
+    expect(parseKvPayload("USA_GRID")).toEqual({ _legacy: "USA_GRID" });
+  });
+
+  it("returns empty for an empty payload", () => {
+    expect(parseKvPayload("")).toEqual({});
+    expect(parseKvPayload("   ")).toEqual({});
+  });
+
+  it("trims whitespace inside k=v", () => {
+    expect(parseKvPayload(" budget = 3 , mode = edge ")).toEqual({ budget: "3", mode: "edge" });
+  });
+});
+
+// ─── Coercion tests ─────────────────────────────────────────────
+
+describe("coerceAndValidate", () => {
+  it("validates a required string", () => {
+    const shape = { node: { type: "string", required: true } } as const satisfies ParamShape;
+    expect(coerceAndValidate(shape, { node: "USA_GRID" }, undefined).ok).toBe(true);
+    const missing = coerceAndValidate(shape, {}, undefined);
+    expect(missing.ok).toBe(false);
+    if (!missing.ok) expect(missing.error).toMatch(/Missing required/);
+  });
+
+  it("routes the legacy payload onto the designated legacyParam", () => {
+    const shape = { node: { type: "string", required: true } } as const satisfies ParamShape;
+    const result = coerceAndValidate(shape, { _legacy: "USA_GRID" }, "node");
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.params.node).toBe("USA_GRID");
+  });
+
+  it("splits string[] on `|` (not `,`)", () => {
+    const shape = { ids: { type: "string[]" } } as const satisfies ParamShape;
+    const result = coerceAndValidate(shape, { ids: "A|B|C" }, undefined);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.params.ids).toEqual(["A", "B", "C"]);
+  });
+
+  it("clamps numbers to declared min/max", () => {
+    const shape = {
+      budget: { type: "number", min: 1, max: 10, required: true },
+    } as const satisfies ParamShape;
+    const tooHigh = coerceAndValidate(shape, { budget: "999" }, undefined);
+    expect(tooHigh.ok).toBe(true);
+    if (tooHigh.ok) expect(tooHigh.params.budget).toBe(10);
+    const tooLow = coerceAndValidate(shape, { budget: "0" }, undefined);
+    expect(tooLow.ok).toBe(true);
+    if (tooLow.ok) expect(tooLow.params.budget).toBe(1);
+  });
+
+  it("applies a default when the param is missing", () => {
+    const shape = {
+      budget: { type: "number", default: 3 },
+      mode: { type: "enum", values: ["edge", "node"] as const, default: "edge" },
+    } as const satisfies ParamShape;
+    const result = coerceAndValidate(shape, {}, undefined);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.params.budget).toBe(3);
+      expect(result.params.mode).toBe("edge");
+    }
+  });
+
+  it("rejects enum values outside the declared set", () => {
+    const shape = {
+      mode: { type: "enum", values: ["edge", "node"] as const, required: true },
+    } as const satisfies ParamShape;
+    const bad = coerceAndValidate(shape, { mode: "purple" }, undefined);
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) expect(bad.error).toMatch(/not in/);
+  });
+});
+
+// ─── Registry + execution ───────────────────────────────────────
+
+describe("registry — defineTool / executeTag", () => {
+  beforeEach(() => {
+    __resetRegistryForTests();
+  });
+
+  it("returns 'Unknown action' for an unregistered name", () => {
+    const result = executeTag(
+      { name: "nope", payload: "", raw: "" },
+      { getStore: () => ({}) as ApexState },
+    );
+    expect(result).toMatch(/Unknown action: nope/);
+  });
+
+  it("rejects invalid params with a clear error before invoking the handler", () => {
+    let called = false;
+    defineTool({
+      name: "select_node",
+      description: "test",
+      params: { node: { type: "string", required: true } },
+      legacyParam: "node",
+      handler: () => {
+        called = true;
+        return "ok";
+      },
+    });
+    const result = executeTag(
+      { name: "select_node", payload: "", raw: "" },
+      { getStore: () => ({}) as ApexState },
+    );
+    expect(result).toMatch(/Missing required/);
+    expect(called).toBe(false);
+  });
+
+  it("dispatches to the handler with typed params on a happy path", () => {
+    let received: { node?: string } | null = null;
+    defineTool({
+      name: "select_node",
+      description: "test",
+      params: { node: { type: "string", required: true } },
+      legacyParam: "node",
+      handler: (params) => {
+        received = params;
+        return "selected";
+      },
+    });
+    const result = executeTag(
+      { name: "select_node", payload: "USA_GRID", raw: "" },
+      { getStore: () => ({}) as ApexState },
+    );
+    expect(result).toBe("selected");
+    expect(received).toEqual({ node: "USA_GRID" });
+  });
+
+  it("catches handler exceptions and returns a readable error", () => {
+    defineTool({
+      name: "boom",
+      description: "test",
+      params: {},
+      handler: () => {
+        throw new Error("kaboom");
+      },
+    });
+    const result = executeTag(
+      { name: "boom", payload: "", raw: "" },
+      { getStore: () => ({}) as ApexState },
+    );
+    expect(result).toMatch(/boom failed: kaboom/);
+  });
+});
+
+// ─── End-to-end on built-in tools ───────────────────────────────
+
+describe("built-in tools — wired via the registry", () => {
+  // We import the tool definitions for their side effect (registration).
+  // beforeEach below does NOT reset because we want the real registrations.
+
+  it("isolate_nodes filters by free-text query", async () => {
+    await import("@/lib/copilot/tools");
+    const graph = buildSampleGraph();
+    const { ctx, spy } = makeMockContext(graph);
+
+    const result = executeTag(
+      { name: "isolate_nodes", payload: "query=energy", raw: "" },
+      ctx,
+    );
+    expect(result).toMatch(/Isolated 2 nodes/);
+    expect(spy.setIsolateSelection.calls).toEqual([true]);
+    expect(spy.setSelectedNodes.calls[0]?.sort()).toEqual(["GRID_USA", "OIL_TX"]);
+  });
+
+  it("isolate_nodes filters by explicit ids using `|` separator", async () => {
+    await import("@/lib/copilot/tools");
+    const graph = buildSampleGraph();
+    const { ctx, spy } = makeMockContext(graph);
+
+    const result = executeTag(
+      { name: "isolate_nodes", payload: "ids=GRID_USA|FAB_TW", raw: "" },
+      ctx,
+    );
+    expect(result).toMatch(/Isolated 2 nodes/);
+    expect(spy.setSelectedNodes.calls[0]?.sort()).toEqual(["FAB_TW", "GRID_USA"]);
+    expect(spy.setIsolateSelection.calls).toEqual([true]);
+  });
+
+  it("isolate_nodes with no matches reports the failure and does NOT toggle isolation", async () => {
+    await import("@/lib/copilot/tools");
+    const graph = buildSampleGraph();
+    const { ctx, spy } = makeMockContext(graph);
+
+    const result = executeTag(
+      { name: "isolate_nodes", payload: "query=nonexistent_topic", raw: "" },
+      ctx,
+    );
+    expect(result).toMatch(/No nodes matched/);
+    expect(spy.setIsolateSelection.calls).toEqual([]);
+    expect(spy.setSelectedNodes.calls).toEqual([]);
+  });
+
+  it("isolate_nodes errors when neither query nor ids is provided", async () => {
+    await import("@/lib/copilot/tools");
+    const graph = buildSampleGraph();
+    const { ctx, spy } = makeMockContext(graph);
+
+    const result = executeTag({ name: "isolate_nodes", payload: "", raw: "" }, ctx);
+    expect(result).toMatch(/provide either query=/);
+    expect(spy.setIsolateSelection.calls).toEqual([]);
+  });
+
+  it("reset_isolation clears both selection and isolation flag", async () => {
+    await import("@/lib/copilot/tools");
+    const graph = buildSampleGraph();
+    const { ctx, spy } = makeMockContext(graph);
+
+    executeTag({ name: "reset_isolation", payload: "", raw: "" }, ctx);
+    expect(spy.setIsolateSelection.calls).toEqual([false]);
+    expect(spy.setSelectedNodes.calls).toEqual([[]]);
+  });
+
+  it("select_node still works with the legacy single-string payload", async () => {
+    await import("@/lib/copilot/tools");
+    const graph = buildSampleGraph();
+    const { ctx, spy } = makeMockContext(graph);
+
+    const result = executeTag({ name: "select_node", payload: "GRID_USA", raw: "" }, ctx);
+    expect(result).toMatch(/Selected node/);
+    expect(spy.setSelectedNode.calls).toEqual(["GRID_USA"]);
+  });
+
+  it("executeActions strips tags from displayText and runs each handler", async () => {
+    await import("@/lib/copilot/tools");
+    const graph = buildSampleGraph();
+    const { ctx } = makeMockContext(graph);
+
+    const text = "Focus on the energy stuff. <<<ACTION:isolate_nodes:query=energy>>>";
+    const { displayText, toolResults } = executeActions(text, ctx);
+    expect(displayText).toBe("Focus on the energy stuff.");
+    expect(toolResults).toHaveLength(1);
+    expect(toolResults[0]).toMatch(/Isolated 2 nodes/);
+  });
+});
+
+// ─── System-prompt rendering ────────────────────────────────────
+
+describe("renderToolsForPrompt", () => {
+  it("includes every registered tool with its description", async () => {
+    await import("@/lib/copilot/tools");
+    const rendered = renderToolsForPrompt();
+    expect(rendered).toContain("=== COPILOT ACTIONS ===");
+    expect(rendered).toContain("isolate_nodes");
+    expect(rendered).toContain("reset_isolation");
+    expect(rendered).toContain("select_node");
+    expect(rendered).toContain("solve_interdiction");
+  });
+
+  it("documents the kv + `|` wire format for the LLM", async () => {
+    await import("@/lib/copilot/tools");
+    const rendered = renderToolsForPrompt();
+    expect(rendered).toContain("key=value");
+    expect(rendered).toContain("|");
+  });
+});
+
+describe("renderToolsAsJsonSchema (proves MCP/Anthropic-compat)", () => {
+  it("emits a JSON-Schema input_schema for each tool", async () => {
+    await import("@/lib/copilot/tools");
+    const schemas = renderToolsAsJsonSchema();
+    const isolate = schemas.find((s) => s.name === "isolate_nodes");
+    expect(isolate).toBeDefined();
+    expect(isolate!.input_schema.type).toBe("object");
+    expect(isolate!.input_schema.properties).toHaveProperty("query");
+    expect(isolate!.input_schema.properties).toHaveProperty("ids");
+  });
+});
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+function buildSampleGraph(): CausalGraph {
+  const nodes: CausalNode[] = [
+    makeNode({ id: "GRID_USA", label: "USA Power Grid", category: "energy", domain: "Energy" }),
+    makeNode({ id: "OIL_TX", label: "TX Oil Pipeline", category: "energy", domain: "Energy" }),
+    makeNode({ id: "FAB_TW", label: "TSMC Fab", category: "manufacturing", domain: "Semiconductors" }),
+    makeNode({ id: "BANK_NY", label: "NY Clearing Bank", category: "finance", domain: "Finance" }),
+  ];
+  const edges = [
+    makeEdge({ id: "e1", source: "GRID_USA", target: "FAB_TW" }),
+    makeEdge({ id: "e2", source: "OIL_TX", target: "FAB_TW" }),
+  ];
+  return makeGraph(nodes, edges);
+}

--- a/src/lib/copilot-actions.ts
+++ b/src/lib/copilot-actions.ts
@@ -1,13 +1,23 @@
-// ─── Copilot Action Router ──────────────────────────────────────
-// Parses <<<ACTION:type:param>>> blocks from LLM responses and
-// executes them against the Apex store.
+// ─── Copilot Action Router (compat shim) ────────────────────────
+//
+// The action runner moved to src/lib/copilot/tool-registry.ts.
+// This file is kept so existing callers (`processLlmActions`,
+// `parseActions`, `stripActions`, `executeAction`) keep working
+// while we migrate them to the registry directly.
+//
+// Importing this module also pulls in the tool definitions side
+// effect — registering every built-in tool with the registry.
 
-import { useApexStore } from "@/stores/useApexStore";
-import { getPresetShocks } from "./omega-engine";
-import { DOMAIN_CARDS } from "@/lib/domains";
-import { buildGraphFromDomains } from "@/lib/build-domain-graph";
-import { solveInterdiction } from "./interdiction-engine";
-import type { InterdictionCandidate } from "./interdiction-engine";
+import {
+  parseActionTags,
+  stripActionTags,
+  executeTag,
+  executeActions,
+  type ParsedActionTag,
+} from "./copilot/tool-registry";
+
+// Side-effect import: registers all built-in tools with the registry.
+import "./copilot/tools";
 
 export interface ParsedAction {
   type: string;
@@ -15,322 +25,32 @@ export interface ParsedAction {
   raw: string;
 }
 
-// ─── Parse actions from LLM response text ───────────────────────
-
-const ACTION_REGEX = /<<<ACTION:(\w+):?(.*?)>>>/g;
-
+/** Parse <<<ACTION:...>>> tags into the legacy {type, param, raw} shape. */
 export function parseActions(text: string): ParsedAction[] {
-  const actions: ParsedAction[] = [];
-  let match;
-  while ((match = ACTION_REGEX.exec(text)) !== null) {
-    actions.push({
-      type: match[1],
-      param: match[2] ?? "",
-      raw: match[0],
-    });
-  }
-  return actions;
+  return parseActionTags(text).map((t) => ({ type: t.name, param: t.payload, raw: t.raw }));
 }
 
-// ─── Strip action blocks from display text ──────────────────────
+/** Strip action tags from text for display. */
+export const stripActions = stripActionTags;
 
-export function stripActions(text: string): string {
-  return text.replace(ACTION_REGEX, "").replace(/\n{3,}/g, "\n\n").trim();
-}
-
-// ─── Execute a parsed action against the store ──────────────────
-
+/**
+ * Execute a single parsed action. Returns a human-readable result
+ * string, or null if the action produced no output (kept for
+ * backward compatibility — the registry always returns a string).
+ */
 export function executeAction(action: ParsedAction): string | null {
-  const store = useApexStore.getState();
-  const presetShocks = getPresetShocks();
-
-  switch (action.type) {
-    case "select_node": {
-      const node = store.graphData.nodes.find(
-        (n) => n.id === action.param || n.shortLabel.toLowerCase() === action.param.toLowerCase()
-          || n.label.toLowerCase() === action.param.toLowerCase()
-      );
-      if (node) {
-        store.setSelectedNode(node.id);
-        return `Selected node: ${node.label}`;
-      }
-      return `Node not found: ${action.param}`;
-    }
-
-    case "add_shock": {
-      const shock = presetShocks.find((s) => s.id === action.param);
-      if (shock) {
-        // Check if already active
-        if (!store.shocks.find((s) => s.id === shock.id)) {
-          store.addShock(shock);
-          return `Injected shock: ${shock.name}`;
-        }
-        return `Shock already active: ${shock.name}`;
-      }
-      return `Unknown shock: ${action.param}`;
-    }
-
-    case "remove_shock": {
-      const existing = store.shocks.find((s) => s.id === action.param);
-      if (existing) {
-        store.removeShock(action.param);
-        return `Removed shock: ${existing.name}`;
-      }
-      return `Shock not active: ${action.param}`;
-    }
-
-    case "set_module": {
-      const valid = ["spirtes", "tarski", "pearl", "pareto"];
-      if (valid.includes(action.param)) {
-        store.setActiveModule(action.param as "spirtes" | "tarski" | "pearl" | "pareto");
-        return `Switched to ${action.param.toUpperCase()} module`;
-      }
-      return `Invalid module: ${action.param}`;
-    }
-
-    case "set_view": {
-      if (action.param === "2d" || action.param === "3d") {
-        store.setViewMode(action.param);
-        return `Switched to ${action.param.toUpperCase()} view`;
-      }
-      return `Invalid view mode: ${action.param}`;
-    }
-
-    case "sever_edge": {
-      const edge = store.graphData.edges.find((e) => e.id === action.param);
-      if (edge) {
-        store.severEdge(edge.id);
-        return `Severed edge: ${edge.source} → ${edge.target}`;
-      }
-      return `Edge not found: ${action.param}`;
-    }
-
-    case "reset_severed": {
-      store.resetSeveredEdges();
-      return "Reset all severed edges";
-    }
-
-    case "start_replay": {
-      store.startReplay();
-      return "Started cascade replay";
-    }
-
-    case "stop_replay": {
-      store.stopReplay();
-      return "Stopped cascade replay";
-    }
-
-    case "set_truth_filter": {
-      if (action.param === "raw" || action.param === "verified") {
-        store.setTruthFilter(action.param);
-        return `Truth filter set to: ${action.param.toUpperCase()}`;
-      }
-      return `Invalid filter: ${action.param}`;
-    }
-
-    case "set_domains": {
-      const domainIds = action.param.split(",").map((d) => d.trim()).filter(Boolean);
-      // Validate domain IDs against known domains
-      const validIds = domainIds.filter((id) => DOMAIN_CARDS.find((d) => d.id === id && d.hasData));
-      if (validIds.length > 0) {
-        // Rebuild graph from the selected domains
-        const graph = buildGraphFromDomains(validIds);
-        store.setGraphData(graph);
-        store.setSelectedDomains(validIds);
-        store.setIsMultiDomainMode(validIds.length > 1);
-        const labels = validIds.map((id) => DOMAIN_CARDS.find((d) => d.id === id)?.label ?? id);
-        return `Filtered network to: ${labels.join(", ")} (${graph.metadata.totalNodes} nodes, ${graph.metadata.totalEdges} edges)`;
-      }
-      return `No valid domains found. Available: ${DOMAIN_CARDS.filter((d) => d.hasData).map((d) => d.id).join(", ")}`;
-    }
-
-    case "select_domains": {
-      // Alias for set_domains — LLM may use either
-      const domainIds = action.param.split(",").map((d) => d.trim()).filter(Boolean);
-      const validIds = domainIds.filter((id) => DOMAIN_CARDS.find((d) => d.id === id && d.hasData));
-      if (validIds.length > 0) {
-        const graph = buildGraphFromDomains(validIds);
-        store.setGraphData(graph);
-        store.setSelectedDomains(validIds);
-        store.setIsMultiDomainMode(validIds.length > 1);
-        const labels = validIds.map((id) => DOMAIN_CARDS.find((d) => d.id === id)?.label ?? id);
-        return `Filtered network to: ${labels.join(", ")} (${graph.metadata.totalNodes} nodes, ${graph.metadata.totalEdges} edges)`;
-      }
-      return `No valid domains found. Available: ${DOMAIN_CARDS.filter((d) => d.hasData).map((d) => d.id).join(", ")}`;
-    }
-
-    case "solve_interdiction": {
-      // Parse params: budget=3,mode=edge
-      const params = Object.fromEntries(
-        action.param.split(",").map((p) => {
-          const [k, v] = p.split("=");
-          return [k?.trim(), v?.trim()];
-        })
-      );
-      const budget = Math.min(10, Math.max(1, parseInt(params.budget ?? "3", 10) || 3));
-      const mode = (["edge", "node", "both"].includes(params.mode ?? "") ? params.mode : "edge") as "edge" | "node" | "both";
-
-      const result = solveInterdiction(
-        store.graphData,
-        store.shocks,
-        store.severedEdges,
-        budget,
-        mode,
-      );
-
-      // Format results as readable text for the copilot to reference
-      const lines = [
-        `Interdiction solved (budget=${budget}, mode=${mode}):`,
-        `  Baseline damage: ${result.baselineDamage.toFixed(1)}/100`,
-        `  Optimal damage: ${result.bestDamage.toFixed(1)}/100`,
-        `  Reduction: ${result.reductionPct.toFixed(1)}%`,
-      ];
-
-      if (result.interventions.length > 0) {
-        lines.push(`  Recommended cuts:`);
-        result.interventions.forEach((iv, i) => {
-          lines.push(`    ${i + 1}. [${iv.target.type}] ${iv.target.label} (${iv.target.id}) — saves ${iv.marginalReduction.toFixed(1)}pts`);
-        });
-        lines.push(`  → Switched to PEARL module. Review cuts in the intervention panel.`);
-        store.setLastInterdictionResult(result);
-      } else {
-        // Solver returned no cuts (cascade damage too low to discriminate
-        // targets). Fall back to structural vulnerability: highest-weight
-        // edges and/or highest-Ω nodes. Pack those into the result so the
-        // Pearl panel renders them as actionable SEVER/ABLATE buttons, not
-        // just text in the chat transcript.
-        const fallbackCandidates: InterdictionCandidate[] = [];
-
-        if (mode !== "node") {
-          const criticalEdges = store.graphData.edges
-            .filter((e) => e.weight >= 0.7 && !e.isSevered)
-            .sort((a, b) => b.weight - a.weight)
-            .slice(0, budget);
-          for (const e of criticalEdges) {
-            const src = store.graphData.nodes.find((n) => n.id === e.source);
-            const tgt = store.graphData.nodes.find((n) => n.id === e.target);
-            fallbackCandidates.push({
-              target: {
-                type: "edge",
-                id: e.id,
-                label: `${src?.shortLabel ?? e.source} → ${tgt?.shortLabel ?? e.target}`,
-              },
-              damage: result.baselineDamage,
-              // Use edge weight as a proxy for structural importance so the
-              // panel can rank cuts even when the cascade delta is ~0.
-              marginalReduction: e.weight * 10,
-            });
-          }
-        }
-
-        if (mode !== "edge") {
-          const highOmegaNodes = [...store.graphData.nodes]
-            .sort((a, b) => b.omegaFragility.composite - a.omegaFragility.composite)
-            .slice(0, budget);
-          for (const n of highOmegaNodes) {
-            fallbackCandidates.push({
-              target: {
-                type: "node",
-                id: n.id,
-                label: n.shortLabel,
-              },
-              damage: result.baselineDamage,
-              marginalReduction: n.omegaFragility.composite,
-            });
-          }
-        }
-
-        // Keep the top `budget` overall, ranked by our proxy score.
-        fallbackCandidates.sort((a, b) => b.marginalReduction - a.marginalReduction);
-        const trimmed = fallbackCandidates.slice(0, budget);
-
-        const reason =
-          "Cascade damage too low to rank cuts — showing highest structural vulnerability (edge weight / ΩF) instead.";
-
-        store.setLastInterdictionResult({
-          ...result,
-          interventions: trimmed,
-          fallbackReason: reason,
-        });
-
-        lines.push(`  No high-damage cascade detected — recommending structural vulnerability cuts:`);
-        trimmed.forEach((iv, i) => {
-          const suffix =
-            iv.target.type === "edge"
-              ? `(w-score ${iv.marginalReduction.toFixed(1)}, id:${iv.target.id})`
-              : `(ΩF ${iv.marginalReduction.toFixed(1)}, id:${iv.target.id})`;
-          lines.push(`    ${i + 1}. [${iv.target.type}] ${iv.target.label} ${suffix}`);
-        });
-        lines.push(`  → Switched to PEARL module. Cuts rendered in the intervention panel.`);
-      }
-
-      // Auto-switch to Pearl module to show intervention UI
-      store.setActiveModule("pearl");
-
-      return lines.join("\n");
-    }
-
-    case "apply_interdiction": {
-      // Apply specific intervention by index (1-based) or "all"
-      const lastResult = store.lastInterdictionResult;
-      if (!lastResult || lastResult.interventions.length === 0) {
-        return "No interdiction results to apply. Run solve_interdiction first.";
-      }
-
-      if (action.param === "all") {
-        const applied: string[] = [];
-        for (const iv of lastResult.interventions) {
-          if (iv.target.type === "edge") {
-            store.severEdge(iv.target.id);
-            applied.push(iv.target.label);
-          } else {
-            store.toggleAblatedNode(iv.target.id);
-            applied.push(iv.target.label);
-          }
-        }
-        return `Applied all ${applied.length} interdictions: ${applied.join(", ")}`;
-      }
-
-      // Apply specific indices: "1,3" or "1"
-      const indices = action.param.split(",").map((s) => parseInt(s.trim(), 10) - 1);
-      const applied: string[] = [];
-      for (const idx of indices) {
-        const iv = lastResult.interventions[idx];
-        if (!iv) continue;
-        if (iv.target.type === "edge") {
-          store.severEdge(iv.target.id);
-          applied.push(iv.target.label);
-        } else {
-          store.toggleAblatedNode(iv.target.id);
-          applied.push(iv.target.label);
-        }
-      }
-      return applied.length > 0
-        ? `Applied interdictions: ${applied.join(", ")}`
-        : `No valid intervention indices: ${action.param}`;
-    }
-
-    default:
-      return `Unknown action: ${action.type}`;
-  }
+  const tag: ParsedActionTag = { name: action.type, payload: action.param, raw: action.raw };
+  return executeTag(tag);
 }
 
-// ─── Process all actions from an LLM response ──────────────────
-
+/**
+ * Process all actions in an LLM response. Returns the cleaned
+ * display text plus the list of action results.
+ */
 export function processLlmActions(text: string): {
   displayText: string;
   actionResults: string[];
 } {
-  const actions = parseActions(text);
-  const displayText = stripActions(text);
-  const actionResults: string[] = [];
-
-  for (const action of actions) {
-    const result = executeAction(action);
-    if (result) {
-      actionResults.push(result);
-    }
-  }
-
-  return { displayText, actionResults };
+  const { displayText, toolResults } = executeActions(text);
+  return { displayText, actionResults: toolResults };
 }

--- a/src/lib/copilot-context.ts
+++ b/src/lib/copilot-context.ts
@@ -9,6 +9,10 @@ import {
   renderEngineStateText,
   summarizeEngineState,
 } from "./engine-state-summary";
+import { renderToolsForPrompt } from "./copilot/tool-registry";
+// Side-effect import: ensures all built-in tools are registered
+// before we render the prompt section.
+import "./copilot/tools";
 
 interface ContextOptions {
   selectedNode: string | null;
@@ -57,37 +61,10 @@ export function serializeGraphContext(
 ): string {
   const lines: string[] = [];
 
-  // Available actions
-  lines.push("=== COPILOT ACTIONS ===");
-  lines.push("You can control the graph by emitting action tags in your response.");
-  lines.push("Format: <<<ACTION:type:param>>>");
-  lines.push("Available actions:");
-  lines.push("  select_node:<node_id or label> — Select and highlight a node");
-  lines.push("  set_domains:<id1,id2,...> — Filter network to specific domains (rebuilds graph)");
-  lines.push("  add_shock:<shock_id> — Inject a stress scenario");
-  lines.push("  remove_shock:<shock_id> — Remove an active shock");
-  lines.push("  sever_edge:<edge_id> — Pearl link-break on an edge");
-  lines.push("  reset_severed — Reset all severed edges");
-  lines.push("  set_module:<spirtes|tarski|pearl|pareto> — Switch analysis module");
-  lines.push("  set_view:<2d|3d> — Switch visualization mode");
-  lines.push("  start_replay / stop_replay — Control cascade animation");
-  lines.push("  solve_interdiction:budget=N,mode=edge|node|both — Run greedy minimax solver to find optimal defensive cuts (budget=1-10)");
-  lines.push("  apply_interdiction:all — Apply all recommended interdictions from the last solve");
-  lines.push("  apply_interdiction:1,2 — Apply specific recommendations by index (1-based)");
-  lines.push("");
-  lines.push("INTERDICTION WORKFLOW — CRITICAL: When a user asks about interdiction, optimal cuts, defensive cuts,");
-  lines.push("where to intervene, how to defend, what to sever, minimax, or any variant of 'find/solve/recommend cuts',");
-  lines.push("you MUST emit the solve_interdiction action. Do not just describe — trigger it. Steps:");
-  lines.push("  1. If no shocks are active, first inject one: <<<ACTION:add_shock:SHOCK_ID>>>");
-  lines.push("  2. Emit the solver action on its own line: <<<ACTION:solve_interdiction:budget=3,mode=edge>>>");
-  lines.push("     (the solver auto-switches to the PEARL module and renders the results panel)");
-  lines.push("  3. After the action fires, explain the returned cuts in plain language and their damage reduction");
-  lines.push("  4. Offer to apply: <<<ACTION:apply_interdiction:all>>> or specific indices like <<<ACTION:apply_interdiction:1,2>>>");
-  lines.push("  5. Optionally visualize: <<<ACTION:start_replay>>>");
-  lines.push("EXAMPLE user turn -> expected response:");
-  lines.push("  USER: 'where should we cut to defend against this?'");
-  lines.push("  YOU:  'Running the minimax interdiction solver now. <<<ACTION:solve_interdiction:budget=3,mode=edge>>>'");
-  lines.push("        (then explain results once they come back)");
+  // Available actions — auto-generated from the tool registry. Adding
+  // a new tool means defining it in src/lib/copilot/tools.ts; the
+  // prompt picks it up here automatically.
+  lines.push(renderToolsForPrompt());
   lines.push("");
   lines.push("=== AVAILABLE DOMAINS ===");
   const available = DOMAIN_CARDS.filter((d) => d.hasData);

--- a/src/lib/copilot/tool-registry.ts
+++ b/src/lib/copilot/tool-registry.ts
@@ -1,0 +1,398 @@
+// ─── Copilot Tool Registry ──────────────────────────────────────
+//
+// Declarative tool definitions for the copilot. Each tool registers
+// its name, description, parameter schema, and handler. The system
+// prompt is generated from the registry, and the wire format
+// (<<<ACTION:name:payload>>>) is parsed + validated against the
+// schema before the handler runs.
+//
+// The shape is deliberately MCP / Anthropic-tool-use-compatible so
+// we can later (a) auto-generate `tools` arrays for native tool use
+// and (b) swap the hand-rolled schema layer for zod without changing
+// call sites.
+
+import { useApexStore } from "@/stores/useApexStore";
+import type { ApexState } from "@/stores/useApexStore";
+
+// ─── Schema primitives ──────────────────────────────────────────
+
+/**
+ * A parameter schema describes one input field on a tool. The shape
+ * is deliberately small — string / string[] / number / enum / boolean —
+ * because tool params come off the wire as strings and we coerce.
+ *
+ * Adding a new variant: extend the union, then handle it in
+ * `coerceParam` and `renderParamSignature`.
+ */
+export type ParamSchema =
+  | { type: "string"; required?: boolean; description?: string }
+  | { type: "string[]"; required?: boolean; description?: string }
+  | { type: "number"; required?: boolean; description?: string; min?: number; max?: number; default?: number }
+  | { type: "enum"; values: readonly string[]; required?: boolean; description?: string; default?: string }
+  | { type: "boolean"; required?: boolean; description?: string };
+
+export type ParamShape = Record<string, ParamSchema>;
+
+/** Type-level inference: schema → typed params object. */
+// A field with `required: true` OR `default: <value>` is always defined
+// at runtime. We treat both the same way for inference.
+type IsAlwaysDefined<S> = S extends { required: true }
+  ? true
+  : S extends { default: unknown }
+    ? true
+    : false;
+
+export type InferParams<P extends ParamShape> = {
+  [K in keyof P]: P[K] extends { type: "string" }
+    ? IsAlwaysDefined<P[K]> extends true ? string : string | undefined
+    : P[K] extends { type: "string[]" }
+      ? string[]
+      : P[K] extends { type: "number" }
+        ? IsAlwaysDefined<P[K]> extends true ? number : number | undefined
+        : P[K] extends { type: "enum"; values: infer V }
+          ? V extends readonly string[]
+            ? IsAlwaysDefined<P[K]> extends true ? V[number] : V[number] | undefined
+            : never
+          : P[K] extends { type: "boolean" }
+            ? IsAlwaysDefined<P[K]> extends true ? boolean : boolean | undefined
+            : never;
+};
+
+// ─── Tool definition ────────────────────────────────────────────
+
+export interface ToolContext {
+  /**
+   * Returns the current store snapshot. Injectable for tests.
+   * Defaults to `useApexStore.getState()` in production.
+   */
+  getStore: () => ApexState;
+}
+
+export interface Tool<P extends ParamShape = ParamShape> {
+  /** Stable identifier emitted in <<<ACTION:name:...>>>. */
+  name: string;
+  /** One-line description for the LLM. Shown in the system prompt. */
+  description: string;
+  /** Optional longer guidance — shown to the LLM when this tool is non-obvious. */
+  guidance?: string;
+  /** Parameter schema. Empty {} for nullary tools. */
+  params: P;
+  /**
+   * For backward compatibility with single-string payloads
+   * (<<<ACTION:select_node:USA_GRID>>>). When the payload contains
+   * no `=`, it is routed into this param.
+   */
+  legacyParam?: keyof P & string;
+  /** Handler — receives validated params and a context object. */
+  handler: (params: InferParams<P>, ctx: ToolContext) => string;
+}
+
+// ─── Registry ───────────────────────────────────────────────────
+
+const REGISTRY = new Map<string, Tool<ParamShape>>();
+
+export function defineTool<P extends ParamShape>(tool: Tool<P>): Tool<P> {
+  if (REGISTRY.has(tool.name)) {
+    // Re-registration is allowed (e.g. HMR in dev). Last write wins.
+    REGISTRY.set(tool.name, tool as unknown as Tool<ParamShape>);
+  } else {
+    REGISTRY.set(tool.name, tool as unknown as Tool<ParamShape>);
+  }
+  return tool;
+}
+
+export function getTool(name: string): Tool<ParamShape> | undefined {
+  return REGISTRY.get(name);
+}
+
+export function getAllTools(): Tool<ParamShape>[] {
+  return Array.from(REGISTRY.values());
+}
+
+/** Test-only: clear the registry. Production code should never call this. */
+export function __resetRegistryForTests(): void {
+  REGISTRY.clear();
+}
+
+// ─── Wire format parsing ────────────────────────────────────────
+
+// k=v,k=v is the kv separator (comma). Arrays inside a value use `|`.
+// Bare payloads (no `=`) are passed through as legacy single-string.
+
+export interface ParsedActionTag {
+  /** The full <<<ACTION:...>>> match. */
+  raw: string;
+  /** Tool name (between first and second colon). */
+  name: string;
+  /** Raw payload text (after the second colon). May be empty. */
+  payload: string;
+}
+
+const ACTION_REGEX = /<<<ACTION:(\w+):?(.*?)>>>/g;
+
+export function parseActionTags(text: string): ParsedActionTag[] {
+  const tags: ParsedActionTag[] = [];
+  // Reset regex state — it's stateful with /g flag.
+  ACTION_REGEX.lastIndex = 0;
+  let match;
+  while ((match = ACTION_REGEX.exec(text)) !== null) {
+    tags.push({ raw: match[0], name: match[1], payload: match[2] ?? "" });
+  }
+  return tags;
+}
+
+export function stripActionTags(text: string): string {
+  return text.replace(ACTION_REGEX, "").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+/**
+ * Parse a `k=v,k=v` payload into a flat string map. A bare payload
+ * (no `=`) returns `{ _legacy: payload }` — the caller maps that
+ * onto the tool's `legacyParam`.
+ */
+export function parseKvPayload(payload: string): Record<string, string> {
+  const trimmed = payload.trim();
+  if (trimmed === "") return {};
+  if (!trimmed.includes("=")) return { _legacy: trimmed };
+
+  const out: Record<string, string> = {};
+  for (const pair of trimmed.split(",")) {
+    const eq = pair.indexOf("=");
+    if (eq === -1) continue;
+    const k = pair.slice(0, eq).trim();
+    const v = pair.slice(eq + 1).trim();
+    if (k) out[k] = v;
+  }
+  return out;
+}
+
+// ─── Validation + coercion ──────────────────────────────────────
+
+export type CoerceResult<P extends ParamShape> =
+  | { ok: true; params: InferParams<P> }
+  | { ok: false; error: string };
+
+function coerceParam(
+  name: string,
+  schema: ParamSchema,
+  raw: string | undefined,
+): { ok: true; value: unknown } | { ok: false; error: string } {
+  // Missing value
+  if (raw === undefined || raw === "") {
+    if ("default" in schema && schema.default !== undefined) {
+      return { ok: true, value: schema.default };
+    }
+    if (schema.required) {
+      return { ok: false, error: `Missing required param: ${name}` };
+    }
+    return { ok: true, value: schema.type === "string[]" ? [] : undefined };
+  }
+
+  switch (schema.type) {
+    case "string":
+      return { ok: true, value: raw };
+    case "string[]": {
+      // `|` is the array separator inside a value. Comma is reserved
+      // for the kv separator at the payload level. Empty entries are
+      // dropped so trailing/leading separators don't matter.
+      const items = raw
+        .split("|")
+        .map((s) => s.trim())
+        .filter(Boolean);
+      return { ok: true, value: items };
+    }
+    case "number": {
+      const n = Number(raw);
+      if (Number.isNaN(n)) return { ok: false, error: `Param ${name}: "${raw}" is not a number` };
+      const clamped = Math.min(schema.max ?? Infinity, Math.max(schema.min ?? -Infinity, n));
+      return { ok: true, value: clamped };
+    }
+    case "enum":
+      if (!schema.values.includes(raw)) {
+        return { ok: false, error: `Param ${name}: "${raw}" not in [${schema.values.join("|")}]` };
+      }
+      return { ok: true, value: raw };
+    case "boolean": {
+      const lc = raw.toLowerCase();
+      if (lc === "true" || lc === "1" || lc === "yes") return { ok: true, value: true };
+      if (lc === "false" || lc === "0" || lc === "no") return { ok: true, value: false };
+      return { ok: false, error: `Param ${name}: "${raw}" is not a boolean` };
+    }
+  }
+}
+
+export function coerceAndValidate<P extends ParamShape>(
+  shape: P,
+  raw: Record<string, string>,
+  legacyParam: keyof P & string | undefined,
+): CoerceResult<P> {
+  // If we got a legacy single-string payload, rewrite it onto the
+  // designated legacyParam. Tools without a legacyParam ignore it.
+  const kv = { ...raw };
+  if ("_legacy" in kv && legacyParam !== undefined) {
+    kv[legacyParam] = kv._legacy;
+  }
+  delete kv._legacy;
+
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(shape) as (keyof P & string)[]) {
+    const schema = shape[key];
+    const result = coerceParam(key, schema, kv[key]);
+    if (!result.ok) return { ok: false, error: result.error };
+    out[key] = result.value;
+  }
+  return { ok: true, params: out as InferParams<P> };
+}
+
+// ─── Execution ──────────────────────────────────────────────────
+
+const defaultContext: ToolContext = {
+  getStore: () => useApexStore.getState(),
+};
+
+export interface ExecutionResult {
+  displayText: string;
+  toolResults: string[];
+}
+
+/**
+ * Top-level entry point: parse all <<<ACTION:...>>> tags from an
+ * LLM response, validate each, run handlers, and return the cleaned
+ * display text plus the list of human-readable tool results.
+ */
+export function executeActions(
+  text: string,
+  ctx: ToolContext = defaultContext,
+): ExecutionResult {
+  const tags = parseActionTags(text);
+  const displayText = stripActionTags(text);
+  const toolResults: string[] = [];
+
+  for (const tag of tags) {
+    const result = executeTag(tag, ctx);
+    if (result) toolResults.push(result);
+  }
+
+  return { displayText, toolResults };
+}
+
+/** Execute a single parsed action tag. Exported for tests. */
+export function executeTag(tag: ParsedActionTag, ctx: ToolContext = defaultContext): string {
+  const tool = REGISTRY.get(tag.name);
+  if (!tool) return `Unknown action: ${tag.name}`;
+
+  const kv = parseKvPayload(tag.payload);
+  const validated = coerceAndValidate(tool.params, kv, tool.legacyParam);
+  if (!validated.ok) return `${tag.name}: ${validated.error}`;
+
+  try {
+    return tool.handler(validated.params, ctx);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return `${tag.name} failed: ${msg}`;
+  }
+}
+
+// ─── Prompt rendering ───────────────────────────────────────────
+
+/** Render one param's signature for the system prompt. */
+function renderParamSignature(name: string, schema: ParamSchema): string {
+  let typeStr: string;
+  switch (schema.type) {
+    case "string":
+      typeStr = "string";
+      break;
+    case "string[]":
+      typeStr = "list (use | between items)";
+      break;
+    case "number":
+      typeStr =
+        schema.min !== undefined || schema.max !== undefined
+          ? `number (${schema.min ?? "..."}–${schema.max ?? "..."})`
+          : "number";
+      break;
+    case "enum":
+      typeStr = schema.values.join("|");
+      break;
+    case "boolean":
+      typeStr = "true|false";
+      break;
+  }
+  const req = schema.required ? "" : "?";
+  const desc = schema.description ? ` — ${schema.description}` : "";
+  return `${name}${req}=<${typeStr}>${desc}`;
+}
+
+/**
+ * Render the system-prompt section listing all registered tools.
+ * Replaces the hand-written `=== COPILOT ACTIONS ===` block in
+ * copilot-context.ts.
+ */
+export function renderToolsForPrompt(): string {
+  const lines: string[] = [];
+  lines.push("=== COPILOT ACTIONS ===");
+  lines.push("Emit action tags to control the platform. Format:");
+  lines.push("  <<<ACTION:name:key=value,key=value>>>");
+  lines.push("Inside a value, use `|` to separate list items (ids=A|B|C).");
+  lines.push("Single-arg actions accept a bare payload (<<<ACTION:select_node:USA_GRID>>>).");
+  lines.push("");
+  lines.push("Available actions:");
+
+  const tools = getAllTools();
+  for (const tool of tools) {
+    const params = Object.entries(tool.params);
+    if (params.length === 0) {
+      lines.push(`  ${tool.name} — ${tool.description}`);
+    } else {
+      const sig = params.map(([n, s]) => renderParamSignature(n, s)).join(", ");
+      lines.push(`  ${tool.name}:${sig} — ${tool.description}`);
+    }
+    if (tool.guidance) {
+      for (const line of tool.guidance.split("\n")) {
+        lines.push(`    ${line}`);
+      }
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Render tools as Anthropic-tool-use-compatible JSON (for the
+ * eventual native-tool-use migration). Not used in this PR but
+ * proves the schema shape converts cleanly.
+ */
+export function renderToolsAsJsonSchema(): Array<{
+  name: string;
+  description: string;
+  input_schema: { type: "object"; properties: Record<string, unknown>; required: string[] };
+}> {
+  return getAllTools().map((tool) => {
+    const properties: Record<string, unknown> = {};
+    const required: string[] = [];
+    for (const [name, schema] of Object.entries(tool.params)) {
+      properties[name] = paramToJsonSchema(schema);
+      if (schema.required) required.push(name);
+    }
+    return {
+      name: tool.name,
+      description: tool.description + (tool.guidance ? `\n\n${tool.guidance}` : ""),
+      input_schema: { type: "object", properties, required },
+    };
+  });
+}
+
+function paramToJsonSchema(schema: ParamSchema): Record<string, unknown> {
+  switch (schema.type) {
+    case "string":
+      return { type: "string", description: schema.description };
+    case "string[]":
+      return { type: "array", items: { type: "string" }, description: schema.description };
+    case "number":
+      return { type: "number", minimum: schema.min, maximum: schema.max, description: schema.description };
+    case "enum":
+      return { type: "string", enum: schema.values, description: schema.description };
+    case "boolean":
+      return { type: "boolean", description: schema.description };
+  }
+}

--- a/src/lib/copilot/tools.ts
+++ b/src/lib/copilot/tools.ts
@@ -1,0 +1,448 @@
+// ─── Built-in copilot tools ─────────────────────────────────────
+//
+// Every tool the copilot can call is registered here via defineTool.
+// Adding a new tool: define its name, params, and handler. The
+// system prompt and the action runner pick it up automatically.
+
+import { defineTool } from "./tool-registry";
+import { getPresetShocks } from "../omega-engine";
+import { DOMAIN_CARDS } from "@/lib/domains";
+import { buildGraphFromDomains } from "@/lib/build-domain-graph";
+import { solveInterdiction, type InterdictionCandidate } from "../interdiction-engine";
+import type { ApexState } from "@/stores/useApexStore";
+
+// ─── Selection ──────────────────────────────────────────────────
+
+defineTool({
+  name: "select_node",
+  description: "Select and highlight a single node by id or label.",
+  params: {
+    node: {
+      type: "string",
+      required: true,
+      description: "Node id, shortLabel, or label",
+    },
+  },
+  legacyParam: "node",
+  handler: ({ node }, ctx) => {
+    const store = ctx.getStore();
+    const target = node.toLowerCase();
+    const found = store.graphData.nodes.find(
+      (n) =>
+        n.id === node ||
+        n.shortLabel.toLowerCase() === target ||
+        n.label.toLowerCase() === target,
+    );
+    if (!found) return `Node not found: ${node}`;
+    store.setSelectedNode(found.id);
+    return `Selected node: ${found.label}`;
+  },
+});
+
+// ─── Isolation ──────────────────────────────────────────────────
+
+defineTool({
+  name: "isolate_nodes",
+  description:
+    "Filter the visible graph to a subset of nodes — by free-text query or explicit ids. Non-matching nodes dim out across 2D / 3D / map views.",
+  guidance:
+    "Use whenever the user names a topic, theme, sector, or set of entities ('focus on energy infrastructure', 'just show me the semiconductor stuff'). Match a query against label/category/domain; pass ids when the user names specific nodes. Emit reset_isolation when the conversation broadens again.",
+  params: {
+    query: {
+      type: "string",
+      description: "Free-text match against id/shortLabel/label/category/domain (case-insensitive substring)",
+    },
+    ids: {
+      type: "string[]",
+      description: "Explicit node ids — separated with `|` (ids=USA_GRID|EU_GRID)",
+    },
+  },
+  handler: ({ query, ids }, ctx) => {
+    const store = ctx.getStore();
+    const nodes = store.graphData.nodes;
+
+    let matched: typeof nodes = [];
+    let basis: string;
+
+    if (ids && ids.length > 0) {
+      const idSet = new Set(ids);
+      matched = nodes.filter((n) => idSet.has(n.id));
+      basis = `ids=${ids.join(",")}`;
+    } else if (query && query.trim() !== "") {
+      const q = query.toLowerCase();
+      matched = nodes.filter(
+        (n) =>
+          n.id.toLowerCase().includes(q) ||
+          n.shortLabel.toLowerCase().includes(q) ||
+          n.label.toLowerCase().includes(q) ||
+          n.category.toLowerCase().includes(q) ||
+          n.domain.toLowerCase().includes(q),
+      );
+      basis = `query="${query}"`;
+    } else {
+      return "isolate_nodes: provide either query=<text> or ids=A|B|C";
+    }
+
+    if (matched.length === 0) {
+      return `No nodes matched ${basis}. Isolation not applied.`;
+    }
+
+    store.setSelectedNodes(matched.map((n) => n.id));
+    store.setIsolateSelection(true);
+
+    const preview = matched
+      .slice(0, 5)
+      .map((n) => n.shortLabel || n.id)
+      .join(", ");
+    const more = matched.length > 5 ? ` (+${matched.length - 5} more)` : "";
+    return `Isolated ${matched.length} node${matched.length === 1 ? "" : "s"} matching ${basis}: ${preview}${more}`;
+  },
+});
+
+defineTool({
+  name: "reset_isolation",
+  description: "Clear node isolation — show the full graph again.",
+  params: {},
+  handler: (_params, ctx) => {
+    const store = ctx.getStore();
+    store.setIsolateSelection(false);
+    store.setSelectedNodes([]);
+    return "Cleared isolation; showing full graph.";
+  },
+});
+
+// ─── Shocks ─────────────────────────────────────────────────────
+
+defineTool({
+  name: "add_shock",
+  description: "Inject a stress scenario by id (TAIWAN_BLOCKADE, GRID_CASCADE, etc).",
+  params: {
+    id: { type: "string", required: true, description: "Preset shock id" },
+  },
+  legacyParam: "id",
+  handler: ({ id }, ctx) => {
+    const store = ctx.getStore();
+    const presets = getPresetShocks();
+    const shock = presets.find((s) => s.id === id);
+    if (!shock) return `Unknown shock: ${id}`;
+    if (store.shocks.find((s) => s.id === shock.id)) {
+      return `Shock already active: ${shock.name}`;
+    }
+    store.addShock(shock);
+    return `Injected shock: ${shock.name}`;
+  },
+});
+
+defineTool({
+  name: "remove_shock",
+  description: "Remove an active shock by id.",
+  params: {
+    id: { type: "string", required: true, description: "Active shock id" },
+  },
+  legacyParam: "id",
+  handler: ({ id }, ctx) => {
+    const store = ctx.getStore();
+    const existing = store.shocks.find((s) => s.id === id);
+    if (!existing) return `Shock not active: ${id}`;
+    store.removeShock(id);
+    return `Removed shock: ${existing.name}`;
+  },
+});
+
+// ─── Module + view ──────────────────────────────────────────────
+
+defineTool({
+  name: "set_module",
+  description: "Switch the active analysis module.",
+  params: {
+    module: {
+      type: "enum",
+      values: ["spirtes", "tarski", "pearl", "pareto"] as const,
+      required: true,
+    },
+  },
+  legacyParam: "module",
+  handler: ({ module }, ctx) => {
+    ctx.getStore().setActiveModule(module);
+    return `Switched to ${module.toUpperCase()} module`;
+  },
+});
+
+defineTool({
+  name: "set_view",
+  description: "Switch the visualization mode.",
+  params: {
+    mode: { type: "enum", values: ["2d", "3d"] as const, required: true },
+  },
+  legacyParam: "mode",
+  handler: ({ mode }, ctx) => {
+    ctx.getStore().setViewMode(mode);
+    return `Switched to ${mode.toUpperCase()} view`;
+  },
+});
+
+// ─── Edges ──────────────────────────────────────────────────────
+
+defineTool({
+  name: "sever_edge",
+  description: "Pearl link-break on a single edge.",
+  params: {
+    edge: { type: "string", required: true, description: "Edge id" },
+  },
+  legacyParam: "edge",
+  handler: ({ edge }, ctx) => {
+    const store = ctx.getStore();
+    const found = store.graphData.edges.find((e) => e.id === edge);
+    if (!found) return `Edge not found: ${edge}`;
+    store.severEdge(found.id);
+    return `Severed edge: ${found.source} → ${found.target}`;
+  },
+});
+
+defineTool({
+  name: "reset_severed",
+  description: "Reset all severed edges.",
+  params: {},
+  handler: (_params, ctx) => {
+    ctx.getStore().resetSeveredEdges();
+    return "Reset all severed edges";
+  },
+});
+
+// ─── Replay ─────────────────────────────────────────────────────
+
+defineTool({
+  name: "start_replay",
+  description: "Start the cascade replay animation.",
+  params: {},
+  handler: (_params, ctx) => {
+    ctx.getStore().startReplay();
+    return "Started cascade replay";
+  },
+});
+
+defineTool({
+  name: "stop_replay",
+  description: "Stop the cascade replay animation.",
+  params: {},
+  handler: (_params, ctx) => {
+    ctx.getStore().stopReplay();
+    return "Stopped cascade replay";
+  },
+});
+
+// ─── Truth filter ───────────────────────────────────────────────
+
+defineTool({
+  name: "set_truth_filter",
+  description: "Toggle Tarski truth filter between RAW and VERIFIED.",
+  params: {
+    mode: { type: "enum", values: ["raw", "verified"] as const, required: true },
+  },
+  legacyParam: "mode",
+  handler: ({ mode }, ctx) => {
+    ctx.getStore().setTruthFilter(mode);
+    return `Truth filter set to: ${mode.toUpperCase()}`;
+  },
+});
+
+// ─── Domains ────────────────────────────────────────────────────
+
+function applyDomainFilter(domainIds: string[], store: ApexState): string {
+  // Validate against known domains.
+  const validIds = domainIds.filter((id) => DOMAIN_CARDS.find((d) => d.id === id && d.hasData));
+  if (validIds.length === 0) {
+    return `No valid domains found. Available: ${DOMAIN_CARDS.filter((d) => d.hasData).map((d) => d.id).join(", ")}`;
+  }
+  const graph = buildGraphFromDomains(validIds);
+  store.setGraphData(graph);
+  store.setSelectedDomains(validIds);
+  store.setIsMultiDomainMode(validIds.length > 1);
+  const labels = validIds.map((id) => DOMAIN_CARDS.find((d) => d.id === id)?.label ?? id);
+  return `Filtered network to: ${labels.join(", ")} (${graph.metadata.totalNodes} nodes, ${graph.metadata.totalEdges} edges)`;
+}
+
+defineTool({
+  name: "set_domains",
+  description: "Filter the network to specific domains (rebuilds the graph).",
+  guidance:
+    "When the user describes a role, strategy, or context ('I am a CDS trader'), pick the relevant domains and filter. Then explain why.",
+  params: {
+    domains: {
+      type: "string[]",
+      required: true,
+      description: "Domain ids — separated with `|` (domains=energy|semiconductors)",
+    },
+  },
+  legacyParam: "domains",
+  handler: ({ domains }, ctx) => applyDomainFilter(domains, ctx.getStore()),
+});
+
+defineTool({
+  name: "select_domains",
+  description: "Alias for set_domains.",
+  params: {
+    domains: { type: "string[]", required: true, description: "Domain ids — separated with `|`" },
+  },
+  legacyParam: "domains",
+  handler: ({ domains }, ctx) => applyDomainFilter(domains, ctx.getStore()),
+});
+
+// ─── Interdiction ───────────────────────────────────────────────
+
+defineTool({
+  name: "solve_interdiction",
+  description:
+    "Run the greedy minimax interdiction solver. Auto-switches to PEARL and renders cuts in the panel.",
+  guidance:
+    "Trigger this whenever the user asks about optimal cuts, defensive cuts, where to intervene, how to defend, what to sever, or any 'find/solve/recommend cuts'. If no shocks are active, inject one first via add_shock. After the solver returns, explain the cuts and offer apply_interdiction:targets=all or specific indices.",
+  params: {
+    budget: { type: "number", min: 1, max: 10, default: 3, description: "Max number of cuts" },
+    mode: { type: "enum", values: ["edge", "node", "both"] as const, default: "edge" },
+  },
+  handler: ({ budget, mode }, ctx) => {
+    const store = ctx.getStore();
+    const result = solveInterdiction(
+      store.graphData,
+      store.shocks,
+      store.severedEdges,
+      budget,
+      mode,
+    );
+
+    const lines = [
+      `Interdiction solved (budget=${budget}, mode=${mode}):`,
+      `  Baseline damage: ${result.baselineDamage.toFixed(1)}/100`,
+      `  Optimal damage: ${result.bestDamage.toFixed(1)}/100`,
+      `  Reduction: ${result.reductionPct.toFixed(1)}%`,
+    ];
+
+    if (result.interventions.length > 0) {
+      lines.push(`  Recommended cuts:`);
+      result.interventions.forEach((iv, i) => {
+        lines.push(
+          `    ${i + 1}. [${iv.target.type}] ${iv.target.label} (${iv.target.id}) — saves ${iv.marginalReduction.toFixed(1)}pts`,
+        );
+      });
+      lines.push(`  → Switched to PEARL module. Review cuts in the intervention panel.`);
+      store.setLastInterdictionResult(result);
+    } else {
+      // Fall back to structural vulnerability when cascade damage is
+      // too low to discriminate — same logic as the pre-registry version.
+      const fallbackCandidates: InterdictionCandidate[] = [];
+
+      if (mode !== "node") {
+        const criticalEdges = store.graphData.edges
+          .filter((e) => e.weight >= 0.7 && !e.isSevered)
+          .sort((a, b) => b.weight - a.weight)
+          .slice(0, budget);
+        for (const e of criticalEdges) {
+          const src = store.graphData.nodes.find((n) => n.id === e.source);
+          const tgt = store.graphData.nodes.find((n) => n.id === e.target);
+          fallbackCandidates.push({
+            target: {
+              type: "edge",
+              id: e.id,
+              label: `${src?.shortLabel ?? e.source} → ${tgt?.shortLabel ?? e.target}`,
+            },
+            damage: result.baselineDamage,
+            marginalReduction: e.weight * 10,
+          });
+        }
+      }
+
+      if (mode !== "edge") {
+        const highOmegaNodes = [...store.graphData.nodes]
+          .sort((a, b) => b.omegaFragility.composite - a.omegaFragility.composite)
+          .slice(0, budget);
+        for (const n of highOmegaNodes) {
+          fallbackCandidates.push({
+            target: { type: "node", id: n.id, label: n.shortLabel },
+            damage: result.baselineDamage,
+            marginalReduction: n.omegaFragility.composite,
+          });
+        }
+      }
+
+      fallbackCandidates.sort((a, b) => b.marginalReduction - a.marginalReduction);
+      const trimmed = fallbackCandidates.slice(0, budget);
+
+      const reason =
+        "Cascade damage too low to rank cuts — showing highest structural vulnerability (edge weight / ΩF) instead.";
+
+      store.setLastInterdictionResult({
+        ...result,
+        interventions: trimmed,
+        fallbackReason: reason,
+      });
+
+      lines.push(`  No high-damage cascade detected — recommending structural vulnerability cuts:`);
+      trimmed.forEach((iv, i) => {
+        const suffix =
+          iv.target.type === "edge"
+            ? `(w-score ${iv.marginalReduction.toFixed(1)}, id:${iv.target.id})`
+            : `(ΩF ${iv.marginalReduction.toFixed(1)}, id:${iv.target.id})`;
+        lines.push(`    ${i + 1}. [${iv.target.type}] ${iv.target.label} ${suffix}`);
+      });
+      lines.push(`  → Switched to PEARL module. Cuts rendered in the intervention panel.`);
+    }
+
+    store.setActiveModule("pearl");
+    return lines.join("\n");
+  },
+});
+
+defineTool({
+  name: "apply_interdiction",
+  description:
+    "Apply interventions from the most recent solve_interdiction. Pass targets=all or targets=1|3 (1-based indices).",
+  params: {
+    targets: {
+      type: "string",
+      required: true,
+      description: "'all' or pipe-separated 1-based indices",
+    },
+  },
+  legacyParam: "targets",
+  handler: ({ targets }, ctx) => {
+    const store = ctx.getStore();
+    const last = store.lastInterdictionResult;
+    if (!last || last.interventions.length === 0) {
+      return "No interdiction results to apply. Run solve_interdiction first.";
+    }
+
+    if (targets === "all") {
+      const applied: string[] = [];
+      for (const iv of last.interventions) {
+        if (iv.target.type === "edge") {
+          store.severEdge(iv.target.id);
+          applied.push(iv.target.label);
+        } else {
+          store.toggleAblatedNode(iv.target.id);
+          applied.push(iv.target.label);
+        }
+      }
+      return `Applied all ${applied.length} interdictions: ${applied.join(", ")}`;
+    }
+
+    // Accept either pipe-separated (new format) or comma-separated
+    // (back-compat with legacy `apply_interdiction:1,2`).
+    const sep = targets.includes("|") ? "|" : ",";
+    const indices = targets.split(sep).map((s) => parseInt(s.trim(), 10) - 1);
+    const applied: string[] = [];
+    for (const idx of indices) {
+      const iv = last.interventions[idx];
+      if (!iv) continue;
+      if (iv.target.type === "edge") {
+        store.severEdge(iv.target.id);
+        applied.push(iv.target.label);
+      } else {
+        store.toggleAblatedNode(iv.target.id);
+        applied.push(iv.target.label);
+      }
+    }
+    return applied.length > 0
+      ? `Applied interdictions: ${applied.join(", ")}`
+      : `No valid intervention indices: ${targets}`;
+  },
+});

--- a/src/stores/useApexStore.ts
+++ b/src/stores/useApexStore.ts
@@ -92,7 +92,7 @@ function prunePinsToGraph(graph: CausalGraph, pins: string[]): string[] {
   return filtered.length === pins.length ? pins : filtered;
 }
 
-interface ApexState {
+export interface ApexState {
   // Module navigation
   activeModule: ModuleId;
   setActiveModule: (id: ModuleId) => void;


### PR DESCRIPTION
## Summary

Replaces the hand-written `switch` in `copilot-actions.ts` with a **declarative tool registry**. Every tool now registers via `defineTool({ name, description, params, handler })` with a typed param schema, and the system prompt is **auto-generated from the registry** instead of a hand-written list that drifted out of sync.

Adds the first registry-native tool: **`isolate_nodes`** — filters the visible graph by free-text query or explicit ids and toggles the existing `isolateSelection` state, so 2D/3D/Map views immediately dim non-matching nodes. Also adds `reset_isolation` as the inverse.

## Why this shape

Long-term the copilot needs to produce **structured trace data** `(tool, params, result)` we can replay, eval, and use as training material. Inlined `switch` handlers can't generate that. The registry shape is deliberately MCP / Anthropic-tool-use-compatible (see `renderToolsAsJsonSchema()`) so the next PR can drop in trace logging, and a later one can swap the text wire format for native `tool_use` blocks without touching call sites.

## Changes

- **New** `src/lib/copilot/tool-registry.ts`: `defineTool`, schema layer (`string` / `string[]` / `number` / `enum` / `boolean` with required + default + min/max), wire-format parser (`k=v,k=v` with `|` as the list separator inside values), validation + coercion, prompt rendering, JSON-Schema export.
- **New** `src/lib/copilot/tools.ts`: every existing action migrated, plus `isolate_nodes` and `reset_isolation`. `legacyParam` keeps `<<<ACTION:select_node:USA_GRID>>>` working unchanged.
- `copilot-context.ts`: the hand-written `=== COPILOT ACTIONS ===` block is gone — replaced by `renderToolsForPrompt()`.
- `copilot-actions.ts`: thin compat shim — `parseActions` / `stripActions` / `processLlmActions` still exported so `SystemCopilot.tsx` keeps working.
- `useApexStore`: `ApexState` exported (consumed by tool handlers).

## Wire format

| Form | Example | Notes |
| --- | --- | --- |
| Bare payload | `<<<ACTION:select_node:USA_GRID>>>` | routed onto `legacyParam` — every existing action keeps working |
| kv pairs | `<<<ACTION:solve_interdiction:budget=3,mode=edge>>>` | unchanged |
| Lists | `<<<ACTION:isolate_nodes:ids=GRID_USA\|FAB_TW>>>` | `\|` separates list items; `,` is the kv separator |

## Stats

348 lines of switch-case removed; 1,264 added (registry + tools + 28 unit tests). New code is declarative and schema-typed.

## Test plan

- [x] `vitest run` — 720/720 pass (28 new tests cover parser, coercion, registry, isolate_nodes happy/empty/error paths, prompt rendering, JSON-Schema export)
- [x] `tsc --noEmit` — clean
- [x] `eslint` on touched files — clean (only pre-existing warnings)
- [ ] Manual: ask the copilot "focus on the energy stuff" → graph isolates to energy nodes
- [ ] Manual: "show me everything again" → `reset_isolation` clears isolation
- [ ] Manual: existing actions (`add_shock`, `solve_interdiction`, `set_module`, etc.) still work end-to-end through the chat

## Next steps (out of scope here)

1. Trace logger → `copilot_traces` Supabase table (every invocation as `{conversation_id, tool, params, result, latency_ms}`) — the training-data substrate.
2. Migrate the wire format from text regex to native Anthropic `tool_use` blocks. Traces stay schema-identical.
3. Eval harness: replay traces, compare across model versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
