### PR TITLE
feat(tour): lift expandedPillar to store + gate node-inspector step on real interaction

### DIFF
--- a/src/components/NodeInspector.tsx
+++ b/src/components/NodeInspector.tsx
@@ -179,7 +179,12 @@ function PillarRadar({
 // / future verticals each carry their own vocabulary without branching here.
 
 export default function NodeInspector() {
-  const [expandedPillar, setExpandedPillar] = useState<PillarKey | null>(null);
+  // expandedPillar lifted to the zustand store so the onboarding tour
+  // can gate its "click a pillar vertex" step on real interaction.
+  // The store resets it to null whenever selectedNode changes, so we
+  // don't carry an explanation card from a previous node forward.
+  const expandedPillar = useApexStore((s) => s.expandedPillar);
+  const setExpandedPillar = useApexStore((s) => s.setExpandedPillar);
   const [showMethodology, setShowMethodology] = useState(false);
   const [showDataExplainer, setShowDataExplainer] = useState(false);
   const selectedNode = useApexStore((s) => s.selectedNode);

--- a/src/lib/__tests__/store-expanded-pillar.test.ts
+++ b/src/lib/__tests__/store-expanded-pillar.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useApexStore } from "@/stores/useApexStore";
+
+// Per-test reset of the two fields we care about. The store is a
+// module-level singleton in zustand; without resetting the previous
+// test's state would bleed into ours.
+function resetSelection() {
+  useApexStore.setState({ selectedNode: null, expandedPillar: null });
+}
+
+describe("expandedPillar store integration", () => {
+  beforeEach(resetSelection);
+
+  it("starts as null", () => {
+    expect(useApexStore.getState().expandedPillar).toBeNull();
+  });
+
+  it("setExpandedPillar updates the field", () => {
+    useApexStore.getState().setExpandedPillar("irreplaceability");
+    expect(useApexStore.getState().expandedPillar).toBe("irreplaceability");
+  });
+
+  it("changes to selectedNode reset expandedPillar to null", () => {
+    // Simulate the tour state machine: user selects node A, expands the
+    // I pillar, then clicks node B. The explanation card should not
+    // carry over from A — it would read against the previous node's
+    // ΩF values.
+    useApexStore.getState().setSelectedNode("node-a");
+    useApexStore.getState().setExpandedPillar("cascadeLoad");
+    expect(useApexStore.getState().expandedPillar).toBe("cascadeLoad");
+
+    useApexStore.getState().setSelectedNode("node-b");
+    expect(useApexStore.getState().expandedPillar).toBeNull();
+  });
+
+  it("setting selectedNode to its current value preserves expandedPillar", () => {
+    // Re-clicking the same node (a no-op selection) should NOT reset
+    // the explanation card — annoying flicker when the user just
+    // clicks the inspector empty area or a re-render fires the same id.
+    useApexStore.getState().setSelectedNode("node-a");
+    useApexStore.getState().setExpandedPillar("tailDepth");
+    useApexStore.getState().setSelectedNode("node-a");
+    expect(useApexStore.getState().expandedPillar).toBe("tailDepth");
+  });
+
+  it("setSelectedNode(null) resets expandedPillar (deselection)", () => {
+    useApexStore.getState().setSelectedNode("node-a");
+    useApexStore.getState().setExpandedPillar("restorationLatency");
+    useApexStore.getState().setSelectedNode(null);
+    expect(useApexStore.getState().expandedPillar).toBeNull();
+  });
+});

--- a/src/lib/tour-steps.ts
+++ b/src/lib/tour-steps.ts
@@ -135,6 +135,10 @@ const FIRST_RUN_STEPS: TourStep[] = [
           "The inspector centerpiece is a criticality radar pentagon. Composite score (0–10) sits at the center; each vertex carries a pillar letter — I (Irreplaceability of mechanism), R (Restoration latency), J (Regulatory exposure), C (Complication load), T (Outcome tail) — and its score. Click any vertex letter to drop in that pillar's explanation, detail, and formula inline.",
       },
     },
+    awaitInteraction: {
+      hint: "Click any pillar letter (I, R, J, C, T) on the radar to continue.",
+      predicate: (s) => s.expandedPillar !== null,
+    },
   },
   {
     id: "engines-overview",

--- a/src/stores/useApexStore.ts
+++ b/src/stores/useApexStore.ts
@@ -25,7 +25,7 @@ import {
   type TarskiValidationReport,
 } from "@/lib/tarski-data";
 import { applyOmegaLiveAdjustments } from "@/lib/omega-pillar-wiring";
-import { resolveDomainProfile } from "@/lib/domain-profiles";
+import { resolveDomainProfile, type PillarKey } from "@/lib/domain-profiles";
 
 export interface ImportedDataset {
   id: string;
@@ -142,6 +142,15 @@ export interface ApexState {
   // Selected node (focus)
   selectedNode: string | null;
   setSelectedNode: (nodeId: string | null) => void;
+
+  // Which pillar (if any) is expanded inside NodeInspector. Lifted from
+  // NodeInspector local state to the store so the onboarding tour can
+  // gate the "click a pillar vertex" step on real interaction (the
+  // node-inspector step's awaitInteraction predicate reads this).
+  // Reset to null whenever the selected node changes — explanation card
+  // is per-node, not per-app.
+  expandedPillar: PillarKey | null;
+  setExpandedPillar: (key: PillarKey | null) => void;
 
   // Selected edge (for edge inspector popup)
   selectedEdgeId: string | null;
@@ -505,7 +514,17 @@ export const useApexStore = create<ApexState>((set, get) => ({
 
   // Selected node
   selectedNode: null,
-  setSelectedNode: (nodeId) => set({ selectedNode: nodeId }),
+  setSelectedNode: (nodeId) =>
+    set((s) => ({
+      selectedNode: nodeId,
+      // Reset the expanded pillar when the selected node changes; the
+      // explanation card belongs to the previous node and would read
+      // misleadingly against fresh ΩF values.
+      expandedPillar: nodeId === s.selectedNode ? s.expandedPillar : null,
+    })),
+
+  expandedPillar: null,
+  setExpandedPillar: (key) => set({ expandedPillar: key }),
 
   // Selected edge
   selectedEdgeId: null,


### PR DESCRIPTION
## Summary

Closes the open thread "Lift `expandedPillar` from `NodeInspector` local state to the store — would let the node-inspector tour step gate on actual vertex click instead of being descriptive-only."

The node-inspector first-run tour step used to say *"Click any vertex letter to drop in that pillar's explanation"* but didn't actually wait for the click. `expandedPillar` lived in `NodeInspector`'s local `useState`, invisible to the tour state machine, so the step was descriptive-only — the user could just click Next without ever interacting.

Lifting `expandedPillar` to the zustand store closes that gap and slots cleanly into the existing `awaitInteraction` pattern (same shape as `canvas-and-node` waiting on `selectedNode !== null`).

## Files

| File | Change |
|------|--------|
| `src/stores/useApexStore.ts` | New `expandedPillar: PillarKey \| null` + `setExpandedPillar` action. `setSelectedNode` now resets `expandedPillar` to null when the node id actually changes — the explanation card belongs to the previous node and would read misleadingly against fresh ΩF values. Re-clicking the same node preserves `expandedPillar` (avoids flicker). |
| `src/components/NodeInspector.tsx` | useState → store reads. Render output unchanged. Toggle behaviour preserved (clicking same vertex twice closes; clicking another vertex swaps). |
| `src/lib/tour-steps.ts` | `node-inspector` step gains `awaitInteraction` with predicate `s.expandedPillar !== null`. Hint: "Click any pillar letter (I, R, J, C, T) on the radar to continue." |
| `src/lib/__tests__/store-expanded-pillar.test.ts` | 5 tests covering starts-null, set-updates, node-change-resets, same-node-preserves, deselect-resets. |

## Bonus bug fix

The previous local-state pattern hid a small bug: clicking node B with the I pillar expanded from node A would keep showing node A's I-pillar score in the card title even after node B's radar rendered. The reset-on-node-change in the new store action fixes that — the explanation card now follows the selected node rather than persisting across selections.

## Test plan

- [x] 5 new store-expanded-pillar tests pass
- [x] Full vitest suite: 798 / 798 (was 793)
- [x] `npm run build` passes locally with placeholder envs
- [ ] PR-validate workflow green
- [ ] Vercel preview eyeball: open the tour, get to the NODE INSPECTOR step — it should now wait for a pillar click before the Next button activates; the hint should appear in the tooltip footer

## Backwards compat

`NodeInspector`'s render output is unchanged. Existing callers that don't touch `expandedPillar` see no change. The auto-reset on node change is new behaviour — argued as a bug fix above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
