### PR TITLE
fix(2d): click no longer reheats the layout sim

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -634,6 +634,25 @@ The cryptic three-letter labels surfaced no meaning, and three other visual enco
 
 **Verification.** `tsc --noEmit` clean; lint clean on touched files (pre-existing `ablationMode` warning unchanged); vitest 778/778 pass.
 
+### 2026-05-07 — Shipped: 2D click no longer reheats the layout sim
+
+**PR:** TBD (about to open).
+
+**Trigger.** User: *"Click any one of the nodes under 2D, and then everything disappears … it disappears for, like, a few seconds, and then it rerenders again. But it's weird because when it rerenders, nothing is selected."*
+
+**Diagnosis.** RF fires `onNodeDragStart` on mousedown — even for a pure click. The handler called `sim.reheat(0.5)` + `startSimLoop()`, so every click ran the force-directed layout for ~1.5s while alpha decayed from 0.5 to 0.005. The orbs drifted (sometimes far enough to leave the viewport) and settled back, which the user perceived as "everything disappeared then re-rendered." The selection ring was technically still applied but invisible because the selected orb had moved off-frame mid-drift.
+
+**What shipped.** Click-vs-drag distinction in `CausalDAG2D`:
+- `onNodeDragStart` now only pins the node (cheap). No reheat, no sim loop.
+- `onNodeDrag` (which fires only when actual movement occurs) reheats and starts the sim on its first tick, then keeps re-pinning to the cursor.
+- `onNodeDragStop` only calls `sim.cool()` if a drag actually happened — pure-click → pin/unpin pair is a no-op for the simulator.
+A `draggedRef` tracks whether motion fired between drag start/stop.
+
+**Files.**
+- `src/components/CausalDAG2D.tsx` — drag-vs-click handlers.
+
+**Verification.** `tsc --noEmit` clean; lint clean on touched files; vitest 782/782 pass.
+
 ---
 
 ## How a fresh session resumes

--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -971,28 +971,45 @@ function CausalDAG2DInner() {
     setHoveredNodeId(null);
   }, []);
 
-  const onNodeDragStart: NodeMouseHandler = useCallback(
+  // RF fires onNodeDragStart on mousedown — even for a pure click. The
+  // earlier path called `sim.reheat(0.5)` here, which made every click
+  // run the layout sim for ~1.5s while alpha decayed from 0.5 to 0.005.
+  // Visually that read as the canvas blanking and re-rendering "with
+  // nothing selected" because the orbs drifted before settling back.
+  // Now: pin immediately (cheap), but don't reheat or start the sim
+  // loop until actual drag motion fires `onNodeDrag`. A pure click
+  // pins → unpins, no ticks, no layout disturbance.
+  const draggedRef = useRef(false);
+  const onNodeDragStart: NodeMouseHandler = useCallback((_event, rfNode) => {
+    const sim = liveSimRef.current;
+    if (!sim) return;
+    draggedRef.current = false;
+    sim.pin(rfNode.id, rfNode.position.x, rfNode.position.y);
+  }, []);
+
+  const onNodeDrag: NodeMouseHandler = useCallback(
     (_event, rfNode) => {
       const sim = liveSimRef.current;
       if (!sim) return;
+      if (!draggedRef.current) {
+        draggedRef.current = true;
+        sim.reheat(0.5);
+        startSimLoop();
+      }
       sim.pin(rfNode.id, rfNode.position.x, rfNode.position.y);
-      sim.reheat(0.5);
-      startSimLoop();
     },
     [startSimLoop],
   );
-
-  const onNodeDrag: NodeMouseHandler = useCallback((_event, rfNode) => {
-    const sim = liveSimRef.current;
-    if (!sim) return;
-    sim.pin(rfNode.id, rfNode.position.x, rfNode.position.y);
-  }, []);
 
   const onNodeDragStop: NodeMouseHandler = useCallback((_event, rfNode) => {
     const sim = liveSimRef.current;
     if (!sim) return;
     sim.unpin(rfNode.id);
-    sim.cool();
+    // Only cool the sim if we actually heated it. A pure click never
+    // reheated, so calling cool() here would needlessly tick the
+    // simulation toward a colder state from already-cold.
+    if (draggedRef.current) sim.cool();
+    draggedRef.current = false;
   }, []);
 
   // Resolve labels for edge inspector — O(1) via nodeById Map.


### PR DESCRIPTION
## Summary

Diagnoses the user's "click a 2D node and everything disappears for a few seconds, then re-renders with nothing selected" report.

**Root cause.** React Flow fires `onNodeDragStart` on mousedown — even for a pure click. The handler called `sim.reheat(0.5)` + `startSimLoop()`, so every click ran the force-directed layout for ~1.5s while alpha decayed from 0.5 to 0.005. Orbs drifted (sometimes far enough to leave the viewport) and settled back, which read as "the canvas blanked then rebuilt." The selection ring was actually applied — the selected orb had just moved off-frame.

**Fix.** Click-vs-drag distinction in `CausalDAG2D`:
- `onNodeDragStart` only pins the node. No reheat, no sim loop.
- `onNodeDrag` (fires only on actual movement) reheats + starts the sim on its first tick.
- `onNodeDragStop` only cools if a real drag happened. A pure click is now a pin/unpin pair, no ticks.

A `draggedRef` tracks whether motion fired between start and stop.

## Test plan

- [ ] In 2D, click a node — confirm the canvas does NOT visibly drift, and the selection ring lights up immediately on the clicked node.
- [ ] In 2D, drag a node — confirm the layout still reheats and surrounding nodes flow into a new equilibrium (the existing drag-to-rearrange behaviour).
- [ ] In 2D, click then drag the same node — first click is instantaneous, then the drag triggers the heat-up.

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_