### PR TITLE
feat(canvas): 3D card removed, TOPO legend anchored to peak, Map de-cluttered

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -653,6 +653,30 @@ A `draggedRef` tracks whether motion fired between drag start/stop.
 
 **Verification.** `tsc --noEmit` clean; lint clean on touched files; vitest 782/782 pass.
 
+### 2026-05-07 — Shipped: 3D card removed, TOPO legend anchored to peak, Map basemap de-cluttered
+
+**PR:** TBD (about to open).
+
+**Trigger.** Three-item batch:
+
+1. *"Under 3D, selecting any node still gives us a whole box that's hard to get rid of. All it needs to do is give a small title hovering above it along with its nearest neighbors. Like 2D."* — even after PR #265 narrowed the in-canvas detail card to single-click only, the user wants no in-canvas card at all. The 2D pattern is the model: small floating label + neighbour spotlight.
+2. *"The legend on the side of the topology diagram is really off to the side. It should kinda be floating above wherever we're scaling to so we can always kind of see how it compares."* — the SE-corner placement of `InSceneElevationLegend` was visually disconnected from the actual peaks.
+3. *"For the map, … it's almost a globe-like looking map. Looks somewhat like Google Maps, but it gets all the way down to the street. … This is just getting very busy."* — the CARTO `dark_all` basemap rendered street labels and city names under the causal-graph overlay.
+
+**What shipped.**
+
+- **3D in-canvas detail card removed entirely.** Dropped the `Html`-mounted card from `DAGNode3D` (was ~140 lines of JSX rendering a 280px panel with axis bars, network metrics, metadata). The small floating label above the orb is now the only on-canvas affordance — same gate as before (`!dimmed && !isOrbiting && (hovered || isSelected || isNeighborOfSelected)`). Full ΩF profile / network metrics still live in `NodeInspector` and `ModulePanel` as side panels — the right home for the heavy data. Cleanup: removed `isSingleSelected` prop, dead helpers (`getBarColor`, `getCentralityLabel`), unused imports (`getDomainColor`, `resolveDomainProfile`), and the `axes` / `selectedDomains` / `profile` / `pillarLabels` locals.
+- **TOPO legend anchored to the peak.** `InSceneElevationLegend` now takes a `peakAnchor` (translated x/z of the highest-Ω node, in surface coords) and stands the column 12 world units beside it. Cascade replay re-anchors as the peak shifts. Falls back to the SE corner if no anchor is available.
+- **Map basemap switched to `dark_nolabels` + zoom cap 6.** No more street labels / city names. `maxzoom: 6` caps tile detail at country / sub-region scale so the basemap stops loading new tiles past that — pinch-zooming further is allowed but doesn't reveal streets. Same dark theme; just much less competing visual density under the graph.
+
+**Files.**
+- `src/components/dag3d/DAGNode3D.tsx` — card removed; props + helpers / locals trimmed.
+- `src/components/CausalDAG3D.tsx` — stop passing `isSingleSelected`.
+- `src/components/CausalDAGRelief.tsx` — `peakNodeId` + `peakAnchor` derivation; `InSceneElevationLegend` accepts `peakAnchor`.
+- `src/components/CausalDAGMap.tsx` — `dark_nolabels` tile URL, `maxzoom: 6`.
+
+**Verification.** `tsc --noEmit` clean; lint clean on touched files (pre-existing `ablationMode` warning unchanged); vitest 793/793 pass.
+
 ---
 
 ## How a fresh session resumes

--- a/src/components/CausalDAG3D.tsx
+++ b/src/components/CausalDAG3D.tsx
@@ -1041,7 +1041,6 @@ export default function CausalDAG3D() {
                 isInterventionTarget={isTarget}
                 isVerifiedRestricted={isRestricted}
                 isSelected={isSelected}
-                isSingleSelected={selectedNode === node.id}
                 isNeighborOfSelected={isNeighborOfSelected}
                 anyNodeSelected={anyNodeSelected}
                 isConsequence={node.isConsequence ?? false}

--- a/src/components/CausalDAGMap.tsx
+++ b/src/components/CausalDAGMap.tsx
@@ -582,7 +582,15 @@ function CausalDAGMapInner() {
     );
   }, [fitKey]);
 
