### PR TITLE
feat(canvas): softer 2D click-dim, TOPO neighbour pillars + in-scene Ω legend, collapsible domain panel

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -573,6 +573,35 @@ The cryptic three-letter labels surfaced no meaning, and three other visual enco
 - Verify on production: hover a 3D orb → only the small label appears. Click an orb → the full detail card appears (and stays until you click elsewhere or hit ESC).
 - Backlog: deferred 3D `onPointerMove` throttle (PR #199), map-view imperative-setData refactor, real bundle-analyzer perf sweep using PR #222's tooling.
 
+### 2026-05-07 — Shipped: 2D click-dim softened, TOPO neighbour pillars, in-scene Ω legend, collapsible domain panel
+
+**PR:** TBD (about to open).
+
+**Trigger.** Four-item feedback batch from the user, in order:
+1. *"If you click on it, the screen all the notes disappear, so it kinda goes black. That needs to fixed."* — 2D click was producing a permanent dim (0.18 node, 0.10 edge) that read as a blacked-out canvas.
+2. *"Anytime you select the node … it should be persistent across all ball mapping options. … The same thing in topology as well."* — node + neighbours highlight existed in 2D and 3D, but TOPO only marked the selected node itself.
+3. *"It could be nice if that gradient identifier was actually hung up above the or around the mountains and so you could easily use it as a comparison element. Rather than … on the side of the screen."* — TOPO Ω legend was a DOM strip pinned to the right edge with no relationship to actual peak heights.
+4. *"The bottom-left domain selector … takes too much room. I think it should be a collapsible menu."*
+
+**What shipped.**
+
+- **Click-dim softened, hover-dim untouched.** In `CausalDAG2D` (the same `computeNodeEmphasis` + `EmphasizedEdge` path) the dim *strength* now branches on whether `hoveredNodeId` is set:
+  - Hover-driven (transient): nodes 0.18, edges 0.10 / multi 0.08 — full spotlight, what the user said is "kinda cool".
+  - Click-driven (persistent): nodes 0.50, edges 0.35 / multi 0.25 — non-neighbour orbs and edges still legible, no "black canvas" feel.
+  The clicked node itself is still "focus" via the existing emphasis path, so it stays vivid.
+- **TOPO neighbour pillars.** `SelectionMarkers` now also receives `edges` and renders a second "neighbour" tier: shorter, thinner, dimmer cyan pillars at every node adjacent to a primary selection. Same spotlight semantics as 2D and 3D — clicking a node in any view now lights up the same neighbourhood across all three.
+- **In-scene Ω elevation legend.** `ElevationLegend` (right-edge DOM strip) replaced by `InSceneElevationLegend` rendered inside the `<Canvas>` at the SE corner of the field. The column is a 1×128 `CanvasTexture` standing 140 world units tall — the same `heightScale` the surface uses — so the user can compare a peak's height directly to the legend's Ω ticks. Tick labels (`Ω 0`, two intermediates, `Ω peak`) are placed on the gamma-shaped curve (`pow(t, heightGamma=1.6) * 140`) so they line up with what the eye reads off a mountain at the same height.
+- **Collapsible bottom-left DOMAINS panel.** `DAGOverlay` got a `domainPanelOpen` state (default closed). Header is always visible with a chevron toggle and a count summary; the body (per-domain rows with click-to-highlight) only mounts when expanded.
+
+**Files.**
+- `src/components/CausalDAG2D.tsx` — node + edge dim splits on `isHoverDriven`.
+- `src/components/CausalDAGRelief.tsx` — neighbour-pillar tier in `SelectionMarkers`, new `InSceneElevationLegend`, removed DOM-side `ElevationLegend`.
+- `src/components/dag3d/DAGOverlay.tsx` — chevron toggle on the DOMAINS panel.
+
+**Out of scope (flagged to data/engines).** "Nodes from unselected domains still appear" (likely a `selectedDomains` filter bug) and "domain grouping looks apples-to-oranges" (sovereign risk vs Saudi/Iran co-energy in the same group) — both belong with the engines team's domain-data layer, not with rendering.
+
+**Verification.** `tsc --noEmit` clean; lint clean on touched files; vitest 778/778 pass.
+
 ---
 
 ## How a fresh session resumes

--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -67,6 +67,11 @@ const Dag2DContext = createContext<Dag2DContextValue>({
  * its own id, the hover/selection state, the multi-selection set, and
  * the adjacency Map. Used by both `CausalNode2D` and `EmphasizedEdge`
  * (via source/target lookups) so the two stay in lockstep.
+ *
+ * Both hover and click drive a "focus + neighbours" spotlight here so the
+ * effect is consistent across the four canvas surfaces (2D / 3D / Map /
+ * TOPO). The DIFFERENCE between hover and click is the dim *strength* —
+ * see the consumers below for the per-source opacity choice.
  */
 function computeNodeEmphasis(
   id: string,
@@ -149,13 +154,21 @@ function CausalNode2D({ data, selected, id }: NodeProps) {
     : "";
   const boxShadow = [selectionRing, shockShadow, baseShadow].filter(Boolean).join(", ") || "none";
 
+  // Hover-driven dim is dramatic (0.18 → strong spotlight); click-driven
+  // dim is gentle (0.5 → non-neighbour orbs still legible) so a pinned
+  // selection doesn't read as a blacked-out canvas. The pinned node
+  // itself is "focus" via the emphasis path above, so it stays vivid
+  // either way.
+  const isHoverDriven = hoveredNodeId !== null;
+  const dimOpacity = isHoverDriven ? 0.18 : 0.5;
+
   return (
     <motion.div
       className="relative"
       style={{
         width: diameter,
         height: diameter,
-        opacity: isDim ? 0.18 : 1,
+        opacity: isDim ? dimOpacity : 1,
         transition: "opacity 180ms ease-out",
       }}
       animate={isRinged ? { scale: 1.1 } : { scale: 1 }}
@@ -424,9 +437,13 @@ function EmphasizedEdge(props: EdgeProps<EmphasizedEdgeData>) {
   if (!edgePath) return null;
 
   // Emphasis: an edge is "in scope" if either endpoint is the current
-  // emphasis target (hover or single-select). When something IS in scope
-  // and this edge isn't, drop opacity to 0.1 to match the dimmed nodes.
+  // emphasis target (hover or single-select). The dim STRENGTH below
+  // differs based on whether hover or click is driving — hover stays
+  // dramatic (matches the user's "kinda cool" framing) while click
+  // softens to keep non-neighbour edges legible (earlier 0.1 click-dim
+  // read as "the canvas went black").
   const emphasisTarget = hoveredNodeId ?? selectedNode ?? null;
+  const isHoverDriven = hoveredNodeId !== null;
   const inScope =
     !emphasisTarget || source === emphasisTarget || target === emphasisTarget;
 
@@ -442,10 +459,16 @@ function EmphasizedEdge(props: EdgeProps<EmphasizedEdgeData>) {
   const isThisSelected = selectedEdgeId === id;
   const otherEdgeSelected = !!selectedEdgeId && !isThisSelected;
 
+  // Hover-driven dim is dramatic (0.1 → strong spotlight); click-driven
+  // dim is gentle (0.35 → non-neighbour edges still legible). Same idea
+  // for the multi-select "isolation" dim — slightly softer when no hover
+  // is active so the persistent state feels like context, not erasure.
+  const dimOutOfScope = isHoverDriven ? 0.1 : 0.35;
+  const dimMultiOutOfScope = isHoverDriven ? 0.08 : 0.25;
   let opacity = d.baseOpacity;
   if (otherEdgeSelected) opacity = Math.min(opacity, 0.15);
-  if (!inScope) opacity = Math.min(opacity, 0.1);
-  if (!multiInScope) opacity = Math.min(opacity, 0.08);
+  if (!inScope) opacity = Math.min(opacity, dimOutOfScope);
+  if (!multiInScope) opacity = Math.min(opacity, dimMultiOutOfScope);
   if (isThisSelected) opacity = 1;
   if (d.propagationSignal > 0) {
     opacity = Math.min(1, d.baseOpacity + d.propagationSignal * 0.3);

--- a/src/components/CausalDAGRelief.tsx
+++ b/src/components/CausalDAGRelief.tsx
@@ -395,68 +395,10 @@ function DomainLegend({ field }: { field: FusedReliefField }) {
   );
 }
 
-/**
- * Vertical Ω-intensity legend on the right edge — answers "what does each
- * iso-contour band represent?". Maps the same elevationColor() ramp the
- * surface uses to a visible scale, with the maximum-composite contributor
- * shown as the "PEAK Ω" reference. The mapping isn't strictly linear
- * (kernel sums + heightGamma both bend it) but it's the right qualitative
- * read: cooler colour = quieter region, hotter = more critical cluster.
- */
-function ElevationLegend({ peakOmega }: { peakOmega: number }) {
-  // Ramp built from the JS elevationColor() at 21 stops — gives a smooth
-  // CSS gradient that matches what the shader paints.
-  const stops: string[] = [];
-  for (let i = 0; i <= 20; i++) {
-    const t = i / 20;
-    const [r, g, b] = elevationColorJS(t);
-    stops.push(
-      `rgb(${Math.round(r * 255)}, ${Math.round(g * 255)}, ${Math.round(b * 255)}) ${i * 5}%`,
-    );
-  }
-  // 14 ticks matches the shader's BANDS uniform (default 14) so the
-  // strip's tick density mirrors the rings on the surface.
-  const ticks = 14;
-  return (
-    <div className="absolute top-1/2 right-4 -translate-y-1/2 z-10 flex items-stretch gap-2 pointer-events-none">
-      <div className="flex flex-col justify-between text-[8px] font-mono text-text-muted py-0.5">
-        <span style={{ color: "#ff5566" }}>Ω {peakOmega.toFixed(1)}</span>
-        <span>HIGH</span>
-        <span>MID</span>
-        <span>LOW</span>
-        <span>Ω 0</span>
-      </div>
-      <div className="relative w-2 h-44 rounded overflow-hidden border border-border">
-        <div
-          className="absolute inset-0"
-          style={{
-            background: `linear-gradient(to top, ${stops.join(", ")})`,
-          }}
-        />
-        {/* Tick marks aligned with shader bands — the user can read
-            "this iso-ring on the surface = roughly this elevation". */}
-        {Array.from({ length: ticks - 1 }).map((_, i) => {
-          const top = ((i + 1) / ticks) * 100;
-          return (
-            <div
-              key={i}
-              className="absolute left-0 right-0 h-px"
-              style={{ top: `${top}%`, backgroundColor: "rgba(0,0,0,0.45)" }}
-            />
-          );
-        })}
-      </div>
-      <div className="flex items-end pb-0 pl-1">
-        <div
-          className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted"
-          style={{ writingMode: "vertical-rl", transform: "rotate(180deg)" }}
-        >
-          Ω INTENSITY
-        </div>
-      </div>
-    </div>
-  );
-}
+/* The previous DOM-side `ElevationLegend` (right-edge vertical strip)
+ * was replaced by `InSceneElevationLegend` below — see its docstring for
+ * why the in-canvas placement makes the gradient directly comparable to
+ * the actual mountain heights instead of just being a screen-space chip. */
 
 /** JS-side mirror of the shader's elevationColor — keep in lockstep with the
  *  ramp baked into TOPO_FRAGMENT_SHADER and graph-relief-field's
@@ -477,38 +419,203 @@ function elevationColorJS(t: number): [number, number, number] {
   return [1.0, lerp(0.67, 0.09, k), lerp(0.0, 0.27, k)];
 }
 
+/**
+ * In-scene elevation legend. Stands vertically inside the canvas at the
+ * SE edge of the field so its physical height (= 0..heightScale, the
+ * exact same world-space units the surface lives in) lets the user
+ * eyeball any mountain peak's Ω by tracing horizontally to the column.
+ *
+ * Earlier this was a DOM strip pinned to the right edge of the screen;
+ * the user pointed out it was disconnected from the math because the
+ * pixel positions had no relationship to the actual peak heights.
+ *
+ * Texture is a 1×128 vertical CanvasTexture sampling elevationColorJS
+ * at every row — same ramp the fragment shader paints onto the surface.
+ */
+function InSceneElevationLegend({
+  field,
+  peakOmega,
+}: {
+  field: ReliefField;
+  peakOmega: number;
+}) {
+  const HEIGHT = 140; // matches DEFAULT_OPTIONS.heightScale in graph-relief-field
+  const HEIGHT_GAMMA = 1.6; // matches heightGamma — keep in sync
+
+  // 1×N gradient texture. Memoised on peakOmega? No — the ramp is constant
+  // (it's purely a function of normalised t), so build once.
+  const texture = useMemo(() => {
+    const N = 128;
+    const canvas = document.createElement("canvas");
+    canvas.width = 1;
+    canvas.height = N;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return null;
+    for (let i = 0; i < N; i++) {
+      const t = (N - 1 - i) / (N - 1); // bottom = 0, top = 1
+      const [r, g, b] = elevationColorJS(t);
+      ctx.fillStyle = `rgb(${(r * 255) | 0}, ${(g * 255) | 0}, ${(b * 255) | 0})`;
+      ctx.fillRect(0, i, 1, 1);
+    }
+    const tex = new THREE.CanvasTexture(canvas);
+    tex.minFilter = THREE.LinearFilter;
+    tex.magFilter = THREE.LinearFilter;
+    tex.needsUpdate = true;
+    return tex;
+  }, []);
+
+  // Park the column at the SE corner of the field, pulled out far enough
+  // that it doesn't clip into the surface mesh edge. Y rests on the
+  // ground plane (y=0) so its base aligns with mountain bases.
+  const cornerX = field.width / 2 + 30;
+  const cornerZ = field.height / 2 + 30;
+
+  // Convert tick Ω values back to the world height the surface would
+  // assign them. Peak label sits at top of column (Ω = peakOmega), Ω 0
+  // at base. Two intermediate ticks (1/3, 2/3) match the surface's
+  // gamma-shaped elevation curve so they line up with what the eye reads
+  // off a mountain at the same height.
+  const ticks = [
+    { omega: 0, y: 0, label: "0" },
+    {
+      omega: peakOmega / 3,
+      y: Math.pow(1 / 3, HEIGHT_GAMMA) * HEIGHT,
+      label: (peakOmega / 3).toFixed(1),
+    },
+    {
+      omega: (2 * peakOmega) / 3,
+      y: Math.pow(2 / 3, HEIGHT_GAMMA) * HEIGHT,
+      label: ((2 * peakOmega) / 3).toFixed(1),
+    },
+    { omega: peakOmega, y: HEIGHT, label: peakOmega.toFixed(1) },
+  ];
+
+  if (!texture) return null;
+
+  return (
+    <group position={[cornerX, 0, cornerZ]}>
+      {/* Column — a thin upright plane facing the camera arc. Width is
+          small (4 world units) so it reads as a totem, not a wall. */}
+      <mesh position={[0, HEIGHT / 2, 0]}>
+        <planeGeometry args={[4, HEIGHT]} />
+        <meshBasicMaterial map={texture} side={THREE.DoubleSide} />
+      </mesh>
+      {/* Tick marks — thin horizontal bars at each Ω level. Drawn as
+          slightly oversized planes so they protrude past the column. */}
+      {ticks.map((t) => (
+        <mesh key={t.omega} position={[0, t.y, 0]}>
+          <planeGeometry args={[6.5, 0.6]} />
+          <meshBasicMaterial color="#ffffff" transparent opacity={0.55} />
+        </mesh>
+      ))}
+      {/* Labels — Html drei billboards. Project from world space so they
+          stay anchored to their Ω level even as the camera orbits. */}
+      {ticks.map((t) => (
+        <Html
+          key={`l-${t.omega}`}
+          position={[5, t.y, 0]}
+          center={false}
+          distanceFactor={120}
+          style={{ pointerEvents: "none", whiteSpace: "nowrap" }}
+        >
+          <span
+            style={{
+              fontFamily: "var(--font-mono, ui-monospace, monospace)",
+              fontSize: 11,
+              color: t.omega === peakOmega ? "#ff5566" : "rgba(220,220,230,0.85)",
+              textShadow: "0 0 4px rgba(0,0,0,0.85)",
+            }}
+          >
+            {"Ω "}
+            {t.label}
+          </span>
+        </Html>
+      ))}
+      <Html
+        position={[0, HEIGHT + 12, 0]}
+        center
+        distanceFactor={120}
+        style={{ pointerEvents: "none", whiteSpace: "nowrap" }}
+      >
+        <span
+          style={{
+            fontFamily: "var(--font-michroma, sans-serif)",
+            fontSize: 9,
+            letterSpacing: "0.15em",
+            color: "rgba(180,180,200,0.8)",
+            textShadow: "0 0 4px rgba(0,0,0,0.85)",
+          }}
+        >
+          Ω INTENSITY
+        </span>
+      </Html>
+    </group>
+  );
+}
+
 function SelectionMarkers({
   layout,
   field,
+  edges,
 }: {
   layout: Map<string, { x: number; y: number }>;
   field: ReliefField | null | undefined;
+  edges: { source: string; target: string }[];
 }) {
   const selectedNode = useApexStore((s) => s.selectedNode);
   const selectedNodes = useApexStore((s) => s.selectedNodes);
 
-  const markers = useMemo(() => {
-    if (!field || layout.size === 0) return [];
-    const ids = new Set<string>(selectedNodes);
-    if (selectedNode) ids.add(selectedNode);
-    const out: { id: string; x: number; z: number }[] = [];
-    for (const id of ids) {
-      const p = layout.get(id);
-      if (!p || !Number.isFinite(p.x) || !Number.isFinite(p.y)) continue;
-      out.push({ id, x: p.x - field.cx, z: p.y - field.cy });
-    }
-    return out;
-  }, [layout, field, selectedNode, selectedNodes]);
+  // Two marker tiers so TOPO matches the spotlight semantics of 2D/3D:
+  //   - "primary" — explicitly selected (single-click or marquee). Tall,
+  //     bright cyan pillar with a glowing sphere on top.
+  //   - "neighbour" — adjacent to a primary selection. Shorter, dimmer
+  //     pillar without the sphere cap. Mirrors the "select node + its
+  //     nearest neighbours" effect the user already gets in 2D and 3D.
+  const { primary, neighbours } = useMemo(() => {
+    if (!field || layout.size === 0) return { primary: [], neighbours: [] };
+    const primaryIds = new Set<string>(selectedNodes);
+    if (selectedNode) primaryIds.add(selectedNode);
 
-  if (markers.length === 0 || !field) return null;
+    const neighbourIds = new Set<string>();
+    if (primaryIds.size > 0) {
+      for (const e of edges) {
+        if (primaryIds.has(e.source) && !primaryIds.has(e.target)) {
+          neighbourIds.add(e.target);
+        } else if (primaryIds.has(e.target) && !primaryIds.has(e.source)) {
+          neighbourIds.add(e.source);
+        }
+      }
+    }
+
+    const project = (id: string) => {
+      const p = layout.get(id);
+      if (!p || !Number.isFinite(p.x) || !Number.isFinite(p.y)) return null;
+      return { id, x: p.x - field.cx, z: p.y - field.cy };
+    };
+    const primary: { id: string; x: number; z: number }[] = [];
+    for (const id of primaryIds) {
+      const m = project(id);
+      if (m) primary.push(m);
+    }
+    const neighbours: { id: string; x: number; z: number }[] = [];
+    for (const id of neighbourIds) {
+      const m = project(id);
+      if (m) neighbours.push(m);
+    }
+    return { primary, neighbours };
+  }, [layout, field, edges, selectedNode, selectedNodes]);
+
+  if (primary.length === 0 || !field) return null;
 
   const PILLAR_HEIGHT = 140;
   const PILLAR_RADIUS = 1.4;
+  const NEIGHBOUR_HEIGHT = 70;
+  const NEIGHBOUR_RADIUS = 0.8;
 
   return (
     <group>
-      {markers.map((m) => (
-        <group key={m.id} position={[m.x, 0, m.z]}>
+      {primary.map((m) => (
+        <group key={`p-${m.id}`} position={[m.x, 0, m.z]}>
           <mesh position={[0, PILLAR_HEIGHT / 2, 0]}>
             <cylinderGeometry args={[PILLAR_RADIUS, PILLAR_RADIUS, PILLAR_HEIGHT, 10]} />
             <meshBasicMaterial color="#00e5ff" transparent opacity={0.65} />
@@ -524,6 +631,18 @@ function SelectionMarkers({
           <mesh position={[0, PILLAR_HEIGHT, 0]}>
             <sphereGeometry args={[5.5, 14, 14]} />
             <meshBasicMaterial color="#00e5ff" transparent opacity={0.25} />
+          </mesh>
+        </group>
+      ))}
+      {neighbours.map((m) => (
+        <group key={`n-${m.id}`} position={[m.x, 0, m.z]}>
+          <mesh position={[0, NEIGHBOUR_HEIGHT / 2, 0]}>
+            <cylinderGeometry args={[NEIGHBOUR_RADIUS, NEIGHBOUR_RADIUS, NEIGHBOUR_HEIGHT, 8]} />
+            <meshBasicMaterial color="#00e5ff" transparent opacity={0.32} />
+          </mesh>
+          <mesh position={[0, NEIGHBOUR_HEIGHT, 0]}>
+            <sphereGeometry args={[1.4, 10, 10]} />
+            <meshBasicMaterial color="#00e5ff" transparent opacity={0.55} />
           </mesh>
         </group>
       ))}
@@ -709,7 +828,10 @@ function CausalDAGReliefInner() {
           />
         )}
         {!isEmpty && (
-          <SelectionMarkers layout={layout} field={activeField} />
+          <SelectionMarkers layout={layout} field={activeField} edges={graphData.edges} />
+        )}
+        {!isEmpty && activeField && peakOmega > 0 && (
+          <InSceneElevationLegend field={activeField} peakOmega={peakOmega} />
         )}
         {!isEmpty && <NodeLabels anchors={anchors} />}
         {!isEmpty && activeField && (
@@ -734,9 +856,12 @@ function CausalDAGReliefInner() {
       {!isEmpty && multilayer && fusedField && (
         <DomainLegend field={fusedField} />
       )}
-      {!isEmpty && peakOmega > 0 && (
-        <ElevationLegend peakOmega={peakOmega} />
-      )}
+      {/* ElevationLegend (DOM, right edge) has been replaced by
+          InSceneElevationLegend, which renders a vertical column
+          inside the Canvas at the SE corner of the field. The column's
+          physical height matches the surface's heightScale, so the
+          user can compare a peak's height directly to the legend's
+          Ω ticks. */}
       {currentSnapshot && (
         <div className="absolute top-4 right-4 z-10 px-3 py-1.5 rounded border border-accent-amber/60 bg-surface-elevated/90 backdrop-blur-sm pointer-events-none">
           <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-accent-amber">

--- a/src/components/dag3d/DAGOverlay.tsx
+++ b/src/components/dag3d/DAGOverlay.tsx
@@ -261,6 +261,10 @@ export default function DAGOverlay() {
   const isLive = useApexStore((s) => s.isLive);
   const timelinePosition = useApexStore((s) => s.timelinePosition);
   const [activeDomain, setActiveDomain] = useState<string | null>(null);
+  // Domain panel collapses by default — the full list (often 6–10 rows
+  // with counts) was eating real estate on every canvas. The chevron
+  // header always stays visible so the affordance is discoverable.
+  const [domainPanelOpen, setDomainPanelOpen] = useState(false);
   // The encoding key (size + colour + glow + edge meanings) used to live
   // as a cryptic `SIZE: ΩF / EIG / BTW` button trio next to the view-mode
   // buttons. Users couldn't tell what BTW meant, and there was no
@@ -529,51 +533,71 @@ export default function DAGOverlay() {
         </div>
       )}
 
-      {/* Bottom Left: Domain legend (interactive) */}
+      {/* Bottom Left: Domain legend (interactive, collapsible) */}
       <div className="absolute bottom-12 left-3 pointer-events-auto">
         <div className="text-[8px] font-mono px-2 py-1.5 rounded border border-border bg-surface-elevated/80">
-          <div className="text-[7px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted mb-1">
-            DOMAINS <span className="text-text-muted/40">— click to highlight</span>
-          </div>
-          <div className="flex flex-col gap-0.5">
-            {domainCounts.map(([domain, count]) => {
-              const isActive = activeDomain === domain;
-              const domainColor = getDomainColor(domain);
-              return (
-                <div
-                  key={domain}
-                  className="flex items-center gap-1.5 cursor-pointer rounded px-1 -mx-1 py-0.5 transition-colors hover:bg-white/5"
-                  style={{
-                    backgroundColor: isActive ? `${domainColor}15` : undefined,
-                    borderLeft: isActive ? `2px solid ${domainColor}` : "2px solid transparent",
-                  }}
-                  onClick={() => {
-                    if (isActive) {
-                      setActiveDomain(null);
-                      setSelectedNodes([]);
-                    } else {
-                      setActiveDomain(domain);
-                      const nodeIds = activeGraph.nodes
-                        .filter((n) => n.domain === domain)
-                        .map((n) => n.id);
-                      setSelectedNodes(nodeIds);
-                    }
-                  }}
-                >
+          <button
+            onClick={() => setDomainPanelOpen((p) => !p)}
+            className="flex items-center gap-1.5 text-[7px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted hover:text-accent-cyan transition-colors w-full"
+            aria-expanded={domainPanelOpen}
+            title={domainPanelOpen ? "Collapse domains" : "Expand domains"}
+          >
+            <span
+              className="inline-block transition-transform"
+              style={{ transform: domainPanelOpen ? "rotate(90deg)" : "rotate(0deg)" }}
+            >
+              ▶
+            </span>
+            DOMAINS
+            <span className="text-text-muted/40">
+              {activeDomain
+                ? `· ${activeDomain}`
+                : domainPanelOpen
+                  ? "— click to highlight"
+                  : `(${domainCounts.length})`}
+            </span>
+          </button>
+          {domainPanelOpen && (
+            <div className="flex flex-col gap-0.5 mt-1">
+              {domainCounts.map(([domain, count]) => {
+                const isActive = activeDomain === domain;
+                const domainColor = getDomainColor(domain);
+                return (
                   <div
-                    className="w-1.5 h-1.5 rounded-full flex-shrink-0"
-                    style={{ backgroundColor: domainColor }}
-                  />
-                  <span className="text-[8px]" style={{ color: isActive ? domainColor : "var(--text-muted)" }}>
-                    {domain}
-                  </span>
-                  <span className="text-[7px] text-text-muted/50">
-                    ({count})
-                  </span>
-                </div>
-              );
-            })}
-          </div>
+                    key={domain}
+                    className="flex items-center gap-1.5 cursor-pointer rounded px-1 -mx-1 py-0.5 transition-colors hover:bg-white/5"
+                    style={{
+                      backgroundColor: isActive ? `${domainColor}15` : undefined,
+                      borderLeft: isActive ? `2px solid ${domainColor}` : "2px solid transparent",
+                    }}
+                    onClick={() => {
+                      if (isActive) {
+                        setActiveDomain(null);
+                        setSelectedNodes([]);
+                      } else {
+                        setActiveDomain(domain);
+                        const nodeIds = activeGraph.nodes
+                          .filter((n) => n.domain === domain)
+                          .map((n) => n.id);
+                        setSelectedNodes(nodeIds);
+                      }
+                    }}
+                  >
+                    <div
+                      className="w-1.5 h-1.5 rounded-full flex-shrink-0"
+                      style={{ backgroundColor: domainColor }}
+                    />
+                    <span className="text-[8px]" style={{ color: isActive ? domainColor : "var(--text-muted)" }}>
+                      {domain}
+                    </span>
+                    <span className="text-[7px] text-text-muted/50">
+                      ({count})
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Four-item feedback batch from the rendering-perf session:

- **2D click no longer blacks out the canvas.** Hover and click previously shared the same dim level (nodes 0.18, edges 0.10) — fine when transient (hover), claustrophobic when persistent (click). Split the dim *strength* on whether `hoveredNodeId` is set: hover keeps the dramatic spotlight the user explicitly liked, click softens to nodes 0.5 / edges 0.35 so non-neighbour orbs stay legible. The clicked node itself is still "focus" via the existing emphasis path, so it stays vivid.
- **TOPO now matches 2D/3D selection semantics.** `SelectionMarkers` got a second "neighbour" tier — shorter/thinner/dimmer cyan pillars at every node adjacent to a primary selection. Click in any view → same neighbourhood lights up across all three.
- **TOPO Ω legend lives inside the canvas now.** `InSceneElevationLegend` (a 1×128 `CanvasTexture` standing 140 world units tall — same `heightScale` the surface uses) replaces the right-edge DOM strip. Tick labels sit on the gamma-shaped curve (`pow(t, 1.6) * 140`) so eyeballing a peak's Ω is just tracing horizontally to the column.
- **Collapsible bottom-left DOMAINS panel.** Default closed; chevron header with count + active-domain summary always visible; per-domain rows mount only when expanded.

Out of scope (flagged for engines): "nodes from unselected domains still appear" (`selectedDomains` filter bug) and "domain grouping looks apples-to-oranges" — both belong with the data layer.

## Test plan

- [ ] In 2D, click a node — confirm the rest of the canvas stays legible (no "black screen") and the clicked node + neighbours read as the focused subgraph.
- [ ] In 2D, hover a node — confirm the spotlight is still dramatic (non-neighbour orbs/edges fade strongly).
- [ ] Click a node in 2D, switch to 3D, switch to TOPO — confirm the same node + its neighbours are highlighted in each view.
- [ ] In TOPO, confirm the elevation legend stands as a vertical column at the SE corner of the field; tick labels (`Ω 0`, two intermediates, `Ω peak`) align with what you'd read off a mountain at the same height.
- [ ] In any canvas view, confirm the bottom-left DOMAINS panel starts collapsed; clicking the chevron expands the per-domain rows; click-to-highlight still works once expanded.

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_