### PR TITLE
fix(api): lazy-init Supabase clients to unblock production build

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -463,10 +463,45 @@ This was the work deferred in PR #198 with the note *"would need a custom edge c
 
 **Verification.** `tsc --noEmit` clean; lint clean on touched files; vitest 729/729 pass.
 
+### 2026-05-03 — Hotfix (out-of-scope but blocking prod): lazy-init Supabase clients in API routes
+
+**PR:** TBD (about to open).
+
+**Trigger.** User reported `manifold.apexanalytica.co` → Vercel **404 DEPLOYMENT_NOT_FOUND**. Local `npm run build` reproduced: `Error: supabaseUrl is required.` at the "Collecting page data" step, dying on `/api/admin/billing/expire`. Bisected — none of the rendering/perf commits touched these routes; the failure is structural.
+
+**Root cause.** Ten API route files were instantiating service-role Supabase clients (and one Resend client) **at module-load time** at the top of the file:
+
+```ts
+const service = createServiceClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+```
+
+Next.js 16's Turbopack production builder is more aggressive about evaluating route modules during page-data collection, so any missing env var at build time crashes the entire build. On Vercel that took out the production deployment alias and produced the user-facing DEPLOYMENT_NOT_FOUND.
+
+**Fix.** All 10 routes wrapped the client creation in a `function getService() { return createClient(...) }` and switched callsites to call `getService()` (or `getSupabase()` / `getResend()`) inside the request handler. Module-load no longer touches env vars; the client is constructed at request time when env vars are guaranteed present (or fails with a clearer 500).
+
+**Files touched.**
+- `src/app/api/admin/billing/expire/route.ts`
+- `src/app/api/admin/billing/grant-tier/route.ts`
+- `src/app/api/admin/billing/customers/route.ts`
+- `src/app/api/admin/feedback/[id]/approve/route.ts`
+- `src/app/api/admin/feedback/[id]/reject/route.ts`
+- `src/app/api/admin/leads/[id]/route.ts`
+- `src/app/api/request-access/route.ts` (also lazy-inits Resend)
+- `src/app/api/feedback/route.ts`
+- `src/app/api/webhooks/github/route.ts`
+- `src/app/api/trusted-signup/route.ts`
+
+**Verification.** Local `npm run build` now passes the "Collecting page data" step (where it was failing). Static page pre-rendering still requires env vars present (e.g. `/forgot-password` uses `@supabase/ssr`); that's expected on Vercel where the env vars exist and was always working there.
+
+**Out of scope (deliberate).** This is auth/platform code, not rendering/perf. Logging the hotfix here because it's the only session that's been touching the codebase today and prod was down.
+
 ### 2026-05-03 — Next up
 
