### PR TITLE
feat(2d): floating straight-line edges + node-size toggle parity

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -443,9 +443,29 @@ This was the work deferred in PR #198 with the note *"would need a custom edge c
 
 **Verification.** `tsc --noEmit` clean; lint clean on touched files; vitest 729/729 pass. (Three pre-existing lint warnings outside the diff.)
 
+### 2026-05-03 — Shipped: 2D floating edges + node-size toggle parity
+
+**PR:** TBD (about to open).
+
+**Trigger.** User feedback after the 3D readability pass: *"some 2D lines are still all curvy. It almost seems like they have to be pointing to the bottom or top of any node. Can't we have them just pointing straight from whatever direction makes the most sense? Also the size differences should also be available in 2D rendering."*
+
+**Floating edges.** The previous `EmphasizedEdge` used `getBezierPath` against React Flow's handle-anchored `sourceX/Y` / `targetX/Y` — every line had to pass through one of the four invisible handles (top/bottom/left/right) on each circle, so a node placed to the left of another would still draw a line that detoured up to the top handle and curved back down. Replaced with the "floating edge" pattern from the RF docs: read the source/target `nodeInternals` via `useReactFlowStore`, compute centre-to-centre direction, trim each end to the circle perimeter, draw a single straight `M…L…` SVG path. Now lines go in the geometrically natural direction, no curvature, no detours. Arrowhead lands on the circle perimeter cleanly.
+
+**Node-size toggle parity.** The 3D `SIZE: ΩF / EIG / BTW` toggle now drives 2D node diameter too:
+- `CausalDAG2D` computes `networkMetrics` via the existing `computeNetworkMetrics` util (same one 3D uses) and caches on `graphSignature`. Replay scrubs / hover don't re-run the centrality sweep.
+- Each node's `data` now carries `metrics: NodeMetrics`.
+- `CausalNode2D` reads `nodeSizeMetric` from the store and maps the chosen signal into a 14–34 px diameter range.
+- `DAGOverlay` SIZE toggle visibility extended from `viewMode === "3d"` to `(viewMode === "3d" || viewMode === "2d")`. MAP / TOPO stay hidden since their visual primitive isn't a sized node.
+
+**Files.**
+- `src/components/CausalDAG2D.tsx` — `EmphasizedEdge` switched to floating straight path via `useReactFlowStore`; `CausalNode2D` accepts `metrics` and reads `nodeSizeMetric`; parent `nodes` useMemo passes per-node metrics; `networkMetrics` useMemo cached on `sig`.
+- `src/components/dag3d/DAGOverlay.tsx` — SIZE toggle now visible in 2D as well.
+
+**Verification.** `tsc --noEmit` clean; lint clean on touched files; vitest 729/729 pass.
+
 ### 2026-05-03 — Next up
 
