### PR TITLE
feat(graph): cross-domain edges from AI Safety to Infrastructure / Financial (3)

### DIFF
--- a/src/lib/graph-data.ts
+++ b/src/lib/graph-data.ts
@@ -3244,6 +3244,15 @@ const EDGES: CausalEdge[] = [
   { id: "ais_replay_buffer__ais_gat", source: "ais_replay_buffer", target: "ais_gat", weight: 0.65, lag: 1, type: "temporal", confidence: 0.8, isInconsistent: false, physicalMechanism: "Replay buffer feeds rehearsal samples back into the next-window training batch. Closes the topology-aware-replay loop; halves catastrophic forgetting in Ch 8 §6 experiments." },
   { id: "ais_gat__ais_eval_harness", source: "ais_gat", target: "ais_eval_harness", weight: 0.85, lag: 0, type: "directed", confidence: 0.9, isInconsistent: false, physicalMechanism: "Evaluation harness reads GAT predictions per window and computes FR, BES, HES, and F1 trajectories." },
   { id: "ais_eval_harness__ais_replay_buffer", source: "ais_eval_harness", target: "ais_replay_buffer", weight: 0.6, lag: 1, type: "temporal", confidence: 0.75, isInconsistent: false, physicalMechanism: "FR / BES outputs inform the next-window replay-buffer sampling weights — closing the structure-aware feedback loop between evaluation and training." },
+
+  // ── AI Safety / IDS ↔ Infrastructure / Financial cross-domain links (3) ──
+  // The IDS attack classes aren't only academic — they're the realised
+  // threat vectors that drive systemic-risk events in the geopolitical
+  // graph. DDoS targets telecom hubs → cascading latency; MITM targets
+  // cross-border banking → financial-message integrity loss.
+  { id: "ais_attack_ddos__ic_telecom_egypt", source: "ais_attack_ddos", target: "ic_telecom_egypt", weight: 0.55, lag: 1, type: "directed", confidence: 0.7, isInconsistent: false, physicalMechanism: "DDoS attacks target telecom-aggregation hubs (Telecom Egypt's 10 landing stations are a high-value target by traffic concentration). Successful saturation cascades to all transit cables landing there." },
+  { id: "ais_attack_ddos__ic_latency_risk", source: "ais_attack_ddos", target: "ic_latency_risk", weight: 0.6, lag: 1, type: "directed", confidence: 0.75, isInconsistent: false, physicalMechanism: "Volumetric DDoS against transit infrastructure produces measurable latency spikes — the same risk surface measured by ic_latency_risk for cable-failure scenarios." },
+  { id: "ais_attack_mitm__fc_cross_border_banking", source: "ais_attack_mitm", target: "fc_cross_border_banking", weight: 0.5, lag: 1, type: "directed", confidence: 0.65, isInconsistent: false, physicalMechanism: "MITM attacks targeting interbank message integrity (SWIFT, downgrade, downgrade-after-handshake) erode the trust assumptions cross-border settlement depends on. Manifests as latency + reconciliation drift in the financial-contagion graph." },
 ];
 
 const METADATA: GraphMetadata = {


### PR DESCRIPTION
## Summary

PR 3 of the AI Safety / IDS thesis-integration series. Adds three cross-domain edges from the AI Safety attack-class nodes into the existing geopolitical risk graph.

## Why

The IDS attack classes from the dissertation's case studies aren't only academic — they're the realised threat vectors that drive systemic-risk events in the geopolitical graph. Wiring them as outgoing edges from the AI Safety domain into Infrastructure / Financial Contagion makes the connection explicit and lets the cascade simulator propagate from cyber attack class through to economic / infrastructure consequence.

## Edges (3)

| Source (AI Safety) | Target (Geopolitical) | Mechanism |
|---|---|---|
| `ais_attack_ddos` | `ic_telecom_egypt` | DDoS targets telecom-aggregation hubs; Telecom Egypt's 10 landing stations carry 15+ cables — single-point saturation cascades to all transit cables |
| `ais_attack_ddos` | `ic_latency_risk` | Volumetric DDoS produces measurable latency spikes — same risk surface measured for cable-failure scenarios |
| `ais_attack_mitm` | `fc_cross_border_banking` | MITM on interbank messaging (SWIFT, downgrade, post-handshake) erodes settlement trust; manifests as latency + reconciliation drift in the financial-contagion graph |

All three target nodes already exist in the geopolitical graph:
- `fc_cross_border_banking` @ line 1080
- `ic_telecom_egypt` @ line 1502
- `ic_latency_risk` @ line 1642

## What this PR does NOT do

- Doesn't add a DomainSelector card → AI Safety domain still not user-selectable. Final PR in series.
- Doesn't add ATHENA-domain edges (Drone Swarms / SATCOM / Kill Chain) — those nodes live in `athena-graph-data.ts` rather than `graph-data.ts`. Separate concern; defer.

## Test plan

- [x] `tsc --noEmit src/lib/graph-data.ts` clean.
- [x] `vitest run` — 798 passing, no regressions.
- [x] All three target node IDs verified to exist in `graph-data.ts`.

## Sequence

PR 1 ([#274](https://github.com/ApexAnalytica/apex-terminal/pull/274)) ✅ profile entry.
PR 2 ([#275](https://github.com/ApexAnalytica/apex-terminal/pull/275)) ✅ graph data (17 nodes + 18 internal edges).
**PR 3 (this) — cross-domain edges (3).**
PR 4 — DomainSelector card + DOMAIN_MAP entry — makes the domain user-selectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
