### PR TITLE
feat(profiles): add AI Safety / IDS DomainProfile (Ghauri 2025 integration)

### DIFF
--- a/src/lib/__tests__/registry-profile-coverage.test.ts
+++ b/src/lib/__tests__/registry-profile-coverage.test.ts
@@ -21,10 +21,15 @@ import { getAllEstimatorMeta } from "../criticality-registry";
 import {
   GEOPOLITICAL_PROFILE,
   T1D_PROFILE,
+  AI_SAFETY_PROFILE,
   type EstimatorId,
 } from "../domain-profiles";
 
-const PRODUCTION_PROFILES = [GEOPOLITICAL_PROFILE, T1D_PROFILE];
+const PRODUCTION_PROFILES = [
+  GEOPOLITICAL_PROFILE,
+  T1D_PROFILE,
+  AI_SAFETY_PROFILE,
+];
 
 /**
  * Estimators allowed to be "ready" in the registry without being

--- a/src/lib/domain-profiles.ts
+++ b/src/lib/domain-profiles.ts
@@ -277,6 +277,121 @@ export const T1D_PROFILE: DomainProfile = {
   ],
 };
 
+// ─── AI Safety / IDS — endogenous catastrophic failure in AI systems ─
+//
+// Demonstrates the Ω-Robustness framework from Ghauri (2025) JHU D.Eng.
+// dissertation as a third profile alongside Geopolitical and T1D. Failure
+// mode is endogenous (catastrophic forgetting, χ★-bridge cascade,
+// adversarial drift) rather than exogenous shock. Initial empirical
+// substrate: CICIDS-2017, UNSW-NB15, AWID-H23Q intrusion-detection
+// benchmarks (Chapters 5–8 of the dissertation).
+
+const AI_SAFETY_MODULES: ManifoldModule[] = [
+  {
+    id: "spirtes",
+    name: "TOPOLOGY",
+    subtitle: "Architecture Discovery",
+    description:
+      "Causal DAG learning across attention layers, replay buffers, and training dependencies",
+    icon: "◇",
+    color: "var(--accent-cyan)",
+    status: "ACTIVE",
+  },
+  {
+    id: "tarski",
+    name: "INVARIANTS",
+    subtitle: "Threat-Model Verification",
+    description:
+      "Formal threat-model and deployment-axiom verification — reject inconsistent claims",
+    icon: "⊢",
+    color: "var(--accent-green)",
+    status: "ACTIVE",
+  },
+  {
+    id: "pearl",
+    name: "INTERVENTION",
+    subtitle: "Architectural Counterfactual",
+    description:
+      "do-calculus on architecture — which mechanism if compromised, what fallback restores capability",
+    icon: "⟐",
+    color: "var(--accent-amber)",
+    status: "STANDBY",
+  },
+  {
+    id: "pareto",
+    name: "FRAGILITY",
+    subtitle: "Endogenous Failure Detection",
+    description:
+      "Catastrophic forgetting, adversarial bridging, χ⋆-edge cascade analysis",
+    icon: "⚠",
+    color: "var(--accent-red)",
+    status: "ALERT",
+  },
+];
+
+const AI_SAFETY_PILLARS: PillarLabels = {
+  composite: "ENDOGENOUS FRAGILITY",
+  irreplaceability: "MECHANISM RARITY",
+  restorationLatency: "FORGETTING LATENCY",
+  jurisdictionalHazard: "THREAT-MODEL EXPOSURE",
+  cascadeLoad: "CASCADE SUSCEPTIBILITY",
+  tailDepth: "ADVERSARIAL TAIL DEPTH",
+};
+
+const AI_SAFETY_PILLAR_DETAILS: Record<PillarKey, PillarDetail> = {
+  irreplaceability: {
+    label: AI_SAFETY_PILLARS.irreplaceability,
+    short: "How rare is this AI mechanism — can a deployed alternative substitute under compromise?",
+    detail:
+      "Measures architectural substitutability. A unique attention pattern, training paradigm, or capability scoring 10 means no alternative architecture preserves the function if this mechanism is compromised. A commodity component scoring 2 has many drop-in replacements. Derived from architecture diversity in the model registry, capability uniqueness benchmarks, and Pearl-engine counterfactual substitution analysis.",
+    formula: "I = f(architecture_uniqueness, capability_diversity, drop_in_alternatives)",
+  },
+  restorationLatency: {
+    label: AI_SAFETY_PILLARS.restorationLatency,
+    short: "How costly is recovery from catastrophic forgetting onset?",
+    detail:
+      "Captures the rate of knowledge decay (Forgetting Rate, FR) and reinforcement cost to restore the model after catastrophic forgetting. Nodes with high FR need long retraining cycles or significant rehearsal; nodes with low FR are stable. Drawn from continual-learning evaluation: peak-task performance vs current performance, replay-buffer recovery curves, EWC regularisation cost. Per Ghauri (2025) Chapter 4.",
+    formula: "R = g(forgetting_rate, replay_cost, retraining_horizon)",
+  },
+  jurisdictionalHazard: {
+    label: AI_SAFETY_PILLARS.jurisdictionalHazard,
+    short: "How exposed is this deployment to regulatory, adversarial, or operational threat-models?",
+    detail:
+      "Reflects threat-model exposure: jurisdictions where the model is deployed (EU AI Act, NIST AI RMF), classes of adversaries assumed by the threat model, and regulatory tier. A healthcare deployment under EU AI Act with adversarial-injection threat model scores high; internal-tooling under assumed-friendly users scores low. Tarski engine verifies formal threat-model claims as axioms.",
+    formula: "J = h(regulatory_tier, adversary_class, axiom_verification_score)",
+  },
+  cascadeLoad: {
+    label: AI_SAFETY_PILLARS.cascadeLoad,
+    short: "How structurally vulnerable is this architecture to cross-component cascade failure?",
+    detail:
+      "Topological vulnerability to cross-component cascade. Measured by χ⋆ bridge density (top-5% high-betweenness, CVaR-impact edges identified by Ω-Robustness solvers) and BES (Bridge-Edge Strength) as a temporal indicator that model attention is concentrating on χ⋆ edges — predictive of cascade onset by 0–1 windows in continual-learning settings (Ghauri 2025, Chapter 8 §4.1). Spirtes topology metrics provide the structural baseline; χ⋆ and BES extend it.",
+    formula: "C = density(χ⋆) + temporal_BES(χ⋆) + spirtes_topology",
+  },
+  tailDepth: {
+    label: AI_SAFETY_PILLARS.tailDepth,
+    short: "How severe is the worst-case adversarial outcome under distributional ambiguity?",
+    detail:
+      "Conditional Value-at-Risk under Wasserstein-1 ambiguity ball over plausible adversarial-attack distributions. Captures worst-α% adversarial outcomes (e.g., α = 0.05 for worst 5% of attack scenarios). Strong-duality reformulation gives a tractable convex program even for non-trivial sample sizes (Mohajerin Esfahani & Kuhn 2018; Ghauri 2025 §5.3).",
+    formula: "T = inf_t { t + (1/(αN)) Σ max{ℓ(x, ξ_i) − t, 0} + δ ‖x‖_* }",
+  },
+};
+
+const AI_SAFETY_METHODOLOGY =
+  "The ENDOGENOUS FRAGILITY composite aggregates five orthogonal AI-system risk pillars, each scored 0–10: mechanism rarity, forgetting latency, threat-model exposure, cascade susceptibility, adversarial tail depth. AI-domain weights skew toward C(0.30) and T(0.30) — cascade and tail are the dominant failure modes per Ghauri (2025) — with I(0.10) + R(0.20) + J(0.10) summing the remainder. Scores above 7.0 flag mechanisms worth structural hardening (χ⋆-edge intervention, topology-aware replay); above 9.0 indicates architectural Achilles' heels where compromise cascades across reasoning, memory, and decision subsystems.";
+
+export const AI_SAFETY_PROFILE: DomainProfile = {
+  id: "ai-safety",
+  displayName: "AI Safety / Endogenous Catastrophe",
+  modules: AI_SAFETY_MODULES,
+  pillarLabels: AI_SAFETY_PILLARS,
+  pillarDetails: AI_SAFETY_PILLAR_DETAILS,
+  compositeMethodology: AI_SAFETY_METHODOLOGY,
+  // v1 reuses geopolitical's criticality estimator set as a working fallback.
+  // AI-domain-specific estimators (FR, BES temporal monitoring) arrive in
+  // Phase 3 once Pearl session wires them up.
+  criticalityEstimators: ["csd", "ph", "lppls", "bocpd"],
+};
+
 // ─── Resolution ─────────────────────────────────────────────────────
 
 const PROFILES_BY_DOMAIN_ID: Record<string, DomainProfile> = {
@@ -295,6 +410,8 @@ const PROFILES_BY_DOMAIN_ID: Record<string, DomainProfile> = {
   // Life sciences
   "t1d-beta-cell": T1D_PROFILE,
   "t1d-vx880": T1D_PROFILE,
+  // AI Safety / endogenous catastrophe (Ghauri 2025 D.Eng. dissertation)
+  "ai-safety-ids": AI_SAFETY_PROFILE,
 };
 
 export function resolveDomainProfile(


### PR DESCRIPTION
## Summary

Adds **AI Safety / IDS** as a third `DomainProfile` alongside Geopolitical and T1D, demonstrating the Ω-Robustness framework from Junaid's JHU D.Eng. dissertation (Ghauri 2025) as a Manifold profile.

## What this PR does

- **`AI_SAFETY_PROFILE`** in `domain-profiles.ts` with the full pattern matched against `GEOPOLITICAL_PROFILE` and `T1D_PROFILE`:
  - **Modules**: TOPOLOGY (spirtes) / INVARIANTS (tarski) / INTERVENTION (pearl) / FRAGILITY (pareto) — domain-resonant labels for the same four engines.
  - **Pillar labels**: I = Mechanism Rarity, R = Forgetting Latency, J = Threat-Model Exposure, C = Cascade Susceptibility, T = Adversarial Tail Depth.
  - **Pillar details**: full short / detail / formula entries grounded in the dissertation. Pillar T's formula is the formal CVaR-W₁ closed form (Mohajerin Esfahani & Kuhn 2018, dissertation §5.3); Pillar C references χ⋆ bridge density and BES temporal monitoring (dissertation Chapter 8 §4.1).
  - **Methodology copy**: AI-domain weights skew toward C(0.30) + T(0.30) — cascade and tail are the dominant endogenous failure modes per the dissertation. I(0.10) + R(0.20) + J(0.10) take the remainder.
  - **Default estimators**: v1 reuses `[csd, ph, lppls, bocpd]` as a working fallback. Domain-specific estimators (FR / BES / χ⋆ / CVaR-W₁) arrive in follow-on PRs once engine sessions land them.

- **Domain ID `ai-safety-ids`** mapped to the new profile in `PROFILES_BY_DOMAIN_ID`.

- **`registry-profile-coverage.test.ts`** updated: `AI_SAFETY_PROFILE` joins `PRODUCTION_PROFILES` so the registry-vs-profile coverage contract enforces consistency on the new profile.

## What this PR does NOT do

- Doesn't add a DomainSelector card → profile is exported and wired in `PROFILES_BY_DOMAIN_ID` but not yet user-selectable in the UI. Next PR.
- Doesn't add graph data for AI Safety nodes (the ~17 nodes from the spec — CICIDS-2017, UNSW-NB15, AWID-H23Q datasets + attack classes + IDS components). Next PR.
- Doesn't add cross-domain edges to Geopolitical. Next PR.
- Doesn't ship FR, BES, χ⋆, or CVaR-W₁ estimators — those are the Phase 1/3 engine-session specs (separate Drive docs).

## Test plan

- [x] `vitest run src/lib/__tests__/registry-profile-coverage.test.ts` — 3 tests pass (registry-vs-AI_SAFETY_PROFILE coverage check passes).
- [x] Full suite — `vitest run` — 793 passing, no regressions.
- [x] tsc --noEmit on `src/lib/domain-profiles.ts` clean.

## Sequence

This is **PR 1 of ~4** for the AI Safety vertical:
1. **(this PR)** Profile entry + domain ID mapping.
2. Graph data — ~17 nodes (datasets / attack classes / IDS components) in `graph-data.ts`.
3. Cross-domain edges to Geopolitical (DDoS / Wireless Injection anchors).
4. DomainSelector card + DOMAIN_MAP entry + getDomainColor — UI plumbing.

Spec doc: [AI Safety / IDS DomainProfile — Spec (May 2026)](https://docs.google.com/document/d/1hKdtUy_XLbbM4SBQGkMjjHq4UD0aVhVXUGWLJUVTl68/edit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)