-- Verify 3D readability on production: hard-refresh, switch to 3D — expect (a) no labels at idle, only on hover or selection, (b) orbs visibly larger and brighter, (c) `SIZE: ΩF / EIG / BTW` toggle in the top-right strip switches the orb-radius metric live.
+- Verify on production: hard-refresh, switch to 2D — expect (a) edges drawing as straight lines between circle perimeters in whatever direction makes geometric sense (no more "always entering top/bottom"), (b) the same `SIZE: ΩF / EIG / BTW` toggle in the top-right resizing the 2D circles live.
 - Outside this: deferred 3D `onPointerMove` throttle (PR #199), map-view imperative-setData refactor, real bundle-analyzer perf sweep using PR #222's tooling.
 
 ---

--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -17,7 +17,7 @@ import ReactFlow, {
   MarkerType,
   EdgeProps,
   BaseEdge,
-  getBezierPath,
+  useStore as useReactFlowStore,
   useReactFlow,
   ReactFlowProvider,
 } from "reactflow";
@@ -37,6 +37,7 @@ import {
   type LiveSimulation,
   type Position2D,
 } from "@/lib/graph-layout-2d";
+import { computeNetworkMetrics, type NodeMetrics } from "@/lib/graph-layout";
 import { AnimatePresence } from "framer-motion";
 
 type NodeEmphasis = "focus" | "neighbor" | "dim" | "none";
@@ -94,10 +95,19 @@ function computeNodeEmphasis(
 }
 
 function CausalNode2D({ data, selected, id }: NodeProps) {
-  const { label, category, omegaComposite, isRestricted, datasetColor, shockIntensity } = data;
+  const { label, category, omegaComposite, isRestricted, datasetColor, shockIntensity, metrics } = data as {
+    label: string;
+    category: string;
+    omegaComposite: number;
+    isRestricted: boolean;
+    datasetColor?: string;
+    shockIntensity?: number;
+    metrics?: NodeMetrics;
+  };
   const { adjacency, hoveredNodeId } = useContext(Dag2DContext);
   const selectedNode = useApexStore((s) => s.selectedNode);
   const multiSelectedNodes = useApexStore((s) => s.selectedNodes);
+  const nodeSizeMetric = useApexStore((s) => s.nodeSizeMetric);
   const emphasis = useMemo(
     () => computeNodeEmphasis(id, hoveredNodeId, selectedNode, multiSelectedNodes, adjacency),
     [id, hoveredNodeId, selectedNode, multiSelectedNodes, adjacency],
@@ -111,8 +121,22 @@ function CausalNode2D({ data, selected, id }: NodeProps) {
   const isFocus = nodeEmphasis === "focus";
   const isRinged = selected || isFocus;
 
-  // Diameter scales with \u03A9F: low-risk nodes are small, high-risk are larger.
-  const diameter = 14 + Math.min(10, Math.max(0, omegaComposite)) * 2;
+  // Diameter scales with the user-selected metric. Same toggle the 3D
+  // view honours (`nodeSizeMetric` in the store): "omega" \u2192 \u03A9F
+  // composite (criticality), "eigenvector" \u2192 influence-hub centrality,
+  // "betweenness" \u2192 bridge centrality. All paths normalise to a 0..1
+  // unit and map into a 14..34 px range so the visual delta between
+  // smallest and largest stays consistent across metrics.
+  const ec = metrics?.eigenvectorCentrality ?? 0.5;
+  const bc = metrics?.betweennessCentrality ?? 0.5;
+  const omegaUnit = Math.min(1, Math.max(0, omegaComposite / 10));
+  const sizeUnit =
+    nodeSizeMetric === "betweenness"
+      ? Math.min(1, Math.max(0, bc))
+      : nodeSizeMetric === "eigenvector"
+        ? Math.min(1, Math.max(0, ec))
+        : omegaUnit;
+  const diameter = 14 + sizeUnit * 20;
 
   // Layered box-shadow: selection ring (sharp), shock glow (pulsing), base
   // omega glow (soft halo). All applied to the same circle element.
@@ -352,12 +376,6 @@ function EmphasizedEdge(props: EdgeProps<EmphasizedEdgeData>) {
     id,
     source,
     target,
-    sourceX,
-    sourceY,
-    targetX,
-    targetY,
-    sourcePosition,
-    targetPosition,
     data,
     markerEnd,
   } = props;
@@ -365,14 +383,45 @@ function EmphasizedEdge(props: EdgeProps<EmphasizedEdgeData>) {
   const selectedNode = useApexStore((s) => s.selectedNode);
   const multiSelectedNodes = useApexStore((s) => s.selectedNodes);
 
-  const [edgePath] = getBezierPath({
-    sourceX,
-    sourceY,
-    targetX,
-    targetY,
-    sourcePosition,
-    targetPosition,
-  });
+  // "Floating" edge geometry. The earlier path used getBezierPath against
+  // RF's handle-anchored sourceX/Y/targetX/Y, which forced every line to
+  // route through one of the four invisible handles (top/bottom/left/right)
+  // and gave the curvy "always entering top or bottom" look the user
+  // flagged. Reading the actual node centres from the RF store and
+  // trimming the line to each circle's perimeter draws a straight edge
+  // in whatever direction makes geometric sense.
+  const sourceNode = useReactFlowStore((s) => s.nodeInternals.get(source));
+  const targetNode = useReactFlowStore((s) => s.nodeInternals.get(target));
+
+  let edgePath: string | null = null;
+  if (sourceNode && targetNode) {
+    const sw = sourceNode.width ?? 30;
+    const sh = sourceNode.height ?? 30;
+    const tw = targetNode.width ?? 30;
+    const th = targetNode.height ?? 30;
+    const sxC = (sourceNode.positionAbsolute?.x ?? sourceNode.position.x) + sw / 2;
+    const syC = (sourceNode.positionAbsolute?.y ?? sourceNode.position.y) + sh / 2;
+    const txC = (targetNode.positionAbsolute?.x ?? targetNode.position.x) + tw / 2;
+    const tyC = (targetNode.positionAbsolute?.y ?? targetNode.position.y) + th / 2;
+    const dx = txC - sxC;
+    const dy = tyC - syC;
+    const dist = Math.hypot(dx, dy);
+    if (dist > 0.5) {
+      const ndx = dx / dist;
+      const ndy = dy / dist;
+      // Trim each endpoint to the node's circle perimeter (radius = half
+      // the rendered diameter). Without trimming, the line passes through
+      // the orb and overruns the arrow head.
+      const sr = sw / 2;
+      const tr = tw / 2;
+      const x1 = sxC + ndx * sr;
+      const y1 = syC + ndy * sr;
+      const x2 = txC - ndx * tr;
+      const y2 = tyC - ndy * tr;
+      edgePath = `M ${x1} ${y1} L ${x2} ${y2}`;
+    }
+  }
+  if (!edgePath) return null;
 
   // Emphasis: an edge is "in scope" if either endpoint is the current
   // emphasis target (hover or single-select). When something IS in scope
@@ -532,9 +581,18 @@ function CausalDAG2DInner() {
     return map;
   }, [graphData.edges]);
 
+  // Network metrics (eigenvector / betweenness / degree). Same util the 3D
+  // view uses; cached on graph signature so replay scrubs / hover don't
+  // re-run the (O(E) for degree, O(N×E) for centrality) sweep. Drives
+  // the 2D node-size toggle.
   const sig = useMemo(
     () => graphSignature(graphData.nodes, graphData.edges),
     [graphData.nodes, graphData.edges],
+  );
+  const networkMetrics = useMemo(
+    () => computeNetworkMetrics(graphData.nodes, graphData.edges),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pin to sig
+    [sig],
   );
   const [prevSig, setPrevSig] = useState<string>("");
   const [cachedLayout, setCachedLayout] = useState<Map<string, Position2D>>(
@@ -675,10 +733,11 @@ function CausalDAG2DInner() {
           isRestricted: truthFilter === "verified" && n.isRestricted,
           datasetColor: n.datasetColor,
           shockIntensity: epochShock,
+          metrics: networkMetrics[n.id],
         },
       };
     });
-  }, [graphData, nodePositions, truthFilter, currentSnapshot, adjacency]);
+  }, [graphData, nodePositions, truthFilter, currentSnapshot, adjacency, networkMetrics]);
 
   // Filter nodes for isolation mode
   const visibleNodes = useMemo(() => {

--- a/src/components/dag3d/DAGOverlay.tsx
+++ b/src/components/dag3d/DAGOverlay.tsx
@@ -91,11 +91,13 @@ export default function DAGOverlay() {
           the corner stays clean. View labels still say which view is
           active via the highlighted button. */}
       <div className="absolute top-3 right-3 flex items-center gap-2 pointer-events-auto">
-        {/* 3D-only: orb-size metric toggle. ΩF reads as "criticality"; the
-            two centralities reveal structure (eigenvector → influence
-            hubs; betweenness → bridges). Hidden in other views since the
-            orbs only exist in 3D. */}
-        {viewMode === "3d" && (
+        {/* Node-size metric toggle. ΩF reads as "criticality"; the two
+            centralities reveal structure (eigenvector → influence hubs;
+            betweenness → bridges). Visible in both 3D and 2D since the
+            same store slot drives orb radius in 3D and circle diameter
+            in 2D. Hidden in MAP/TOPO where the visual primitive isn't a
+            sized node. */}
+        {(viewMode === "3d" || viewMode === "2d") && (
           <span className="flex items-center gap-1 px-1.5 py-0.5 rounded border border-border bg-surface-elevated">
             <span className="text-[8px] font-mono text-text-muted pr-0.5">SIZE:</span>
             {(
@@ -113,7 +115,7 @@ export default function DAGOverlay() {
                     ? "text-accent-cyan bg-accent-cyan/15"
                     : "text-text-muted hover:text-accent-cyan"
                 }`}
-                title={`Map orb size to ${opt.label}`}
+                title={`Map node size to ${opt.label}`}
               >
                 {opt.label}
               </button>


### PR DESCRIPTION
## Summary

User feedback after the 3D readability pass: *"some 2D lines are still all curvy. It almost seems like they have to be pointing to the bottom or top of any node. Can't we have them just pointing straight from whatever direction makes the most sense? Also the size differences should also be available in 2D rendering."*

Two things in one PR.

### Floating straight-line edges

The previous `EmphasizedEdge` used `getBezierPath` against React Flow's handle-anchored `sourceX/Y` / `targetX/Y` — every line had to pass through one of the four invisible handles (top/bottom/left/right) on each circle, so a node placed to the left of another would still draw a line that detoured up to the top handle and curved back down. Replaced with the floating-edge pattern from the RF docs:

- Read the source/target `nodeInternals` via `useReactFlowStore`.
- Compute centre-to-centre direction.
- Trim each end to the circle perimeter (`radius = width/2`).
- Draw a single straight `M…L…` SVG path.

Arrowhead now lands cleanly on the circle perimeter, not at a handle anchor.

### Node-size toggle parity with 3D

The `SIZE: ΩF / EIG / BTW` toggle now drives 2D circle diameter too:

- `CausalDAG2D` computes `networkMetrics` via the existing `computeNetworkMetrics` util (same one 3D uses) and caches on `graphSignature` so replay scrubs / hover don't re-run the centrality sweep.
- Each node's `data` now carries `metrics: NodeMetrics`.
- `CausalNode2D` reads `nodeSizeMetric` from the store and maps the chosen signal into a 14–34 px diameter range.
- `DAGOverlay` SIZE toggle visibility extended from `"3d"` to `("3d" || "2d")`. MAP / TOPO stay hidden since their visual primitive isn't a sized node.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Lint clean on touched files
- [x] vitest 729/729 pass
- [ ] Visual: hard-refresh production, switch to 2D — expect (a) edges drawing as straight lines between circle perimeters in whatever direction makes geometric sense (no more "always entering top/bottom"), (b) the same `SIZE: ΩF / EIG / BTW` toggle in the top-right resizing the 2D circles live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_