### PR TITLE
feat(feeds): 3 more FRED series + transform-aware routing key

### DIFF
--- a/src/lib/__tests__/feeds/fred.test.ts
+++ b/src/lib/__tests__/feeds/fred.test.ts
@@ -96,9 +96,13 @@ describe("mockFredFeed", () => {
     }
   });
 
-  it("seriesIds are unique", () => {
-    const ids = FRED_SERIES.map((s) => s.id);
-    expect(new Set(ids).size).toBe(ids.length);
+  it("transform-aware routing keys are unique", () => {
+    // Two FRED entries can intentionally share an `id` when they pull
+    // the same series with different `units` transforms (e.g. PAYEMS
+    // as level + chg, CES0500000003 as Y/Y + M/M). The proxy and
+    // provider both key off `{id}_{units?}` to keep them distinct.
+    const keys = FRED_SERIES.map((s) => (s.units ? `${s.id}_${s.units}` : s.id));
+    expect(new Set(keys).size).toBe(keys.length);
   });
 
   it("includes the Phase 4 expansion series (Labor Force, EmRatio, GDP QoQ, PPI, Forward Inflation, Wheat)", () => {

--- a/src/lib/feeds/fred.ts
+++ b/src/lib/feeds/fred.ts
@@ -34,8 +34,9 @@ export interface FredSeriesConfig {
    *    pc1 = % change Y/Y (12-month)
    *    pch = % change period-over-period
    *    pca = % change at compounded annual rate (Q/Q annualized)
+   *    chg = absolute change period-over-period (e.g. PAYEMS thousands)
    *    lin = level (default if omitted) */
-  units?: "pc1" | "pch" | "pca" | "lin";
+  units?: "pc1" | "pch" | "pca" | "chg" | "lin";
   /** Plausible mock value for dev mode. */
   mockValue: number;
 }
@@ -105,6 +106,19 @@ export const FRED_SERIES: FredSeriesConfig[] = [
   { id: "ULCNFB", label: "Unit Labor Costs Q/Q Annualized", labelPatterns: ["unit labor costs qoq annualized", "unit labor costs"], unit: "%", capacity: 5, units: "pca", mockValue: 2.8 },
   { id: "CUSR0000SEHC", label: "CPI Owners' Equivalent Rent Y/Y", labelPatterns: ["owners' equivalent rent (oer)", "owners equivalent rent", "oer"], unit: "%", capacity: 8, units: "pc1", mockValue: 4.5 },
   { id: "JTSHIR", label: "JOLTS Hires Rate", labelPatterns: ["hiring rate", "hires rate"], unit: "%", capacity: 5, mockValue: 3.4 },
+  // Phase 11 — Tier-1 audit follow-up. Three more bare-modeled nodes
+  // closed by adding new FRED transforms or alternative series.
+  // - PAYEMS with units=chg gives the headline NFP CHANGE (different
+  //   from the level entry above which uses no transform).
+  // - DTWEXBGS is FRED's Nominal Broad U.S. Dollar Index — not the
+  //   ICE DXY but the standard FRED proxy. The ICE 6-currency index
+  //   isn't on FRED at all. Synthetic DXY in graph-data.ts shares the
+  //   shape closely enough that the live tick reads in the same regime.
+  // - CES0500000003 we already pull as Y/Y (entry above); the MoM
+  //   variant uses the same series with units=pch.
+  { id: "PAYEMS", label: "Headline Nonfarm Payroll Change", labelPatterns: ["headline nonfarm payroll change", "nonfarm payroll change"], unit: "K", capacity: 250, units: "chg", mockValue: 175 },
+  { id: "DTWEXBGS", label: "Nominal Broad U.S. Dollar Index", labelPatterns: ["us dollar index (dxy)", "dollar index", "dxy"], unit: "", capacity: 130, mockValue: 122 },
+  { id: "CES0500000003", label: "Average Hourly Earnings M/M %", labelPatterns: ["average hourly earnings mom", "average hourly earnings m/m"], unit: "%", capacity: 0.5, units: "pch", mockValue: 0.3 },
 ];
 
 /** A single observation per FRED series, returned by the proxy and
@@ -183,8 +197,13 @@ export function parseFredSeriesResponse(
     .slice(1)
     .reverse()
     .map((p) => ({ value: p.value, observedAt: p.observedAt }));
+  // Include the units transform in the routing key so two FRED_SERIES
+  // entries that share the same series id (e.g. PAYEMS as level + chg,
+  // CES0500000003 as Y/Y + M/M) don't collide in the provider's
+  // matchSeriesToNode lookup.
+  const seriesId = config.units ? `${config.id}_${config.units}` : config.id;
   return {
-    seriesId: config.id,
+    seriesId,
     label: config.label,
     value: latest.value,
     unit: config.unit,
@@ -207,7 +226,10 @@ export function mockFredFeed(): FredFeed {
   return {
     fetchedAt: observedAt,
     observations: FRED_SERIES.map((s) => ({
-      seriesId: s.id,
+      // Same transform-aware key as parseFredSeriesResponse so the mock
+      // feed routes the same way the live one does (no PAYEMS-level vs
+      // PAYEMS-chg collision).
+      seriesId: s.units ? `${s.id}_${s.units}` : s.id,
       label: s.label,
       value: s.mockValue,
       unit: s.unit,

--- a/src/lib/feeds/providers/fred.ts
+++ b/src/lib/feeds/providers/fred.ts
@@ -11,12 +11,18 @@ import {
 import type { FeedDispatchBatch, FeedProvider } from "./types";
 
 /** Find the first node whose label matches any of the series' labelPatterns
- *  (case-insensitive substring). */
+ *  (case-insensitive substring). The lookup uses the transform-aware
+ *  routing key (`{seriesId}_{units?}`) so duplicate FRED ids with
+ *  different transforms (PAYEMS level + chg, CES0500000003 Y/Y + M/M)
+ *  resolve to their respective configs. */
 function matchSeriesToNode(
   obs: FredObservation,
   nodes: ReadonlyArray<CausalNode>,
 ): CausalNode | undefined {
-  const config = FRED_SERIES.find((s) => s.id === obs.seriesId);
+  const config = FRED_SERIES.find((s) => {
+    const key = s.units ? `${s.id}_${s.units}` : s.id;
+    return key === obs.seriesId;
+  });
   if (!config) return undefined;
   for (const pattern of config.labelPatterns) {
     const needle = pattern.toLowerCase();


### PR DESCRIPTION
## Summary

Audit follow-up. After PR #228 closed 5 of the 8 labor/growth bare nodes, 3 more turn out to be reachable on FRED without any new data sources — they just need entries with different transforms or an alternative series.

| Node | New entry | Source |
|---|---|---|
| `mi_nonfarm_payrolls` (Headline NFP Change) | `PAYEMS` with `units=chg` | Same series as level, different transform |
| `ip_dxy` (US Dollar Index) | `DTWEXBGS` | Nominal Broad USD Index — FRED's standard proxy. ICE DXY itself isn't on FRED. |
| `mi_ahe_mom` (AHE M/M %) | `CES0500000003` with `units=pch` | Same series as Y/Y, different transform |

## Routing collision fix

Two of these (PAYEMS, CES0500000003) intentionally share a series ID with an existing entry but use a different transform. That exposed a bug:

```ts
const config = FRED_SERIES.find((s) => s.id === obs.seriesId);
```

`find()` returns only the first match — so both PAYEMS configs would have routed to the level entry's labelPattern, dropping the change variant.

Fix: include the units transform in the dispatch key. Both `parseFredSeriesResponse` and `mockFredFeed` now emit observations with `{id}_{units?}` as `seriesId`; the provider matcher looks up by the same key. Type union for `units` adds `"chg"` for absolute-change transforms.

The existing test asserting `seriesIds are unique` was a stricter invariant than we want now — replaced with `transform-aware routing keys are unique` (same purpose, correct dimension).

## Coverage delta

```
Before: 17/211 bare modeled
After:  14/211 bare
```

Remaining bare nodes are all documented:
- 6 frontier-science (intentional placeholder, `dataStatus: "blank-needs-data"`)
- 5 Ma'aden private infrastructure (no public source — Saudi corporate)
- 2 ISM PMI (proprietary since ~2015)
- 1 NY Fed Consumer Inflation Expectations (NY Fed SCE webpage; would need a custom batch fetcher)

## Test plan

- [x] `npm test -- --run` → 793/793 passing
- [x] `npx tsc --noEmit` clean
- [ ] Vercel preview deploys
- [ ] When `FRED_API_KEY` is set, confirm `ip_dxy`, `mi_nonfarm_payrolls`, and `mi_ahe_mom` all show non-mock live values on prod (the source string in the tooltip should NOT contain `(mock — FRED_API_KEY unset)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014AELhRkzeHMphQeQLwTGZF)_