### PR TITLE
feat(domains): make AI Safety / IDS user-selectable (UI plumbing)

### DIFF
--- a/src/hooks/useFilteredGraph.ts
+++ b/src/hooks/useFilteredGraph.ts
@@ -39,6 +39,10 @@ export const DOMAIN_MAP: Record<string, string[]> = {
   // VX-880 stem-cell islet transplant subgraph — every node in
   // t1d-vx880-graph-data.ts carries domain "T1D VX-880".
   "t1d-vx880": ["T1D VX-880"],
+  // AI Safety / IDS — continual-learning intrusion detection substrate
+  // from Ghauri 2025 D.Eng. dissertation. 17 nodes (3 datasets, 9 attack
+  // classes, 5 IDS components) all carry domain "AI Safety / IDS".
+  "ai-safety-ids": ["AI Safety / IDS"],
 };
 
 /**

--- a/src/lib/domains.ts
+++ b/src/lib/domains.ts
@@ -50,8 +50,9 @@ export const PERSONA_GROUPS: Record<Persona, Set<string>> = {
     "MENA ENERGY & COMMODITIES",
     "INFRASTRUCTURE & DEFENSE",
     "FINANCIAL & SOVEREIGN",
+    "AI SAFETY",
   ]),
-  scientist: new Set(["LIFE SCIENCES", "FRONTIER"]),
+  scientist: new Set(["LIFE SCIENCES", "FRONTIER", "AI SAFETY"]),
   cross: new Set([
     "MENA ENERGY & COMMODITIES",
     "FINANCIAL & SOVEREIGN",
@@ -59,6 +60,7 @@ export const PERSONA_GROUPS: Record<Persona, Set<string>> = {
     "MACRO IMPACT",
     "LIFE SCIENCES",
     "FRONTIER",
+    "AI SAFETY",
   ]),
 };
 
@@ -200,6 +202,22 @@ export const DOMAIN_GROUPS: DomainGroup[] = [
         description: "Vertex VX-880 trial topology: HLA/autoantibody risk → dose + immunosuppression → engraftment → graft β-mass → MMTT / insulin-independence / severe-hypo endpoints",
         hasData: true,
         dataset: "vx880",
+      },
+    ],
+  },
+  {
+    label: "AI SAFETY",
+    color: "#7B68EE",
+    domains: [
+      {
+        id: "ai-safety-ids",
+        label: "AI Safety / Endogenous Catastrophe",
+        icon: "\u{1F9E0}",
+        color: "#7B68EE",
+        colorVar: "var(--accent-violet)",
+        description: "Catastrophic forgetting in continual-learning IDS, χ★-bridge cascade, adversarial drift — built from CICIDS-2017 / UNSW-NB15 / AWID-H23Q substrate (Ghauri 2025 D.Eng.)",
+        hasData: true,
+        dataset: "main",
       },
     ],
   },


### PR DESCRIPTION
## Summary

Final PR of the AI Safety / IDS thesis-integration series. Wires the graph-data + profile + cross-domain edges from PRs 1–3 into the DomainSelector so users can actually pick the domain in the UI.

## What changed

### `src/lib/domains.ts`
- New `AI SAFETY` DomainGroup with color `#7B68EE` (medium slate violet, distinct from the existing palette), placed between `LIFE SCIENCES` and `FRONTIER`.
- Single DomainCard inside it:

  | field | value |
  |---|---|
  | `id` | `ai-safety-ids` |
  | `label` | `AI Safety / Endogenous Catastrophe` |
  | `icon` | 🧠 (`U+1F9E0`) |
  | `description` | Catastrophic forgetting in continual-learning IDS, χ★-bridge cascade, adversarial drift — built from CICIDS-2017 / UNSW-NB15 / AWID-H23Q substrate (Ghauri 2025 D.Eng.) |
  | `dataset` | `main` |
  | `hasData` | `true` |

- `PERSONA_GROUPS` extension (already in this branch) surfaces `"AI SAFETY"` in the **geopolitical**, **scientist**, and **cross** personas — matching the cross-cutting nature of the IDS attack-class → geopolitical-cascade story from PR 3.

### `src/hooks/useFilteredGraph.ts`
- `DOMAIN_MAP` entry: `"ai-safety-ids": ["AI Safety / IDS"]` — maps the selector ID to the graph-node `domain` field that all 17 `ais_*` nodes from PR 2 carry.

## Why this is the last PR in the series

| PR | What it shipped | User-visible? |
|---|---|---|
| [#274](https://github.com/ApexAnalytica/apex-terminal/pull/274) | `AI_SAFETY_PROFILE` + domain ID mapping | No (registry only) |
| [#275](https://github.com/ApexAnalytica/apex-terminal/pull/275) | 17 nodes + 18 internal edges + `getDomainColor` | No (data not selectable) |
| [#276](https://github.com/ApexAnalytica/apex-terminal/pull/276) | 3 cross-domain edges into geopolitical graph | No (data not selectable) |
| **#4 (this)** | DomainSelector card + DOMAIN_MAP entry | **Yes** |

After this lands, picking "AI Safety / Endogenous Catastrophe" in the DomainSelector renders the IDS substrate plus the cross-domain bridges into Telecom Egypt / latency risk / cross-border banking.

## Test plan

- [x] `vitest run` — **798 passing**, no regressions.
- [x] `tsc --noEmit` clean for both edited files (the 3 pre-existing unrelated module errors in `next.config.ts`, `route.ts`, `layout.tsx` are not introduced by this change).
- [x] DOMAIN_MAP target string `"AI Safety / IDS"` matches the `domain` field on the 17 `ais_*` nodes shipped in PR #275.

## Series complete

PR 1 ([#274](https://github.com/ApexAnalytica/apex-terminal/pull/274)) ✅ profile entry.
PR 2 ([#275](https://github.com/ApexAnalytica/apex-terminal/pull/275)) ✅ graph data (17 nodes + 18 internal edges).
PR 3 ([#276](https://github.com/ApexAnalytica/apex-terminal/pull/276)) ✅ cross-domain edges (3).
**PR 4 (this) — DomainSelector card + DOMAIN_MAP. Series done.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