-- Verify on production: hard-refresh, switch to 2D — expect (a) edges drawing as straight lines between circle perimeters in whatever direction makes geometric sense (no more "always entering top/bottom"), (b) the same `SIZE: ΩF / EIG / BTW` toggle in the top-right resizing the 2D circles live.
-- Outside this: deferred 3D `onPointerMove` throttle (PR #199), map-view imperative-setData refactor, real bundle-analyzer perf sweep using PR #222's tooling.
+- Verify production deploys past the build step. If still 404, the next likely failure mode is `/forgot-password` or another auth-page pre-render — that would need its own investigation.
+- Resume rendering work: 2D floating-edge verification, plus deferred 3D `onPointerMove` throttle (PR #199), map-view imperative-setData refactor, real bundle-analyzer perf sweep using PR #222's tooling.
 
 ---
 

--- a/src/app/api/admin/billing/customers/route.ts
+++ b/src/app/api/admin/billing/customers/route.ts
@@ -3,10 +3,14 @@ import { createClient as createServiceClient } from "@supabase/supabase-js";
 import { requireAdmin } from "@/lib/admin-auth";
 import type { Tier, SubscriptionStatus } from "@/lib/billing";
 
-const service = createServiceClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-);
+// Lazy service-client construction — see comment in
+// `src/app/api/admin/billing/expire/route.ts`.
+function getService() {
+  return createServiceClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+}
 
 export interface AdminCustomerRow {
   id: string;
@@ -32,7 +36,7 @@ export async function GET() {
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
 
-  const { data, error } = await service
+  const { data, error } = await getService()
     .from("profiles")
     .select(
       "id, email, org_name, tier, subscription_status, current_period_start, current_period_end, mercury_invoice_id, seats, domain_access, trial_expires_at, created_at"

--- a/src/app/api/admin/billing/expire/route.ts
+++ b/src/app/api/admin/billing/expire/route.ts
@@ -2,10 +2,18 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient as createServiceClient } from "@supabase/supabase-js";
 import { requireAdmin } from "@/lib/admin-auth";
 
-const service = createServiceClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-);
+// Lazy service-client construction — calling createServiceClient at module
+// load tripped Next.js's build-time page-data collection when env vars
+// were absent (`Error: supabaseUrl is required.`), failing the entire
+// production build. Defer to request time so the build never instantiates
+// it; missing-env failures still surface, just as a runtime 500 instead
+// of breaking deploy.
+function getService() {
+  return createServiceClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+}
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -26,7 +34,7 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const { error } = await service
+  const { error } = await getService()
     .from("profiles")
     .update({
       tier: "expired",

--- a/src/app/api/admin/billing/grant-tier/route.ts
+++ b/src/app/api/admin/billing/grant-tier/route.ts
@@ -3,10 +3,15 @@ import { createClient as createServiceClient } from "@supabase/supabase-js";
 import { requireAdmin } from "@/lib/admin-auth";
 import type { SubscriptionStatus, Tier } from "@/lib/billing";
 
-const service = createServiceClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-);
+// Lazy service-client construction — see comment in
+// `src/app/api/admin/billing/expire/route.ts`. Eager init at module
+// load was failing the production build's page-data collection.
+function getService() {
+  return createServiceClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+}
 
 const VALID_TIERS = new Set<Tier>([
   "trial",
@@ -127,7 +132,7 @@ export async function POST(req: NextRequest) {
     }
   }
 
-  const { error } = await service
+  const { error } = await getService()
     .from("profiles")
     .update(update)
     .eq("id", body.userId);

--- a/src/app/api/admin/feedback/[id]/approve/route.ts
+++ b/src/app/api/admin/feedback/[id]/approve/route.ts
@@ -3,10 +3,14 @@ import { createClient as createServiceClient } from "@supabase/supabase-js";
 import { requireAdmin } from "@/lib/admin-auth";
 import { createFeedbackIssue } from "@/lib/github";
 
-const service = createServiceClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!,
-);
+// Lazy service-client construction — see comment in
+// `src/app/api/admin/billing/expire/route.ts`.
+function getService() {
+  return createServiceClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
 
 export async function POST(
   request: NextRequest,
@@ -28,6 +32,7 @@ export async function POST(
   const adminNotes = body.admin_notes?.trim() || null;
 
   // Load the feedback row
+  const service = getService();
   const { data: row, error: selectErr } = await service
     .from("feedback")
     .select("id, type, message, email, status")

--- a/src/app/api/admin/feedback/[id]/reject/route.ts
+++ b/src/app/api/admin/feedback/[id]/reject/route.ts
@@ -2,10 +2,14 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient as createServiceClient } from "@supabase/supabase-js";
 import { requireAdmin } from "@/lib/admin-auth";
 
-const service = createServiceClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!,
-);
+// Lazy service-client construction — see comment in
+// `src/app/api/admin/billing/expire/route.ts`.
+function getService() {
+  return createServiceClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
 
 export async function POST(
   request: NextRequest,
@@ -26,7 +30,7 @@ export async function POST(
   };
   const adminNotes = body.admin_notes?.trim() || null;
 
-  const { error } = await service
+  const { error } = await getService()
     .from("feedback")
     .update({ status: "rejected", admin_notes: adminNotes })
     .eq("id", feedbackId)

--- a/src/app/api/admin/leads/[id]/route.ts
+++ b/src/app/api/admin/leads/[id]/route.ts
@@ -2,10 +2,14 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient as createServiceClient } from "@supabase/supabase-js";
 import { requireAdmin } from "@/lib/admin-auth";
 
-const service = createServiceClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-);
+// Lazy service-client construction — see comment in
+// `src/app/api/admin/billing/expire/route.ts`.
+function getService() {
+  return createServiceClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+}
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -76,7 +80,7 @@ export async function POST(
     );
   }
 
-  const { error } = await service.from("leads").update(update).eq("id", id);
+  const { error } = await getService().from("leads").update(update).eq("id", id);
   if (error) {
     console.error("admin/leads update:", error);
     return NextResponse.json({ error: error.message }, { status: 500 });

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,10 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-);
+// Lazy service-client construction — see comment in
+// `src/app/api/admin/billing/expire/route.ts`. Eager init at module
+// load failed Next.js's build-time page-data collection.
+function getSupabase() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -18,7 +23,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { error } = await supabase
+    const { error } = await getSupabase()
       .from("feedback")
       .insert({ type, message, email: email || null });
 

--- a/src/app/api/request-access/route.ts
+++ b/src/app/api/request-access/route.ts
@@ -8,18 +8,25 @@ import { Resend } from "resend";
 // RLS predictably (the policy already allows anon inserts, this is
 // belt-and-suspenders).
 
-const service = createServiceClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-);
+// Lazy service-client construction — see comment in
+// `src/app/api/admin/billing/expire/route.ts`. Eager init at module
+// load was breaking the production build's page-data collection.
+function getService() {
+  return createServiceClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+}
 
 // Resend is optional — if RESEND_API_KEY isn't set (dev environments,
 // preview deploys without the secret) we skip the notification email
 // and the lead still lands in public.leads. Admins fall back to
-// /admin/leads in that case.
-const resend = process.env.RESEND_API_KEY
-  ? new Resend(process.env.RESEND_API_KEY)
-  : null;
+// /admin/leads in that case. Lazy-init for the same build-time reason.
+function getResend(): Resend | null {
+  return process.env.RESEND_API_KEY
+    ? new Resend(process.env.RESEND_API_KEY)
+    : null;
+}
 
 const NOTIFY_TO =
   process.env.RESEND_NOTIFY_TO ?? "info@apexanalytica.co";
@@ -133,7 +140,7 @@ export async function POST(req: NextRequest) {
 
   const lowercaseEmail = email.toLowerCase();
 
-  const { error } = await service.from("leads").insert({
+  const { error } = await getService().from("leads").insert({
     name,
     email: lowercaseEmail,
     organization,
@@ -153,6 +160,7 @@ export async function POST(req: NextRequest) {
   // point; an email failure should not roll the request back. We
   // await the send so Vercel doesn't kill the function before the
   // request hits Resend, but catch any error and log it.
+  const resend = getResend();
   if (resend) {
     const lead: NotificationLead = {
       name,

--- a/src/app/api/trusted-signup/route.ts
+++ b/src/app/api/trusted-signup/route.ts
@@ -2,10 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 
 // Service-role client — bypasses RLS, never exposed to the browser.
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-);
+// Lazy-init: see comment in `src/app/api/admin/billing/expire/route.ts`.
+function getSupabase() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -48,6 +51,7 @@ export async function POST(request: NextRequest) {
     // The handle_new_user trigger reads `tier` from raw_user_meta_data
     // when invoked under service-role. Browser callers cannot reach
     // this path, so the metadata is trustworthy.
+    const supabase = getSupabase();
     const { data, error: createError } =
       await supabase.auth.admin.createUser({
         email,

--- a/src/app/api/webhooks/github/route.ts
+++ b/src/app/api/webhooks/github/route.ts
@@ -2,10 +2,14 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import crypto from "crypto";
 
-const service = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!,
-);
+// Lazy service-client construction — see comment in
+// `src/app/api/admin/billing/expire/route.ts`.
+function getService() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
 
 function verifySignature(payload: string, signature: string | null): boolean {
   const secret = process.env.GITHUB_WEBHOOK_SECRET;
@@ -58,7 +62,7 @@ async function handlePullRequest(payload: PullRequestEvent) {
     return { ignored: true, reason: "No Feedback-ID trailer" };
   }
 
-  const { error } = await service
+  const { error } = await getService()
     .from("feedback")
     .update({ status: "in_progress", pr_url: pr.html_url })
     .eq("id", feedbackId)
@@ -82,7 +86,7 @@ async function handleDeploymentStatus(payload: DeploymentStatusEvent) {
 
   // Any feedback row at in_progress (= PR merged to main) is necessarily part
   // of the latest prod deploy once it succeeds — flip all to shipped.
-  const { data, error } = await service
+  const { data, error } = await getService()
     .from("feedback")
     .update({ status: "shipped", shipped_at: new Date().toISOString() })
     .eq("status", "in_progress")


### PR DESCRIPTION
## Summary

User reported `manifold.apexanalytica.co` → Vercel **404 DEPLOYMENT_NOT_FOUND**. Local `npm run build` reproduced: `Error: supabaseUrl is required.` at the "Collecting page data" step, dying on `/api/admin/billing/expire`.

### Root cause

Ten API route files were instantiating service-role Supabase clients (and one Resend client) **at module-load time** at the top of the file:

```ts
const service = createServiceClient(
  process.env.NEXT_PUBLIC_SUPABASE_URL!,
  process.env.SUPABASE_SERVICE_ROLE_KEY!
);
```

Next.js 16's Turbopack production builder is more aggressive about evaluating route modules during page-data collection, so any missing env var at build time crashes the entire build. On Vercel that took out the production deployment alias and produced the user-facing DEPLOYMENT_NOT_FOUND.

### Fix

All 10 routes wrap the client creation in a `function getService() { return createClient(...) }` and call `getService()` (or `getSupabase()` / `getResend()`) inside the request handler. Module-load no longer touches env vars; the client is constructed at request time when env vars are guaranteed present (or the request fails with a clearer 500).

Routes touched:
- `src/app/api/admin/billing/expire/route.ts`
- `src/app/api/admin/billing/grant-tier/route.ts`
- `src/app/api/admin/billing/customers/route.ts`
- `src/app/api/admin/feedback/[id]/approve/route.ts`
- `src/app/api/admin/feedback/[id]/reject/route.ts`
- `src/app/api/admin/leads/[id]/route.ts`
- `src/app/api/request-access/route.ts` (also lazy-inits Resend)
- `src/app/api/feedback/route.ts`
- `src/app/api/webhooks/github/route.ts`
- `src/app/api/trusted-signup/route.ts`

### Out of scope (deliberate)

Auth/platform code, not rendering/perf. Logging in `docs/sessions/rendering-perf.md` because that's the only session that's been touching the codebase today and prod was down.

## Test plan

- [x] Local `npm run build` now passes the page-data collection step where it was failing
- [ ] Vercel deploy of this commit succeeds and `manifold.apexanalytica.co` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_