### PR TITLE
feat(copilot): five more tools — explain/compare/run_tarski/size/reset_ablation

### DIFF
--- a/src/lib/__tests__/copilot-tools-extended.test.ts
+++ b/src/lib/__tests__/copilot-tools-extended.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from "vitest";
+import { executeTag } from "@/lib/copilot/tool-registry";
+import "@/lib/copilot/tools";
+import type { ApexState } from "@/stores/useApexStore";
+import type { CausalGraph } from "@/lib/types";
+import type { TarskiValidationReport } from "@/lib/tarski-data";
+import { makeNode, makeEdge, makeGraph } from "./fixtures/graph-fixtures";
+
+// ─── Fixture + mock context ─────────────────────────────────────
+
+function buildGraph(): CausalGraph {
+  const nodes = [
+    makeNode({
+      id: "GRID_USA",
+      label: "USA Power Grid",
+      shortLabel: "USA",
+      category: "energy",
+      domain: "Energy",
+      omegaFragility: {
+        composite: 8.5,
+        irreplaceability: 9,
+        cascadeLoad: 8,
+        tailDepth: 8,
+        restorationLatency: 9,
+        jurisdictionalHazard: 8,
+      },
+    }),
+    makeNode({
+      id: "FAB_TW",
+      label: "TSMC Fab",
+      shortLabel: "TSMC",
+      category: "manufacturing",
+      domain: "Semiconductors",
+      omegaFragility: {
+        composite: 9.5,
+        irreplaceability: 10,
+        cascadeLoad: 9,
+        tailDepth: 9,
+        restorationLatency: 10,
+        jurisdictionalHazard: 9,
+      },
+    }),
+    makeNode({
+      id: "OIL_TX",
+      label: "TX Oil Pipeline",
+      shortLabel: "OIL",
+      category: "energy",
+      domain: "Energy",
+    }),
+  ];
+  const edges = [
+    makeEdge({ id: "e1", source: "GRID_USA", target: "FAB_TW" }),
+    makeEdge({ id: "e2", source: "OIL_TX", target: "FAB_TW" }),
+  ];
+  return makeGraph(nodes, edges);
+}
+
+interface StoreSpy {
+  runTarskiCalls: number;
+  nodeSizeMetricCalls: string[];
+  resetAblationCalls: number;
+}
+
+function makeMockContext(graph: CausalGraph, tarskiReport: TarskiValidationReport | null = null) {
+  const spy: StoreSpy = {
+    runTarskiCalls: 0,
+    nodeSizeMetricCalls: [],
+    resetAblationCalls: 0,
+  };
+
+  const fakeStore = {
+    graphData: graph,
+    tarskiReport,
+    runTarskiWithAxioms: () => {
+      spy.runTarskiCalls++;
+    },
+    setNodeSizeMetric: (m: string) => {
+      spy.nodeSizeMetricCalls.push(m);
+    },
+    resetAblation: () => {
+      spy.resetAblationCalls++;
+    },
+  } as unknown as ApexState;
+
+  return { ctx: { getStore: () => fakeStore }, spy };
+}
+
+// ─── explain_node ───────────────────────────────────────────────
+
+describe("explain_node", () => {
+  it("returns a compact Ω-fragility breakdown for a known node", () => {
+    const { ctx } = makeMockContext(buildGraph());
+    const result = executeTag({ name: "explain_node", payload: "GRID_USA", raw: "" }, ctx);
+    expect(result).toContain("USA Power Grid");
+    expect(result).toContain("Energy");
+    expect(result).toContain("Ω composite 8.5/10");
+    expect(result).toContain("HIGH RISK");
+    expect(result).toContain("Upstream");
+    expect(result).toContain("Downstream");
+  });
+
+  it("resolves nodes by shortLabel as well as id", () => {
+    const { ctx } = makeMockContext(buildGraph());
+    const result = executeTag({ name: "explain_node", payload: "TSMC", raw: "" }, ctx);
+    expect(result).toContain("TSMC Fab");
+    expect(result).toContain("OMEGA-CRITICAL");
+  });
+
+  it("returns 'Node not found' for unknown refs", () => {
+    const { ctx } = makeMockContext(buildGraph());
+    const result = executeTag({ name: "explain_node", payload: "NONEXISTENT", raw: "" }, ctx);
+    expect(result).toMatch(/Node not found/);
+  });
+});
+
+// ─── compare_nodes ──────────────────────────────────────────────
+
+describe("compare_nodes", () => {
+  it("returns side-by-side analysis + delta on Ω composite", () => {
+    const { ctx } = makeMockContext(buildGraph());
+    const result = executeTag(
+      { name: "compare_nodes", payload: "ids=GRID_USA|FAB_TW", raw: "" },
+      ctx,
+    );
+    expect(result).toContain("USA Power Grid");
+    expect(result).toContain("TSMC Fab");
+    expect(result).toContain("Delta:");
+    // FAB_TW (9.5) − GRID_USA (8.5) = 1.0
+    expect(result).toContain("TSMC is 1.0 Ω points more fragile than USA");
+  });
+
+  it("rejects a single id with a clear error", () => {
+    const { ctx } = makeMockContext(buildGraph());
+    const result = executeTag(
+      { name: "compare_nodes", payload: "ids=GRID_USA", raw: "" },
+      ctx,
+    );
+    expect(result).toMatch(/needs at least two ids/);
+  });
+
+  it("reports missing ids before doing any work", () => {
+    const { ctx } = makeMockContext(buildGraph());
+    const result = executeTag(
+      { name: "compare_nodes", payload: "ids=GRID_USA|GHOST_NODE", raw: "" },
+      ctx,
+    );
+    expect(result).toMatch(/Nodes not found: GHOST_NODE/);
+  });
+});
+
+// ─── run_tarski ─────────────────────────────────────────────────
+
+describe("run_tarski", () => {
+  it("invokes the store's runTarskiWithAxioms and summarizes the report", () => {
+    const fakeReport: TarskiValidationReport = {
+      inconsistentEdgeIds: new Set(["e_1", "e_2"]),
+      restrictedNodeIds: new Set(["n_1"]),
+      proofTraces: [
+        {
+          edgeId: "e_1",
+          verdict: "REJECTED",
+          violatedAxioms: ["A-01"],
+          solverUsed: "Z3",
+          checkTimeMs: 1,
+        },
+      ],
+      totalViolations: 3,
+    };
+    const { ctx, spy } = makeMockContext(buildGraph(), fakeReport);
+    const result = executeTag({ name: "run_tarski", payload: "", raw: "" }, ctx);
+    expect(spy.runTarskiCalls).toBe(1);
+    expect(result).toContain("2 inconsistent edge(s)");
+    expect(result).toContain("1 restricted node(s)");
+    expect(result).toContain("1 proof trace(s)");
+  });
+
+  it("handles the no-report case without throwing", () => {
+    const { ctx, spy } = makeMockContext(buildGraph(), null);
+    const result = executeTag({ name: "run_tarski", payload: "", raw: "" }, ctx);
+    expect(spy.runTarskiCalls).toBe(1);
+    expect(result).toMatch(/produced no report/);
+  });
+});
+
+// ─── set_node_size_metric ───────────────────────────────────────
+
+describe("set_node_size_metric", () => {
+  it("sets the metric on the store", () => {
+    const { ctx, spy } = makeMockContext(buildGraph());
+    const result = executeTag(
+      { name: "set_node_size_metric", payload: "betweenness", raw: "" },
+      ctx,
+    );
+    expect(spy.nodeSizeMetricCalls).toEqual(["betweenness"]);
+    expect(result).toMatch(/betweenness/);
+  });
+
+  it("rejects values not in the enum", () => {
+    const { ctx, spy } = makeMockContext(buildGraph());
+    const result = executeTag(
+      { name: "set_node_size_metric", payload: "purple", raw: "" },
+      ctx,
+    );
+    expect(spy.nodeSizeMetricCalls).toEqual([]);
+    expect(result).toMatch(/not in/);
+  });
+});
+
+// ─── reset_ablation ─────────────────────────────────────────────
+
+describe("reset_ablation", () => {
+  it("calls resetAblation on the store", () => {
+    const { ctx, spy } = makeMockContext(buildGraph());
+    const result = executeTag({ name: "reset_ablation", payload: "", raw: "" }, ctx);
+    expect(spy.resetAblationCalls).toBe(1);
+    expect(result).toMatch(/Reset all ablations/);
+  });
+});

