### PR TITLE
feat(canvas): cross-view multi-select parity + domain-panel roll-up

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -602,6 +602,38 @@ The cryptic three-letter labels surfaced no meaning, and three other visual enco
 
 **Verification.** `tsc --noEmit` clean; lint clean on touched files; vitest 778/778 pass.
 
+### 2026-05-07 — Shipped: Map multi-select dim, 3D card-explosion fix, TOPO isolate, domain panel rolled up
+
+**PR:** TBD (about to open).
+
+**Trigger.** Four-item batch from the user after merging PR #262:
+
+1. *"On maps, it didn't actually shade out the rest of them. … in the same way that it did under 2D."* — Map only dimmed when `isolateSelection` was on; 2D dims unconditionally on multi-select.
+2. *"Under 3D, it has, like, a million different cards open. … It should only just have, like, that short little title above that node."* — When PR #261 moved the heavy detail card behind `isSelected`, multi-select set `isSelected=true` for every selected node, popping a wall of overlapping cards.
+3. *"Under topology … it hasn't isolated the region, which I guess is what it should be doing."* — TOPO didn't honour `isolateSelection` at all.
+4. *"Under the bottom-left domain section … sovereign risk Saudi Aramco Energy. These look like not the same level of complexity. And on top of that, you're also showing certain domains for which there are not any nodes."* — The panel iterated raw `n.domain` strings, which carry inconsistent abstraction (per-company vs per-theme), and showed buckets the user hadn't selected at landing.
+
+**What shipped.**
+
+- **Map dim-on-multi-select.** `nodeGeoJSON` now dims non-selected nodes whenever `selectedNodes.length > 0` (0.35 with isolate off, 0.15 with isolate on). Edges branch three ways: cull when isolate ON and not fully in scope, dim to 0.08 when isolate OFF and no endpoint is selected, otherwise render normally.
+- **3D `isSingleSelected` prop.** `DAGNode3D` now takes both `isSelected` (single OR multi → drives ring/scale/label) and `isSingleSelected` (the singular click target → drives the heavy detail card). Multi-selected nodes still get the floating label, never the card.
+- **TOPO isolate + tint.**
+  - With `isolateSelection && multiSelected.size > 0`, `fieldNodes` filters to the selected subset before the relief field is computed — non-selected mountains literally don't render.
+  - Without isolate but with a multi-selection, the surface gets a `uSurfaceTint=0.4` uniform multiplier (new in `TOPO_FRAGMENT_SHADER`) so mountains read as faded context behind the cyan selection pillars. Vanilla `meshStandardMaterial` path mirrors via `transparent + opacity`.
+  - Uniform held in `useState`, mutated imperatively through a `materialRef` to avoid rebuilding the shader pipeline on tint changes.
+- **Domain panel rolled up to card labels.** Replaced the raw `n.domain` enumeration with a card-keyed pipeline: reverse `DOMAIN_MAP` (selector-id → raw-domain[]) into raw → card, bucket nodes by card, show `card.label` (e.g. "Energy Systems") and `card.color`. Cross-domain connectors (`Geopolitical`, `Energy Grid`) keep their raw-name row since they have no card mapping. When `selectedDomains.length > 0`, non-cross-domain rows filter to the user's actual landing-page picks; otherwise fall back to "show everything in the visible graph". Click-to-highlight now selects every node whose raw `n.domain` is in the row's mapped set.
+
+**Files.**
+- `src/components/CausalDAGMap.tsx` — node + edge dim branches.
+- `src/components/dag3d/DAGNode3D.tsx` — new `isSingleSelected` prop, gate on detail card, memo equality.
+- `src/components/CausalDAG3D.tsx` — pass `isSingleSelected={selectedNode === node.id}` to `DAGNode3D`.
+- `src/components/CausalDAGRelief.tsx` — `uSurfaceTint` uniform + shader update; `surfaceTint` prop on `ReliefMesh`; `fieldNodes` isolate filter; multi-select state read in the parent.
+- `src/components/dag3d/DAGOverlay.tsx` — `domainPanelRows` (card-keyed), updated panel render + click handler.
+
+**Caveats / what's still data-side.** "Apples-to-oranges" was addressed at the rendering layer by displaying card labels instead of raw `n.domain` strings. The underlying data still has nodes labelled at multiple abstraction levels — that's an engines-team thing if the picker / canvas ever needs to surface the raw string.
+
+**Verification.** `tsc --noEmit` clean; lint clean on touched files (pre-existing `ablationMode` warning unchanged); vitest 778/778 pass.
+
 ---
 
 ## How a fresh session resumes

