### PR TITLE
feat(website): add insurance as the 8th domain

### DIFF
--- a/website/src/app/domains/[slug]/page.tsx
+++ b/website/src/app/domains/[slug]/page.tsx
@@ -45,6 +45,7 @@ const colorMap: Record<
   green:   { text: "text-accent-green",   border: "border-accent-green/30",   bg: "bg-accent-green",   soft: "bg-accent-green/5",   glow: "text-glow-cyan" },
   red:     { text: "text-accent-red",     border: "border-accent-red/30",     bg: "bg-accent-red",     soft: "bg-accent-red/5",     glow: "text-glow-amber" },
   magenta: { text: "text-accent-magenta", border: "border-accent-magenta/30", bg: "bg-accent-magenta", soft: "bg-accent-magenta/5", glow: "text-glow-cyan" },
+  blue:    { text: "text-accent-blue",    border: "border-accent-blue/30",    bg: "bg-accent-blue",    soft: "bg-accent-blue/5",    glow: "text-glow-cyan" },
 };
 
 export function generateStaticParams() {

--- a/website/src/app/domains/page.tsx
+++ b/website/src/app/domains/page.tsx
@@ -6,7 +6,7 @@ import { DOMAINS, DOMAIN_SLUGS, type Color } from "@/lib/domains";
 export const metadata: Metadata = {
   title: "Domains · Apex Analytica",
   description:
-    "Seven domains where Manifold maps, scores, and stress-tests fragility. Pick the one that matches the system you care about.",
+    "Eight domains where Manifold maps, scores, and stress-tests fragility. Pick the one that matches the system you care about.",
 };
 
 const colorMap: Record<
@@ -20,6 +20,7 @@ const colorMap: Record<
   green:   { text: "text-accent-green",   border: "border-accent-green/30",   bg: "bg-accent-green",   soft: "bg-accent-green/5",   glow: "text-glow-cyan",  rule: "bg-accent-green" },
   red:     { text: "text-accent-red",     border: "border-accent-red/30",     bg: "bg-accent-red",     soft: "bg-accent-red/5",     glow: "text-glow-amber", rule: "bg-accent-red" },
   magenta: { text: "text-accent-magenta", border: "border-accent-magenta/30", bg: "bg-accent-magenta", soft: "bg-accent-magenta/5", glow: "text-glow-cyan",  rule: "bg-accent-magenta" },
+  blue:    { text: "text-accent-blue",    border: "border-accent-blue/30",    bg: "bg-accent-blue",    soft: "bg-accent-blue/5",    glow: "text-glow-cyan",  rule: "bg-accent-blue" },
 };
 
 export default function DomainsIndexPage() {
@@ -37,10 +38,10 @@ export default function DomainsIndexPage() {
             </span>
             <span className="font-mono text-[10px] text-text-muted/60">manifold.domains</span>
             <span className="text-text-muted/40">·</span>
-            <span className="font-mono text-[10px] text-text-muted/60">07 CONFIGURED</span>
+            <span className="font-mono text-[10px] text-text-muted/60">08 CONFIGURED</span>
           </div>
           <h1 className="font-[family-name:var(--font-michroma)] text-3xl md:text-5xl tracking-[0.04em] leading-[1.15] text-foreground max-w-3xl">
-            Seven domains.{" "}
+            Eight domains.{" "}
             <span className="text-accent-cyan text-glow-cyan">One graph engine.</span>
           </h1>
           <p className="mt-5 text-sm md:text-base font-mono text-text-muted leading-relaxed max-w-2xl">

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -30,6 +30,7 @@ const DOMAINS = [
   { label: "ENERGY",         slug: "energy",         text: "text-accent-green",   border: "border-accent-green/25",   dot: "bg-accent-green",   sub: "Grid · oil · gas · transition tech" },
   { label: "GEOPOLITICAL",   slug: "geopolitical",   text: "text-accent-red",     border: "border-accent-red/25",     dot: "bg-accent-red",     sub: "Sanctions · conflict · export controls" },
   { label: "SCIENCE",        slug: "science",        text: "text-accent-magenta", border: "border-accent-magenta/25", dot: "bg-accent-magenta", sub: "Research infra · instrumentation · talent" },
+  { label: "INSURANCE",      slug: "insurance",      text: "text-accent-blue",    border: "border-accent-blue/25",    dot: "bg-accent-blue",    sub: "Reinsurance · specialty lines · ILS · cat" },
 ];
 
 /* ───────── page ───────── */
@@ -92,7 +93,7 @@ export default function Home() {
               <div className="pt-6 grid grid-cols-3 gap-4 max-w-md">
                 <Stat label="ENGINES" value="04" />
                 <Stat label="ΩF PILLARS" value="05" />
-                <Stat label="DOMAINS" value="07" />
+                <Stat label="DOMAINS" value="08" />
               </div>
             </div>
 
@@ -123,7 +124,7 @@ export default function Home() {
 
       {/* ───────── // DOMAINS ───────── */}
       <Section id="domains" className="py-10 md:py-14 border-t border-border">
-        <TerminalHeader label="// DOMAINS" path="manifold.domains" right="07 CONFIGURED · CLICK TO EXPLORE" />
+        <TerminalHeader label="// DOMAINS" path="manifold.domains" right="08 CONFIGURED · CLICK TO EXPLORE" />
 
         <p className="mb-5 text-[13px] md:text-sm font-mono text-text-muted leading-relaxed max-w-2xl">
           Find your domain. Each one explains the problem Manifold solves

--- a/website/src/components/ui/Section.tsx
+++ b/website/src/components/ui/Section.tsx
@@ -16,7 +16,7 @@ export function Section({
   );
 }
 
-export function SectionLabel({ children, color = "cyan" }: { children: ReactNode; color?: "cyan" | "amber" | "purple" | "green" | "red" | "magenta" | "orange" }) {
+export function SectionLabel({ children, color = "cyan" }: { children: ReactNode; color?: "cyan" | "amber" | "purple" | "green" | "red" | "magenta" | "orange" | "blue" }) {
   const map: Record<string, string> = {
     cyan: "text-accent-cyan",
     amber: "text-accent-amber",
@@ -25,6 +25,7 @@ export function SectionLabel({ children, color = "cyan" }: { children: ReactNode
     red: "text-accent-red",
     magenta: "text-accent-magenta",
     orange: "text-accent-orange",
+    blue: "text-accent-blue",
   };
   return (
     <div className="flex items-center gap-3">
@@ -65,7 +66,7 @@ export function TerminalHeader({
   label: string;
   path?: string;
   right?: string;
-  color?: "cyan" | "amber" | "purple" | "green" | "red" | "magenta" | "orange";
+  color?: "cyan" | "amber" | "purple" | "green" | "red" | "magenta" | "orange" | "blue";
 }) {
   const map: Record<string, string> = {
     cyan: "text-accent-cyan/90",
@@ -75,6 +76,7 @@ export function TerminalHeader({
     red: "text-accent-red/90",
     magenta: "text-accent-magenta/90",
     orange: "text-accent-orange/90",
+    blue: "text-accent-blue/90",
   };
   return (
     <div className="flex items-center justify-between border-b border-border pb-2 mb-6">

--- a/website/src/lib/domains.ts
+++ b/website/src/lib/domains.ts
@@ -11,7 +11,7 @@
  * sees themselves in the persona list.
  */
 
-export type Color = "cyan" | "amber" | "purple" | "orange" | "green" | "red" | "magenta";
+export type Color = "cyan" | "amber" | "purple" | "orange" | "green" | "red" | "magenta" | "blue";
 
 export type Persona = {
   /** Who the reader is (job title, org type). */
@@ -327,6 +327,42 @@ export const DOMAINS: Record<string, DomainContent> = {
         title: "R&D Strategy · Biotech / Pharma",
         pain: "Research bets assume inputs are fungible. Often they aren't — a single instrument supplier, a single CRO, a single specialist team can stall a program for a year.",
         gain: "Graph view of the research supply chain. Cascade simulation on supplier and CRO failure across the pipeline.",
+      },
+    ],
+  },
+
+  insurance: {
+    slug: "insurance",
+    name: "Insurance",
+    color: "blue",
+    tagline: "Reinsurance, specialty lines, and the cascade exposure cat models miss.",
+    problem: [
+      "Insurance and reinsurance run on cat models that price physical damage well — wind, flood, quake — and price the network around the asset poorly. The cascade between insureds, between treaties, and between regions is rarely modeled. The peak exposures that actually move a portfolio are usually structural, not perils.",
+      "Aggregate exposure across a book is monitored line-by-line. The joint event that lights up multiple lines at once — a tropical storm that takes a port offline that strands manufacturing capacity that breaks supplier covenants — sits in the seams between underwriting silos. By the time it materializes, retro spirals are already running.",
+      "Specialty and ILS markets price tail risk explicitly, but the tail itself is graph-shaped: parametric triggers, reinstatements, capacity caps, retrocession layers. The tail event isn't a single number; it's a sequence of dependent draws across a network of obligations. Most pricing tools don't model that network.",
+    ],
+    mapping: [
+      "Manifold ingests the insurance graph at three layers: the physical exposure graph (insured assets, geographies, occupancy), the contractual graph (treaties, layers, retrocession towers, capacity providers), and the regulatory graph (state filings, run-off jurisdictions, capital requirements). Edges encode physical correlation, ceding obligation, and jurisdictional dependency.",
+      "PEARL runs counterfactuals on named events (a 1-in-200 tropical storm hitting this exposure footprint; a sovereign ratings shock impacting these reinsurers' balance sheets). PARETO simulates the cascade through retrocession and aggregate-stop-loss layers. SPIRTES discovers latent exposure correlations the actuarial categories don't capture. TARSKI verifies which paths through the graph remain compliant under filed treaty terms and regulatory regimes.",
+    ],
+    engines: ["SPIRTES", "PEARL", "PARETO", "TARSKI"],
+    pillars: ["I", "R", "J", "C", "T"],
+    signals: [],
+    personas: [
+      {
+        title: "CAT Underwriter · Specialty Reinsurance",
+        pain: "Peak-peril exposure is priced asset-by-asset; the cross-asset cascade is footnoted. When a named event hits, the actual loss includes second-order claims from infrastructure interdependency that the cat model never saw.",
+        gain: "Network-aware exposure across the insured graph. Cascade load and tail-depth on the lines you actually wrote. Counterfactual loss distribution under named scenarios, with the second-order term priced.",
+      },
+      {
+        title: "CRO · P&C Insurer",
+        pain: "Aggregate exposure is monitored per line of business. The joint event that hits multiple lines at once is rarely sized. When it lands, the loss is computed after the fact and the capital case is reactive.",
+        gain: "Joint-shock simulation across the full book. ΩSF / ΩSX as steady metrics on the portfolio graph. Defensible economic-capital case before the next renewal cycle.",
+      },
+      {
+        title: "ILS / Sidecar Manager",
+        pain: "Capital-markets reinsurance prices tail explicitly, but the tail is graph-shaped — reinstatements, retro spirals, parametric triggers — and the structuring tools treat each layer as independent.",
+        gain: "Tail-depth simulation that respects the network: dependent reinstatements, retro propagation, parametric trigger interactions. Defensible structuring of new layers and sidecar capacity.",
       },
     ],
   },


### PR DESCRIPTION
## Summary

User requested an insurance domain on `/domains`. Reinsurance, specialty lines, and ILS markets price tail risk explicitly but treat the network around the asset poorly — exactly the shape Manifold maps. Adds it as the 8th tile alongside the existing seven.

**Content depth matches the other domains:**
- 3 paragraphs of problem framing
- 2 paragraphs of mapping (named layers + engine roles)
- 3 personas: CAT Underwriter (specialty reinsurance), CRO of P&C insurer, ILS / sidecar manager
- **Engines**: SPIRTES + PEARL + PARETO + TARSKI (TARSKI handles treaty + regulatory verification)
- **Pillars**: all 5 (I/R/J/C/T) — insurance touches every fragility axis

**Wiring changes:**
- New `Color` value `'blue'` (uses existing brand token `--accent-blue` = `#448aff`)
- `blue` row added to the colorMap in `/domains` index page and `/domains/[slug]` page
- `blue` added to TerminalHeader / SectionLabel color unions in `Section.tsx`
- Homepage `// DOMAINS` tile data + the hero `Stat` (07 → 08) + section `right="07 CONFIGURED"` (→ 08) + `/domains` index "Seven domains." H1 (→ "Eight domains.") all updated

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Post-merge: `/domains` shows 8 tiles
- [ ] `/domains/insurance` returns 200 with the expected content
- [ ] Homepage `// DOMAINS` section shows 8 tiles, `08 CONFIGURED` label, `08` stat
- [ ] Blue accent color renders correctly on the tile + slug page

🤖 Generated with [Claude Code](https://claude.com/claude-code)