--- a/src/lib/copilot/tools.ts
+++ b/src/lib/copilot/tools.ts
@@ -10,6 +10,7 @@ import { DOMAIN_CARDS } from "@/lib/domains";
 import { buildGraphFromDomains } from "@/lib/build-domain-graph";
 import { solveInterdiction, type InterdictionCandidate } from "../interdiction-engine";
 import type { ApexState } from "@/stores/useApexStore";
+import type { CausalNode, CausalGraph } from "../types";
 
 // ─── Selection ──────────────────────────────────────────────────
 
@@ -444,5 +445,177 @@ defineTool({
     return applied.length > 0
       ? `Applied interdictions: ${applied.join(", ")}`
       : `No valid intervention indices: ${targets}`;
+  },
+});
+
+// ─── Node analysis ──────────────────────────────────────────────
+
+/**
+ * Resolve a node ref (id, shortLabel, or label) on the active
+ * graph. Returns null if no match. Shared between explain_node
+ * and compare_nodes so they treat references the same way the
+ * other tools do.
+ */
+function resolveNode(graph: CausalGraph, ref: string): CausalNode | null {
+  const target = ref.toLowerCase();
+  return (
+    graph.nodes.find(
+      (n) =>
+        n.id === ref ||
+        n.shortLabel.toLowerCase() === target ||
+        n.label.toLowerCase() === target,
+    ) ?? null
+  );
+}
+
+/** Compact analysis text for an LLM context window. */
+function nodeAnalysisText(node: CausalNode, graph: CausalGraph): string {
+  const omega = node.omegaFragility;
+  const tier =
+    omega.composite > 9
+      ? "OMEGA-CRITICAL"
+      : omega.composite >= 7
+        ? "HIGH RISK"
+        : omega.composite >= 5
+          ? "ELEVATED"
+          : "MODERATE";
+  const inEdges = graph.edges.filter((e) => e.target === node.id);
+  const outEdges = graph.edges.filter((e) => e.source === node.id);
+  const upstreamLabels = inEdges
+    .slice(0, 8)
+    .map((e) => graph.nodes.find((n) => n.id === e.source)?.shortLabel ?? e.source)
+    .join(", ");
+  const downstreamLabels = outEdges
+    .slice(0, 8)
+    .map((e) => graph.nodes.find((n) => n.id === e.target)?.shortLabel ?? e.target)
+    .join(", ");
+
+  const flags: string[] = [];
+  if (node.isConfounded) flags.push("CONFOUNDED");
+  if (node.isRestricted) flags.push("TARSKI-RESTRICTED");
+
+  return [
+    `${node.label} [${node.id}] — ${node.domain} / ${node.category} — ${tier}`,
+    `  Ω composite ${omega.composite.toFixed(1)}/10 ` +
+      `(irr ${omega.irreplaceability.toFixed(1)}, rest ${omega.restorationLatency.toFixed(1)}, ` +
+      `jur ${omega.jurisdictionalHazard.toFixed(1)}, casc ${omega.cascadeLoad.toFixed(1)}, ` +
+      `tail ${omega.tailDepth.toFixed(1)})`,
+    `  Concentration: ${node.globalConcentration} | Replacement: ${node.replacementTime}`,
+    node.physicalConstraint ? `  Physical: ${node.physicalConstraint}` : null,
+    flags.length > 0 ? `  Flags: ${flags.join(", ")}` : null,
+    `  Upstream (${inEdges.length}): ${upstreamLabels || "none"}`,
+    `  Downstream (${outEdges.length}): ${downstreamLabels || "none"}`,
+  ]
+    .filter((line): line is string => line !== null)
+    .join("\n");
+}
+
+defineTool({
+  name: "explain_node",
+  description:
+    "Return a compact Ω-fragility breakdown + upstream/downstream summary for a single node. Useful when the user asks 'what is X?' or 'why does X matter?'.",
+  params: {
+    node: { type: "string", required: true, description: "Node id, shortLabel, or label" },
+  },
+  legacyParam: "node",
+  handler: ({ node }, ctx) => {
+    const graph = ctx.getStore().graphData;
+    const found = resolveNode(graph, node);
+    if (!found) return `Node not found: ${node}`;
+    return nodeAnalysisText(found, graph);
+  },
+});
+
+defineTool({
+  name: "compare_nodes",
+  description:
+    "Side-by-side Ω-fragility comparison of two or more nodes. Useful when the user asks 'how does X compare to Y?' or 'which is more critical?'.",
+  guidance:
+    "Pass at least 2 nodes (ids=A|B or ids=A|B|C). The handler emits each node's compact analysis followed by a delta on Ω composite — that's enough for the LLM to reason about which is more fragile and on which dimension.",
+  params: {
+    ids: {
+      type: "string[]",
+      required: true,
+      description: "Two or more node ids — separated with `|` (ids=USA_GRID|EU_GRID)",
+    },
+  },
+  legacyParam: "ids",
+  handler: ({ ids }, ctx) => {
+    if (ids.length < 2) {
+      return `compare_nodes needs at least two ids; got ${ids.length}.`;
+    }
+    const graph = ctx.getStore().graphData;
+    const resolved = ids.map((ref) => ({ ref, node: resolveNode(graph, ref) }));
+    const missing = resolved.filter((r) => r.node === null).map((r) => r.ref);
+    if (missing.length > 0) return `Nodes not found: ${missing.join(", ")}`;
+
+    const blocks = resolved
+      .map((r) => nodeAnalysisText(r.node as CausalNode, graph))
+      .join("\n\n");
+
+    // Highlight the delta on Ω composite — the most-asked dimension.
+    const sortedByOmega = resolved
+      .map((r) => r.node as CausalNode)
+      .sort((a, b) => b.omegaFragility.composite - a.omegaFragility.composite);
+    const winner = sortedByOmega[0];
+    const loser = sortedByOmega[sortedByOmega.length - 1];
+    const delta = winner.omegaFragility.composite - loser.omegaFragility.composite;
+
+    return (
+      blocks +
+      `\n\nDelta: ${winner.shortLabel} is ${delta.toFixed(1)} Ω points more fragile than ${loser.shortLabel}.`
+    );
+  },
+});
+
+// ─── Tarski validation ─────────────────────────────────────────
+
+defineTool({
+  name: "run_tarski",
+  description:
+    "Re-run Tarski axiom validation against the current graph. Returns inconsistent-edge / restricted-node counts so the LLM can talk about the result.",
+  params: {},
+  handler: (_params, ctx) => {
+    const store = ctx.getStore();
+    store.runTarskiWithAxioms();
+    // After the synchronous re-run the report is back on the store.
+    const report = ctx.getStore().tarskiReport;
+    if (!report) return "Tarski validation ran but produced no report.";
+    return (
+      `Tarski validation complete: ${report.inconsistentEdgeIds.size} inconsistent edge(s), ` +
+      `${report.restrictedNodeIds.size} restricted node(s), ${report.proofTraces.length} proof trace(s).`
+    );
+  },
+});
+
+// ─── Visualization controls ─────────────────────────────────────
+
+defineTool({
+  name: "set_node_size_metric",
+  description:
+    "Change what the 3D orb sizes encode. omega = Ω-fragility composite (default). eigenvector / betweenness = network-centrality metrics from layout.",
+  params: {
+    metric: {
+      type: "enum",
+      values: ["omega", "eigenvector", "betweenness"] as const,
+      required: true,
+    },
+  },
+  legacyParam: "metric",
+  handler: ({ metric }, ctx) => {
+    ctx.getStore().setNodeSizeMetric(metric);
+    return `Node size metric set to: ${metric}`;
+  },
+});
+
+// ─── Ablation reset (symmetric with reset_severed) ──────────────
+
+defineTool({
+  name: "reset_ablation",
+  description: "Clear all ablated nodes and edges. Symmetric with reset_severed.",
+  params: {},
+  handler: (_params, ctx) => {
+    ctx.getStore().resetAblation();
+    return "Reset all ablations";
   },
 });