--- a/src/components/CausalDAG3D.tsx
+++ b/src/components/CausalDAG3D.tsx
@@ -1041,6 +1041,7 @@ export default function CausalDAG3D() {
                 isInterventionTarget={isTarget}
                 isVerifiedRestricted={isRestricted}
                 isSelected={isSelected}
+                isSingleSelected={selectedNode === node.id}
                 isNeighborOfSelected={isNeighborOfSelected}
                 anyNodeSelected={anyNodeSelected}
                 isConsequence={node.isConsequence ?? false}

--- a/src/components/CausalDAGMap.tsx
+++ b/src/components/CausalDAGMap.tsx
@@ -169,7 +169,14 @@ function CausalDAGMapInner() {
       );
       const domainColor = node.datasetColor || getDomainColor(node.domain);
       const isSelected = selectedNode === node.id || selectedSet.has(node.id);
-      const isDimmed = isolateSelection && selectedSet.size > 0 && !selectedSet.has(node.id);
+      // Two dim modes:
+      //  - isolate ON  → opacity 0.15 (existing behaviour)
+      //  - isolate OFF → opacity 0.35 (multi-select spotlight, matches 2D
+      //    where multiSelected.length > 0 alone dims non-selected nodes)
+      const isMultiSelectActive = selectedSet.size > 0;
+      const isOutOfScope = isMultiSelectActive && !selectedSet.has(node.id);
+      const isDimmed = isOutOfScope;
+      const dimOpacity = isolateSelection ? 0.15 : 0.35;
       const omega = node.omegaFragility.composite;
 
       return {
@@ -187,7 +194,7 @@ function CausalDAGMapInner() {
           isDimmed,
           // Size based on omega score
           radius: Math.max(4, omega * 1.2),
-          opacity: isDimmed ? 0.15 : 1,
+          opacity: isDimmed ? dimOpacity : 1,
           strokeColor: isSelected ? "#00e5ff" : "rgba(255,255,255,0.3)",
           strokeWidth: isSelected ? 2.5 : 0.5,
         },
@@ -220,12 +227,20 @@ function CausalDAGMapInner() {
       const target = nodeMap.get(edge.target);
       if (!source || !target) return;
 
-      // Isolation: hide edges that don't connect two selected nodes (matches 3D behavior)
-      if (
-        isolateSelection &&
-        selectedSet.size > 0 &&
-        !(selectedSet.has(edge.source) && selectedSet.has(edge.target))
-      ) return;
+      // Three modes for edges when a multi-selection is active:
+      //  - isolate ON   → cull edges that don't connect two selected nodes
+      //  - isolate OFF  → render but dim edges with no selected endpoint
+      //                   (matches 2D's `multiInScope` spotlight)
+      //  - no selection → render normally
+      const inScope =
+        selectedSet.size === 0 ||
+        selectedSet.has(edge.source) ||
+        selectedSet.has(edge.target);
+      const fullScope =
+        selectedSet.size === 0 ||
+        (selectedSet.has(edge.source) && selectedSet.has(edge.target));
+      if (isolateSelection && selectedSet.size > 0 && !fullScope) return;
+      const edgeIsDimmed = !isolateSelection && selectedSet.size > 0 && !inScope;
 
       // Curved line via midpoint offset (MapLibre renders LineStrings as
       // straight segments between vertices, so we sample the quadratic
@@ -278,7 +293,8 @@ function CausalDAGMapInner() {
       // Dashed: confounded, inconsistent, or severed (matches 3D isDashed logic)
       const isDashed = edge.type === "confounded" || edge.isInconsistent || isSevered;
 
-      const opacity = isSevered ? 0.45 : 0.5;
+      const baseOpacity = isSevered ? 0.45 : 0.5;
+      const opacity = edgeIsDimmed ? 0.08 : baseOpacity;
 
       const feature: Feature<LineString> = {
         type: "Feature",

--- a/src/components/CausalDAGRelief.tsx
+++ b/src/components/CausalDAGRelief.tsx
@@ -53,6 +53,11 @@ const TOPO_FRAGMENT_SHADER = /* glsl */ `
   uniform vec3 uLightDir;
   uniform float uBands;
   uniform float uLineWidth;
+  // Multiplied into the final colour. Drives the "dim the surface to
+  // foreground a multi-selection" mode — at 1.0 the surface renders
+  // normally, at 0.4 mountains read as faded context behind the
+  // selection's pillars.
+  uniform float uSurfaceTint;
 
   // Mirror of elevationColor() in graph-relief-field.ts. Keep in sync.
   vec3 elevationColor(float t) {
@@ -98,7 +103,7 @@ const TOPO_FRAGMENT_SHADER = /* glsl */ `
     float lambert = max(dot(N, L), 0.0);
     float light = 0.45 + 0.55 * lambert;
 
-    gl_FragColor = vec4(surface * light, 1.0);
+    gl_FragColor = vec4(surface * light * uSurfaceTint, 1.0);
   }
 `;
 import CanvasWatermark from "./CanvasWatermark";
@@ -149,12 +154,18 @@ function ReliefMesh({
   field,
   norms,
   onPick,
+  surfaceTint = 1,
 }: {
   field: ReliefField;
   /** Per-vertex normalised height. Present for fused-mode renders; the
    *  single-domain path falls back to vertex-colour rendering. */
   norms?: Float32Array;
   onPick?: (clickX: number, clickZ: number) => void;
+  /** 0..1 multiplier on final surface colour. Parent passes 0.4 when a
+   *  multi-selection is active without isolate mode, so the mountains
+   *  fade into context while the cyan selection pillars stay vivid.
+   *  Default 1 = normal rendering. */
+  surfaceTint?: number;
 }) {
   const useShader = !!(norms && norms.length === field.positions.length / 3);
 
@@ -183,15 +194,22 @@ function ReliefMesh({
 
   useEffect(() => () => geometry.dispose(), [geometry]);
 
-  // Uniforms — recreated only on first mount; values are stable.
-  const uniforms = useMemo(
-    () => ({
-      uLightDir: { value: new THREE.Vector3(0.45, 1.0, 0.6).normalize() },
-      uBands: { value: 14 },
-      uLineWidth: { value: 0.04 },
-    }),
-    [],
-  );
+  // Uniforms — built once via lazy useState so the GPU-side reference
+  // is stable. The `uSurfaceTint` field is mutated imperatively below
+  // via an attached ref to the shaderMaterial; that's the canonical
+  // r3f pattern for cheap per-frame uniform updates and avoids
+  // rebuilding the shader pipeline on every tint change.
+  const [uniforms] = useState(() => ({
+    uLightDir: { value: new THREE.Vector3(0.45, 1.0, 0.6).normalize() },
+    uBands: { value: 14 },
+    uLineWidth: { value: 0.04 },
+    uSurfaceTint: { value: 1 },
+  }));
+  const materialRef = useRef<THREE.ShaderMaterial | null>(null);
+  useEffect(() => {
+    const mat = materialRef.current;
+    if (mat) mat.uniforms.uSurfaceTint.value = surfaceTint;
+  }, [surfaceTint]);
 
   if (field.positions.length === 0) return null;
 
@@ -210,6 +228,7 @@ function ReliefMesh({
     >
       {useShader ? (
         <shaderMaterial
+          ref={materialRef}
           vertexShader={TOPO_VERTEX_SHADER}
           fragmentShader={TOPO_FRAGMENT_SHADER}
           uniforms={uniforms}
@@ -223,6 +242,8 @@ function ReliefMesh({
           metalness={0.05}
           side={THREE.DoubleSide}
           flatShading={false}
+          transparent={surfaceTint < 1}
+          opacity={surfaceTint}
         />
       )}
     </mesh>
@@ -699,25 +720,46 @@ function CausalDAGReliefInner() {
     [sig],
   );
 
+  // Multi-select / isolate state. TOPO mirrors the spotlight semantics
+  // of 2D / 3D / Map: a multi-selection focuses the user's attention on
+  // a subset, and the rest of the canvas is contextual. Two modes:
+  //   - isolate ON  → recompute the field using ONLY the selected
+  //     subset, so non-selected mountains literally don't render.
+  //   - isolate OFF → keep all mountains, but tint the surface to ~0.4
+  //     so the cyan selection pillars (and the new neighbour pillars)
+  //     read as the foreground.
+  const selectedNodesArr = useApexStore((s) => s.selectedNodes);
+  const isolateSelection = useApexStore((s) => s.isolateSelection);
+  const multiSelectedSet = useMemo(
+    () => new Set(selectedNodesArr),
+    [selectedNodesArr],
+  );
+
   // Field-input nodes. When a replay snapshot is active, override each
   // node's `omegaFragility.composite` with the snapshot's per-node
   // ΩF — the mountain at node N now grows / shrinks as the cascade
   // propagates. When no snapshot is active, fall through to graphData
   // unchanged so the static view stays cheap.
   const fieldNodes = useMemo(() => {
-    if (!currentSnapshot) return graphData.nodes;
-    return graphData.nodes.map((n) => {
-      const state = currentSnapshot.nodeStates[n.id];
-      if (!state) return n;
-      return {
-        ...n,
-        omegaFragility: {
-          ...n.omegaFragility,
-          composite: state.omegaComposite,
-        },
-      };
-    });
-  }, [graphData.nodes, currentSnapshot]);
+    let nodes = graphData.nodes;
+    if (currentSnapshot) {
+      nodes = nodes.map((n) => {
+        const state = currentSnapshot.nodeStates[n.id];
+        if (!state) return n;
+        return {
+          ...n,
+          omegaFragility: { ...n.omegaFragility, composite: state.omegaComposite },
+        };
+      });
+    }
+    if (isolateSelection && multiSelectedSet.size > 0) {
+      nodes = nodes.filter((n) => multiSelectedSet.has(n.id));
+    }
+    return nodes;
+  }, [graphData.nodes, currentSnapshot, isolateSelection, multiSelectedSet]);
+
+  const surfaceTint =
+    !isolateSelection && multiSelectedSet.size > 0 ? 0.4 : 1;
 
   const uniqueDomains = useMemo(() => {
     const set = new Set<string>();
@@ -825,6 +867,7 @@ function CausalDAGReliefInner() {
             field={activeField}
             norms={fusedField?.norms}
             onPick={handlePick}
+            surfaceTint={surfaceTint}
           />
         )}
         {!isEmpty && (

--- a/src/components/dag3d/DAGNode3D.tsx
+++ b/src/components/dag3d/DAGNode3D.tsx
@@ -35,7 +35,15 @@ interface DAGNode3DProps {
   position: [number, number, number];
   isInterventionTarget: boolean;
   isVerifiedRestricted: boolean;
+  // True if this node is the singular click-selected node OR a member of
+  // a marquee/domain multi-selection. Drives ring + scale + label.
   isSelected: boolean;
+  // True ONLY when this node is the singular `selectedNode` (ie. user
+  // clicked it directly). Drives the heavy "ΩF profile + metrics" card —
+  // earlier the card mounted for every `isSelected` node, so a 25-node
+  // domain pick popped 25 cards into the canvas. Multi-selected nodes
+  // get the small floating label, not the heavy card.
+  isSingleSelected: boolean;
   isNeighborOfSelected: boolean;
   anyNodeSelected: boolean;
   isConsequence?: boolean;
@@ -74,6 +82,7 @@ function DAGNode3DInner({
   isInterventionTarget,
   isVerifiedRestricted,
   isSelected,
+  isSingleSelected,
   isNeighborOfSelected,
   anyNodeSelected,
   isConsequence = false,
@@ -302,13 +311,15 @@ function DAGNode3DInner({
         </Html>
       )}
 
-      {/* Detail Card — full ΩF profile + network metrics. Was previously
-           gated on `hovered`, which made the heavy card pop up on every
-           mouse-move and obscured the canvas. User feedback: the small
-           floating label (above) is the right hover affordance; the
-           heavy card should only appear on explicit selection (click).
-           Mirrors the 2D view's hover-vs-click split. */}
-      {isSelected && !dimmed && (
+      {/* Detail Card — full ΩF profile + network metrics. Gated on
+           `isSingleSelected`, NOT `isSelected`: when the user picks a
+           domain (or shift-marquees a region) every node in that set
+           reads as `isSelected=true`, and the earlier gate popped the
+           heavy card on every one of them — a wall of overlapping
+           boxes. Only the singular click-selected node opens the card;
+           multi-selected nodes still get the small floating label
+           above. Mirrors the 2D hover-vs-click split. */}
+      {isSingleSelected && !dimmed && (
         <Html
           position={[0, size + (isSelected ? 3.5 : 2.5), 0]}
           center
@@ -484,6 +495,7 @@ function arePropsEqual(prev: DAGNode3DProps, next: DAGNode3DProps) {
   if (prev.isInterventionTarget !== next.isInterventionTarget) return false;
   if (prev.isVerifiedRestricted !== next.isVerifiedRestricted) return false;
   if (prev.isSelected !== next.isSelected) return false;
+  if (prev.isSingleSelected !== next.isSingleSelected) return false;
   if (prev.isNeighborOfSelected !== next.isNeighborOfSelected) return false;
   if (prev.anyNodeSelected !== next.anyNodeSelected) return false;
   if (prev.isConsequence !== next.isConsequence) return false;

--- a/src/components/dag3d/DAGOverlay.tsx
+++ b/src/components/dag3d/DAGOverlay.tsx
@@ -4,6 +4,8 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useApexStore } from "@/stores/useApexStore";
 import { getDomainColor } from "@/lib/graph-data";
 import { useTemporalGraph } from "@/hooks/useTemporalGraph";
+import { DOMAIN_CARDS } from "@/lib/domains";
+import { DOMAIN_MAP } from "@/hooks/useFilteredGraph";
 import type { NodeSizeMetric } from "@/lib/types";
 
 /**
@@ -291,14 +293,89 @@ export default function DAGOverlay() {
     return nodeById.get(selectedNode) ?? null;
   }, [selectedNode, nodeById]);
 
-  // Domain legend: count nodes per domain
-  const domainCounts = useMemo(() => {
-    const map: Record<string, number> = {};
-    activeGraph.nodes.forEach((n) => {
-      map[n.domain] = (map[n.domain] || 0) + 1;
-    });
-    return Object.entries(map).sort((a, b) => b[1] - a[1]);
-  }, [activeGraph.nodes]);
+  // Domain legend rows. Was previously a raw `Object.entries` over
+  // `n.domain` strings, which the user flagged as apples-to-oranges:
+  // "Sovereign Risk" sat alongside "Saudi Aramco Energy" — same panel,
+  // different abstraction levels. The data layer carries node-domain
+  // strings at multiple granularities (per-company, per-sector,
+  // per-theme); the only level that's user-recognisable is the
+  // DomainCard catalog the landing-page picker shows.
+  //
+  // The new pipeline:
+  //   1. Reverse DOMAIN_MAP (selector-id → raw-domain[]) into
+  //      raw-domain → card.
+  //   2. Walk activeGraph.nodes, bucket each by its card (or by raw
+  //      name if the node belongs to a cross-domain connector like
+  //      "Geopolitical" / "Energy Grid" with no card mapping).
+  //   3. If the user picked specific domains at landing, filter buckets
+  //      to that subset (cross-domain rows always pass).
+  // Result: every row corresponds to something the user actually
+  // chose, displayed with the same label they recognised on the way in.
+  const selectedDomainCardIds = useApexStore((s) => s.selectedDomains);
+  const domainPanelRows = useMemo(() => {
+    const cardById = new Map(DOMAIN_CARDS.map((c) => [c.id, c]));
+    const rawDomainToCardId = new Map<string, string>();
+    for (const [cardId, rawDomains] of Object.entries(DOMAIN_MAP)) {
+      for (const raw of rawDomains) rawDomainToCardId.set(raw, cardId);
+    }
+    type Row = {
+      key: string;
+      label: string;
+      color: string;
+      count: number;
+      rawDomains: string[];
+      isCrossDomain: boolean;
+    };
+    const byKey = new Map<string, Row>();
+    for (const n of activeGraph.nodes) {
+      const cardId = rawDomainToCardId.get(n.domain);
+      if (cardId) {
+        const card = cardById.get(cardId);
+        if (!card) continue;
+        const existing = byKey.get(cardId);
+        if (existing) {
+          existing.count += 1;
+          if (!existing.rawDomains.includes(n.domain)) {
+            existing.rawDomains.push(n.domain);
+          }
+        } else {
+          byKey.set(cardId, {
+            key: cardId,
+            label: card.label,
+            color: card.color,
+            count: 1,
+            rawDomains: [n.domain],
+            isCrossDomain: false,
+          });
+        }
+      } else {
+        // Cross-domain connectors ("Geopolitical", "Energy Grid") have
+        // no card mapping — keep them as their raw-name row so the
+        // user still sees them when they auto-attach to a selection.
+        const key = `_raw:${n.domain}`;
+        const existing = byKey.get(key);
+        if (existing) {
+          existing.count += 1;
+        } else {
+          byKey.set(key, {
+            key,
+            label: n.domain,
+            color: getDomainColor(n.domain),
+            count: 1,
+            rawDomains: [n.domain],
+            isCrossDomain: true,
+          });
+        }
+      }
+    }
+    let rows = Array.from(byKey.values());
+    if (selectedDomainCardIds.length > 0) {
+      const allowed = new Set(selectedDomainCardIds);
+      rows = rows.filter((r) => r.isCrossDomain || allowed.has(r.key));
+    }
+    rows.sort((a, b) => b.count - a.count);
+    return rows;
+  }, [activeGraph.nodes, selectedDomainCardIds]);
 
   // Top-Ω nodes
   const topOmega = useMemo(() => {
@@ -554,30 +631,30 @@ export default function DAGOverlay() {
                 ? `· ${activeDomain}`
                 : domainPanelOpen
                   ? "— click to highlight"
-                  : `(${domainCounts.length})`}
+                  : `(${domainPanelRows.length})`}
             </span>
           </button>
           {domainPanelOpen && (
             <div className="flex flex-col gap-0.5 mt-1">
-              {domainCounts.map(([domain, count]) => {
-                const isActive = activeDomain === domain;
-                const domainColor = getDomainColor(domain);
+              {domainPanelRows.map((row) => {
+                const isActive = activeDomain === row.key;
                 return (
                   <div
-                    key={domain}
+                    key={row.key}
                     className="flex items-center gap-1.5 cursor-pointer rounded px-1 -mx-1 py-0.5 transition-colors hover:bg-white/5"
                     style={{
-                      backgroundColor: isActive ? `${domainColor}15` : undefined,
-                      borderLeft: isActive ? `2px solid ${domainColor}` : "2px solid transparent",
+                      backgroundColor: isActive ? `${row.color}15` : undefined,
+                      borderLeft: isActive ? `2px solid ${row.color}` : "2px solid transparent",
                     }}
                     onClick={() => {
                       if (isActive) {
                         setActiveDomain(null);
                         setSelectedNodes([]);
                       } else {
-                        setActiveDomain(domain);
+                        setActiveDomain(row.key);
+                        const allowed = new Set(row.rawDomains);
                         const nodeIds = activeGraph.nodes
-                          .filter((n) => n.domain === domain)
+                          .filter((n) => allowed.has(n.domain))
                           .map((n) => n.id);
                         setSelectedNodes(nodeIds);
                       }
@@ -585,13 +662,13 @@ export default function DAGOverlay() {
                   >
                     <div
                       className="w-1.5 h-1.5 rounded-full flex-shrink-0"
-                      style={{ backgroundColor: domainColor }}
+                      style={{ backgroundColor: row.color }}
                     />
-                    <span className="text-[8px]" style={{ color: isActive ? domainColor : "var(--text-muted)" }}>
-                      {domain}
+                    <span className="text-[8px]" style={{ color: isActive ? row.color : "var(--text-muted)" }}>
+                      {row.label}
                     </span>
                     <span className="text-[7px] text-text-muted/50">
-                      ({count})
+                      ({row.count})
                     </span>
                   </div>
                 );


### PR DESCRIPTION
## Summary

Four-item follow-up to PR #262, all reported against the live build:

- **Map dim-on-multi-select.** Map only dimmed when `isolateSelection` was on; 2D dims unconditionally on multi-select. Map now matches: nodes 0.35 / edges 0.08 with isolate off, 0.15 / cull with isolate on.
- **3D detail-card explosion.** PR #261 moved the heavy detail card behind `isSelected`, but multi-select sets `isSelected=true` for every selected node, so a 25-node domain pick popped 25 overlapping cards. New `isSingleSelected` prop drives the card; multi-selected nodes still get the small floating label.
- **TOPO isolation.** TOPO now respects `isolateSelection` — isolate ON + multi-select filters `fieldNodes` to the subset before the field is computed (non-selected mountains literally don't render). Isolate OFF + multi-select tints the surface to 0.4 via a new `uSurfaceTint` shader uniform so the cyan selection pillars foreground. Uniform mutated through a `materialRef` to avoid rebuilding the shader pipeline on tint changes.
- **Domain panel rolled up to card labels.** Replaced the raw `n.domain` enumeration with a card-keyed pipeline. Reverse `DOMAIN_MAP` (selector-id → raw-domain[]) → raw → card; bucket nodes by card; display `card.label` (e.g. "Energy Systems") and `card.color` instead of the per-company raw name. Cross-domain connectors ("Geopolitical", "Energy Grid") keep their raw row. When `selectedDomains.length > 0`, non-cross rows filter to the user's actual landing-page picks so domains the user never selected stop appearing.

## Test plan

- [ ] Open the Map view, multi-select a domain via the bottom-left DOMAINS panel — confirm non-selected nodes/edges fade to context (not culled, just dimmed).
- [ ] Open the Map view, toggle `isolateSelection` on top of a multi-selection — confirm out-of-scope edges are now culled and out-of-scope nodes drop further to 0.15.
- [ ] In 3D, click a single node — exactly one detail card appears.
- [ ] In 3D, multi-select a domain via the bottom-left panel or shift+drag — confirm only floating-title labels appear over the selected nodes (no detail cards), and the rest of the canvas dims as before.
- [ ] In TOPO with isolate OFF, multi-select a domain — surface mountains fade and the cyan selection pillars stand out as the foreground.
- [ ] In TOPO with isolate ON + multi-select, only the selected nodes' mountains render.
- [ ] In any canvas view, expand the bottom-left DOMAINS panel — confirm rows are card labels (e.g. "Energy Systems"), counts roll up correctly, cross-domain rows ("Geopolitical", "Energy Grid") still show, and rows that weren't part of the landing-page selection are absent.

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_