### PR TITLE
docs(sessions): add copilot.md scope doc

### DIFF
--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -10,6 +10,7 @@ Manifold development is split across focused sessions. Each session owns a slice
 | Platform | [`platform.md`](./platform.md) | Auth, Supabase plumbing, middleware, webhooks, admin/feedback triage backend, account provisioning |
 | Payments | [`payments.md`](./payments.md) | Billing, tier gating logic, payment flows |
 | Rendering | [`rendering.md`](./rendering.md) | 2D/3D/MAP canvas, layout algorithms, viewport, selection, render performance |
+| Copilot | [`copilot.md`](./copilot.md) | Chat-as-platform-control: tool registry, system prompt, trace store, LLM provider, conversation memory |
 | SPIRTES | [`spirtes.md`](./spirtes.md) | Causal-discovery engine (DCD/NOTEARS, PCMCI+, FCI) |
 | TARSKI | [`tarski.md`](./tarski.md) | Constraint-verification engine (PHYSICAL / REGULATORY / HEURISTIC axioms) |
 | PEARL | [`pearl.md`](./pearl.md) | Do-calculus interventions, ablations, CASCADE DEFENSE auto-interdiction |

--- a/docs/sessions/copilot.md
+++ b/docs/sessions/copilot.md
@@ -1,0 +1,98 @@
+# Session: Copilot (Linguistic Access Layer)
+
+Owns the chat/copilot as the linguistic access layer to the platform: tool-use primitive, intent routing, node isolation, system prompt, LLM provider selection, conversation memory, trace logging. Long-term this evolves into a hybrid LLM/agent specialized for Apex Analytica's domain.
+
+> **Status:** Active. Tool registry shipped ([#249](https://github.com/ApexAnalytica/apex-terminal/pull/249)). Trace store shipped ([#251](https://github.com/ApexAnalytica/apex-terminal/pull/251)). Provider abstraction (Vercel AI SDK) is the next planned PR.
+
+## Scope summary (in)
+
+- **Tool registry** — `defineTool` / param schemas / wire-format parsing / system-prompt rendering (`src/lib/copilot/tool-registry.ts`).
+- **Built-in tools** — every action the LLM can emit (`src/lib/copilot/tools.ts`). Adding a new copilot capability = `defineTool({...})` here.
+- **System prompt construction** — auto-generated tool list + graph context + engine state (`src/lib/copilot-context.ts`).
+- **Trace logging** — every turn captured as a structured row in `public.copilot_traces` (`src/lib/copilot/trace-logger.ts`, `src/app/api/copilot/trace/route.ts`, `supabase-copilot-traces.sql`).
+- **LLM call site** — `streamLlmQuery` in `src/lib/copilot-engine.ts`. Today: direct Anthropic / Gemini / Ollama calls. Planned: Vercel AI SDK provider abstraction so the call site is provider-agnostic.
+- **Action routing into the store** — every tool handler accepts a `ToolContext` and reads/writes `useApexStore`. The handler decides what platform state changes (selection, isolation, shock injection, module switch, …).
+- **Wire format** — `<<<ACTION:name:k=v,k=v>>>` text protocol. Comma separates kv pairs; `|` separates list items inside a value. Bare payloads (`<<<ACTION:select_node:USA_GRID>>>`) routed onto the tool's `legacyParam`.
+
+## Scope summary (out — route elsewhere)
+
+- **Chat panel chrome** — `SystemCopilot.tsx` UI (input box, message list, autocomplete dropdown, settings panel, voice input/output) → **UX & Onboarding**. This session changes `SystemCopilot.tsx` only when wiring trace capture or model providers — not for visual / interaction tweaks.
+- **Engine state itself** — TARSKI / SPIRTES / PEARL / PARETO own their own data and validation. Copilot only *consumes* engine state via `summarizeEngineState` (already wired into `copilot-context.ts` via #215 + #217). New engine outputs that should appear in the prompt: route through `engine-state-summary.ts`, not the copilot directly.
+- **Snapshot serialization** — `src/lib/snapshots/` is platform-state plumbing. Copilot reads snapshots via `serializeSnapshotContext` but doesn't author the snapshot format.
+- **Auth / billing gates around the copilot** — **Platform** session.
+- **Domain selection / dataset switching** — owned by data sessions (Geopolitical/Macro, T1D). The copilot has a `set_domains` tool to *invoke* their behavior; it doesn't define which domains exist.
+
+## Boundary clarifications
+
+- **A new tool**: define it in `src/lib/copilot/tools.ts`. The system prompt and the action runner pick it up automatically via `renderToolsForPrompt()`. Don't hand-write a list anywhere.
+- **A new param type** (e.g. nested object): extend the discriminated union in `tool-registry.ts` (`ParamSchema`) and add cases to `coerceParam` + `renderParamSignature`. Keep the shape zod-compatible so we can swap to zod later without changing call sites.
+- **Capturing more about a turn**: extend `TurnTrace` in `trace-logger.ts`, add the column to `supabase-copilot-traces.sql`, and add the field to the API route's validator. Schema changes are append-only — never rename or drop columns once in production.
+- **A new model provider**: today this means a branch in `streamLlmQuery`. After PR3 (Vercel AI SDK abstraction) it'll be a provider config entry. Either way, the trace shape stays identical so traces remain comparable across providers.
+- **Conversation memory**: there is no formal conversation-memory layer yet. Today the LLM gets the full message history per turn (`copilotMessages`). The trace store is the seed for proper memory: replay past conversations to build a per-user retrieval index.
+
+## What's shipped
+
+### PR #249 — tool registry
+Replaced the hand-written `switch` in `copilot-actions.ts` with declarative `defineTool` registrations. Schema-typed params (`string` / `string[]` / `number` / `enum` / `boolean` with `required` / `default` / `min` / `max`). Auto-generated system prompt. JSON-Schema export (`renderToolsAsJsonSchema`) ready for native Anthropic `tool_use` migration. 14 existing actions migrated. Two new tools: `isolate_nodes` (filter visible graph by query or ids), `reset_isolation`. 28 unit tests.
+
+### PR #251 — trace store
+Every copilot turn becomes a row in `public.copilot_traces`. One row = one turn (user msg → assistant msg) with all tool calls colocated in `tool_calls jsonb[]`. Schema captures: conversation id + turn index, full message pair, structured tool calls (`{name, params, result, error, latency_ms}`), model provider/id, system-prompt hash + size, dataset / active module / selected node / shock count, free-form `client_meta`. RLS: users read own rows; writes via service role only. GIN index on `tool_calls` for `@>` containment queries. 13 new tests.
+
+## Architecture
+
+```
+src/lib/copilot/
+  tool-registry.ts     defineTool / schemas / parsers / coercion / prompt rendering / JSON-schema export
+  tools.ts             every built-in tool — register here, system prompt picks it up automatically
+  trace-logger.ts      logTurnTrace (fire-and-forget POST) + hashPrompt + newConversationId
+
+src/lib/
+  copilot-actions.ts   thin compat shim — parseActions / stripActions / processLlmActions(WithTrace)
+  copilot-context.ts   serializeGraphContext — system prompt builder (consumes engine summary)
+  copilot-engine.ts    streamLlmQuery — direct provider calls (PR3 will refactor this)
+
+src/app/api/copilot/
+  route.ts             POST /api/copilot — proxies to the LLM provider (Anthropic/Gemini)
+  trace/route.ts       POST /api/copilot/trace — validates + inserts copilot_traces row
+
+src/components/SystemCopilot.tsx
+                       chat UI. Owned by UX & Onboarding for chrome; this session touches only the
+                       LLM call site + trace-capture block
+
+supabase-copilot-traces.sql
+                       run in Supabase SQL Editor; ships with example analytics queries in comments
+```
+
+## How a turn flows
+
+1. User types a message in `SystemCopilot.tsx` → `handleStreamingQuery(userContent)`.
+2. `serializeGraphContext` builds the system prompt: `renderToolsForPrompt()` (auto-generated tool list) + engine state summary + graph context + active shocks/severed edges + Tarski report.
+3. `streamLlmQuery` POSTs to the provider, streams tokens back.
+4. After streaming completes, `processLlmActionsWithTrace(accumulated)` parses every `<<<ACTION:...>>>` tag, validates params against the registered schema, runs the handler, and returns `{displayText, actionResults, toolCalls}`.
+5. Display text flushes to the store; action results render as a system message; structured `toolCalls` go into a `TurnTrace` and fire-and-forget POST to `/api/copilot/trace`.
+6. Server validates, attaches `user_id` from the auth session, inserts via service role.
+
+## Open follow-ups (priority-ordered)
+
+1. **PR3 — provider abstraction (Vercel AI SDK)**. Replace direct provider calls in `streamLlmQuery` with a unified SDK so flipping between Claude / Gemini / local Ollama / vLLM is a config change, not code. Trace shape stays identical so we can A/B providers on the same conversation distribution. Ship a model picker in the chat UI. **5–7 days of work** — biggest architectural change post-#251.
+2. **Eval harness**. Hand-curate 30–50 user queries with expected tool calls. Run them against current model + candidate models, score on tool-call accuracy + response quality. Use trace data to grow the eval set over time.
+3. **Conversation memory**. Per-user retrieval index built from the trace store. Surfaces relevant past turns into the system prompt instead of dumping the entire `copilotMessages` array every time.
+4. **Native tool-use migration**. Once PR3 ships, optionally swap the `<<<ACTION:...>>>` text wire format for native `tool_use` blocks (Anthropic) / functions (OpenAI) where the provider supports it. The text format stays as the fallback for providers / local models that don't. Registry already exports compatible JSON Schema (`renderToolsAsJsonSchema`).
+5. **Distillation**. When trace volume hits ~10K rows: train a small open model (Llama 3.1 8B / Qwen 3 14B) on Claude/Gemini's traces from this platform via Unsloth + ART (Agent Reinforcement Trainer). Specialized, faster, cheaper, self-hosted. The traces are the moat — general LLMs don't see Apex's domain vocabulary.
+6. **Dataset routing field**. `TurnTrace.dataset` is currently always null because the store doesn't have a top-level `activeDataset` field. Either add one to the store (cheap) or derive it from `selectedDomains` (also cheap). Useful for slicing traces by `main` / `athena` / `t1d` once we do.
+7. **Per-user trace UI**. A "your conversation history" view that reads `copilot_traces` filtered to `auth.uid() = user_id`. Useful for users to revisit past sessions; also a debug tool for us.
+
+## How to start a task
+
+1. Read this file end-to-end.
+2. `git log --oneline main -10` to spot anything that landed since the "Status" line above.
+3. Check open PRs: `gh pr list` (or filter to copilot: `gh pr list --search "copilot in:title"`).
+4. Pick from "Open follow-ups" or take fresh user direction.
+5. **Update this file** at the end of every material change — especially the "What's shipped" section and any architecture diagram drift.
+
+## Cross-session etiquette
+
+- A request that's *about how the chat looks* → route to **UX & Onboarding**.
+- A request that's *about what an engine computes* → route to the engine session (TARSKI / SPIRTES / PEARL / PARETO).
+- A request that's *about new tools the copilot can call* → this session.
+- A request that's *about which model powers the copilot, how it's prompted, or how its output is captured* → this session.

--- a/docs/sessions/copilot.md
+++ b/docs/sessions/copilot.md
@@ -4,6 +4,13 @@ Owns the chat/copilot as the linguistic access layer to the platform: tool-use p
 
 > **Status:** Active. Tool registry shipped ([#249](https://github.com/ApexAnalytica/apex-terminal/pull/249)). Trace store shipped ([#251](https://github.com/ApexAnalytica/apex-terminal/pull/251)). Provider abstraction (Vercel AI SDK) is the next planned PR.
 
+## Defaults & invariants (DO NOT change without explicit user direction)
+
+- **Copilot LLM defaults to Gemini.** This is hardcoded in `SystemCopilot.tsx:93` (`copilotProvider = llmProvider === "ollama" ? "ollama" : "gemini"`) and called out in the comment at `SystemCopilot.tsx:31`: *"Copilot is locked to Gemini; Claude is used exclusively for compute."* Gemini is the chat path because the chat is high-frequency and Gemini is the cheaper / faster choice; Claude is reserved for the low-frequency, heavy-reasoning compute path (snapshot validation, Tarski runs, etc).
+- **Switching providers requires explicit user action.** Today that means picking Ollama in the settings panel. Nothing flips automatically.
+- **PR3 (Vercel AI SDK) preserves this default.** The provider abstraction adds *optionality* (model picker, easier A/B), not a default change. The out-of-the-box experience stays Gemini-on-load. Any change to that default is a separate, explicit user decision — not bundled into the abstraction PR.
+- **Trace shape stays provider-agnostic.** `model_provider` is a column on `copilot_traces`, so we can compare Gemini vs. Claude vs. local Ollama on the same conversation distribution if/when the user opts in — but the comparison is read from the data, not assumed in the prompt or the prompt-rendering code.
+
 ## Scope summary (in)
 
 - **Tool registry** — `defineTool` / param schemas / wire-format parsing / system-prompt rendering (`src/lib/copilot/tool-registry.ts`).
@@ -74,7 +81,7 @@ supabase-copilot-traces.sql
 
 ## Open follow-ups (priority-ordered)
 
-1. **PR3 — provider abstraction (Vercel AI SDK)**. Replace direct provider calls in `streamLlmQuery` with a unified SDK so flipping between Claude / Gemini / local Ollama / vLLM is a config change, not code. Trace shape stays identical so we can A/B providers on the same conversation distribution. Ship a model picker in the chat UI. **5–7 days of work** — biggest architectural change post-#251.
+1. **PR3 — provider abstraction (Vercel AI SDK)**. Replace direct provider calls in `streamLlmQuery` with a unified SDK so flipping between Claude / Gemini / local Ollama / vLLM is a config change, not code. Trace shape stays identical so we can A/B providers on the same conversation distribution. Ship a model picker in the chat UI. **5–7 days of work** — biggest architectural change post-#251. ⚠️ **Default stays Gemini** — see the Defaults & invariants section. The picker adds optionality; the out-of-the-box on-load provider does not change.
 2. **Eval harness**. Hand-curate 30–50 user queries with expected tool calls. Run them against current model + candidate models, score on tool-call accuracy + response quality. Use trace data to grow the eval set over time.
 3. **Conversation memory**. Per-user retrieval index built from the trace store. Surfaces relevant past turns into the system prompt instead of dumping the entire `copilotMessages` array every time.
 4. **Native tool-use migration**. Once PR3 ships, optionally swap the `<<<ACTION:...>>>` text wire format for native `tool_use` blocks (Anthropic) / functions (OpenAI) where the provider supports it. The text format stays as the fallback for providers / local models that don't. Registry already exports compatible JSON Schema (`renderToolsAsJsonSchema`).

--- a/src/app/api/copilot/trace/route.ts
+++ b/src/app/api/copilot/trace/route.ts
@@ -1,0 +1,152 @@
+// ─── POST /api/copilot/trace ────────────────────────────────────
+//
+// Receives a copilot TurnTrace from the browser and inserts it
+// into public.copilot_traces. Uses the service-role client (the
+// table has RLS but no insert policy — only the server side, with
+// a verified user_id from the session, may write).
+//
+// Logging is best-effort. Failures here MUST NOT cascade into the
+// user's chat experience — the route returns 4xx/5xx but the
+// client treats logging as fire-and-forget.
+
+import { NextRequest, NextResponse } from "next/server";
+import { createClient as createServiceClient } from "@supabase/supabase-js";
+import { createClient as createServerClient } from "@/lib/supabase/server";
+
+const supabaseAdmin = createServiceClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+);
+
+// ─── Validation ─────────────────────────────────────────────────
+
+interface IncomingTrace {
+  conversation_id?: unknown;
+  turn_index?: unknown;
+  user_message?: unknown;
+  assistant_message?: unknown;
+  display_text?: unknown;
+  tool_calls?: unknown;
+  model_provider?: unknown;
+  model_id?: unknown;
+  system_prompt_hash?: unknown;
+  system_prompt_size?: unknown;
+  dataset?: unknown;
+  active_module?: unknown;
+  selected_node?: unknown;
+  active_shock_count?: unknown;
+  client_meta?: unknown;
+}
+
+function isString(v: unknown): v is string {
+  return typeof v === "string";
+}
+function isInt(v: unknown): v is number {
+  return typeof v === "number" && Number.isFinite(v) && Number.isInteger(v);
+}
+function isArray(v: unknown): v is unknown[] {
+  return Array.isArray(v);
+}
+
+// Hard caps so a misbehaving client can't fill the table with
+// gigabyte rows. These are generous — typical assistant message
+// is a few KB, system prompt is ~50-200KB.
+const MAX_MESSAGE_LEN = 200_000;
+const MAX_TOOL_CALLS = 50;
+const MAX_TOOL_RESULT_LEN = 50_000;
+
+function clampString(v: unknown, max: number): string | null {
+  if (!isString(v)) return null;
+  return v.length > max ? v.slice(0, max) : v;
+}
+
+interface ToolCallShape {
+  name: string;
+  params: Record<string, unknown>;
+  result: string;
+  error: string | null;
+  latency_ms: number;
+}
+
+function sanitizeToolCalls(input: unknown): ToolCallShape[] | null {
+  if (!isArray(input)) return null;
+  if (input.length > MAX_TOOL_CALLS) return null;
+  const out: ToolCallShape[] = [];
+  for (const tc of input) {
+    if (typeof tc !== "object" || tc === null) return null;
+    const t = tc as Record<string, unknown>;
+    if (!isString(t.name) || t.name.length > 200) return null;
+    const params =
+      typeof t.params === "object" && t.params !== null && !Array.isArray(t.params)
+        ? (t.params as Record<string, unknown>)
+        : {};
+    const result = clampString(t.result, MAX_TOOL_RESULT_LEN) ?? "";
+    const error = t.error === null || t.error === undefined ? null : clampString(t.error, 1000);
+    const latency_ms = isInt(t.latency_ms) && t.latency_ms >= 0 ? t.latency_ms : 0;
+    out.push({ name: t.name, params, result, error, latency_ms });
+  }
+  return out;
+}
+
+// ─── Handler ────────────────────────────────────────────────────
+
+export async function POST(request: NextRequest) {
+  let body: IncomingTrace;
+  try {
+    body = (await request.json()) as IncomingTrace;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (!isString(body.conversation_id) || body.conversation_id.length > 100) {
+    return NextResponse.json({ error: "Invalid conversation_id" }, { status: 400 });
+  }
+  if (!isInt(body.turn_index) || body.turn_index < 0) {
+    return NextResponse.json({ error: "Invalid turn_index" }, { status: 400 });
+  }
+  const toolCalls = sanitizeToolCalls(body.tool_calls);
+  if (toolCalls === null) {
+    return NextResponse.json({ error: "Invalid tool_calls" }, { status: 400 });
+  }
+
+  // Resolve user_id from the auth session (don't trust the client
+  // to claim it). null is fine — anonymous traces are allowed.
+  let userId: string | null = null;
+  try {
+    const supabaseSession = await createServerClient();
+    const { data } = await supabaseSession.auth.getUser();
+    userId = data.user?.id ?? null;
+  } catch {
+    // Anonymous turn — leave userId null.
+  }
+
+  const row = {
+    user_id: userId,
+    conversation_id: body.conversation_id,
+    turn_index: body.turn_index,
+    user_message: clampString(body.user_message, MAX_MESSAGE_LEN),
+    assistant_message: clampString(body.assistant_message, MAX_MESSAGE_LEN),
+    display_text: clampString(body.display_text, MAX_MESSAGE_LEN),
+    tool_calls: toolCalls,
+    model_provider: clampString(body.model_provider, 50),
+    model_id: clampString(body.model_id, 200),
+    system_prompt_hash: clampString(body.system_prompt_hash, 64),
+    system_prompt_size: isInt(body.system_prompt_size) ? body.system_prompt_size : null,
+    dataset: clampString(body.dataset, 100),
+    active_module: clampString(body.active_module, 50),
+    selected_node: clampString(body.selected_node, 200),
+    active_shock_count: isInt(body.active_shock_count) ? body.active_shock_count : null,
+    client_meta:
+      typeof body.client_meta === "object" && body.client_meta !== null && !Array.isArray(body.client_meta)
+        ? (body.client_meta as Record<string, unknown>)
+        : {},
+  };
+
+  const { error } = await supabaseAdmin.from("copilot_traces").insert(row);
+  if (error) {
+    console.error("[copilot-trace] insert failed:", error);
+    return NextResponse.json({ error: "Failed to log trace" }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/components/SystemCopilot.tsx
+++ b/src/components/SystemCopilot.tsx
@@ -10,7 +10,13 @@ import {
   streamLlmQuery,
   CopilotAction,
 } from "@/lib/copilot-engine";
-import { processLlmActions, stripActions } from "@/lib/copilot-actions";
+import { processLlmActionsWithTrace, stripActions } from "@/lib/copilot-actions";
+import {
+  logTurnTrace,
+  hashPrompt,
+  newConversationId,
+  type TurnTrace,
+} from "@/lib/copilot/trace-logger";
 import { CopilotMessage } from "@/lib/types";
 import { getModelsForProvider, type LLMProvider } from "@/lib/llm-providers";
 import { serializeGraphContext, serializeSnapshotContext, serializeTimeWindowContext } from "@/lib/copilot-context";
@@ -129,6 +135,15 @@ export default function SystemCopilot() {
   const badgeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const recognitionRef = useRef<SpeechRecognition | null>(null);
   const lastSpokenMsgRef = useRef<string | null>(null);
+  // Conversation identity for trace logging. Stable across the
+  // session; resets when the chat is cleared. turn_index is a
+  // monotonically increasing counter so we can replay traces in
+  // order. Lazily initialized so SSR doesn't call crypto.randomUUID.
+  const conversationIdRef = useRef<string | null>(null);
+  const turnIndexRef = useRef<number>(0);
+  if (conversationIdRef.current === null && typeof window !== "undefined") {
+    conversationIdRef.current = newConversationId();
+  }
 
   // Gemini is always active — server-side env var provides the key if client doesn't
   const isLlmActive = copilotProvider === "ollama" || copilotProvider === "gemini" || copilotApiKey.length > 0;
@@ -407,7 +422,7 @@ export default function SystemCopilot() {
         }
 
         // After streaming completes, execute any actions from the full response
-        const { displayText, actionResults } = processLlmActions(accumulated);
+        const { displayText, actionResults, toolCalls } = processLlmActionsWithTrace(accumulated);
         // Flush final text to the store in one write
         useApexStore.setState((s) => ({
           copilotMessages: s.copilotMessages.map((m) =>
@@ -426,6 +441,51 @@ export default function SystemCopilot() {
             content: `ACTIONS EXECUTED:\n${actionSummary}`,
             timestamp: Date.now(),
           });
+        }
+
+        // \u2500\u2500\u2500 Trace logging (PR2) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+        // Fire-and-forget POST to /api/copilot/trace. We hash the
+        // system prompt instead of storing the full text \u2014 too large
+        // to log every turn. Logging never awaits and never blocks
+        // the chat; failures land in console.warn only.
+        try {
+          const conversationId = conversationIdRef.current ?? newConversationId();
+          conversationIdRef.current = conversationId;
+          const turnIndex = turnIndexRef.current++;
+          const systemPromptText = serializeGraphContext(graphData, {
+            selectedNode,
+            severedEdges,
+            shocks,
+            interventionMode,
+            interventionTarget,
+            ablationMode,
+            ablatedNodeIds,
+            ablatedEdgeIds,
+            tarskiReport,
+          }) + (snapshotContext ? "\n\n" + snapshotContext : "");
+          const trace: TurnTrace = {
+            conversation_id: conversationId,
+            turn_index: turnIndex,
+            user_message: userContent,
+            assistant_message: accumulated,
+            display_text: displayText,
+            tool_calls: toolCalls,
+            model_provider: copilotProvider,
+            model_id: copilotModel,
+            system_prompt_hash: hashPrompt(systemPromptText),
+            system_prompt_size: systemPromptText.length,
+            // dataset routing isn't in the store yet (PR3 candidate);
+            // leave null so the column is still queryable when added.
+            dataset: null,
+            active_module: activeModule,
+            selected_node: selectedNode,
+            active_shock_count: shocks.length,
+          };
+          // Intentionally not awaited \u2014 logging is best-effort.
+          void logTurnTrace(trace);
+        } catch (logErr) {
+          // Never let trace prep errors leak into the chat.
+          console.warn("[copilot-trace] prep failed:", logErr);
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : "LLM request failed";
@@ -459,6 +519,8 @@ export default function SystemCopilot() {
       ablationMode,
       ablatedNodeIds,
       ablatedEdgeIds,
+      activeModule,
+      tarskiReport,
       addCopilotMessage,
       setIsLlmStreaming,
     ]

--- a/src/lib/__tests__/copilot-tool-registry.test.ts
+++ b/src/lib/__tests__/copilot-tool-registry.test.ts
@@ -1,0 +1,373 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  defineTool,
+  parseActionTags,
+  parseKvPayload,
+  coerceAndValidate,
+  executeTag,
+  executeActions,
+  renderToolsForPrompt,
+  renderToolsAsJsonSchema,
+  __resetRegistryForTests,
+  type ToolContext,
+  type ParamShape,
+} from "@/lib/copilot/tool-registry";
+import type { ApexState } from "@/stores/useApexStore";
+import type { CausalGraph, CausalNode } from "@/lib/types";
+import { makeNode, makeEdge, makeGraph } from "./fixtures/graph-fixtures";
+
+// ─── Mock context ───────────────────────────────────────────────
+
+interface StoreSpy {
+  setSelectedNode: { calls: (string | null)[] };
+  setSelectedNodes: { calls: string[][] };
+  setIsolateSelection: { calls: boolean[] };
+  graph: CausalGraph;
+  selectedNodes: string[];
+  isolateSelection: boolean;
+}
+
+function makeMockContext(graph: CausalGraph): { ctx: ToolContext; spy: StoreSpy } {
+  const spy: StoreSpy = {
+    setSelectedNode: { calls: [] },
+    setSelectedNodes: { calls: [] },
+    setIsolateSelection: { calls: [] },
+    graph,
+    selectedNodes: [],
+    isolateSelection: false,
+  };
+
+  const fakeStore = {
+    graphData: graph,
+    selectedNodes: spy.selectedNodes,
+    isolateSelection: spy.isolateSelection,
+    setSelectedNode: (id: string | null) => spy.setSelectedNode.calls.push(id),
+    setSelectedNodes: (ids: string[]) => {
+      spy.setSelectedNodes.calls.push(ids);
+      spy.selectedNodes = ids;
+    },
+    setIsolateSelection: (on: boolean) => {
+      spy.setIsolateSelection.calls.push(on);
+      spy.isolateSelection = on;
+    },
+  } as unknown as ApexState;
+
+  return { ctx: { getStore: () => fakeStore }, spy };
+}
+
+// ─── Parser tests ───────────────────────────────────────────────
+
+describe("parseActionTags", () => {
+  it("extracts a single bare action tag", () => {
+    const tags = parseActionTags("Hello <<<ACTION:select_node:USA_GRID>>> world.");
+    expect(tags).toHaveLength(1);
+    expect(tags[0]).toMatchObject({ name: "select_node", payload: "USA_GRID" });
+  });
+
+  it("extracts multiple tags from one response", () => {
+    const tags = parseActionTags("<<<ACTION:add_shock:TAIWAN>>> then <<<ACTION:set_module:pearl>>>");
+    expect(tags).toHaveLength(2);
+    expect(tags.map((t) => t.name)).toEqual(["add_shock", "set_module"]);
+  });
+
+  it("handles a payload-less tag (nullary action)", () => {
+    const tags = parseActionTags("<<<ACTION:reset_severed>>>");
+    expect(tags).toHaveLength(1);
+    expect(tags[0]).toMatchObject({ name: "reset_severed", payload: "" });
+  });
+});
+
+describe("parseKvPayload", () => {
+  it("parses a single k=v pair", () => {
+    expect(parseKvPayload("budget=3")).toEqual({ budget: "3" });
+  });
+
+  it("parses multiple k=v pairs separated by commas", () => {
+    expect(parseKvPayload("budget=3,mode=edge")).toEqual({ budget: "3", mode: "edge" });
+  });
+
+  it("preserves a bare payload as _legacy for back-compat", () => {
+    expect(parseKvPayload("USA_GRID")).toEqual({ _legacy: "USA_GRID" });
+  });
+
+  it("returns empty for an empty payload", () => {
+    expect(parseKvPayload("")).toEqual({});
+    expect(parseKvPayload("   ")).toEqual({});
+  });
+
+  it("trims whitespace inside k=v", () => {
+    expect(parseKvPayload(" budget = 3 , mode = edge ")).toEqual({ budget: "3", mode: "edge" });
+  });
+});
+
+// ─── Coercion tests ─────────────────────────────────────────────
+
+describe("coerceAndValidate", () => {
+  it("validates a required string", () => {
+    const shape = { node: { type: "string", required: true } } as const satisfies ParamShape;
+    expect(coerceAndValidate(shape, { node: "USA_GRID" }, undefined).ok).toBe(true);
+    const missing = coerceAndValidate(shape, {}, undefined);
+    expect(missing.ok).toBe(false);
+    if (!missing.ok) expect(missing.error).toMatch(/Missing required/);
+  });
+
+  it("routes the legacy payload onto the designated legacyParam", () => {
+    const shape = { node: { type: "string", required: true } } as const satisfies ParamShape;
+    const result = coerceAndValidate(shape, { _legacy: "USA_GRID" }, "node");
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.params.node).toBe("USA_GRID");
+  });
+
+  it("splits string[] on `|` (not `,`)", () => {
+    const shape = { ids: { type: "string[]" } } as const satisfies ParamShape;
+    const result = coerceAndValidate(shape, { ids: "A|B|C" }, undefined);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.params.ids).toEqual(["A", "B", "C"]);
+  });
+
+  it("clamps numbers to declared min/max", () => {
+    const shape = {
+      budget: { type: "number", min: 1, max: 10, required: true },
+    } as const satisfies ParamShape;
+    const tooHigh = coerceAndValidate(shape, { budget: "999" }, undefined);
+    expect(tooHigh.ok).toBe(true);
+    if (tooHigh.ok) expect(tooHigh.params.budget).toBe(10);
+    const tooLow = coerceAndValidate(shape, { budget: "0" }, undefined);
+    expect(tooLow.ok).toBe(true);
+    if (tooLow.ok) expect(tooLow.params.budget).toBe(1);
+  });
+
+  it("applies a default when the param is missing", () => {
+    const shape = {
+      budget: { type: "number", default: 3 },
+      mode: { type: "enum", values: ["edge", "node"] as const, default: "edge" },
+    } as const satisfies ParamShape;
+    const result = coerceAndValidate(shape, {}, undefined);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.params.budget).toBe(3);
+      expect(result.params.mode).toBe("edge");
+    }
+  });
+
+  it("rejects enum values outside the declared set", () => {
+    const shape = {
+      mode: { type: "enum", values: ["edge", "node"] as const, required: true },
+    } as const satisfies ParamShape;
+    const bad = coerceAndValidate(shape, { mode: "purple" }, undefined);
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) expect(bad.error).toMatch(/not in/);
+  });
+});
+
+// ─── Registry + execution ───────────────────────────────────────
+
+describe("registry — defineTool / executeTag", () => {
+  beforeEach(() => {
+    __resetRegistryForTests();
+  });
+
+  it("returns 'Unknown action' for an unregistered name", () => {
+    const result = executeTag(
+      { name: "nope", payload: "", raw: "" },
+      { getStore: () => ({}) as ApexState },
+    );
+    expect(result).toMatch(/Unknown action: nope/);
+  });
+
+  it("rejects invalid params with a clear error before invoking the handler", () => {
+    let called = false;
+    defineTool({
+      name: "select_node",
+      description: "test",
+      params: { node: { type: "string", required: true } },
+      legacyParam: "node",
+      handler: () => {
+        called = true;
+        return "ok";
+      },
+    });
+    const result = executeTag(
+      { name: "select_node", payload: "", raw: "" },
+      { getStore: () => ({}) as ApexState },
+    );
+    expect(result).toMatch(/Missing required/);
+    expect(called).toBe(false);
+  });
+
+  it("dispatches to the handler with typed params on a happy path", () => {
+    let received: { node?: string } | null = null;
+    defineTool({
+      name: "select_node",
+      description: "test",
+      params: { node: { type: "string", required: true } },
+      legacyParam: "node",
+      handler: (params) => {
+        received = params;
+        return "selected";
+      },
+    });
+    const result = executeTag(
+      { name: "select_node", payload: "USA_GRID", raw: "" },
+      { getStore: () => ({}) as ApexState },
+    );
+    expect(result).toBe("selected");
+    expect(received).toEqual({ node: "USA_GRID" });
+  });
+
+  it("catches handler exceptions and returns a readable error", () => {
+    defineTool({
+      name: "boom",
+      description: "test",
+      params: {},
+      handler: () => {
+        throw new Error("kaboom");
+      },
+    });
+    const result = executeTag(
+      { name: "boom", payload: "", raw: "" },
+      { getStore: () => ({}) as ApexState },
+    );
+    expect(result).toMatch(/boom failed: kaboom/);
+  });
+});
+
+// ─── End-to-end on built-in tools ───────────────────────────────
+
+describe("built-in tools — wired via the registry", () => {
+  // We import the tool definitions for their side effect (registration).
+  // beforeEach below does NOT reset because we want the real registrations.
+
+  it("isolate_nodes filters by free-text query", async () => {
+    await import("@/lib/copilot/tools");
+    const graph = buildSampleGraph();
+    const { ctx, spy } = makeMockContext(graph);
+
+    const result = executeTag(
+      { name: "isolate_nodes", payload: "query=energy", raw: "" },
+      ctx,
+    );
+    expect(result).toMatch(/Isolated 2 nodes/);
+    expect(spy.setIsolateSelection.calls).toEqual([true]);
+    expect(spy.setSelectedNodes.calls[0]?.sort()).toEqual(["GRID_USA", "OIL_TX"]);
+  });
+
+  it("isolate_nodes filters by explicit ids using `|` separator", async () => {
+    await import("@/lib/copilot/tools");
+    const graph = buildSampleGraph();
+    const { ctx, spy } = makeMockContext(graph);
+
+    const result = executeTag(
+      { name: "isolate_nodes", payload: "ids=GRID_USA|FAB_TW", raw: "" },
+      ctx,
+    );
+    expect(result).toMatch(/Isolated 2 nodes/);
+    expect(spy.setSelectedNodes.calls[0]?.sort()).toEqual(["FAB_TW", "GRID_USA"]);
+    expect(spy.setIsolateSelection.calls).toEqual([true]);
+  });
+
+  it("isolate_nodes with no matches reports the failure and does NOT toggle isolation", async () => {
+    await import("@/lib/copilot/tools");
+    const graph = buildSampleGraph();
+    const { ctx, spy } = makeMockContext(graph);
+
+    const result = executeTag(
+      { name: "isolate_nodes", payload: "query=nonexistent_topic", raw: "" },
+      ctx,
+    );
+    expect(result).toMatch(/No nodes matched/);
+    expect(spy.setIsolateSelection.calls).toEqual([]);
+    expect(spy.setSelectedNodes.calls).toEqual([]);
+  });
+
+  it("isolate_nodes errors when neither query nor ids is provided", async () => {
+    await import("@/lib/copilot/tools");
+    const graph = buildSampleGraph();
+    const { ctx, spy } = makeMockContext(graph);
+
+    const result = executeTag({ name: "isolate_nodes", payload: "", raw: "" }, ctx);
+    expect(result).toMatch(/provide either query=/);
+    expect(spy.setIsolateSelection.calls).toEqual([]);
+  });
+
+  it("reset_isolation clears both selection and isolation flag", async () => {
+    await import("@/lib/copilot/tools");
+    const graph = buildSampleGraph();
+    const { ctx, spy } = makeMockContext(graph);
+
+    executeTag({ name: "reset_isolation", payload: "", raw: "" }, ctx);
+    expect(spy.setIsolateSelection.calls).toEqual([false]);
+    expect(spy.setSelectedNodes.calls).toEqual([[]]);
+  });
+
+  it("select_node still works with the legacy single-string payload", async () => {
+    await import("@/lib/copilot/tools");
+    const graph = buildSampleGraph();
+    const { ctx, spy } = makeMockContext(graph);
+
+    const result = executeTag({ name: "select_node", payload: "GRID_USA", raw: "" }, ctx);
+    expect(result).toMatch(/Selected node/);
+    expect(spy.setSelectedNode.calls).toEqual(["GRID_USA"]);
+  });
+
+  it("executeActions strips tags from displayText and runs each handler", async () => {
+    await import("@/lib/copilot/tools");
+    const graph = buildSampleGraph();
+    const { ctx } = makeMockContext(graph);
+
+    const text = "Focus on the energy stuff. <<<ACTION:isolate_nodes:query=energy>>>";
+    const { displayText, toolResults } = executeActions(text, ctx);
+    expect(displayText).toBe("Focus on the energy stuff.");
+    expect(toolResults).toHaveLength(1);
+    expect(toolResults[0]).toMatch(/Isolated 2 nodes/);
+  });
+});
+
+// ─── System-prompt rendering ────────────────────────────────────
+
+describe("renderToolsForPrompt", () => {
+  it("includes every registered tool with its description", async () => {
+    await import("@/lib/copilot/tools");
+    const rendered = renderToolsForPrompt();
+    expect(rendered).toContain("=== COPILOT ACTIONS ===");
+    expect(rendered).toContain("isolate_nodes");
+    expect(rendered).toContain("reset_isolation");
+    expect(rendered).toContain("select_node");
+    expect(rendered).toContain("solve_interdiction");
+  });
+
+  it("documents the kv + `|` wire format for the LLM", async () => {
+    await import("@/lib/copilot/tools");
+    const rendered = renderToolsForPrompt();
+    expect(rendered).toContain("key=value");
+    expect(rendered).toContain("|");
+  });
+});
+
+describe("renderToolsAsJsonSchema (proves MCP/Anthropic-compat)", () => {
+  it("emits a JSON-Schema input_schema for each tool", async () => {
+    await import("@/lib/copilot/tools");
+    const schemas = renderToolsAsJsonSchema();
+    const isolate = schemas.find((s) => s.name === "isolate_nodes");
+    expect(isolate).toBeDefined();
+    expect(isolate!.input_schema.type).toBe("object");
+    expect(isolate!.input_schema.properties).toHaveProperty("query");
+    expect(isolate!.input_schema.properties).toHaveProperty("ids");
+  });
+});
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+function buildSampleGraph(): CausalGraph {
+  const nodes: CausalNode[] = [
+    makeNode({ id: "GRID_USA", label: "USA Power Grid", category: "energy", domain: "Energy" }),
+    makeNode({ id: "OIL_TX", label: "TX Oil Pipeline", category: "energy", domain: "Energy" }),
+    makeNode({ id: "FAB_TW", label: "TSMC Fab", category: "manufacturing", domain: "Semiconductors" }),
+    makeNode({ id: "BANK_NY", label: "NY Clearing Bank", category: "finance", domain: "Finance" }),
+  ];
+  const edges = [
+    makeEdge({ id: "e1", source: "GRID_USA", target: "FAB_TW" }),
+    makeEdge({ id: "e2", source: "OIL_TX", target: "FAB_TW" }),
+  ];
+  return makeGraph(nodes, edges);
+}

--- a/src/lib/__tests__/copilot-trace-logger.test.ts
+++ b/src/lib/__tests__/copilot-trace-logger.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  defineTool,
+  executeTagWithTrace,
+  executeActionsWithTrace,
+  __resetRegistryForTests,
+  type ToolCallTrace,
+} from "@/lib/copilot/tool-registry";
+import { hashPrompt, newConversationId, logTurnTrace } from "@/lib/copilot/trace-logger";
+import type { ApexState } from "@/stores/useApexStore";
+
+// ─── Registry trace shape ───────────────────────────────────────
+
+describe("executeTagWithTrace — structured trace shape", () => {
+  beforeEach(() => __resetRegistryForTests());
+
+  it("returns name + validated params + result + null error + latency on success", () => {
+    defineTool({
+      name: "select_node",
+      description: "test",
+      params: { node: { type: "string", required: true } },
+      legacyParam: "node",
+      handler: () => "Selected node: USA_GRID",
+    });
+
+    const trace = executeTagWithTrace(
+      { name: "select_node", payload: "USA_GRID", raw: "" },
+      { getStore: () => ({}) as ApexState },
+    );
+
+    expect(trace.name).toBe("select_node");
+    expect(trace.params).toEqual({ node: "USA_GRID" });
+    expect(trace.result).toBe("Selected node: USA_GRID");
+    expect(trace.error).toBeNull();
+    expect(typeof trace.latency_ms).toBe("number");
+    expect(trace.latency_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it("populates error when validation fails", () => {
+    defineTool({
+      name: "needs_arg",
+      description: "test",
+      params: { x: { type: "string", required: true } },
+      handler: () => "ok",
+    });
+
+    const trace = executeTagWithTrace(
+      { name: "needs_arg", payload: "", raw: "" },
+      { getStore: () => ({}) as ApexState },
+    );
+
+    expect(trace.error).toMatch(/Missing required/);
+    expect(trace.result).toMatch(/Missing required/);
+  });
+
+  it("populates error when handler throws", () => {
+    defineTool({
+      name: "boom",
+      description: "test",
+      params: {},
+      handler: () => {
+        throw new Error("kaboom");
+      },
+    });
+
+    const trace = executeTagWithTrace(
+      { name: "boom", payload: "", raw: "" },
+      { getStore: () => ({}) as ApexState },
+    );
+
+    expect(trace.error).toBe("kaboom");
+    expect(trace.result).toMatch(/boom failed: kaboom/);
+  });
+
+  it("emits a trace per parsed tag from executeActionsWithTrace", () => {
+    defineTool({
+      name: "a",
+      description: "",
+      params: {},
+      handler: () => "did a",
+    });
+    defineTool({
+      name: "b",
+      description: "",
+      params: { v: { type: "string", required: true } },
+      legacyParam: "v",
+      handler: ({ v }) => `did b with ${v}`,
+    });
+
+    const text = "Hello <<<ACTION:a>>> middle <<<ACTION:b:hi>>> end";
+    const result = executeActionsWithTrace(text, { getStore: () => ({}) as ApexState });
+
+    expect(result.toolCalls).toHaveLength(2);
+    expect(result.toolCalls[0]).toMatchObject<Partial<ToolCallTrace>>({
+      name: "a",
+      params: {},
+      error: null,
+    });
+    expect(result.toolCalls[1]).toMatchObject<Partial<ToolCallTrace>>({
+      name: "b",
+      params: { v: "hi" },
+      error: null,
+    });
+    expect(result.displayText).toBe("Hello  middle  end");
+  });
+});
+
+// ─── hashPrompt + newConversationId ─────────────────────────────
+
+describe("hashPrompt", () => {
+  it("is deterministic", () => {
+    expect(hashPrompt("hello world")).toBe(hashPrompt("hello world"));
+  });
+
+  it("changes when input changes (collision-resistant for short strings)", () => {
+    expect(hashPrompt("hello world")).not.toBe(hashPrompt("hello world!"));
+    expect(hashPrompt("a")).not.toBe(hashPrompt("b"));
+  });
+
+  it("returns a hex string", () => {
+    expect(hashPrompt("anything")).toMatch(/^[0-9a-f]+$/);
+  });
+});
+
+describe("newConversationId", () => {
+  it("returns a non-empty string", () => {
+    const id = newConversationId();
+    expect(id).toBeTruthy();
+    expect(typeof id).toBe("string");
+  });
+
+  it("is unique across calls", () => {
+    const ids = new Set(Array.from({ length: 50 }, () => newConversationId()));
+    expect(ids.size).toBe(50);
+  });
+});
+
+// ─── logTurnTrace fail-safe ─────────────────────────────────────
+
+describe("logTurnTrace — fail-safe semantics", () => {
+  const validTrace = {
+    conversation_id: "cv_test",
+    turn_index: 0,
+    user_message: "hi",
+    assistant_message: "hello",
+    display_text: "hello",
+    tool_calls: [],
+    model_provider: "gemini",
+    model_id: "gemini-2.5-pro",
+    system_prompt_hash: "abc",
+    system_prompt_size: 100,
+    dataset: null,
+    active_module: "spirtes",
+    selected_node: null,
+    active_shock_count: 0,
+  };
+
+  it("returns true on a 200 response", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true } as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await logTurnTrace(validTrace);
+    expect(result).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/copilot/trace",
+      expect.objectContaining({ method: "POST" }),
+    );
+
+    vi.unstubAllGlobals();
+  });
+
+  it("returns false (does not throw) on a 500 response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 } as Response));
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = await logTurnTrace(validTrace);
+    expect(result).toBe(false);
+    expect(consoleSpy).toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns false (does not throw) when fetch rejects", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = await logTurnTrace(validTrace);
+    expect(result).toBe(false);
+    expect(consoleSpy).toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it("posts the trace as JSON in the request body", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true } as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await logTurnTrace(validTrace);
+    const callArgs = fetchSpy.mock.calls[0]![1] as RequestInit;
+    expect(callArgs.headers).toMatchObject({ "Content-Type": "application/json" });
+    expect(JSON.parse(callArgs.body as string)).toEqual(validTrace);
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/lib/copilot-actions.ts
+++ b/src/lib/copilot-actions.ts
@@ -13,7 +13,9 @@ import {
   stripActionTags,
   executeTag,
   executeActions,
+  executeActionsWithTrace,
   type ParsedActionTag,
+  type ToolCallTrace,
 } from "./copilot/tool-registry";
 
 // Side-effect import: registers all built-in tools with the registry.
@@ -53,4 +55,19 @@ export function processLlmActions(text: string): {
 } {
   const { displayText, toolResults } = executeActions(text);
   return { displayText, actionResults: toolResults };
+}
+
+/**
+ * Same as processLlmActions, but also returns the structured
+ * per-call trace data (for trace-logger / Supabase). Use this when
+ * you want to capture timing + params + errors in addition to the
+ * human-readable result strings.
+ */
+export function processLlmActionsWithTrace(text: string): {
+  displayText: string;
+  actionResults: string[];
+  toolCalls: ToolCallTrace[];
+} {
+  const { displayText, toolResults, toolCalls } = executeActionsWithTrace(text);
+  return { displayText, actionResults: toolResults, toolCalls };
 }

--- a/src/lib/copilot-actions.ts
+++ b/src/lib/copilot-actions.ts
@@ -1,12 +1,23 @@
-// ─── Copilot Action Router ──────────────────────────────────────
-// Parses <<<ACTION:type:param>>> blocks from LLM responses and
-// executes them against the Apex store.
+// ─── Copilot Action Router (compat shim) ────────────────────────
+//
+// The action runner moved to src/lib/copilot/tool-registry.ts.
+// This file is kept so existing callers (`processLlmActions`,
+// `parseActions`, `stripActions`, `executeAction`) keep working
+// while we migrate them to the registry directly.
+//
+// Importing this module also pulls in the tool definitions side
+// effect — registering every built-in tool with the registry.
 
-import { useApexStore } from "@/stores/useApexStore";
-import { getPresetShocks } from "./omega-engine";
-import { DOMAIN_CARDS, buildGraphFromDomains } from "@/components/DomainSelector";
-import { solveInterdiction } from "./interdiction-engine";
-import type { InterdictionCandidate } from "./interdiction-engine";
+import {
+  parseActionTags,
+  stripActionTags,
+  executeTag,
+  executeActions,
+  type ParsedActionTag,
+} from "./copilot/tool-registry";
+
+// Side-effect import: registers all built-in tools with the registry.
+import "./copilot/tools";
 
 export interface ParsedAction {
   type: string;
@@ -14,322 +25,32 @@ export interface ParsedAction {
   raw: string;
 }
 
-// ─── Parse actions from LLM response text ───────────────────────
-
-const ACTION_REGEX = /<<<ACTION:(\w+):?(.*?)>>>/g;
-
+/** Parse <<<ACTION:...>>> tags into the legacy {type, param, raw} shape. */
 export function parseActions(text: string): ParsedAction[] {
-  const actions: ParsedAction[] = [];
-  let match;
-  while ((match = ACTION_REGEX.exec(text)) !== null) {
-    actions.push({
-      type: match[1],
-      param: match[2] ?? "",
-      raw: match[0],
-    });
-  }
-  return actions;
+  return parseActionTags(text).map((t) => ({ type: t.name, param: t.payload, raw: t.raw }));
 }
 
-// ─── Strip action blocks from display text ──────────────────────
+/** Strip action tags from text for display. */
+export const stripActions = stripActionTags;
 
-export function stripActions(text: string): string {
-  return text.replace(ACTION_REGEX, "").replace(/\n{3,}/g, "\n\n").trim();
-}
-
-// ─── Execute a parsed action against the store ──────────────────
-
+/**
+ * Execute a single parsed action. Returns a human-readable result
+ * string, or null if the action produced no output (kept for
+ * backward compatibility — the registry always returns a string).
+ */
 export function executeAction(action: ParsedAction): string | null {
-  const store = useApexStore.getState();
-  const presetShocks = getPresetShocks();
-
-  switch (action.type) {
-    case "select_node": {
-      const node = store.graphData.nodes.find(
-        (n) => n.id === action.param || n.shortLabel.toLowerCase() === action.param.toLowerCase()
-          || n.label.toLowerCase() === action.param.toLowerCase()
-      );
-      if (node) {
-        store.setSelectedNode(node.id);
-        return `Selected node: ${node.label}`;
-      }
-      return `Node not found: ${action.param}`;
-    }
-
-    case "add_shock": {
-      const shock = presetShocks.find((s) => s.id === action.param);
-      if (shock) {
-        // Check if already active
-        if (!store.shocks.find((s) => s.id === shock.id)) {
-          store.addShock(shock);
-          return `Injected shock: ${shock.name}`;
-        }
-        return `Shock already active: ${shock.name}`;
-      }
-      return `Unknown shock: ${action.param}`;
-    }
-
-    case "remove_shock": {
-      const existing = store.shocks.find((s) => s.id === action.param);
-      if (existing) {
-        store.removeShock(action.param);
-        return `Removed shock: ${existing.name}`;
-      }
-      return `Shock not active: ${action.param}`;
-    }
-
-    case "set_module": {
-      const valid = ["spirtes", "tarski", "pearl", "pareto"];
-      if (valid.includes(action.param)) {
-        store.setActiveModule(action.param as "spirtes" | "tarski" | "pearl" | "pareto");
-        return `Switched to ${action.param.toUpperCase()} module`;
-      }
-      return `Invalid module: ${action.param}`;
-    }
-
-    case "set_view": {
-      if (action.param === "2d" || action.param === "3d") {
-        store.setViewMode(action.param);
-        return `Switched to ${action.param.toUpperCase()} view`;
-      }
-      return `Invalid view mode: ${action.param}`;
-    }
-
-    case "sever_edge": {
-      const edge = store.graphData.edges.find((e) => e.id === action.param);
-      if (edge) {
-        store.severEdge(edge.id);
-        return `Severed edge: ${edge.source} → ${edge.target}`;
-      }
-      return `Edge not found: ${action.param}`;
-    }
-
-    case "reset_severed": {
-      store.resetSeveredEdges();
-      return "Reset all severed edges";
-    }
-
-    case "start_replay": {
-      store.startReplay();
-      return "Started cascade replay";
-    }
-
-    case "stop_replay": {
-      store.stopReplay();
-      return "Stopped cascade replay";
-    }
-
-    case "set_truth_filter": {
-      if (action.param === "raw" || action.param === "verified") {
-        store.setTruthFilter(action.param);
-        return `Truth filter set to: ${action.param.toUpperCase()}`;
-      }
-      return `Invalid filter: ${action.param}`;
-    }
-
-    case "set_domains": {
-      const domainIds = action.param.split(",").map((d) => d.trim()).filter(Boolean);
-      // Validate domain IDs against known domains
-      const validIds = domainIds.filter((id) => DOMAIN_CARDS.find((d) => d.id === id && d.hasData));
-      if (validIds.length > 0) {
-        // Rebuild graph from the selected domains
-        const graph = buildGraphFromDomains(validIds);
-        store.setGraphData(graph);
-        store.setSelectedDomains(validIds);
-        store.setIsMultiDomainMode(validIds.length > 1);
-        const labels = validIds.map((id) => DOMAIN_CARDS.find((d) => d.id === id)?.label ?? id);
-        return `Filtered network to: ${labels.join(", ")} (${graph.metadata.totalNodes} nodes, ${graph.metadata.totalEdges} edges)`;
-      }
-      return `No valid domains found. Available: ${DOMAIN_CARDS.filter((d) => d.hasData).map((d) => d.id).join(", ")}`;
-    }
-
-    case "select_domains": {
-      // Alias for set_domains — LLM may use either
-      const domainIds = action.param.split(",").map((d) => d.trim()).filter(Boolean);
-      const validIds = domainIds.filter((id) => DOMAIN_CARDS.find((d) => d.id === id && d.hasData));
-      if (validIds.length > 0) {
-        const graph = buildGraphFromDomains(validIds);
-        store.setGraphData(graph);
-        store.setSelectedDomains(validIds);
-        store.setIsMultiDomainMode(validIds.length > 1);
-        const labels = validIds.map((id) => DOMAIN_CARDS.find((d) => d.id === id)?.label ?? id);
-        return `Filtered network to: ${labels.join(", ")} (${graph.metadata.totalNodes} nodes, ${graph.metadata.totalEdges} edges)`;
-      }
-      return `No valid domains found. Available: ${DOMAIN_CARDS.filter((d) => d.hasData).map((d) => d.id).join(", ")}`;
-    }
-
-    case "solve_interdiction": {
-      // Parse params: budget=3,mode=edge
-      const params = Object.fromEntries(
-        action.param.split(",").map((p) => {
-          const [k, v] = p.split("=");
-          return [k?.trim(), v?.trim()];
-        })
-      );
-      const budget = Math.min(10, Math.max(1, parseInt(params.budget ?? "3", 10) || 3));
-      const mode = (["edge", "node", "both"].includes(params.mode ?? "") ? params.mode : "edge") as "edge" | "node" | "both";
-
-      const result = solveInterdiction(
-        store.graphData,
-        store.shocks,
-        store.severedEdges,
-        budget,
-        mode,
-      );
-
-      // Format results as readable text for the copilot to reference
-      const lines = [
-        `Interdiction solved (budget=${budget}, mode=${mode}):`,
-        `  Baseline damage: ${result.baselineDamage.toFixed(1)}/100`,
-        `  Optimal damage: ${result.bestDamage.toFixed(1)}/100`,
-        `  Reduction: ${result.reductionPct.toFixed(1)}%`,
-      ];
-
-      if (result.interventions.length > 0) {
-        lines.push(`  Recommended cuts:`);
-        result.interventions.forEach((iv, i) => {
-          lines.push(`    ${i + 1}. [${iv.target.type}] ${iv.target.label} (${iv.target.id}) — saves ${iv.marginalReduction.toFixed(1)}pts`);
-        });
-        lines.push(`  → Switched to PEARL module. Review cuts in the intervention panel.`);
-        store.setLastInterdictionResult(result);
-      } else {
-        // Solver returned no cuts (cascade damage too low to discriminate
-        // targets). Fall back to structural vulnerability: highest-weight
-        // edges and/or highest-Ω nodes. Pack those into the result so the
-        // Pearl panel renders them as actionable SEVER/ABLATE buttons, not
-        // just text in the chat transcript.
-        const fallbackCandidates: InterdictionCandidate[] = [];
-
-        if (mode !== "node") {
-          const criticalEdges = store.graphData.edges
-            .filter((e) => e.weight >= 0.7 && !e.isSevered)
-            .sort((a, b) => b.weight - a.weight)
-            .slice(0, budget);
-          for (const e of criticalEdges) {
-            const src = store.graphData.nodes.find((n) => n.id === e.source);
-            const tgt = store.graphData.nodes.find((n) => n.id === e.target);
-            fallbackCandidates.push({
-              target: {
-                type: "edge",
-                id: e.id,
-                label: `${src?.shortLabel ?? e.source} → ${tgt?.shortLabel ?? e.target}`,
-              },
-              damage: result.baselineDamage,
-              // Use edge weight as a proxy for structural importance so the
-              // panel can rank cuts even when the cascade delta is ~0.
-              marginalReduction: e.weight * 10,
-            });
-          }
-        }
-
-        if (mode !== "edge") {
-          const highOmegaNodes = [...store.graphData.nodes]
-            .sort((a, b) => b.omegaFragility.composite - a.omegaFragility.composite)
-            .slice(0, budget);
-          for (const n of highOmegaNodes) {
-            fallbackCandidates.push({
-              target: {
-                type: "node",
-                id: n.id,
-                label: n.shortLabel,
-              },
-              damage: result.baselineDamage,
-              marginalReduction: n.omegaFragility.composite,
-            });
-          }
-        }
-
-        // Keep the top `budget` overall, ranked by our proxy score.
-        fallbackCandidates.sort((a, b) => b.marginalReduction - a.marginalReduction);
-        const trimmed = fallbackCandidates.slice(0, budget);
-
-        const reason =
-          "Cascade damage too low to rank cuts — showing highest structural vulnerability (edge weight / ΩF) instead.";
-
-        store.setLastInterdictionResult({
-          ...result,
-          interventions: trimmed,
-          fallbackReason: reason,
-        });
-
-        lines.push(`  No high-damage cascade detected — recommending structural vulnerability cuts:`);
-        trimmed.forEach((iv, i) => {
-          const suffix =
-            iv.target.type === "edge"
-              ? `(w-score ${iv.marginalReduction.toFixed(1)}, id:${iv.target.id})`
-              : `(ΩF ${iv.marginalReduction.toFixed(1)}, id:${iv.target.id})`;
-          lines.push(`    ${i + 1}. [${iv.target.type}] ${iv.target.label} ${suffix}`);
-        });
-        lines.push(`  → Switched to PEARL module. Cuts rendered in the intervention panel.`);
-      }
-
-      // Auto-switch to Pearl module to show intervention UI
-      store.setActiveModule("pearl");
-
-      return lines.join("\n");
-    }
-
-    case "apply_interdiction": {
-      // Apply specific intervention by index (1-based) or "all"
-      const lastResult = store.lastInterdictionResult;
-      if (!lastResult || lastResult.interventions.length === 0) {
-        return "No interdiction results to apply. Run solve_interdiction first.";
-      }
-
-      if (action.param === "all") {
-        const applied: string[] = [];
-        for (const iv of lastResult.interventions) {
-          if (iv.target.type === "edge") {
-            store.severEdge(iv.target.id);
-            applied.push(iv.target.label);
-          } else {
-            store.toggleAblatedNode(iv.target.id);
-            applied.push(iv.target.label);
-          }
-        }
-        return `Applied all ${applied.length} interdictions: ${applied.join(", ")}`;
-      }
-
-      // Apply specific indices: "1,3" or "1"
-      const indices = action.param.split(",").map((s) => parseInt(s.trim(), 10) - 1);
-      const applied: string[] = [];
-      for (const idx of indices) {
-        const iv = lastResult.interventions[idx];
-        if (!iv) continue;
-        if (iv.target.type === "edge") {
-          store.severEdge(iv.target.id);
-          applied.push(iv.target.label);
-        } else {
-          store.toggleAblatedNode(iv.target.id);
-          applied.push(iv.target.label);
-        }
-      }
-      return applied.length > 0
-        ? `Applied interdictions: ${applied.join(", ")}`
-        : `No valid intervention indices: ${action.param}`;
-    }
-
-    default:
-      return `Unknown action: ${action.type}`;
-  }
+  const tag: ParsedActionTag = { name: action.type, payload: action.param, raw: action.raw };
+  return executeTag(tag);
 }
 
-// ─── Process all actions from an LLM response ──────────────────
-
+/**
+ * Process all actions in an LLM response. Returns the cleaned
+ * display text plus the list of action results.
+ */
 export function processLlmActions(text: string): {
   displayText: string;
   actionResults: string[];
 } {
-  const actions = parseActions(text);
-  const displayText = stripActions(text);
-  const actionResults: string[] = [];
-
-  for (const action of actions) {
-    const result = executeAction(action);
-    if (result) {
-      actionResults.push(result);
-    }
-  }
-
-  return { displayText, actionResults };
+  const { displayText, toolResults } = executeActions(text);
+  return { displayText, actionResults: toolResults };
 }

--- a/src/lib/copilot-context.ts
+++ b/src/lib/copilot-context.ts
@@ -9,6 +9,10 @@ import {
   renderEngineStateText,
   summarizeEngineState,
 } from "./engine-state-summary";
+import { renderToolsForPrompt } from "./copilot/tool-registry";
+// Side-effect import: ensures all built-in tools are registered
+// before we render the prompt section.
+import "./copilot/tools";
 
 interface ContextOptions {
   selectedNode: string | null;
@@ -57,37 +61,10 @@ export function serializeGraphContext(
 ): string {
   const lines: string[] = [];
 
-  // Available actions
-  lines.push("=== COPILOT ACTIONS ===");
-  lines.push("You can control the graph by emitting action tags in your response.");
-  lines.push("Format: <<<ACTION:type:param>>>");
-  lines.push("Available actions:");
-  lines.push("  select_node:<node_id or label> — Select and highlight a node");
-  lines.push("  set_domains:<id1,id2,...> — Filter network to specific domains (rebuilds graph)");
-  lines.push("  add_shock:<shock_id> — Inject a stress scenario");
-  lines.push("  remove_shock:<shock_id> — Remove an active shock");
-  lines.push("  sever_edge:<edge_id> — Pearl link-break on an edge");
-  lines.push("  reset_severed — Reset all severed edges");
-  lines.push("  set_module:<spirtes|tarski|pearl|pareto> — Switch analysis module");
-  lines.push("  set_view:<2d|3d> — Switch visualization mode");
-  lines.push("  start_replay / stop_replay — Control cascade animation");
-  lines.push("  solve_interdiction:budget=N,mode=edge|node|both — Run greedy minimax solver to find optimal defensive cuts (budget=1-10)");
-  lines.push("  apply_interdiction:all — Apply all recommended interdictions from the last solve");
-  lines.push("  apply_interdiction:1,2 — Apply specific recommendations by index (1-based)");
-  lines.push("");
-  lines.push("INTERDICTION WORKFLOW — CRITICAL: When a user asks about interdiction, optimal cuts, defensive cuts,");
-  lines.push("where to intervene, how to defend, what to sever, minimax, or any variant of 'find/solve/recommend cuts',");
-  lines.push("you MUST emit the solve_interdiction action. Do not just describe — trigger it. Steps:");
-  lines.push("  1. If no shocks are active, first inject one: <<<ACTION:add_shock:SHOCK_ID>>>");
-  lines.push("  2. Emit the solver action on its own line: <<<ACTION:solve_interdiction:budget=3,mode=edge>>>");
-  lines.push("     (the solver auto-switches to the PEARL module and renders the results panel)");
-  lines.push("  3. After the action fires, explain the returned cuts in plain language and their damage reduction");
-  lines.push("  4. Offer to apply: <<<ACTION:apply_interdiction:all>>> or specific indices like <<<ACTION:apply_interdiction:1,2>>>");
-  lines.push("  5. Optionally visualize: <<<ACTION:start_replay>>>");
-  lines.push("EXAMPLE user turn -> expected response:");
-  lines.push("  USER: 'where should we cut to defend against this?'");
-  lines.push("  YOU:  'Running the minimax interdiction solver now. <<<ACTION:solve_interdiction:budget=3,mode=edge>>>'");
-  lines.push("        (then explain results once they come back)");
+  // Available actions — auto-generated from the tool registry. Adding
+  // a new tool means defining it in src/lib/copilot/tools.ts; the
+  // prompt picks it up here automatically.
+  lines.push(renderToolsForPrompt());
   lines.push("");
   lines.push("=== AVAILABLE DOMAINS ===");
   const available = DOMAIN_CARDS.filter((d) => d.hasData);

--- a/src/lib/copilot/tool-registry.ts
+++ b/src/lib/copilot/tool-registry.ts
@@ -1,0 +1,398 @@
+// ─── Copilot Tool Registry ──────────────────────────────────────
+//
+// Declarative tool definitions for the copilot. Each tool registers
+// its name, description, parameter schema, and handler. The system
+// prompt is generated from the registry, and the wire format
+// (<<<ACTION:name:payload>>>) is parsed + validated against the
+// schema before the handler runs.
+//
+// The shape is deliberately MCP / Anthropic-tool-use-compatible so
+// we can later (a) auto-generate `tools` arrays for native tool use
+// and (b) swap the hand-rolled schema layer for zod without changing
+// call sites.
+
+import { useApexStore } from "@/stores/useApexStore";
+import type { ApexState } from "@/stores/useApexStore";
+
+// ─── Schema primitives ──────────────────────────────────────────
+
+/**
+ * A parameter schema describes one input field on a tool. The shape
+ * is deliberately small — string / string[] / number / enum / boolean —
+ * because tool params come off the wire as strings and we coerce.
+ *
+ * Adding a new variant: extend the union, then handle it in
+ * `coerceParam` and `renderParamSignature`.
+ */
+export type ParamSchema =
+  | { type: "string"; required?: boolean; description?: string }
+  | { type: "string[]"; required?: boolean; description?: string }
+  | { type: "number"; required?: boolean; description?: string; min?: number; max?: number; default?: number }
+  | { type: "enum"; values: readonly string[]; required?: boolean; description?: string; default?: string }
+  | { type: "boolean"; required?: boolean; description?: string };
+
+export type ParamShape = Record<string, ParamSchema>;
+
+/** Type-level inference: schema → typed params object. */
+// A field with `required: true` OR `default: <value>` is always defined
+// at runtime. We treat both the same way for inference.
+type IsAlwaysDefined<S> = S extends { required: true }
+  ? true
+  : S extends { default: unknown }
+    ? true
+    : false;
+
+export type InferParams<P extends ParamShape> = {
+  [K in keyof P]: P[K] extends { type: "string" }
+    ? IsAlwaysDefined<P[K]> extends true ? string : string | undefined
+    : P[K] extends { type: "string[]" }
+      ? string[]
+      : P[K] extends { type: "number" }
+        ? IsAlwaysDefined<P[K]> extends true ? number : number | undefined
+        : P[K] extends { type: "enum"; values: infer V }
+          ? V extends readonly string[]
+            ? IsAlwaysDefined<P[K]> extends true ? V[number] : V[number] | undefined
+            : never
+          : P[K] extends { type: "boolean" }
+            ? IsAlwaysDefined<P[K]> extends true ? boolean : boolean | undefined
+            : never;
+};
+
+// ─── Tool definition ────────────────────────────────────────────
+
+export interface ToolContext {
+  /**
+   * Returns the current store snapshot. Injectable for tests.
+   * Defaults to `useApexStore.getState()` in production.
+   */
+  getStore: () => ApexState;
+}
+
+export interface Tool<P extends ParamShape = ParamShape> {
+  /** Stable identifier emitted in <<<ACTION:name:...>>>. */
+  name: string;
+  /** One-line description for the LLM. Shown in the system prompt. */
+  description: string;
+  /** Optional longer guidance — shown to the LLM when this tool is non-obvious. */
+  guidance?: string;
+  /** Parameter schema. Empty {} for nullary tools. */
+  params: P;
+  /**
+   * For backward compatibility with single-string payloads
+   * (<<<ACTION:select_node:USA_GRID>>>). When the payload contains
+   * no `=`, it is routed into this param.
+   */
+  legacyParam?: keyof P & string;
+  /** Handler — receives validated params and a context object. */
+  handler: (params: InferParams<P>, ctx: ToolContext) => string;
+}
+
+// ─── Registry ───────────────────────────────────────────────────
+
+const REGISTRY = new Map<string, Tool<ParamShape>>();
+
+export function defineTool<P extends ParamShape>(tool: Tool<P>): Tool<P> {
+  if (REGISTRY.has(tool.name)) {
+    // Re-registration is allowed (e.g. HMR in dev). Last write wins.
+    REGISTRY.set(tool.name, tool as unknown as Tool<ParamShape>);
+  } else {
+    REGISTRY.set(tool.name, tool as unknown as Tool<ParamShape>);
+  }
+  return tool;
+}
+
+export function getTool(name: string): Tool<ParamShape> | undefined {
+  return REGISTRY.get(name);
+}
+
+export function getAllTools(): Tool<ParamShape>[] {
+  return Array.from(REGISTRY.values());
+}
+
+/** Test-only: clear the registry. Production code should never call this. */
+export function __resetRegistryForTests(): void {
+  REGISTRY.clear();
+}
+
+// ─── Wire format parsing ────────────────────────────────────────
+
+// k=v,k=v is the kv separator (comma). Arrays inside a value use `|`.
+// Bare payloads (no `=`) are passed through as legacy single-string.
+
+export interface ParsedActionTag {
+  /** The full <<<ACTION:...>>> match. */
+  raw: string;
+  /** Tool name (between first and second colon). */
+  name: string;
+  /** Raw payload text (after the second colon). May be empty. */
+  payload: string;
+}
+
+const ACTION_REGEX = /<<<ACTION:(\w+):?(.*?)>>>/g;
+
+export function parseActionTags(text: string): ParsedActionTag[] {
+  const tags: ParsedActionTag[] = [];
+  // Reset regex state — it's stateful with /g flag.
+  ACTION_REGEX.lastIndex = 0;
+  let match;
+  while ((match = ACTION_REGEX.exec(text)) !== null) {
+    tags.push({ raw: match[0], name: match[1], payload: match[2] ?? "" });
+  }
+  return tags;
+}
+
+export function stripActionTags(text: string): string {
+  return text.replace(ACTION_REGEX, "").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+/**
+ * Parse a `k=v,k=v` payload into a flat string map. A bare payload
+ * (no `=`) returns `{ _legacy: payload }` — the caller maps that
+ * onto the tool's `legacyParam`.
+ */
+export function parseKvPayload(payload: string): Record<string, string> {
+  const trimmed = payload.trim();
+  if (trimmed === "") return {};
+  if (!trimmed.includes("=")) return { _legacy: trimmed };
+
+  const out: Record<string, string> = {};
+  for (const pair of trimmed.split(",")) {
+    const eq = pair.indexOf("=");
+    if (eq === -1) continue;
+    const k = pair.slice(0, eq).trim();
+    const v = pair.slice(eq + 1).trim();
+    if (k) out[k] = v;
+  }
+  return out;
+}
+
+// ─── Validation + coercion ──────────────────────────────────────
+
+export type CoerceResult<P extends ParamShape> =
+  | { ok: true; params: InferParams<P> }
+  | { ok: false; error: string };
+
+function coerceParam(
+  name: string,
+  schema: ParamSchema,
+  raw: string | undefined,
+): { ok: true; value: unknown } | { ok: false; error: string } {
+  // Missing value
+  if (raw === undefined || raw === "") {
+    if ("default" in schema && schema.default !== undefined) {
+      return { ok: true, value: schema.default };
+    }
+    if (schema.required) {
+      return { ok: false, error: `Missing required param: ${name}` };
+    }
+    return { ok: true, value: schema.type === "string[]" ? [] : undefined };
+  }
+
+  switch (schema.type) {
+    case "string":
+      return { ok: true, value: raw };
+    case "string[]": {
+      // `|` is the array separator inside a value. Comma is reserved
+      // for the kv separator at the payload level. Empty entries are
+      // dropped so trailing/leading separators don't matter.
+      const items = raw
+        .split("|")
+        .map((s) => s.trim())
+        .filter(Boolean);
+      return { ok: true, value: items };
+    }
+    case "number": {
+      const n = Number(raw);
+      if (Number.isNaN(n)) return { ok: false, error: `Param ${name}: "${raw}" is not a number` };
+      const clamped = Math.min(schema.max ?? Infinity, Math.max(schema.min ?? -Infinity, n));
+      return { ok: true, value: clamped };
+    }
+    case "enum":
+      if (!schema.values.includes(raw)) {
+        return { ok: false, error: `Param ${name}: "${raw}" not in [${schema.values.join("|")}]` };
+      }
+      return { ok: true, value: raw };
+    case "boolean": {
+      const lc = raw.toLowerCase();
+      if (lc === "true" || lc === "1" || lc === "yes") return { ok: true, value: true };
+      if (lc === "false" || lc === "0" || lc === "no") return { ok: true, value: false };
+      return { ok: false, error: `Param ${name}: "${raw}" is not a boolean` };
+    }
+  }
+}
+
+export function coerceAndValidate<P extends ParamShape>(
+  shape: P,
+  raw: Record<string, string>,
+  legacyParam: keyof P & string | undefined,
+): CoerceResult<P> {
+  // If we got a legacy single-string payload, rewrite it onto the
+  // designated legacyParam. Tools without a legacyParam ignore it.
+  const kv = { ...raw };
+  if ("_legacy" in kv && legacyParam !== undefined) {
+    kv[legacyParam] = kv._legacy;
+  }
+  delete kv._legacy;
+
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(shape) as (keyof P & string)[]) {
+    const schema = shape[key];
+    const result = coerceParam(key, schema, kv[key]);
+    if (!result.ok) return { ok: false, error: result.error };
+    out[key] = result.value;
+  }
+  return { ok: true, params: out as InferParams<P> };
+}
+
+// ─── Execution ──────────────────────────────────────────────────
+
+const defaultContext: ToolContext = {
+  getStore: () => useApexStore.getState(),
+};
+
+export interface ExecutionResult {
+  displayText: string;
+  toolResults: string[];
+}
+
+/**
+ * Top-level entry point: parse all <<<ACTION:...>>> tags from an
+ * LLM response, validate each, run handlers, and return the cleaned
+ * display text plus the list of human-readable tool results.
+ */
+export function executeActions(
+  text: string,
+  ctx: ToolContext = defaultContext,
+): ExecutionResult {
+  const tags = parseActionTags(text);
+  const displayText = stripActionTags(text);
+  const toolResults: string[] = [];
+
+  for (const tag of tags) {
+    const result = executeTag(tag, ctx);
+    if (result) toolResults.push(result);
+  }
+
+  return { displayText, toolResults };
+}
+
+/** Execute a single parsed action tag. Exported for tests. */
+export function executeTag(tag: ParsedActionTag, ctx: ToolContext = defaultContext): string {
+  const tool = REGISTRY.get(tag.name);
+  if (!tool) return `Unknown action: ${tag.name}`;
+
+  const kv = parseKvPayload(tag.payload);
+  const validated = coerceAndValidate(tool.params, kv, tool.legacyParam);
+  if (!validated.ok) return `${tag.name}: ${validated.error}`;
+
+  try {
+    return tool.handler(validated.params, ctx);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return `${tag.name} failed: ${msg}`;
+  }
+}
+
+// ─── Prompt rendering ───────────────────────────────────────────
+
+/** Render one param's signature for the system prompt. */
+function renderParamSignature(name: string, schema: ParamSchema): string {
+  let typeStr: string;
+  switch (schema.type) {
+    case "string":
+      typeStr = "string";
+      break;
+    case "string[]":
+      typeStr = "list (use | between items)";
+      break;
+    case "number":
+      typeStr =
+        schema.min !== undefined || schema.max !== undefined
+          ? `number (${schema.min ?? "..."}–${schema.max ?? "..."})`
+          : "number";
+      break;
+    case "enum":
+      typeStr = schema.values.join("|");
+      break;
+    case "boolean":
+      typeStr = "true|false";
+      break;
+  }
+  const req = schema.required ? "" : "?";
+  const desc = schema.description ? ` — ${schema.description}` : "";
+  return `${name}${req}=<${typeStr}>${desc}`;
+}
+
+/**
+ * Render the system-prompt section listing all registered tools.
+ * Replaces the hand-written `=== COPILOT ACTIONS ===` block in
+ * copilot-context.ts.
+ */
+export function renderToolsForPrompt(): string {
+  const lines: string[] = [];
+  lines.push("=== COPILOT ACTIONS ===");
+  lines.push("Emit action tags to control the platform. Format:");
+  lines.push("  <<<ACTION:name:key=value,key=value>>>");
+  lines.push("Inside a value, use `|` to separate list items (ids=A|B|C).");
+  lines.push("Single-arg actions accept a bare payload (<<<ACTION:select_node:USA_GRID>>>).");
+  lines.push("");
+  lines.push("Available actions:");
+
+  const tools = getAllTools();
+  for (const tool of tools) {
+    const params = Object.entries(tool.params);
+    if (params.length === 0) {
+      lines.push(`  ${tool.name} — ${tool.description}`);
+    } else {
+      const sig = params.map(([n, s]) => renderParamSignature(n, s)).join(", ");
+      lines.push(`  ${tool.name}:${sig} — ${tool.description}`);
+    }
+    if (tool.guidance) {
+      for (const line of tool.guidance.split("\n")) {
+        lines.push(`    ${line}`);
+      }
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Render tools as Anthropic-tool-use-compatible JSON (for the
+ * eventual native-tool-use migration). Not used in this PR but
+ * proves the schema shape converts cleanly.
+ */
+export function renderToolsAsJsonSchema(): Array<{
+  name: string;
+  description: string;
+  input_schema: { type: "object"; properties: Record<string, unknown>; required: string[] };
+}> {
+  return getAllTools().map((tool) => {
+    const properties: Record<string, unknown> = {};
+    const required: string[] = [];
+    for (const [name, schema] of Object.entries(tool.params)) {
+      properties[name] = paramToJsonSchema(schema);
+      if (schema.required) required.push(name);
+    }
+    return {
+      name: tool.name,
+      description: tool.description + (tool.guidance ? `\n\n${tool.guidance}` : ""),
+      input_schema: { type: "object", properties, required },
+    };
+  });
+}
+
+function paramToJsonSchema(schema: ParamSchema): Record<string, unknown> {
+  switch (schema.type) {
+    case "string":
+      return { type: "string", description: schema.description };
+    case "string[]":
+      return { type: "array", items: { type: "string" }, description: schema.description };
+    case "number":
+      return { type: "number", minimum: schema.min, maximum: schema.max, description: schema.description };
+    case "enum":
+      return { type: "string", enum: schema.values, description: schema.description };
+    case "boolean":
+      return { type: "boolean", description: schema.description };
+  }
+}

--- a/src/lib/copilot/tool-registry.ts
+++ b/src/lib/copilot/tool-registry.ts
@@ -256,41 +256,135 @@ export interface ExecutionResult {
 }
 
 /**
+ * Structured per-call trace. One of these is produced for every
+ * <<<ACTION:...>>> tag the LLM emitted. Designed to land in
+ * Supabase as a row in tool_calls[] — the field shape mirrors the
+ * jsonb structure described in supabase-copilot-traces.sql.
+ */
+export interface ToolCallTrace {
+  /** Tool name (e.g. "isolate_nodes"). */
+  name: string;
+  /** Validated, coerced params — what the handler actually saw. */
+  params: Record<string, unknown>;
+  /** Human-readable result string returned by the handler. */
+  result: string;
+  /** Error message if the handler threw or validation failed; null on success. */
+  error: string | null;
+  /** Wall-clock duration of the handler call. */
+  latency_ms: number;
+}
+
+export interface TracedExecutionResult extends ExecutionResult {
+  /** One entry per parsed action tag, in source order. */
+  toolCalls: ToolCallTrace[];
+}
+
+/**
  * Top-level entry point: parse all <<<ACTION:...>>> tags from an
  * LLM response, validate each, run handlers, and return the cleaned
  * display text plus the list of human-readable tool results.
+ *
+ * Back-compat shape — discards the structured trace data. Use
+ * executeActionsWithTrace when you want the trace for logging.
  */
 export function executeActions(
   text: string,
   ctx: ToolContext = defaultContext,
 ): ExecutionResult {
+  const { displayText, toolResults } = executeActionsWithTrace(text, ctx);
+  return { displayText, toolResults };
+}
+
+/**
+ * Same as executeActions, but also returns structured per-call
+ * trace data (params, result, error, latency_ms) for each tag.
+ * SystemCopilot uses this to build a TurnTrace and POST it to
+ * /api/copilot/trace.
+ */
+export function executeActionsWithTrace(
+  text: string,
+  ctx: ToolContext = defaultContext,
+): TracedExecutionResult {
   const tags = parseActionTags(text);
   const displayText = stripActionTags(text);
   const toolResults: string[] = [];
+  const toolCalls: ToolCallTrace[] = [];
 
   for (const tag of tags) {
-    const result = executeTag(tag, ctx);
-    if (result) toolResults.push(result);
+    const traced = executeTagWithTrace(tag, ctx);
+    toolResults.push(traced.result);
+    toolCalls.push(traced);
   }
 
-  return { displayText, toolResults };
+  return { displayText, toolResults, toolCalls };
 }
 
 /** Execute a single parsed action tag. Exported for tests. */
 export function executeTag(tag: ParsedActionTag, ctx: ToolContext = defaultContext): string {
+  return executeTagWithTrace(tag, ctx).result;
+}
+
+/**
+ * Execute a single tag and return both the result string and the
+ * structured trace. Used by executeActionsWithTrace; exported for
+ * targeted unit tests that want to inspect timing/error semantics.
+ */
+export function executeTagWithTrace(
+  tag: ParsedActionTag,
+  ctx: ToolContext = defaultContext,
+): ToolCallTrace {
+  const start = performanceNow();
   const tool = REGISTRY.get(tag.name);
-  if (!tool) return `Unknown action: ${tag.name}`;
+  if (!tool) {
+    return {
+      name: tag.name,
+      params: {},
+      result: `Unknown action: ${tag.name}`,
+      error: `Unknown action: ${tag.name}`,
+      latency_ms: Math.round(performanceNow() - start),
+    };
+  }
 
   const kv = parseKvPayload(tag.payload);
   const validated = coerceAndValidate(tool.params, kv, tool.legacyParam);
-  if (!validated.ok) return `${tag.name}: ${validated.error}`;
+  if (!validated.ok) {
+    return {
+      name: tag.name,
+      params: kv,
+      result: `${tag.name}: ${validated.error}`,
+      error: validated.error,
+      latency_ms: Math.round(performanceNow() - start),
+    };
+  }
 
   try {
-    return tool.handler(validated.params, ctx);
+    const result = tool.handler(validated.params, ctx);
+    return {
+      name: tag.name,
+      params: validated.params as Record<string, unknown>,
+      result,
+      error: null,
+      latency_ms: Math.round(performanceNow() - start),
+    };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    return `${tag.name} failed: ${msg}`;
+    return {
+      name: tag.name,
+      params: validated.params as Record<string, unknown>,
+      result: `${tag.name} failed: ${msg}`,
+      error: msg,
+      latency_ms: Math.round(performanceNow() - start),
+    };
   }
+}
+
+// performance.now() in browsers + Node 16+; fall back to Date.now()
+// in obscure runtimes (Cloudflare Workers etc) for safety.
+function performanceNow(): number {
+  if (typeof performance !== "undefined" && typeof performance.now === "function") {
+    return performance.now();
+  }
+  return Date.now();
 }
 
 // ─── Prompt rendering ───────────────────────────────────────────

--- a/src/lib/copilot/tools.ts
+++ b/src/lib/copilot/tools.ts
@@ -1,0 +1,447 @@
+// ─── Built-in copilot tools ─────────────────────────────────────
+//
+// Every tool the copilot can call is registered here via defineTool.
+// Adding a new tool: define its name, params, and handler. The
+// system prompt and the action runner pick it up automatically.
+
+import { defineTool } from "./tool-registry";
+import { getPresetShocks } from "../omega-engine";
+import { DOMAIN_CARDS, buildGraphFromDomains } from "@/components/DomainSelector";
+import { solveInterdiction, type InterdictionCandidate } from "../interdiction-engine";
+import type { ApexState } from "@/stores/useApexStore";
+
+// ─── Selection ──────────────────────────────────────────────────
+
+defineTool({
+  name: "select_node",
+  description: "Select and highlight a single node by id or label.",
+  params: {
+    node: {
+      type: "string",
+      required: true,
+      description: "Node id, shortLabel, or label",
+    },
+  },
+  legacyParam: "node",
+  handler: ({ node }, ctx) => {
+    const store = ctx.getStore();
+    const target = node.toLowerCase();
+    const found = store.graphData.nodes.find(
+      (n) =>
+        n.id === node ||
+        n.shortLabel.toLowerCase() === target ||
+        n.label.toLowerCase() === target,
+    );
+    if (!found) return `Node not found: ${node}`;
+    store.setSelectedNode(found.id);
+    return `Selected node: ${found.label}`;
+  },
+});
+
+// ─── Isolation ──────────────────────────────────────────────────
+
+defineTool({
+  name: "isolate_nodes",
+  description:
+    "Filter the visible graph to a subset of nodes — by free-text query or explicit ids. Non-matching nodes dim out across 2D / 3D / map views.",
+  guidance:
+    "Use whenever the user names a topic, theme, sector, or set of entities ('focus on energy infrastructure', 'just show me the semiconductor stuff'). Match a query against label/category/domain; pass ids when the user names specific nodes. Emit reset_isolation when the conversation broadens again.",
+  params: {
+    query: {
+      type: "string",
+      description: "Free-text match against id/shortLabel/label/category/domain (case-insensitive substring)",
+    },
+    ids: {
+      type: "string[]",
+      description: "Explicit node ids — separated with `|` (ids=USA_GRID|EU_GRID)",
+    },
+  },
+  handler: ({ query, ids }, ctx) => {
+    const store = ctx.getStore();
+    const nodes = store.graphData.nodes;
+
+    let matched: typeof nodes = [];
+    let basis: string;
+
+    if (ids && ids.length > 0) {
+      const idSet = new Set(ids);
+      matched = nodes.filter((n) => idSet.has(n.id));
+      basis = `ids=${ids.join(",")}`;
+    } else if (query && query.trim() !== "") {
+      const q = query.toLowerCase();
+      matched = nodes.filter(
+        (n) =>
+          n.id.toLowerCase().includes(q) ||
+          n.shortLabel.toLowerCase().includes(q) ||
+          n.label.toLowerCase().includes(q) ||
+          n.category.toLowerCase().includes(q) ||
+          n.domain.toLowerCase().includes(q),
+      );
+      basis = `query="${query}"`;
+    } else {
+      return "isolate_nodes: provide either query=<text> or ids=A|B|C";
+    }
+
+    if (matched.length === 0) {
+      return `No nodes matched ${basis}. Isolation not applied.`;
+    }
+
+    store.setSelectedNodes(matched.map((n) => n.id));
+    store.setIsolateSelection(true);
+
+    const preview = matched
+      .slice(0, 5)
+      .map((n) => n.shortLabel || n.id)
+      .join(", ");
+    const more = matched.length > 5 ? ` (+${matched.length - 5} more)` : "";
+    return `Isolated ${matched.length} node${matched.length === 1 ? "" : "s"} matching ${basis}: ${preview}${more}`;
+  },
+});
+
+defineTool({
+  name: "reset_isolation",
+  description: "Clear node isolation — show the full graph again.",
+  params: {},
+  handler: (_params, ctx) => {
+    const store = ctx.getStore();
+    store.setIsolateSelection(false);
+    store.setSelectedNodes([]);
+    return "Cleared isolation; showing full graph.";
+  },
+});
+
+// ─── Shocks ─────────────────────────────────────────────────────
+
+defineTool({
+  name: "add_shock",
+  description: "Inject a stress scenario by id (TAIWAN_BLOCKADE, GRID_CASCADE, etc).",
+  params: {
+    id: { type: "string", required: true, description: "Preset shock id" },
+  },
+  legacyParam: "id",
+  handler: ({ id }, ctx) => {
+    const store = ctx.getStore();
+    const presets = getPresetShocks();
+    const shock = presets.find((s) => s.id === id);
+    if (!shock) return `Unknown shock: ${id}`;
+    if (store.shocks.find((s) => s.id === shock.id)) {
+      return `Shock already active: ${shock.name}`;
+    }
+    store.addShock(shock);
+    return `Injected shock: ${shock.name}`;
+  },
+});
+
+defineTool({
+  name: "remove_shock",
+  description: "Remove an active shock by id.",
+  params: {
+    id: { type: "string", required: true, description: "Active shock id" },
+  },
+  legacyParam: "id",
+  handler: ({ id }, ctx) => {
+    const store = ctx.getStore();
+    const existing = store.shocks.find((s) => s.id === id);
+    if (!existing) return `Shock not active: ${id}`;
+    store.removeShock(id);
+    return `Removed shock: ${existing.name}`;
+  },
+});
+
+// ─── Module + view ──────────────────────────────────────────────
+
+defineTool({
+  name: "set_module",
+  description: "Switch the active analysis module.",
+  params: {
+    module: {
+      type: "enum",
+      values: ["spirtes", "tarski", "pearl", "pareto"] as const,
+      required: true,
+    },
+  },
+  legacyParam: "module",
+  handler: ({ module }, ctx) => {
+    ctx.getStore().setActiveModule(module);
+    return `Switched to ${module.toUpperCase()} module`;
+  },
+});
+
+defineTool({
+  name: "set_view",
+  description: "Switch the visualization mode.",
+  params: {
+    mode: { type: "enum", values: ["2d", "3d"] as const, required: true },
+  },
+  legacyParam: "mode",
+  handler: ({ mode }, ctx) => {
+    ctx.getStore().setViewMode(mode);
+    return `Switched to ${mode.toUpperCase()} view`;
+  },
+});
+
+// ─── Edges ──────────────────────────────────────────────────────
+
+defineTool({
+  name: "sever_edge",
+  description: "Pearl link-break on a single edge.",
+  params: {
+    edge: { type: "string", required: true, description: "Edge id" },
+  },
+  legacyParam: "edge",
+  handler: ({ edge }, ctx) => {
+    const store = ctx.getStore();
+    const found = store.graphData.edges.find((e) => e.id === edge);
+    if (!found) return `Edge not found: ${edge}`;
+    store.severEdge(found.id);
+    return `Severed edge: ${found.source} → ${found.target}`;
+  },
+});
+
+defineTool({
+  name: "reset_severed",
+  description: "Reset all severed edges.",
+  params: {},
+  handler: (_params, ctx) => {
+    ctx.getStore().resetSeveredEdges();
+    return "Reset all severed edges";
+  },
+});
+
+// ─── Replay ─────────────────────────────────────────────────────
+
+defineTool({
+  name: "start_replay",
+  description: "Start the cascade replay animation.",
+  params: {},
+  handler: (_params, ctx) => {
+    ctx.getStore().startReplay();
+    return "Started cascade replay";
+  },
+});
+
+defineTool({
+  name: "stop_replay",
+  description: "Stop the cascade replay animation.",
+  params: {},
+  handler: (_params, ctx) => {
+    ctx.getStore().stopReplay();
+    return "Stopped cascade replay";
+  },
+});
+
+// ─── Truth filter ───────────────────────────────────────────────
+
+defineTool({
+  name: "set_truth_filter",
+  description: "Toggle Tarski truth filter between RAW and VERIFIED.",
+  params: {
+    mode: { type: "enum", values: ["raw", "verified"] as const, required: true },
+  },
+  legacyParam: "mode",
+  handler: ({ mode }, ctx) => {
+    ctx.getStore().setTruthFilter(mode);
+    return `Truth filter set to: ${mode.toUpperCase()}`;
+  },
+});
+
+// ─── Domains ────────────────────────────────────────────────────
+
+function applyDomainFilter(domainIds: string[], store: ApexState): string {
+  // Validate against known domains.
+  const validIds = domainIds.filter((id) => DOMAIN_CARDS.find((d) => d.id === id && d.hasData));
+  if (validIds.length === 0) {
+    return `No valid domains found. Available: ${DOMAIN_CARDS.filter((d) => d.hasData).map((d) => d.id).join(", ")}`;
+  }
+  const graph = buildGraphFromDomains(validIds);
+  store.setGraphData(graph);
+  store.setSelectedDomains(validIds);
+  store.setIsMultiDomainMode(validIds.length > 1);
+  const labels = validIds.map((id) => DOMAIN_CARDS.find((d) => d.id === id)?.label ?? id);
+  return `Filtered network to: ${labels.join(", ")} (${graph.metadata.totalNodes} nodes, ${graph.metadata.totalEdges} edges)`;
+}
+
+defineTool({
+  name: "set_domains",
+  description: "Filter the network to specific domains (rebuilds the graph).",
+  guidance:
+    "When the user describes a role, strategy, or context ('I am a CDS trader'), pick the relevant domains and filter. Then explain why.",
+  params: {
+    domains: {
+      type: "string[]",
+      required: true,
+      description: "Domain ids — separated with `|` (domains=energy|semiconductors)",
+    },
+  },
+  legacyParam: "domains",
+  handler: ({ domains }, ctx) => applyDomainFilter(domains, ctx.getStore()),
+});
+
+defineTool({
+  name: "select_domains",
+  description: "Alias for set_domains.",
+  params: {
+    domains: { type: "string[]", required: true, description: "Domain ids — separated with `|`" },
+  },
+  legacyParam: "domains",
+  handler: ({ domains }, ctx) => applyDomainFilter(domains, ctx.getStore()),
+});
+
+// ─── Interdiction ───────────────────────────────────────────────
+
+defineTool({
+  name: "solve_interdiction",
+  description:
+    "Run the greedy minimax interdiction solver. Auto-switches to PEARL and renders cuts in the panel.",
+  guidance:
+    "Trigger this whenever the user asks about optimal cuts, defensive cuts, where to intervene, how to defend, what to sever, or any 'find/solve/recommend cuts'. If no shocks are active, inject one first via add_shock. After the solver returns, explain the cuts and offer apply_interdiction:targets=all or specific indices.",
+  params: {
+    budget: { type: "number", min: 1, max: 10, default: 3, description: "Max number of cuts" },
+    mode: { type: "enum", values: ["edge", "node", "both"] as const, default: "edge" },
+  },
+  handler: ({ budget, mode }, ctx) => {
+    const store = ctx.getStore();
+    const result = solveInterdiction(
+      store.graphData,
+      store.shocks,
+      store.severedEdges,
+      budget,
+      mode,
+    );
+
+    const lines = [
+      `Interdiction solved (budget=${budget}, mode=${mode}):`,
+      `  Baseline damage: ${result.baselineDamage.toFixed(1)}/100`,
+      `  Optimal damage: ${result.bestDamage.toFixed(1)}/100`,
+      `  Reduction: ${result.reductionPct.toFixed(1)}%`,
+    ];
+
+    if (result.interventions.length > 0) {
+      lines.push(`  Recommended cuts:`);
+      result.interventions.forEach((iv, i) => {
+        lines.push(
+          `    ${i + 1}. [${iv.target.type}] ${iv.target.label} (${iv.target.id}) — saves ${iv.marginalReduction.toFixed(1)}pts`,
+        );
+      });
+      lines.push(`  → Switched to PEARL module. Review cuts in the intervention panel.`);
+      store.setLastInterdictionResult(result);
+    } else {
+      // Fall back to structural vulnerability when cascade damage is
+      // too low to discriminate — same logic as the pre-registry version.
+      const fallbackCandidates: InterdictionCandidate[] = [];
+
+      if (mode !== "node") {
+        const criticalEdges = store.graphData.edges
+          .filter((e) => e.weight >= 0.7 && !e.isSevered)
+          .sort((a, b) => b.weight - a.weight)
+          .slice(0, budget);
+        for (const e of criticalEdges) {
+          const src = store.graphData.nodes.find((n) => n.id === e.source);
+          const tgt = store.graphData.nodes.find((n) => n.id === e.target);
+          fallbackCandidates.push({
+            target: {
+              type: "edge",
+              id: e.id,
+              label: `${src?.shortLabel ?? e.source} → ${tgt?.shortLabel ?? e.target}`,
+            },
+            damage: result.baselineDamage,
+            marginalReduction: e.weight * 10,
+          });
+        }
+      }
+
+      if (mode !== "edge") {
+        const highOmegaNodes = [...store.graphData.nodes]
+          .sort((a, b) => b.omegaFragility.composite - a.omegaFragility.composite)
+          .slice(0, budget);
+        for (const n of highOmegaNodes) {
+          fallbackCandidates.push({
+            target: { type: "node", id: n.id, label: n.shortLabel },
+            damage: result.baselineDamage,
+            marginalReduction: n.omegaFragility.composite,
+          });
+        }
+      }
+
+      fallbackCandidates.sort((a, b) => b.marginalReduction - a.marginalReduction);
+      const trimmed = fallbackCandidates.slice(0, budget);
+
+      const reason =
+        "Cascade damage too low to rank cuts — showing highest structural vulnerability (edge weight / ΩF) instead.";
+
+      store.setLastInterdictionResult({
+        ...result,
+        interventions: trimmed,
+        fallbackReason: reason,
+      });
+
+      lines.push(`  No high-damage cascade detected — recommending structural vulnerability cuts:`);
+      trimmed.forEach((iv, i) => {
+        const suffix =
+          iv.target.type === "edge"
+            ? `(w-score ${iv.marginalReduction.toFixed(1)}, id:${iv.target.id})`
+            : `(ΩF ${iv.marginalReduction.toFixed(1)}, id:${iv.target.id})`;
+        lines.push(`    ${i + 1}. [${iv.target.type}] ${iv.target.label} ${suffix}`);
+      });
+      lines.push(`  → Switched to PEARL module. Cuts rendered in the intervention panel.`);
+    }
+
+    store.setActiveModule("pearl");
+    return lines.join("\n");
+  },
+});
+
+defineTool({
+  name: "apply_interdiction",
+  description:
+    "Apply interventions from the most recent solve_interdiction. Pass targets=all or targets=1|3 (1-based indices).",
+  params: {
+    targets: {
+      type: "string",
+      required: true,
+      description: "'all' or pipe-separated 1-based indices",
+    },
+  },
+  legacyParam: "targets",
+  handler: ({ targets }, ctx) => {
+    const store = ctx.getStore();
+    const last = store.lastInterdictionResult;
+    if (!last || last.interventions.length === 0) {
+      return "No interdiction results to apply. Run solve_interdiction first.";
+    }
+
+    if (targets === "all") {
+      const applied: string[] = [];
+      for (const iv of last.interventions) {
+        if (iv.target.type === "edge") {
+          store.severEdge(iv.target.id);
+          applied.push(iv.target.label);
+        } else {
+          store.toggleAblatedNode(iv.target.id);
+          applied.push(iv.target.label);
+        }
+      }
+      return `Applied all ${applied.length} interdictions: ${applied.join(", ")}`;
+    }
+
+    // Accept either pipe-separated (new format) or comma-separated
+    // (back-compat with legacy `apply_interdiction:1,2`).
+    const sep = targets.includes("|") ? "|" : ",";
+    const indices = targets.split(sep).map((s) => parseInt(s.trim(), 10) - 1);
+    const applied: string[] = [];
+    for (const idx of indices) {
+      const iv = last.interventions[idx];
+      if (!iv) continue;
+      if (iv.target.type === "edge") {
+        store.severEdge(iv.target.id);
+        applied.push(iv.target.label);
+      } else {
+        store.toggleAblatedNode(iv.target.id);
+        applied.push(iv.target.label);
+      }
+    }
+    return applied.length > 0
+      ? `Applied interdictions: ${applied.join(", ")}`
+      : `No valid intervention indices: ${targets}`;
+  },
+});

--- a/src/lib/copilot/trace-logger.ts
+++ b/src/lib/copilot/trace-logger.ts
@@ -1,0 +1,105 @@
+// ─── Copilot Trace Logger ───────────────────────────────────────
+//
+// Captures every copilot turn as a structured row for replay,
+// eval, and (eventually) training-data collection. The shape
+// here mirrors the supabase-copilot-traces.sql schema 1:1.
+//
+// Design: fire-and-forget POST to /api/copilot/trace. Logging
+// MUST never block the chat or surface errors to the user — if
+// the POST fails, we log to the console and move on.
+
+import type { ToolCallTrace } from "./tool-registry";
+
+// ─── Types ──────────────────────────────────────────────────────
+
+/**
+ * One row in the copilot_traces table. Mirrors the columns
+ * declared in supabase-copilot-traces.sql.
+ */
+export interface TurnTrace {
+  conversation_id: string;
+  turn_index: number;
+  user_message: string | null;
+  assistant_message: string | null;
+  display_text: string | null;
+  tool_calls: ToolCallTrace[];
+  model_provider: string | null;
+  model_id: string | null;
+  system_prompt_hash: string | null;
+  system_prompt_size: number | null;
+  dataset: string | null;
+  active_module: string | null;
+  selected_node: string | null;
+  active_shock_count: number | null;
+  client_meta?: Record<string, unknown>;
+}
+
+// ─── Public API ─────────────────────────────────────────────────
+
+/**
+ * POST a turn trace to the server. Fire-and-forget — the returned
+ * Promise resolves to true on success, false on any failure, but
+ * callers should NOT await it from the chat hot path. Logging
+ * failures must never break the user's chat experience.
+ */
+export async function logTurnTrace(trace: TurnTrace): Promise<boolean> {
+  // Skip logging in test/SSR environments where fetch isn't available.
+  if (typeof fetch === "undefined") return false;
+
+  try {
+    const res = await fetch("/api/copilot/trace", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(trace),
+      // Never let logging hang the page — give it a generous but
+      // bounded budget.
+      signal: AbortSignal.timeout(5000),
+      // Send in the background so a tab close doesn't lose the
+      // last turn. keepalive payloads are capped at 64KB; if
+      // the trace is bigger than that, the browser will fall
+      // back to a regular fetch.
+      keepalive: true,
+    });
+    if (!res.ok) {
+      console.warn(`[copilot-trace] log failed: HTTP ${res.status}`);
+      return false;
+    }
+    return true;
+  } catch (err) {
+    // Logging never throws upward.
+    console.warn("[copilot-trace] log failed:", err);
+    return false;
+  }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+/**
+ * Cheap, deterministic, non-cryptographic hash of a string. Used
+ * as the system_prompt_hash so we can tell whether two turns
+ * shared a prompt without storing the prompt itself. djb2 is
+ * fast, has good distribution for short-medium strings, and
+ * collisions don't matter for our analytics use case.
+ */
+export function hashPrompt(prompt: string): string {
+  let h = 5381;
+  for (let i = 0; i < prompt.length; i++) {
+    h = (h * 33) ^ prompt.charCodeAt(i);
+  }
+  // 32-bit unsigned, hex — short and stable across runtimes.
+  return (h >>> 0).toString(16);
+}
+
+/**
+ * Generate a fresh conversation id. We use this when a chat
+ * session boots; SystemCopilot keeps it stable across turns and
+ * resets it when the user clears the conversation.
+ */
+export function newConversationId(): string {
+  // crypto.randomUUID is available in all modern browsers + Node 18+.
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  // Fallback for very old runtimes — sufficient entropy for our purposes.
+  return `cv_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/src/stores/useApexStore.ts
+++ b/src/stores/useApexStore.ts
@@ -90,7 +90,7 @@ function prunePinsToGraph(graph: CausalGraph, pins: string[]): string[] {
   return filtered.length === pins.length ? pins : filtered;
 }
 
-interface ApexState {
+export interface ApexState {
   // Module navigation
   activeModule: ModuleId;
   setActiveModule: (id: ModuleId) => void;

--- a/supabase-copilot-traces.sql
+++ b/supabase-copilot-traces.sql
@@ -1,0 +1,127 @@
+-- =============================================================
+-- APEX Terminal — Copilot Trace Store (PR2)
+-- Run this in the Supabase SQL Editor after supabase-setup.sql
+-- =============================================================
+--
+-- Purpose: capture every copilot turn as a structured row so we
+-- can later replay conversations, build evals, and use traces as
+-- training material for distillation / fine-tuning.
+--
+-- One row = one turn (user message → assistant response). All
+-- tool calls fired during that turn are stored together in the
+-- tool_calls jsonb array, keeping related events colocated.
+-- =============================================================
+
+create table if not exists public.copilot_traces (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+
+  -- Identity. user_id is nullable so anonymous / pre-auth turns
+  -- still log (useful for marketing-page demos). RLS keeps users
+  -- restricted to their own rows.
+  user_id uuid references auth.users(id) on delete set null,
+  conversation_id text not null,
+  turn_index integer not null,
+
+  -- Conversation payload. user_message is what the user typed;
+  -- assistant_message is the LLM's full response (including any
+  -- <<<ACTION:...>>> tags); display_text is the cleaned text the
+  -- user actually sees in the chat panel.
+  user_message text,
+  assistant_message text,
+  display_text text,
+
+  -- Structured tool invocations. Shape per element:
+  --   { name: text, params: jsonb, result: text,
+  --     error: text | null, latency_ms: int }
+  tool_calls jsonb not null default '[]'::jsonb,
+
+  -- Model metadata — lets us A/B compare providers later.
+  model_provider text,
+  model_id text,
+
+  -- System prompt accounting. We store size + a cheap hash so we
+  -- can tell "did the prompt change between turns?" without
+  -- copying the full prompt (~50-200KB) into every row. The
+  -- prompt itself is reconstructable from graph state if needed.
+  system_prompt_hash text,
+  system_prompt_size integer,
+
+  -- Active platform context — the inputs that shaped the prompt.
+  -- Enough to roughly recreate the turn for replay/eval.
+  dataset text,
+  active_module text,
+  selected_node text,
+  active_shock_count integer,
+
+  -- Free-form extension point. Client version, feature flags,
+  -- A/B test arms, anything else we want to slice on later.
+  client_meta jsonb not null default '{}'::jsonb
+);
+
+-- Indexes ------------------------------------------------------
+
+-- "Show me my history" — the hot per-user read.
+create index if not exists copilot_traces_user_created_idx
+  on public.copilot_traces (user_id, created_at desc)
+  where user_id is not null;
+
+-- Ordered conversation playback.
+create index if not exists copilot_traces_conversation_idx
+  on public.copilot_traces (conversation_id, turn_index);
+
+-- Global recency for admin dashboards.
+create index if not exists copilot_traces_created_idx
+  on public.copilot_traces (created_at desc);
+
+-- Tool-call lookup: "find all turns where isolate_nodes was
+-- called". jsonb_path_ops is smaller + faster for @> containment
+-- queries than the default jsonb_ops.
+create index if not exists copilot_traces_tool_calls_gin
+  on public.copilot_traces using gin (tool_calls jsonb_path_ops);
+
+-- RLS ----------------------------------------------------------
+
+alter table public.copilot_traces enable row level security;
+
+-- Users can read only their own traces.
+drop policy if exists "Users read own copilot traces" on public.copilot_traces;
+create policy "Users read own copilot traces"
+  on public.copilot_traces for select
+  using (auth.uid() = user_id);
+
+-- Inserts go through the API route under the service role, so
+-- no INSERT policy for anon/authenticated. Service role bypasses
+-- RLS by default, which is what we want.
+
+-- =============================================================
+-- ANALYTICS HELPERS (run on demand in the SQL editor)
+-- =============================================================
+--
+-- Most-called tools in the last 7 days:
+--
+--   select
+--     tc->>'name' as tool,
+--     count(*) as calls,
+--     avg((tc->>'latency_ms')::int) as avg_latency_ms
+--   from public.copilot_traces,
+--        jsonb_array_elements(tool_calls) as tc
+--   where created_at > now() - interval '7 days'
+--   group by 1 order by 2 desc;
+--
+-- Conversations that hit isolate_nodes:
+--
+--   select distinct conversation_id, created_at
+--   from public.copilot_traces
+--   where tool_calls @> '[{"name": "isolate_nodes"}]'::jsonb
+--   order by created_at desc;
+--
+-- Tool failure rate by tool:
+--
+--   select
+--     tc->>'name' as tool,
+--     count(*) filter (where tc->>'error' is not null) * 1.0 / count(*) as failure_rate
+--   from public.copilot_traces,
+--        jsonb_array_elements(tool_calls) as tc
+--   group by 1 order by 2 desc;
+-- =============================================================


### PR DESCRIPTION
## Summary

Adds the missing `docs/sessions/copilot.md` scope doc and registers the new session in the routing table.

The copilot session owns a real slice of the platform now — tool registry (#249), trace store (#251), system prompt construction, LLM call site, and (soon) provider abstraction + conversation memory. Without a scope doc, every future agent dropping into this session has to reverse-engineer the architecture. This file is the entry point.

## What it covers

- **Scope (in / out)** — what the copilot session owns vs. what routes to UX & Onboarding, the engine sessions, or Platform.
- **Boundary clarifications** — how to add a new tool, a new param type, a new field on TurnTrace, or a new model provider.
- **What's shipped** — chronological reference for #249 and #251.
- **Architecture** — file map of `src/lib/copilot/`, `src/lib/copilot-*.ts`, `src/app/api/copilot/`, plus where SystemCopilot gets touched.
- **How a turn flows** — six-step trace from user input through tool execution to trace logging.
- **Open follow-ups (priority-ordered)** — PR3 (Vercel AI SDK), eval harness, conversation memory, native tool-use, distillation, dataset routing field, per-user trace UI.
- **How to start a task** — the standard checklist used in other session docs.
- **Cross-session etiquette** — routing rules at the boundary.

## Branched from main

Independent of #249 and #251 — pure docs, doesn't touch any of the code those PRs introduce. Mergeable in any order.

## Test plan

- [x] Markdown renders cleanly in GitHub preview
- [x] All cross-references and PR links resolve
- [x] Routing table in `README.md` includes the new entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)