### PR DESCRIPTION
## Summary

Five new registry-native tools that fill obvious gaps in the copilot's capability surface, and **stress-test the registry design** before PR3 cements its consumers.

| Tool | Schema shape | Why |
| --- | --- | --- |
| `explain_node` | `node: string (required)` | "What is X? / Why does X matter?" — compact Ω-fragility breakdown returned as a string the LLM can reason about |
| `compare_nodes` | `ids: string[] (required)` | "How does X compare to Y?" — multi-id side-by-side + Δ on Ω composite |
| `run_tarski` | nullary | "Re-check the constraints" — calls `runTarskiWithAxioms()` + summarizes the report |
| `set_node_size_metric` | `metric: enum (omega \| eigenvector \| betweenness)` | "Show eigenvector centrality on the orbs" — first three-option enum tool |
| `reset_ablation` | nullary | symmetric with `reset_severed` |

## What this exercises in the registry

- Multi-id list params via `|` separator (`compare_nodes`)
- Result-oriented tools where the value is the returned text, not a state mutation (`explain_node`, `compare_nodes`)
- Trigger-and-summarize pattern (`run_tarski`) — handler mutates state then reads it back to format a result
- Enum with three values (only `set_view` had two before)
- Shared helpers across tools — `resolveNode` and `nodeAnalysisText` in `tools.ts` are used by both `explain_node` and `compare_nodes` so they treat node refs identically

**No registry changes needed.** Every tool registered with `defineTool` and "just worked" — diagnostic confirmation that the design from #249 holds for varied tool shapes.

## Test plan

- [x] `vitest run` — 789/789 pass (11 new tests covering happy paths + error semantics)
- [x] `tsc --noEmit` — clean
- [x] `eslint` on touched files — clean
- [ ] Manual: ask the copilot "explain GRID_USA" → returns the breakdown
- [ ] Manual: "compare TSMC and SMIC" → side-by-side + Δ
- [ ] Manual: "run a Tarski check" → triggers validation, reports counts
- [ ] Manual: "size the orbs by betweenness" → switches metric

## Stacks

Branched off latest main (post-#249 + #251 merge). No conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
