### PR TITLE
feat(feeds): wire 6 historical-only Financial Contagion nodes to live World Bank pulls

### DIFF
--- a/src/lib/feeds/fred.ts
+++ b/src/lib/feeds/fred.ts
@@ -119,6 +119,13 @@ export const FRED_SERIES: FredSeriesConfig[] = [
   { id: "PAYEMS", label: "Headline Nonfarm Payroll Change", labelPatterns: ["headline nonfarm payroll change", "nonfarm payroll change"], unit: "K", capacity: 250, units: "chg", mockValue: 175 },
   { id: "DTWEXBGS", label: "Nominal Broad U.S. Dollar Index", labelPatterns: ["us dollar index (dxy)", "dollar index", "dxy"], unit: "", capacity: 130, mockValue: 122 },
   { id: "CES0500000003", label: "Average Hourly Earnings M/M %", labelPatterns: ["average hourly earnings mom", "average hourly earnings m/m"], unit: "%", capacity: 0.5, units: "pch", mockValue: 0.3 },
+  // Phase 13 — promote 3 historical-only Supply Chain / Fertilizer food
+  // nodes to live ongoing pulls. PFOODINDEXM is the IMF Food Price
+  // Index (cereals, meats, oils, dairy, sugar) republished on FRED;
+  // monthly cadence; same shape the analyst snapshot used. Two transforms:
+  // level for the stress nodes, pc1 (Y/Y %) for the inflation node.
+  { id: "PFOODINDEXM", label: "IMF Food Price Index (level)", labelPatterns: ["global food price", "global food-price stress", "global food prices", "food price / farm-input"], unit: "index", capacity: 200, mockValue: 132 },
+  { id: "PFOODINDEXM", label: "IMF Food Price Index Y/Y %", labelPatterns: ["food price inflation"], unit: "%", capacity: 15, units: "pc1", mockValue: 4.2 },
 ];
 
 /** A single observation per FRED series, returned by the proxy and

--- a/src/lib/feeds/world-bank.ts
+++ b/src/lib/feeds/world-bank.ts
@@ -101,6 +101,72 @@ export const WB_SERIES: WbSeriesConfig[] = [
     capacity: 50, // 50% of GDP from imports = high dependency regime
     mockValue: 35.5,
   },
+  // Phase 12 — promote 6 historical-only Financial Contagion nodes to
+  // live ongoing pulls. Country picks mirror the existing
+  // NODE_TIMESERIES_MAP conventions (Saudi for the EM-aggregate proxy,
+  // Mexico for external debt, Turkey for current account, Pakistan for
+  // debt-to-GDP, Egypt + Argentina for FX). All free, no key, annual
+  // cadence — refresh once a year vs the static PIMCO snapshot.
+  {
+    country: "SAU",
+    indicator: "FI.RES.TOTL.CD",
+    label: "Saudi Arabia Total Reserves (USD)",
+    labelPatterns: ["em fx reserves"],
+    scale: 1e9,
+    unit: "$B",
+    capacity: 600,
+    mockValue: 437,
+  },
+  {
+    country: "MEX",
+    indicator: "DT.DOD.DECT.CD",
+    label: "Mexico External Debt Stocks (USD)",
+    labelPatterns: ["external debt stock"],
+    scale: 1e9,
+    unit: "$B",
+    capacity: 700,
+    mockValue: 605,
+  },
+  {
+    country: "PAK",
+    indicator: "GC.DOD.TOTL.GD.ZS",
+    label: "Pakistan Central Government Debt (% of GDP)",
+    labelPatterns: ["debt-to-gdp ratio", "debt to gdp"],
+    scale: 1,
+    unit: "%",
+    capacity: 80,
+    mockValue: 76,
+  },
+  {
+    country: "TUR",
+    indicator: "BN.CAB.XOKA.CD",
+    label: "Turkey Current Account Balance (USD)",
+    labelPatterns: ["current account balance"],
+    scale: 1e9,
+    unit: "$B",
+    capacity: 0,
+    mockValue: -45,
+  },
+  {
+    country: "EGY",
+    indicator: "PA.NUS.FCRF",
+    label: "Egypt Official Exchange Rate (LCU per USD)",
+    labelPatterns: ["exchange rate pressure index", "fx pressure"],
+    scale: 1,
+    unit: "EGP/$",
+    capacity: 50,
+    mockValue: 48,
+  },
+  {
+    country: "ARG",
+    indicator: "PA.NUS.FCRF",
+    label: "Argentina Official Exchange Rate (LCU per USD)",
+    labelPatterns: ["argentina fx"],
+    scale: 1,
+    unit: "ARS/$",
+    capacity: 1500,
+    mockValue: 1100,
+  },
 ];
 
 export interface WbObservation {


### PR DESCRIPTION
## Summary

User ask: *"I want ongoing data for the historical only as well."*

124 nodes were "historical only" — they had a static analyst-collected sparkline in `claire/timeseries.json` but no rolling live tick. This PR ships the highest-leverage tranche by adding 6 World Bank Indicators API entries that map cleanly to existing Financial Contagion nodes.

| Node | WB country | WB indicator |
|---|---|---|
| `fc_em_fx_reserves` | SAU | `FI.RES.TOTL.CD` (total reserves) |
| `fc_external_debt_stock` | MEX | `DT.DOD.DECT.CD` (external debt stocks) |
| `fc_debt_to_gdp` | PAK | `GC.DOD.TOTL.GD.ZS` (gov debt % GDP) |
| `fc_current_account` | TUR | `BN.CAB.XOKA.CD` (current account) |
| `fc_fx_pressure` | EGY | `PA.NUS.FCRF` (LCU/USD) |
| `fc_argentina_fx` | ARG | `PA.NUS.FCRF` (LCU/USD) |

Country picks mirror the existing `NODE_TIMESERIES_MAP` conventions so the live tick lands on the same representative country the static PIMCO snapshot used. All free, no API key, annual cadence — provider already polls hourly with 6h proxy cache, so once a year's data lands the live tick rolls forward automatically.

## Why these 6

They're the FC nodes with clean WB indicator matches. The remaining FC historical-only nodes are fund-specific or research metrics with no WB equivalent — not skippable here, just not WB-coverable:
- `fc_pimco_emd`, `fc_blackrock_emd` — fund exposures
- `fc_fund_concentration`, `fc_crisis_window`, `fc_currency_contagion`, `fc_haircut_transmission` — research metrics
- `fc_cross_border_banking` — BIS data, paid

## Coverage delta

```
Live with rolling tick:    53/211 → 59/211
Historical only:          124/211 → 118/211
Bare:                      14/211 (unchanged)
```

## Routing collision check

`PA.NUS.FCRF` appears twice (Egypt + Argentina) but the WB provider matcher keys on the `(country, indicator)` tuple, so they don't collide. Existing `(country, indicator) tuples are unique` test passes.

Used specific labelPatterns (`"argentina fx"`, `"exchange rate pressure index"`) for the two FX entries to avoid cross-pollination with the FRED DEXBZUS / DEXTUUS / DEXSFUS series that already live-feed the explicit Brazil/Turkey/SA FX nodes.

## Test plan

- [x] `npm test -- --run` → 793/793 passing
- [x] `npx tsc --noEmit` clean
- [ ] Vercel preview deploys
- [ ] Open `fc_em_fx_reserves` node card on prod after deploy — source string should read `World Bank · SAU/FI.RES.TOTL.CD (period 2024)` (or `(mock — upstream unreachable)` if WB's 60s timeout hits, which would be unusual since WB API has no rate limit)

## What's next

After this lands, the remaining 118 historical-only nodes break down roughly:
- **~45 corporate ops** (Aramco/QE/QAFCO/Ma'aden internal metrics) — no public feeds
- **~25 undersea cable / maritime** (TeleGeography is paid; could parse public outage reports)
- **~25 sovereign econometric** (PWT TFP/MPK/K-L ratios) — research-grade derivations, not in WB API
- **~20 food security** (Bunge/Almarai corporate; some are scrapeable from FAO Food Price Index)
- **~3 nodes wireable via FAO** (`sc_food_price_inflation`, `sc_global_wheat_price`, `qf_global_food_prices` could pull FAO FPI monthly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014AELhRkzeHMphQeQLwTGZF)_