### PR TITLE
feat(copilot): trace store — every turn becomes a row

### DIFF
--- a/src/app/api/copilot/trace/route.ts
+++ b/src/app/api/copilot/trace/route.ts
@@ -1,0 +1,152 @@
+// ─── POST /api/copilot/trace ────────────────────────────────────
+//
+// Receives a copilot TurnTrace from the browser and inserts it
+// into public.copilot_traces. Uses the service-role client (the
+// table has RLS but no insert policy — only the server side, with
+// a verified user_id from the session, may write).
+//
+// Logging is best-effort. Failures here MUST NOT cascade into the
+// user's chat experience — the route returns 4xx/5xx but the
+// client treats logging as fire-and-forget.
+
+import { NextRequest, NextResponse } from "next/server";
+import { createClient as createServiceClient } from "@supabase/supabase-js";
+import { createClient as createServerClient } from "@/lib/supabase/server";
+
+const supabaseAdmin = createServiceClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+);
+
+// ─── Validation ─────────────────────────────────────────────────
+
+interface IncomingTrace {
+  conversation_id?: unknown;
+  turn_index?: unknown;
+  user_message?: unknown;
+  assistant_message?: unknown;
+  display_text?: unknown;
+  tool_calls?: unknown;
+  model_provider?: unknown;
+  model_id?: unknown;
+  system_prompt_hash?: unknown;
+  system_prompt_size?: unknown;
+  dataset?: unknown;
+  active_module?: unknown;
+  selected_node?: unknown;
+  active_shock_count?: unknown;
+  client_meta?: unknown;
+}
+
+function isString(v: unknown): v is string {
+  return typeof v === "string";
+}
+function isInt(v: unknown): v is number {
+  return typeof v === "number" && Number.isFinite(v) && Number.isInteger(v);
+}
+function isArray(v: unknown): v is unknown[] {
+  return Array.isArray(v);
+}
+
+// Hard caps so a misbehaving client can't fill the table with
+// gigabyte rows. These are generous — typical assistant message
+// is a few KB, system prompt is ~50-200KB.
+const MAX_MESSAGE_LEN = 200_000;
+const MAX_TOOL_CALLS = 50;
+const MAX_TOOL_RESULT_LEN = 50_000;
+
+function clampString(v: unknown, max: number): string | null {
+  if (!isString(v)) return null;
+  return v.length > max ? v.slice(0, max) : v;
+}
+
+interface ToolCallShape {
+  name: string;
+  params: Record<string, unknown>;
+  result: string;
+  error: string | null;
+  latency_ms: number;
+}
+
+function sanitizeToolCalls(input: unknown): ToolCallShape[] | null {
+  if (!isArray(input)) return null;
+  if (input.length > MAX_TOOL_CALLS) return null;
+  const out: ToolCallShape[] = [];
+  for (const tc of input) {
+    if (typeof tc !== "object" || tc === null) return null;
+    const t = tc as Record<string, unknown>;
+    if (!isString(t.name) || t.name.length > 200) return null;
+    const params =
+      typeof t.params === "object" && t.params !== null && !Array.isArray(t.params)
+        ? (t.params as Record<string, unknown>)
+        : {};
+    const result = clampString(t.result, MAX_TOOL_RESULT_LEN) ?? "";
+    const error = t.error === null || t.error === undefined ? null : clampString(t.error, 1000);
+    const latency_ms = isInt(t.latency_ms) && t.latency_ms >= 0 ? t.latency_ms : 0;
+    out.push({ name: t.name, params, result, error, latency_ms });
+  }
+  return out;
+}
+
+// ─── Handler ────────────────────────────────────────────────────
+
+export async function POST(request: NextRequest) {
+  let body: IncomingTrace;
+  try {
+    body = (await request.json()) as IncomingTrace;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (!isString(body.conversation_id) || body.conversation_id.length > 100) {
+    return NextResponse.json({ error: "Invalid conversation_id" }, { status: 400 });
+  }
+  if (!isInt(body.turn_index) || body.turn_index < 0) {
+    return NextResponse.json({ error: "Invalid turn_index" }, { status: 400 });
+  }
+  const toolCalls = sanitizeToolCalls(body.tool_calls);
+  if (toolCalls === null) {
+    return NextResponse.json({ error: "Invalid tool_calls" }, { status: 400 });
+  }
+
+  // Resolve user_id from the auth session (don't trust the client
+  // to claim it). null is fine — anonymous traces are allowed.
+  let userId: string | null = null;
+  try {
+    const supabaseSession = await createServerClient();
+    const { data } = await supabaseSession.auth.getUser();
+    userId = data.user?.id ?? null;
+  } catch {
+    // Anonymous turn — leave userId null.
+  }
+
+  const row = {
+    user_id: userId,
+    conversation_id: body.conversation_id,
+    turn_index: body.turn_index,
+    user_message: clampString(body.user_message, MAX_MESSAGE_LEN),
+    assistant_message: clampString(body.assistant_message, MAX_MESSAGE_LEN),
+    display_text: clampString(body.display_text, MAX_MESSAGE_LEN),
+    tool_calls: toolCalls,
+    model_provider: clampString(body.model_provider, 50),
+    model_id: clampString(body.model_id, 200),
+    system_prompt_hash: clampString(body.system_prompt_hash, 64),
+    system_prompt_size: isInt(body.system_prompt_size) ? body.system_prompt_size : null,
+    dataset: clampString(body.dataset, 100),
+    active_module: clampString(body.active_module, 50),
+    selected_node: clampString(body.selected_node, 200),
+    active_shock_count: isInt(body.active_shock_count) ? body.active_shock_count : null,
+    client_meta:
+      typeof body.client_meta === "object" && body.client_meta !== null && !Array.isArray(body.client_meta)
+        ? (body.client_meta as Record<string, unknown>)
+        : {},
+  };
+
+  const { error } = await supabaseAdmin.from("copilot_traces").insert(row);
+  if (error) {
+    console.error("[copilot-trace] insert failed:", error);
+    return NextResponse.json({ error: "Failed to log trace" }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/components/SystemCopilot.tsx
+++ b/src/components/SystemCopilot.tsx
@@ -10,7 +10,13 @@ import {
   streamLlmQuery,
   CopilotAction,
 } from "@/lib/copilot-engine";
-import { processLlmActions, stripActions } from "@/lib/copilot-actions";
+import { processLlmActionsWithTrace, stripActions } from "@/lib/copilot-actions";
+import {
+  logTurnTrace,
+  hashPrompt,
+  newConversationId,
+  type TurnTrace,
+} from "@/lib/copilot/trace-logger";
 import { CopilotMessage } from "@/lib/types";
 import { getModelsForProvider, type LLMProvider } from "@/lib/llm-providers";
 import { serializeGraphContext, serializeSnapshotContext, serializeTimeWindowContext } from "@/lib/copilot-context";
@@ -129,6 +135,15 @@ export default function SystemCopilot() {
   const badgeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const recognitionRef = useRef<SpeechRecognition | null>(null);
   const lastSpokenMsgRef = useRef<string | null>(null);
+  // Conversation identity for trace logging. Stable across the
+  // session; resets when the chat is cleared. turn_index is a
+  // monotonically increasing counter so we can replay traces in
+  // order. Lazily initialized so SSR doesn't call crypto.randomUUID.
+  const conversationIdRef = useRef<string | null>(null);
+  const turnIndexRef = useRef<number>(0);
+  if (conversationIdRef.current === null && typeof window !== "undefined") {
+    conversationIdRef.current = newConversationId();
+  }
 
   // Gemini is always active — server-side env var provides the key if client doesn't
   const isLlmActive = copilotProvider === "ollama" || copilotProvider === "gemini" || copilotApiKey.length > 0;
@@ -407,7 +422,7 @@ export default function SystemCopilot() {
         }
 
         // After streaming completes, execute any actions from the full response
-        const { displayText, actionResults } = processLlmActions(accumulated);
+        const { displayText, actionResults, toolCalls } = processLlmActionsWithTrace(accumulated);
         // Flush final text to the store in one write
         useApexStore.setState((s) => ({
           copilotMessages: s.copilotMessages.map((m) =>
@@ -426,6 +441,51 @@ export default function SystemCopilot() {
             content: `ACTIONS EXECUTED:\n${actionSummary}`,
             timestamp: Date.now(),
           });
+        }
+
+        // \u2500\u2500\u2500 Trace logging (PR2) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+        // Fire-and-forget POST to /api/copilot/trace. We hash the
+        // system prompt instead of storing the full text \u2014 too large
+        // to log every turn. Logging never awaits and never blocks
+        // the chat; failures land in console.warn only.
+        try {
+          const conversationId = conversationIdRef.current ?? newConversationId();
+          conversationIdRef.current = conversationId;
+          const turnIndex = turnIndexRef.current++;
+          const systemPromptText = serializeGraphContext(graphData, {
+            selectedNode,
+            severedEdges,
+            shocks,
+            interventionMode,
+            interventionTarget,
+            ablationMode,
+            ablatedNodeIds,
+            ablatedEdgeIds,
+            tarskiReport,
+          }) + (snapshotContext ? "\n\n" + snapshotContext : "");
+          const trace: TurnTrace = {
+            conversation_id: conversationId,
+            turn_index: turnIndex,
+            user_message: userContent,
+            assistant_message: accumulated,
+            display_text: displayText,
+            tool_calls: toolCalls,
+            model_provider: copilotProvider,
+            model_id: copilotModel,
+            system_prompt_hash: hashPrompt(systemPromptText),
+            system_prompt_size: systemPromptText.length,
+            // dataset routing isn't in the store yet (PR3 candidate);
+            // leave null so the column is still queryable when added.
+            dataset: null,
+            active_module: activeModule,
+            selected_node: selectedNode,
+            active_shock_count: shocks.length,
+          };
+          // Intentionally not awaited \u2014 logging is best-effort.
+          void logTurnTrace(trace);
+        } catch (logErr) {
+          // Never let trace prep errors leak into the chat.
+          console.warn("[copilot-trace] prep failed:", logErr);
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : "LLM request failed";
@@ -459,6 +519,8 @@ export default function SystemCopilot() {
       ablationMode,
       ablatedNodeIds,
       ablatedEdgeIds,
+      activeModule,
+      tarskiReport,
       addCopilotMessage,
       setIsLlmStreaming,
     ]

--- a/src/lib/__tests__/copilot-trace-logger.test.ts
+++ b/src/lib/__tests__/copilot-trace-logger.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  defineTool,
+  executeTagWithTrace,
+  executeActionsWithTrace,
+  __resetRegistryForTests,
+  type ToolCallTrace,
+} from "@/lib/copilot/tool-registry";
+import { hashPrompt, newConversationId, logTurnTrace } from "@/lib/copilot/trace-logger";
+import type { ApexState } from "@/stores/useApexStore";
+
+// ─── Registry trace shape ───────────────────────────────────────
+
+describe("executeTagWithTrace — structured trace shape", () => {
+  beforeEach(() => __resetRegistryForTests());
+
+  it("returns name + validated params + result + null error + latency on success", () => {
+    defineTool({
+      name: "select_node",
+      description: "test",
+      params: { node: { type: "string", required: true } },
+      legacyParam: "node",
+      handler: () => "Selected node: USA_GRID",
+    });
+
+    const trace = executeTagWithTrace(
+      { name: "select_node", payload: "USA_GRID", raw: "" },
+      { getStore: () => ({}) as ApexState },
+    );
+
+    expect(trace.name).toBe("select_node");
+    expect(trace.params).toEqual({ node: "USA_GRID" });
+    expect(trace.result).toBe("Selected node: USA_GRID");
+    expect(trace.error).toBeNull();
+    expect(typeof trace.latency_ms).toBe("number");
+    expect(trace.latency_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it("populates error when validation fails", () => {
+    defineTool({
+      name: "needs_arg",
+      description: "test",
+      params: { x: { type: "string", required: true } },
+      handler: () => "ok",
+    });
+
+    const trace = executeTagWithTrace(
+      { name: "needs_arg", payload: "", raw: "" },
+      { getStore: () => ({}) as ApexState },
+    );
+
+    expect(trace.error).toMatch(/Missing required/);
+    expect(trace.result).toMatch(/Missing required/);
+  });
+
+  it("populates error when handler throws", () => {
+    defineTool({
+      name: "boom",
+      description: "test",
+      params: {},
+      handler: () => {
+        throw new Error("kaboom");
+      },
+    });
+
+    const trace = executeTagWithTrace(
+      { name: "boom", payload: "", raw: "" },
+      { getStore: () => ({}) as ApexState },
+    );
+
+    expect(trace.error).toBe("kaboom");
+    expect(trace.result).toMatch(/boom failed: kaboom/);
+  });
+
+  it("emits a trace per parsed tag from executeActionsWithTrace", () => {
+    defineTool({
+      name: "a",
+      description: "",
+      params: {},
+      handler: () => "did a",
+    });
+    defineTool({
+      name: "b",
+      description: "",
+      params: { v: { type: "string", required: true } },
+      legacyParam: "v",
+      handler: ({ v }) => `did b with ${v}`,
+    });
+
+    const text = "Hello <<<ACTION:a>>> middle <<<ACTION:b:hi>>> end";
+    const result = executeActionsWithTrace(text, { getStore: () => ({}) as ApexState });
+
+    expect(result.toolCalls).toHaveLength(2);
+    expect(result.toolCalls[0]).toMatchObject<Partial<ToolCallTrace>>({
+      name: "a",
+      params: {},
+      error: null,
+    });
+    expect(result.toolCalls[1]).toMatchObject<Partial<ToolCallTrace>>({
+      name: "b",
+      params: { v: "hi" },
+      error: null,
+    });
+    expect(result.displayText).toBe("Hello  middle  end");
+  });
+});
+
+// ─── hashPrompt + newConversationId ─────────────────────────────
+
+describe("hashPrompt", () => {
+  it("is deterministic", () => {
+    expect(hashPrompt("hello world")).toBe(hashPrompt("hello world"));
+  });
+
+  it("changes when input changes (collision-resistant for short strings)", () => {
+    expect(hashPrompt("hello world")).not.toBe(hashPrompt("hello world!"));
+    expect(hashPrompt("a")).not.toBe(hashPrompt("b"));
+  });
+
+  it("returns a hex string", () => {
+    expect(hashPrompt("anything")).toMatch(/^[0-9a-f]+$/);
+  });
+});
+
+describe("newConversationId", () => {
+  it("returns a non-empty string", () => {
+    const id = newConversationId();
+    expect(id).toBeTruthy();
+    expect(typeof id).toBe("string");
+  });
+
+  it("is unique across calls", () => {
+    const ids = new Set(Array.from({ length: 50 }, () => newConversationId()));
+    expect(ids.size).toBe(50);
+  });
+});
+
+// ─── logTurnTrace fail-safe ─────────────────────────────────────
+
+describe("logTurnTrace — fail-safe semantics", () => {
+  const validTrace = {
+    conversation_id: "cv_test",
+    turn_index: 0,
+    user_message: "hi",
+    assistant_message: "hello",
+    display_text: "hello",
+    tool_calls: [],
+    model_provider: "gemini",
+    model_id: "gemini-2.5-pro",
+    system_prompt_hash: "abc",
+    system_prompt_size: 100,
+    dataset: null,
+    active_module: "spirtes",
+    selected_node: null,
+    active_shock_count: 0,
+  };
+
+  it("returns true on a 200 response", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true } as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await logTurnTrace(validTrace);
+    expect(result).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/copilot/trace",
+      expect.objectContaining({ method: "POST" }),
+    );
+
+    vi.unstubAllGlobals();
+  });
+
+  it("returns false (does not throw) on a 500 response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 } as Response));
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = await logTurnTrace(validTrace);
+    expect(result).toBe(false);
+    expect(consoleSpy).toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns false (does not throw) when fetch rejects", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = await logTurnTrace(validTrace);
+    expect(result).toBe(false);
+    expect(consoleSpy).toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it("posts the trace as JSON in the request body", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true } as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await logTurnTrace(validTrace);
+    const callArgs = fetchSpy.mock.calls[0]![1] as RequestInit;
+    expect(callArgs.headers).toMatchObject({ "Content-Type": "application/json" });
+    expect(JSON.parse(callArgs.body as string)).toEqual(validTrace);
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/lib/copilot-actions.ts
+++ b/src/lib/copilot-actions.ts
@@ -13,7 +13,9 @@ import {
   stripActionTags,
   executeTag,
   executeActions,
+  executeActionsWithTrace,
   type ParsedActionTag,
+  type ToolCallTrace,
 } from "./copilot/tool-registry";
 
 // Side-effect import: registers all built-in tools with the registry.
@@ -53,4 +55,19 @@ export function processLlmActions(text: string): {
 } {
   const { displayText, toolResults } = executeActions(text);
   return { displayText, actionResults: toolResults };
+}
+
+/**
+ * Same as processLlmActions, but also returns the structured
+ * per-call trace data (for trace-logger / Supabase). Use this when
+ * you want to capture timing + params + errors in addition to the
+ * human-readable result strings.
+ */
+export function processLlmActionsWithTrace(text: string): {
+  displayText: string;
+  actionResults: string[];
+  toolCalls: ToolCallTrace[];
+} {
+  const { displayText, toolResults, toolCalls } = executeActionsWithTrace(text);
+  return { displayText, actionResults: toolResults, toolCalls };
 }

--- a/src/lib/copilot/tool-registry.ts
+++ b/src/lib/copilot/tool-registry.ts
@@ -256,41 +256,135 @@ export interface ExecutionResult {
 }
 
 /**
+ * Structured per-call trace. One of these is produced for every
+ * <<<ACTION:...>>> tag the LLM emitted. Designed to land in
+ * Supabase as a row in tool_calls[] — the field shape mirrors the
+ * jsonb structure described in supabase-copilot-traces.sql.
+ */
+export interface ToolCallTrace {
+  /** Tool name (e.g. "isolate_nodes"). */
+  name: string;
+  /** Validated, coerced params — what the handler actually saw. */
+  params: Record<string, unknown>;
+  /** Human-readable result string returned by the handler. */
+  result: string;
+  /** Error message if the handler threw or validation failed; null on success. */
+  error: string | null;
+  /** Wall-clock duration of the handler call. */
+  latency_ms: number;
+}
+
+export interface TracedExecutionResult extends ExecutionResult {
+  /** One entry per parsed action tag, in source order. */
+  toolCalls: ToolCallTrace[];
+}
+
+/**
  * Top-level entry point: parse all <<<ACTION:...>>> tags from an
  * LLM response, validate each, run handlers, and return the cleaned
  * display text plus the list of human-readable tool results.
+ *
+ * Back-compat shape — discards the structured trace data. Use
+ * executeActionsWithTrace when you want the trace for logging.
  */
 export function executeActions(
   text: string,
   ctx: ToolContext = defaultContext,
 ): ExecutionResult {
+  const { displayText, toolResults } = executeActionsWithTrace(text, ctx);
+  return { displayText, toolResults };
+}
+
+/**
+ * Same as executeActions, but also returns structured per-call
+ * trace data (params, result, error, latency_ms) for each tag.
+ * SystemCopilot uses this to build a TurnTrace and POST it to
+ * /api/copilot/trace.
+ */
+export function executeActionsWithTrace(
+  text: string,
+  ctx: ToolContext = defaultContext,
+): TracedExecutionResult {
   const tags = parseActionTags(text);
   const displayText = stripActionTags(text);
   const toolResults: string[] = [];
+  const toolCalls: ToolCallTrace[] = [];
 
   for (const tag of tags) {
-    const result = executeTag(tag, ctx);
-    if (result) toolResults.push(result);
+    const traced = executeTagWithTrace(tag, ctx);
+    toolResults.push(traced.result);
+    toolCalls.push(traced);
   }
 
-  return { displayText, toolResults };
+  return { displayText, toolResults, toolCalls };
 }
 
 /** Execute a single parsed action tag. Exported for tests. */
 export function executeTag(tag: ParsedActionTag, ctx: ToolContext = defaultContext): string {
+  return executeTagWithTrace(tag, ctx).result;
+}
+
+/**
+ * Execute a single tag and return both the result string and the
+ * structured trace. Used by executeActionsWithTrace; exported for
+ * targeted unit tests that want to inspect timing/error semantics.
+ */
+export function executeTagWithTrace(
+  tag: ParsedActionTag,
+  ctx: ToolContext = defaultContext,
+): ToolCallTrace {
+  const start = performanceNow();
   const tool = REGISTRY.get(tag.name);
-  if (!tool) return `Unknown action: ${tag.name}`;
+  if (!tool) {
+    return {
+      name: tag.name,
+      params: {},
+      result: `Unknown action: ${tag.name}`,
+      error: `Unknown action: ${tag.name}`,
+      latency_ms: Math.round(performanceNow() - start),
+    };
+  }
 
   const kv = parseKvPayload(tag.payload);
   const validated = coerceAndValidate(tool.params, kv, tool.legacyParam);
-  if (!validated.ok) return `${tag.name}: ${validated.error}`;
+  if (!validated.ok) {
+    return {
+      name: tag.name,
+      params: kv,
+      result: `${tag.name}: ${validated.error}`,
+      error: validated.error,
+      latency_ms: Math.round(performanceNow() - start),
+    };
+  }
 
   try {
-    return tool.handler(validated.params, ctx);
+    const result = tool.handler(validated.params, ctx);
+    return {
+      name: tag.name,
+      params: validated.params as Record<string, unknown>,
+      result,
+      error: null,
+      latency_ms: Math.round(performanceNow() - start),
+    };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    return `${tag.name} failed: ${msg}`;
+    return {
+      name: tag.name,
+      params: validated.params as Record<string, unknown>,
+      result: `${tag.name} failed: ${msg}`,
+      error: msg,
+      latency_ms: Math.round(performanceNow() - start),
+    };
   }
+}
+
+// performance.now() in browsers + Node 16+; fall back to Date.now()
+// in obscure runtimes (Cloudflare Workers etc) for safety.
+function performanceNow(): number {
+  if (typeof performance !== "undefined" && typeof performance.now === "function") {
+    return performance.now();
+  }
+  return Date.now();
 }
 
 // ─── Prompt rendering ───────────────────────────────────────────

--- a/src/lib/copilot/trace-logger.ts
+++ b/src/lib/copilot/trace-logger.ts
@@ -1,0 +1,105 @@
+// ─── Copilot Trace Logger ───────────────────────────────────────
+//
+// Captures every copilot turn as a structured row for replay,
+// eval, and (eventually) training-data collection. The shape
+// here mirrors the supabase-copilot-traces.sql schema 1:1.
+//
+// Design: fire-and-forget POST to /api/copilot/trace. Logging
+// MUST never block the chat or surface errors to the user — if
+// the POST fails, we log to the console and move on.
+
+import type { ToolCallTrace } from "./tool-registry";
+
+// ─── Types ──────────────────────────────────────────────────────
+
+/**
+ * One row in the copilot_traces table. Mirrors the columns
+ * declared in supabase-copilot-traces.sql.
+ */
+export interface TurnTrace {
+  conversation_id: string;
+  turn_index: number;
+  user_message: string | null;
+  assistant_message: string | null;
+  display_text: string | null;
+  tool_calls: ToolCallTrace[];
+  model_provider: string | null;
+  model_id: string | null;
+  system_prompt_hash: string | null;
+  system_prompt_size: number | null;
+  dataset: string | null;
+  active_module: string | null;
+  selected_node: string | null;
+  active_shock_count: number | null;
+  client_meta?: Record<string, unknown>;
+}
+
+// ─── Public API ─────────────────────────────────────────────────
+
+/**
+ * POST a turn trace to the server. Fire-and-forget — the returned
+ * Promise resolves to true on success, false on any failure, but
+ * callers should NOT await it from the chat hot path. Logging
+ * failures must never break the user's chat experience.
+ */
+export async function logTurnTrace(trace: TurnTrace): Promise<boolean> {
+  // Skip logging in test/SSR environments where fetch isn't available.
+  if (typeof fetch === "undefined") return false;
+
+  try {
+    const res = await fetch("/api/copilot/trace", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(trace),
+      // Never let logging hang the page — give it a generous but
+      // bounded budget.
+      signal: AbortSignal.timeout(5000),
+      // Send in the background so a tab close doesn't lose the
+      // last turn. keepalive payloads are capped at 64KB; if
+      // the trace is bigger than that, the browser will fall
+      // back to a regular fetch.
+      keepalive: true,
+    });
+    if (!res.ok) {
+      console.warn(`[copilot-trace] log failed: HTTP ${res.status}`);
+      return false;
+    }
+    return true;
+  } catch (err) {
+    // Logging never throws upward.
+    console.warn("[copilot-trace] log failed:", err);
+    return false;
+  }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+/**
+ * Cheap, deterministic, non-cryptographic hash of a string. Used
+ * as the system_prompt_hash so we can tell whether two turns
+ * shared a prompt without storing the prompt itself. djb2 is
+ * fast, has good distribution for short-medium strings, and
+ * collisions don't matter for our analytics use case.
+ */
+export function hashPrompt(prompt: string): string {
+  let h = 5381;
+  for (let i = 0; i < prompt.length; i++) {
+    h = (h * 33) ^ prompt.charCodeAt(i);
+  }
+  // 32-bit unsigned, hex — short and stable across runtimes.
+  return (h >>> 0).toString(16);
+}
+
+/**
+ * Generate a fresh conversation id. We use this when a chat
+ * session boots; SystemCopilot keeps it stable across turns and
+ * resets it when the user clears the conversation.
+ */
+export function newConversationId(): string {
+  // crypto.randomUUID is available in all modern browsers + Node 18+.
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  // Fallback for very old runtimes — sufficient entropy for our purposes.
+  return `cv_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/supabase-copilot-traces.sql
+++ b/supabase-copilot-traces.sql
@@ -1,0 +1,127 @@
+-- =============================================================
+-- APEX Terminal — Copilot Trace Store (PR2)
+-- Run this in the Supabase SQL Editor after supabase-setup.sql
+-- =============================================================
+--
+-- Purpose: capture every copilot turn as a structured row so we
+-- can later replay conversations, build evals, and use traces as
+-- training material for distillation / fine-tuning.
+--
+-- One row = one turn (user message → assistant response). All
+-- tool calls fired during that turn are stored together in the
+-- tool_calls jsonb array, keeping related events colocated.
+-- =============================================================
+
+create table if not exists public.copilot_traces (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+
+  -- Identity. user_id is nullable so anonymous / pre-auth turns
+  -- still log (useful for marketing-page demos). RLS keeps users
+  -- restricted to their own rows.
+  user_id uuid references auth.users(id) on delete set null,
+  conversation_id text not null,
+  turn_index integer not null,
+
+  -- Conversation payload. user_message is what the user typed;
+  -- assistant_message is the LLM's full response (including any
+  -- <<<ACTION:...>>> tags); display_text is the cleaned text the
+  -- user actually sees in the chat panel.
+  user_message text,
+  assistant_message text,
+  display_text text,
+
+  -- Structured tool invocations. Shape per element:
+  --   { name: text, params: jsonb, result: text,
+  --     error: text | null, latency_ms: int }
+  tool_calls jsonb not null default '[]'::jsonb,
+
+  -- Model metadata — lets us A/B compare providers later.
+  model_provider text,
+  model_id text,
+
+  -- System prompt accounting. We store size + a cheap hash so we
+  -- can tell "did the prompt change between turns?" without
+  -- copying the full prompt (~50-200KB) into every row. The
+  -- prompt itself is reconstructable from graph state if needed.
+  system_prompt_hash text,
+  system_prompt_size integer,
+
+  -- Active platform context — the inputs that shaped the prompt.
+  -- Enough to roughly recreate the turn for replay/eval.
+  dataset text,
+  active_module text,
+  selected_node text,
+  active_shock_count integer,
+
+  -- Free-form extension point. Client version, feature flags,
+  -- A/B test arms, anything else we want to slice on later.
+  client_meta jsonb not null default '{}'::jsonb
+);
+
+-- Indexes ------------------------------------------------------
+
+-- "Show me my history" — the hot per-user read.
+create index if not exists copilot_traces_user_created_idx
+  on public.copilot_traces (user_id, created_at desc)
+  where user_id is not null;
+
+-- Ordered conversation playback.
+create index if not exists copilot_traces_conversation_idx
+  on public.copilot_traces (conversation_id, turn_index);
+
+-- Global recency for admin dashboards.
+create index if not exists copilot_traces_created_idx
+  on public.copilot_traces (created_at desc);
+
+-- Tool-call lookup: "find all turns where isolate_nodes was
+-- called". jsonb_path_ops is smaller + faster for @> containment
+-- queries than the default jsonb_ops.
+create index if not exists copilot_traces_tool_calls_gin
+  on public.copilot_traces using gin (tool_calls jsonb_path_ops);
+
+-- RLS ----------------------------------------------------------
+
+alter table public.copilot_traces enable row level security;
+
+-- Users can read only their own traces.
+drop policy if exists "Users read own copilot traces" on public.copilot_traces;
+create policy "Users read own copilot traces"
+  on public.copilot_traces for select
+  using (auth.uid() = user_id);
+
+-- Inserts go through the API route under the service role, so
+-- no INSERT policy for anon/authenticated. Service role bypasses
+-- RLS by default, which is what we want.
+
+-- =============================================================
+-- ANALYTICS HELPERS (run on demand in the SQL editor)
+-- =============================================================
+--
+-- Most-called tools in the last 7 days:
+--
+--   select
+--     tc->>'name' as tool,
+--     count(*) as calls,
+--     avg((tc->>'latency_ms')::int) as avg_latency_ms
+--   from public.copilot_traces,
+--        jsonb_array_elements(tool_calls) as tc
+--   where created_at > now() - interval '7 days'
+--   group by 1 order by 2 desc;
+--
+-- Conversations that hit isolate_nodes:
+--
+--   select distinct conversation_id, created_at
+--   from public.copilot_traces
+--   where tool_calls @> '[{"name": "isolate_nodes"}]'::jsonb
+--   order by created_at desc;
+--
+-- Tool failure rate by tool:
+--
+--   select
+--     tc->>'name' as tool,
+--     count(*) filter (where tc->>'error' is not null) * 1.0 / count(*) as failure_rate
+--   from public.copilot_traces,
+--        jsonb_array_elements(tool_calls) as tc
+--   group by 1 order by 2 desc;
+-- =============================================================


### PR DESCRIPTION
**Stacks on [#249](https://github.com/ApexAnalytica/apex-terminal/pull/249).** Review/merge that one first.

## Summary

Every copilot turn now lands as a structured row in `public.copilot_traces`. **From this point forward every conversation is replay-able, analyzable, and training-ready.** That's the foundation for everything else in the LLM roadmap — evals, A/B model bake-offs, distillation onto a small open-weights model.

One row = one turn. All tool calls fired during that turn are colocated in a `tool_calls jsonb[]` array, so a turn is a self-contained training example.

## Schema (`supabase-copilot-traces.sql`)

| Column | Why |
| --- | --- |
| `conversation_id`, `turn_index` | Ordered playback |
| `user_message`, `assistant_message`, `display_text` | The conversation pair |
| `tool_calls jsonb[]` | `{name, params, result, error, latency_ms}` per call |
| `model_provider`, `model_id` | A/B comparable across providers |
| `system_prompt_hash`, `system_prompt_size` | "Did the prompt change?" without storing 50–200KB blobs every turn |
| `dataset`, `active_module`, `selected_node`, `active_shock_count` | Platform context — enough to roughly recreate the turn |
| `client_meta jsonb` | Free-form extension point (feature flags, A/B arms, build version) |

**Indexes:** per-user recency, conversation playback, global recency, plus a GIN index on `tool_calls` so `tool_calls @> '[{"name": "isolate_nodes"}]'` is fast.

**RLS:** users read only their own rows; inserts go through the service role only.

The SQL file ships with three example analytics queries (most-called tools, failure rate by tool, conversations using a specific tool) as comments at the bottom — paste-and-run in the Supabase SQL Editor.

## Client (`src/lib/copilot/trace-logger.ts`)

- `logTurnTrace(trace)` — POSTs to `/api/copilot/trace` with `keepalive: true` + 5s `AbortSignal.timeout`. **Fire-and-forget**; failures land in `console.warn` only. Logging must never break chat.
- `hashPrompt(s)` — djb2 string hash. Cheap, deterministic, sufficient for "did the prompt change between turns?"
- `newConversationId()` — `crypto.randomUUID()` with a Date+Math.random fallback for old runtimes.

## Server (`src/app/api/copilot/trace/route.ts`)

- Validates the payload shape (`conversation_id`, `turn_index`, `tool_calls[]`); clamps oversized fields; rejects bad input with 400.
- **Resolves `user_id` from the auth session server-side** — clients can't spoof identity by setting it in the body.
- Inserts via the service-role client.

## Wiring (`SystemCopilot.tsx`)

- `conversationIdRef` + `turnIndexRef` stable across the chat session.
- After streaming completes, builds a `TurnTrace` and fires `logTurnTrace(...)` (intentionally not awaited).
- `processLlmActions` → `processLlmActionsWithTrace` exposes the structured tool calls alongside the legacy result strings (back-compat preserved).

## Registry extensions

Built on PR #249's tool registry — the registry now also produces structured per-call traces:

- `ToolCallTrace` type
- `executeTagWithTrace(tag, ctx)` returns `{name, params, result, error, latency_ms}`
- `executeActionsWithTrace(text, ctx)` runs all tags and returns `{displayText, toolResults, toolCalls[]}`
- `executeTag` stays as the back-compat string-returning entrypoint

## Test plan

- [x] `vitest run` — **733/733 pass** (13 new trace tests)
- [x] `tsc --noEmit` — clean
- [x] `eslint` on touched files — clean (only pre-existing warnings)
- [ ] Run `supabase-copilot-traces.sql` in the Supabase SQL Editor (production)
- [ ] Confirm `SUPABASE_SERVICE_ROLE_KEY` is set in Vercel env (likely already is — used by `/api/feedback`)
- [ ] Manual: send a chat message, verify a row appears in `copilot_traces` with `tool_calls` populated
- [ ] Manual: induce a tool error (typo a node id), verify the row's `tool_calls[].error` is populated and chat continues uninterrupted
- [ ] Manual: drop the network mid-chat, confirm chat keeps working (logging silently fails)

## Sample analytics queries

```sql
-- Most-called tools in last 7 days
select tc->>'name' as tool, count(*) as calls,
       avg((tc->>'latency_ms')::int) as avg_latency_ms
from public.copilot_traces, jsonb_array_elements(tool_calls) as tc
where created_at > now() - interval '7 days'
group by 1 order by 2 desc;

-- Conversations that used isolate_nodes
select distinct conversation_id, created_at
from public.copilot_traces
where tool_calls @> '[{"name": "isolate_nodes"}]'::jsonb
order by created_at desc;

-- Tool failure rate
select tc->>'name' as tool,
       count(*) filter (where tc->>'error' is not null) * 1.0 / count(*) as failure_rate
from public.copilot_traces, jsonb_array_elements(tool_calls) as tc
group by 1 order by 2 desc;
```

## Next (PR3)

Provider abstraction via [Vercel AI SDK](https://sdk.vercel.ai/) so we can A/B across Claude / Gemini / local Ollama / Llama-via-vLLM without changing call sites. Traces stay schema-identical regardless of which model produced them — meaning we can directly compare provider performance on the same conversation distribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
