### PR TITLE
test: deflake csdRegimeGate + add registry/profile coverage gate

### DIFF
--- a/src/lib/__tests__/pareto-relevance.test.ts
+++ b/src/lib/__tests__/pareto-relevance.test.ts
@@ -93,9 +93,23 @@ describe("akaikeEvidenceWeights", () => {
 describe("csdRegimeGate", () => {
   it("scores higher for a series with rising variance and autocorr", () => {
     // Trajectory whose variance and autocorrelation grow over time.
+    // Seeded RNG so the test is deterministic — was previously using
+    // unseeded Math.random() and intermittently failed when the random
+    // draw produced rising < flat at the assertion threshold.
+    const rng = (() => {
+      // Mulberry32 inline so the test stays in this single file.
+      let a = 20260506 >>> 0;
+      return () => {
+        a = (a + 0x6d2b79f5) >>> 0;
+        let t = a;
+        t = Math.imul(t ^ (t >>> 15), t | 1);
+        t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+      };
+    })();
     const rising: number[] = [];
     for (let i = 0; i < 30; i++) {
-      const noise = (Math.random() - 0.5) * (i / 30);
+      const noise = (rng() - 0.5) * (i / 30);
       const trend = i / 30;
       rising.push(trend + noise);
     }

--- a/src/lib/__tests__/registry-profile-coverage.test.ts
+++ b/src/lib/__tests__/registry-profile-coverage.test.ts
@@ -1,0 +1,95 @@
+// Registry × profile coverage contract.
+//
+// Catches the failure mode that motivated PR #246: an estimator's
+// `defaultAvailability: "ready"` flips on in the registry but no
+// production profile lists it in `criticalityEstimators`, so the new
+// runtime never renders. Production was stuck on three tabs after
+// PR #234 wired BOCPD live, until #246 added "bocpd" to the analyst
+// profile array.
+//
+// Contract: every estimator the registry advertises as "ready" must
+// appear in at least one production profile. New "ready" estimators
+// either need a profile entry or — if scoped to a single domain — an
+// allow-list entry in `EXEMPT_READY_ESTIMATORS` below with a reason.
+//
+// Adding a new "ready" estimator without updating either side fails
+// this test. Future flips from "awaiting-data" → "ready" go through
+// the same gate.
+
+import { describe, it, expect } from "vitest";
+import { getAllEstimatorMeta } from "../criticality-registry";
+import {
+  GEOPOLITICAL_PROFILE,
+  T1D_PROFILE,
+  type EstimatorId,
+} from "../domain-profiles";
+
+const PRODUCTION_PROFILES = [GEOPOLITICAL_PROFILE, T1D_PROFILE];
+
+/**
+ * Estimators allowed to be "ready" in the registry without being
+ * listed in any production profile. Use sparingly — the whole point
+ * of this test is to make profile-coverage gaps fail loudly. Each
+ * entry needs a one-line justification.
+ */
+const EXEMPT_READY_ESTIMATORS: Partial<Record<EstimatorId, string>> = {
+  // No exemptions today. Add entries here only when an estimator is
+  // genuinely ready but intentionally not surfaced in any default
+  // profile (e.g. a flagship-feature gated behind a paid tier).
+};
+
+describe("criticality-registry × domain-profile coverage", () => {
+  it("every registry entry marked 'ready' appears in at least one production profile", () => {
+    const allCovered = new Set<EstimatorId>();
+    for (const profile of PRODUCTION_PROFILES) {
+      for (const eid of profile.criticalityEstimators) {
+        allCovered.add(eid);
+      }
+    }
+
+    const missing: { id: EstimatorId; reason?: string }[] = [];
+    for (const meta of getAllEstimatorMeta()) {
+      if (meta.defaultAvailability !== "ready") continue;
+      if (allCovered.has(meta.id)) continue;
+      if (EXEMPT_READY_ESTIMATORS[meta.id]) continue;
+      missing.push({ id: meta.id });
+    }
+
+    expect(
+      missing,
+      missing.length === 0
+        ? ""
+        : `These estimators are 'ready' in the registry but absent from every production profile:\n  ${missing
+            .map((m) => `- ${m.id}`)
+            .join("\n  ")}\n` +
+          `Either add them to GEOPOLITICAL_PROFILE / T1D_PROFILE in src/lib/domain-profiles.ts, ` +
+          `or whitelist them in EXEMPT_READY_ESTIMATORS in this test with a one-line reason.`,
+    ).toEqual([]);
+  });
+
+  it("every estimator listed in a production profile exists in the registry", () => {
+    const registered = new Set(getAllEstimatorMeta().map((m) => m.id));
+    const orphans: { profile: string; id: EstimatorId }[] = [];
+    for (const profile of PRODUCTION_PROFILES) {
+      for (const eid of profile.criticalityEstimators) {
+        if (!registered.has(eid)) {
+          orphans.push({ profile: profile.id, id: eid });
+        }
+      }
+    }
+    expect(
+      orphans,
+      orphans.length === 0
+        ? ""
+        : `These profile entries reference estimator IDs that the registry doesn't define:\n  ${orphans
+            .map((o) => `- ${o.profile} → ${o.id}`)
+            .join("\n  ")}`,
+    ).toEqual([]);
+  });
+
+  it("no production profile is empty", () => {
+    for (const profile of PRODUCTION_PROFILES) {
+      expect(profile.criticalityEstimators.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Two small test-only discipline improvements bundled together. Zero runtime risk.

## 1. Deflake `csdRegimeGate` rising-vs-flat test

`src/lib/__tests__/pareto-relevance.test.ts:97` was using unseeded `Math.random()` inside the noise generator that drives the `rising` series. With bad luck the random draw could push the rising series's variance slope below the flat baseline at the assertion threshold, intermittently failing on unrelated PRs' CI runs. The session log open-threads list called this out specifically as "will keep biting random PRs until done."

Fix: inline mulberry32 seeded at `20260506`. Test is now reproducible.

## 2. Registry × profile coverage contract

New `src/lib/__tests__/registry-profile-coverage.test.ts` codifies the lesson from PR #246. Three checks:

- **Every `defaultAvailability: "ready"` estimator must appear in ≥ 1 production profile.** Explicit `EXEMPT_READY_ESTIMATORS` allow-list with one-line justification per entry, for the rare case a ready estimator is intentionally hidden.
- **Every profile entry must exist in the registry.** Catches typos / deletions on the registry side.
- **No production profile is empty.**

### Would have caught #234

PR #234 flipped BOCPD to `defaultAvailability: "ready"` in `criticality-registry.ts` but never updated `GEOPOLITICAL_PROFILE.criticalityEstimators`. Production silently kept showing only 3 tabs (CSD, PH, LPPLS) until the user noticed and PR #246 added the missing entry. With this contract in place that gap fails the build gate at PR review time instead of slipping to prod.

### Failure-mode preview

If a future PR removes `"bocpd"` from both profiles while leaving the registry at `"ready"`, the test fails with:

> These estimators are 'ready' in the registry but absent from every production profile:
>   - bocpd
> Either add them to GEOPOLITICAL_PROFILE / T1D_PROFILE in src/lib/domain-profiles.ts, or whitelist them in EXEMPT_READY_ESTIMATORS in this test with a one-line reason.

## Test plan

- [x] Full vitest suite: 732 / 732 (was 729)
- [x] `npm run build` passes locally
- [ ] PR-validate workflow green
- [x] Coverage logic verified against current state (csd / ph / lppls / bocpd are all ready and all in geopolitical; no false positive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