-  // Dark map style matching the app theme
+  // Dark map style matching the app theme. Switched from CARTO's
+  // `dark_all` to `dark_nolabels` so the basemap shows continents,
+  // coastlines, and admin boundaries but skips the street labels and
+  // city names that made the canvas read as busy when the user is
+  // looking at high-level causal flows. `maxzoom: 6` caps the tile
+  // detail at country / sub-region scale — the user can still pinch-
+  // zoom further but the basemap stops loading new tiles, so streets
+  // never appear underneath the nodes. This keeps the view "globe-like"
+  // and stops the basemap from competing with the graph at any zoom.
   const mapStyle = useMemo(
     () => ({
       version: 8 as const,
@@ -591,7 +599,7 @@ function CausalDAGMapInner() {
         "osm-tiles": {
           type: "raster" as const,
           tiles: [
-            "https://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}@2x.png",
+            "https://basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}@2x.png",
           ],
           tileSize: 256,
           attribution:
@@ -604,7 +612,7 @@ function CausalDAGMapInner() {
           type: "raster" as const,
           source: "osm-tiles",
           minzoom: 0,
-          maxzoom: 19,
+          maxzoom: 6,
         },
       ],
     }),

--- a/src/components/CausalDAGRelief.tsx
+++ b/src/components/CausalDAGRelief.tsx
@@ -456,9 +456,16 @@ function elevationColorJS(t: number): [number, number, number] {
 function InSceneElevationLegend({
   field,
   peakOmega,
+  peakAnchor,
 }: {
   field: ReliefField;
   peakOmega: number;
+  /** World-space (x, z) of the highest-Ω node, in the same translated
+   *  coordinate frame the surface uses (i.e. cx/cy already subtracted).
+   *  When provided, the column stands right next to the peak so the
+   *  user can directly compare the column's Ω ticks against the peak's
+   *  height. Falls back to the SE corner of the field if absent. */
+  peakAnchor?: { x: number; z: number };
 }) {
   const HEIGHT = 140; // matches DEFAULT_OPTIONS.heightScale in graph-relief-field
   const HEIGHT_GAMMA = 1.6; // matches heightGamma — keep in sync
@@ -485,11 +492,16 @@ function InSceneElevationLegend({
     return tex;
   }, []);
 
-  // Park the column at the SE corner of the field, pulled out far enough
-  // that it doesn't clip into the surface mesh edge. Y rests on the
-  // ground plane (y=0) so its base aligns with mountain bases.
-  const cornerX = field.width / 2 + 30;
-  const cornerZ = field.height / 2 + 30;
+  // Park the column right next to the highest peak so the user can read
+  // a mountain's Ω directly off the legend at the same horizontal sight
+  // line. The earlier placement was the SE corner of the field, which
+  // the user pointed out was disconnected from the visual it was meant
+  // to explain. The +12 unit offset is far enough to keep the column
+  // out of the mountain's slope but close enough that the comparison
+  // is immediate. Falls back to the SE corner if no anchor is supplied
+  // (e.g. before the layout's settled).
+  const cornerX = peakAnchor ? peakAnchor.x + 12 : field.width / 2 + 30;
+  const cornerZ = peakAnchor ? peakAnchor.z + 12 : field.height / 2 + 30;
 
   // Convert tick Ω values back to the world height the surface would
   // assign them. Peak label sits at top of column (Ω = peakOmega), Ω 0
@@ -791,15 +803,31 @@ function CausalDAGReliefInner() {
 
   // Max Ω composite across the visible (replay-aware) graph — drives
   // the elevation legend's "PEAK Ω" label so users have a numeric
-  // anchor for the heatmap.
-  const peakOmega = useMemo(() => {
+  // anchor for the heatmap. Also surface the peak node so the in-scene
+  // legend can stand next to the tallest mountain.
+  const { peakOmega, peakNodeId } = useMemo(() => {
     let max = 0;
+    let id: string | null = null;
     for (const n of fieldNodes) {
       const c = n.omegaFragility?.composite;
-      if (typeof c === "number" && Number.isFinite(c) && c > max) max = c;
+      if (typeof c === "number" && Number.isFinite(c) && c > max) {
+        max = c;
+        id = n.id;
+      }
     }
-    return max;
+    return { peakOmega: max, peakNodeId: id };
   }, [fieldNodes]);
+
+  // Peak node's translated (x, z) in the same coordinate frame the
+  // surface uses (cx/cy already subtracted). Recomputes when the peak
+  // identity or layout changes, so cascade replay re-anchors the
+  // legend to whichever node is currently tallest.
+  const peakAnchor = useMemo<{ x: number; z: number } | undefined>(() => {
+    if (!activeField || !peakNodeId) return undefined;
+    const p = layout.get(peakNodeId);
+    if (!p || !Number.isFinite(p.x) || !Number.isFinite(p.y)) return undefined;
+    return { x: p.x - activeField.cx, z: p.y - activeField.cy };
+  }, [activeField, peakNodeId, layout]);
 
   const anchors = useMemo<NodeAnchor[]>(() => {
     if (!activeField || isEmpty) return [];
@@ -874,7 +902,11 @@ function CausalDAGReliefInner() {
           <SelectionMarkers layout={layout} field={activeField} edges={graphData.edges} />
         )}
         {!isEmpty && activeField && peakOmega > 0 && (
-          <InSceneElevationLegend field={activeField} peakOmega={peakOmega} />
+          <InSceneElevationLegend
+            field={activeField}
+            peakOmega={peakOmega}
+            peakAnchor={peakAnchor}
+          />
         )}
         {!isEmpty && <NodeLabels anchors={anchors} />}
         {!isEmpty && activeField && (

--- a/src/components/dag3d/DAGNode3D.tsx
+++ b/src/components/dag3d/DAGNode3D.tsx
@@ -5,10 +5,9 @@ import { useFrame } from "@react-three/fiber";
 import { Html } from "@react-three/drei";
 import * as THREE from "three";
 import { CausalNode, NodeEpochState } from "@/lib/types";
-import { getCategoryColor, getDomainColor } from "@/lib/graph-data";
+import { getCategoryColor } from "@/lib/graph-data";
 import { NodeMetrics } from "@/lib/graph-layout";
 import { useApexStore } from "@/stores/useApexStore";
-import { resolveDomainProfile } from "@/lib/domain-profiles";
 
 // Shared reactive flag: set by CameraRig when orbit controls are actively dragging.
 // Uses a subscription pattern so nodes re-render when orbiting starts/stops.
@@ -38,12 +37,6 @@ interface DAGNode3DProps {
   // True if this node is the singular click-selected node OR a member of
   // a marquee/domain multi-selection. Drives ring + scale + label.
   isSelected: boolean;
-  // True ONLY when this node is the singular `selectedNode` (ie. user
-  // clicked it directly). Drives the heavy "ΩF profile + metrics" card —
-  // earlier the card mounted for every `isSelected` node, so a 25-node
-  // domain pick popped 25 cards into the canvas. Multi-selected nodes
-  // get the small floating label, not the heavy card.
-  isSingleSelected: boolean;
   isNeighborOfSelected: boolean;
   anyNodeSelected: boolean;
   isConsequence?: boolean;
@@ -62,27 +55,12 @@ function getOmegaGlowColor(composite: number): string {
   return "#00e676";
 }
 
-function getBarColor(value: number): string {
-  if (value > 9) return "#ff1744";
-  if (value >= 7) return "#ffab00";
-  if (value >= 5) return "#ff6d00";
-  return "#00e676";
-}
-
-function getCentralityLabel(ec: number): string {
-  if (ec >= 0.8) return "CRITICAL HUB";
-  if (ec >= 0.5) return "HIGH INFLUENCE";
-  if (ec >= 0.2) return "MODERATE";
-  return "PERIPHERAL";
-}
-
 function DAGNode3DInner({
   node,
   position,
   isInterventionTarget,
   isVerifiedRestricted,
   isSelected,
-  isSingleSelected,
   isNeighborOfSelected,
   anyNodeSelected,
   isConsequence = false,
@@ -95,10 +73,7 @@ function DAGNode3DInner({
   onDoubleClick,
 }: DAGNode3DProps) {
   const isOrbiting = useOrbitActive();
-  const selectedDomains = useApexStore((s) => s.selectedDomains);
   const nodeSizeMetric = useApexStore((s) => s.nodeSizeMetric);
-  const profile = resolveDomainProfile(selectedDomains);
-  const pillarLabels = profile.pillarLabels;
   const meshRef = useRef<THREE.Mesh>(null);
   const selectionRingRef = useRef<THREE.Mesh>(null);
   const birthProgress = useRef(isConsequence ? 0 : 1);
@@ -163,14 +138,6 @@ function DAGNode3DInner({
       mat.opacity = ringPulse;
     }
   });
-
-  const axes = [
-    { label: pillarLabels.irreplaceability, value: node.omegaFragility.irreplaceability },
-    { label: pillarLabels.restorationLatency, value: node.omegaFragility.restorationLatency },
-    { label: pillarLabels.jurisdictionalHazard, value: node.omegaFragility.jurisdictionalHazard },
-    { label: pillarLabels.cascadeLoad, value: node.omegaFragility.cascadeLoad },
-    { label: pillarLabels.tailDepth, value: node.omegaFragility.tailDepth },
-  ];
 
   return (
     <group position={position} onClick={onClick} onDoubleClick={onDoubleClick}>
@@ -268,10 +235,14 @@ function DAGNode3DInner({
         </mesh>
       )}
 
-      {/* Label — only visible on hover, single-select, or multi-select.
-           v1 painted a label on every orb permanently and dense graphs read
-           as a hodgepodge of overlapping text. The hover detail card below
-           still surfaces full info on demand. */}
+      {/* Label — only visible on hover, single-select, neighbour-of-
+           select, or multi-select. v1 painted a label on every orb
+           permanently and dense graphs read as a hodgepodge of overlapping
+           text. The earlier path also rendered a heavy in-canvas detail
+           card on click; that's been removed because the user wants 3D to
+           match 2D — small floating label + neighbour spotlight, with the
+           full ΩF profile / network metrics surfacing in NodeInspector
+           and ModulePanel side panels rather than over the canvas. */}
       {!dimmed && !isOrbiting && (hovered || isSelected || isNeighborOfSelected) && (
         <Html
           position={[0, size * 1.6 + 0.6, 0]}
@@ -311,155 +282,6 @@ function DAGNode3DInner({
         </Html>
       )}
 
-      {/* Detail Card — full ΩF profile + network metrics. Gated on
-           `isSingleSelected`, NOT `isSelected`: when the user picks a
-           domain (or shift-marquees a region) every node in that set
-           reads as `isSelected=true`, and the earlier gate popped the
-           heavy card on every one of them — a wall of overlapping
-           boxes. Only the singular click-selected node opens the card;
-           multi-selected nodes still get the small floating label
-           above. Mirrors the 2D hover-vs-click split. */}
-      {isSingleSelected && !dimmed && (
-        <Html
-          position={[0, size + (isSelected ? 3.5 : 2.5), 0]}
-          center
-          style={{ pointerEvents: "none" }}
-        >
-          <div
-            style={{
-              background: "rgba(10, 11, 16, 0.95)",
-              border: `1px solid ${isSelected ? "rgba(0, 229, 255, 0.6)" : "rgba(90, 94, 114, 0.4)"}`,
-              borderRadius: "6px",
-              padding: "12px 14px",
-              fontFamily: "monospace",
-              fontSize: "11px",
-              color: "#c8cad0",
-              width: "280px",
-              backdropFilter: "blur(8px)",
-            }}
-          >
-            {/* Header */}
-            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "8px" }}>
-              <div style={{ fontWeight: "bold", color: "#ffffff", fontSize: "12px" }}>
-                {node.label}
-              </div>
-              <div
-                style={{
-                  fontSize: "9px",
-                  padding: "2px 6px",
-                  borderRadius: "3px",
-                  backgroundColor: `${getDomainColor(node.domain)}15`,
-                  color: getDomainColor(node.domain),
-                  border: `1px solid ${getDomainColor(node.domain)}40`,
-                }}
-              >
-                {node.domain.toUpperCase()}
-              </div>
-            </div>
-
-            {/* Omega Composite */}
-            <div style={{ display: "flex", alignItems: "baseline", gap: "6px", marginBottom: "10px" }}>
-              <span style={{ fontSize: "22px", fontWeight: "bold", color: getBarColor(composite) }}>
-                {"\u03A9"} {composite.toFixed(1)}
-              </span>
-              <span style={{ fontSize: "9px", color: "#5a5e72" }}>/ 10.0</span>
-            </div>
-
-            {/* 5-axis bars */}
-            <div style={{ display: "flex", flexDirection: "column", gap: "4px", marginBottom: "10px" }}>
-              {axes.map((axis) => (
-                <div key={axis.label} style={{ display: "flex", alignItems: "center", gap: "6px" }}>
-                  <div style={{ width: "90px", fontSize: "8px", color: "#5a5e72", flexShrink: 0 }}>
-                    {axis.label}
-                  </div>
-                  <div
-                    style={{
-                      flex: 1,
-                      height: "4px",
-                      backgroundColor: "rgba(90, 94, 114, 0.2)",
-                      borderRadius: "2px",
-                      overflow: "hidden",
-                    }}
-                  >
-                    <div
-                      style={{
-                        width: `${(axis.value / 10) * 100}%`,
-                        height: "100%",
-                        backgroundColor: getBarColor(axis.value),
-                        borderRadius: "2px",
-                      }}
-                    />
-                  </div>
-                  <div style={{ width: "28px", fontSize: "9px", color: getBarColor(axis.value), textAlign: "right" }}>
-                    {axis.value.toFixed(1)}
-                  </div>
-                </div>
-              ))}
-            </div>
-
-            {/* Network Position Metrics — explains SIZE and DISTANCE */}
-            {metrics && (
-              <div style={{
-                borderTop: "1px solid rgba(90, 94, 114, 0.2)",
-                paddingTop: "8px",
-                marginBottom: "8px",
-              }}>
-                <div style={{ fontSize: "8px", color: "#5a5e72", marginBottom: "6px", letterSpacing: "1px" }}>
-                  NETWORK POSITION
-                </div>
-                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "4px 12px" }}>
-                  <div style={{ fontSize: "9px" }}>
-                    <span style={{ color: "#5a5e72" }}>CENTRALITY: </span>
-                    <span style={{ color: ec >= 0.5 ? "#ffab00" : "#c8cad0", fontWeight: ec >= 0.5 ? "bold" : "normal" }}>
-                      {(ec * 100).toFixed(0)}%
-                    </span>
-                  </div>
-                  <div style={{ fontSize: "9px" }}>
-                    <span style={{ color: "#5a5e72" }}>DEGREE: </span>
-                    <span style={{ color: "#c8cad0" }}>{metrics.degree}</span>
-                  </div>
-                  <div style={{ fontSize: "9px" }}>
-                    <span style={{ color: "#5a5e72" }}>BETWEENNESS: </span>
-                    <span style={{ color: metrics.betweennessCentrality >= 0.3 ? "#00e5ff" : "#c8cad0" }}>
-                      {(metrics.betweennessCentrality * 100).toFixed(0)}%
-                    </span>
-                  </div>
-                  <div style={{ fontSize: "9px" }}>
-                    <span style={{ color: "#5a5e72" }}>CLUSTERING: </span>
-                    <span style={{ color: "#c8cad0" }}>{metrics.clusteringCoeff.toFixed(2)}</span>
-                  </div>
-                </div>
-                <div style={{ fontSize: "8px", color: "#5a5e72", marginTop: "5px", fontStyle: "italic" }}>
-                  {getCentralityLabel(ec)} — size ∝{" "}
-                  {nodeSizeMetric === "omega"
-                    ? "ΩF composite"
-                    : nodeSizeMetric === "betweenness"
-                      ? "betweenness centrality"
-                      : "eigenvector centrality"}
-                </div>
-              </div>
-            )}
-
-            {/* Metadata */}
-            <div style={{ borderTop: "1px solid rgba(90, 94, 114, 0.2)", paddingTop: "8px", display: "flex", flexDirection: "column", gap: "3px" }}>
-              <div style={{ fontSize: "9px" }}>
-                <span style={{ color: "#5a5e72" }}>CONCENTRATION: </span>
-                <span style={{ color: "#c8cad0" }}>{node.globalConcentration}</span>
-              </div>
-              <div style={{ fontSize: "9px" }}>
-                <span style={{ color: "#5a5e72" }}>REPLACEMENT: </span>
-                <span style={{ color: "#c8cad0" }}>{node.replacementTime}</span>
-              </div>
-              {node.physicalConstraint && (
-                <div style={{ fontSize: "9px" }}>
-                  <span style={{ color: "#5a5e72" }}>CONSTRAINT: </span>
-                  <span style={{ color: "#ff6d00" }}>{node.physicalConstraint}</span>
-                </div>
-              )}
-            </div>
-          </div>
-        </Html>
-      )}
     </group>
   );
 }
@@ -495,7 +317,6 @@ function arePropsEqual(prev: DAGNode3DProps, next: DAGNode3DProps) {
   if (prev.isInterventionTarget !== next.isInterventionTarget) return false;
   if (prev.isVerifiedRestricted !== next.isVerifiedRestricted) return false;
   if (prev.isSelected !== next.isSelected) return false;
-  if (prev.isSingleSelected !== next.isSingleSelected) return false;
   if (prev.isNeighborOfSelected !== next.isNeighborOfSelected) return false;
   if (prev.anyNodeSelected !== next.anyNodeSelected) return false;
   if (prev.isConsequence !== next.isConsequence) return false;


### PR DESCRIPTION
## Summary

Three-item batch of UX feedback against the live build:

- **3D: in-canvas detail card removed.** The Html-mounted ~140-line card on `DAGNode3D` is gone. The small floating label above the orb is now the only on-canvas affordance — same gate as before (`!dimmed && !isOrbiting && (hovered || isSelected || isNeighborOfSelected)`). Full ΩF profile / network metrics still surface in `NodeInspector` and `ModulePanel` as side panels. Mirrors 2D's selection pattern. Cleanup: dropped `isSingleSelected` prop, dead helpers (`getBarColor`, `getCentralityLabel`), unused imports, and now-unused locals (`axes`, `selectedDomains`, `profile`, `pillarLabels`).
- **TOPO elevation legend anchored to the peak.** `InSceneElevationLegend` now accepts a `peakAnchor` (translated x/z of the highest-Ω node) and stands the column 12 world units beside it instead of the SE corner of the field. Direct visual comparison: peak's height vs the column's Ω ticks. Cascade replay re-anchors as the peak shifts. Falls back to the SE corner if no anchor is available.
- **Map basemap de-cluttered.** Switched from CARTO `dark_all` to `dark_nolabels` and capped tile `maxzoom` at 6. No more street labels or city names; tiles stop loading new detail at country / sub-region scale, so pinch-zooming further doesn't reveal streets. Same dark theme.

## Test plan

- [ ] In 3D, click any orb — confirm only the small floating title label appears (no detail box). Selection ring + neighbour spotlight still light up.
- [ ] Confirm `NodeInspector` / `ModulePanel` side panels still surface the full ΩF profile after a 3D click.
- [ ] In TOPO, confirm the elevation legend column stands directly beside the highest mountain rather than at a corner. Top tick label aligns at the same height as the peak.
- [ ] Trigger a cascade replay — confirm the legend follows the new peak as the field shifts.
- [ ] Open Map view — confirm no street labels or city names on the basemap. Pinch-zooming further doesn't reveal more detail (basemap pixelates at zoom 6+).

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_