### PR TITLE
fix(3d): hover shows small label only; detail card opens on click

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -555,10 +555,22 @@ The cryptic three-letter labels surfaced no meaning, and three other visual enco
 
 **Verification.** `tsc --noEmit` clean; lint clean on touched files; vitest 732/732 pass.
 
+### 2026-05-03 — Shipped: 3D hover-vs-click parity with 2D
+
+**PR:** TBD (about to open).
+
+**Trigger.** User feedback on 3D: *"when I hover above a node, I'd like to see just the small label like 2D does. I didn't mean the huge box that appears — that should only appear when I physically click on it."*
+
+**What shipped.** Single one-line change in `DAGNode3D`: the heavy "ΩF profile + network metrics" hover card was gated on `hovered && !dimmed`. Switched to `isSelected && !dimmed`. The lightweight floating-label (`{node.label} | {domain} | Ω X.X`) still shows on hover (gate already includes `hovered || isSelected || isNeighborOfSelected`), so hover gives the small label and only an explicit click opens the heavy card. Mirrors the 2D pattern.
+
+**Files.**
+- `src/components/dag3d/DAGNode3D.tsx` — one conditional swap on the detail-card mount.
+
+**Verification.** `tsc --noEmit` clean; lint clean (pre-existing `ablationMode` warning unchanged); vitest 778/778 pass.
+
 ### 2026-05-03 — Next up
 
-- Verify edge thickness contrast on production: hard-refresh, switch to 2D or 3D — strong-correlation edges should now read visibly thicker than weak ones.
-- LEGEND popover should now have 4 separate edge-type rows (causal / temporal / confounded / inconsistent) instead of the single colour-strip row.
+- Verify on production: hover a 3D orb → only the small label appears. Click an orb → the full detail card appears (and stays until you click elsewhere or hit ESC).
 - Backlog: deferred 3D `onPointerMove` throttle (PR #199), map-view imperative-setData refactor, real bundle-analyzer perf sweep using PR #222's tooling.
 
 ---

--- a/src/components/dag3d/DAGNode3D.tsx
+++ b/src/components/dag3d/DAGNode3D.tsx
@@ -302,8 +302,13 @@ function DAGNode3DInner({
         </Html>
       )}
 
-      {/* Hover Detail Card — shows ΩF profile + network metrics */}
-      {hovered && !dimmed && (
+      {/* Detail Card — full ΩF profile + network metrics. Was previously
+           gated on `hovered`, which made the heavy card pop up on every
+           mouse-move and obscured the canvas. User feedback: the small
+           floating label (above) is the right hover affordance; the
+           heavy card should only appear on explicit selection (click).
+           Mirrors the 2D view's hover-vs-click split. */}
+      {isSelected && !dimmed && (
         <Html
           position={[0, size + (isSelected ? 3.5 : 2.5), 0]}
           center


### PR DESCRIPTION
## Summary

User feedback on 3D: *"when I hover above a node, I'd like to see just the small label like 2D does. I didn't mean the huge box that appears — that should only appear when I physically click on it."*

### Change

`DAGNode3D`'s heavy "ΩF profile + network metrics" detail card was gated on `hovered && !dimmed`, so every mouse-move popped a large HTML overlay over the canvas. Switched the gate to `isSelected && !dimmed` so the heavy card only appears on explicit click.

The lightweight floating-label (`{node.label} | {domain} | Ω X.X`) is still gated on `hovered || isSelected || isNeighborOfSelected`, so hovering keeps giving the small tooltip. This mirrors the 2D view's hover-vs-click split.

One-line conditional swap; no other code paths affected.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Lint clean (pre-existing `ablationMode` warning unchanged)
- [x] vitest 778/778 pass
- [ ] Visual: hard-refresh production → 3D view → hover an orb → only the small label appears. Click an orb → full detail card appears (and stays until click-elsewhere or ESC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_