### PR TITLE
feat(website): source-tracking on /access + 4-col homepage // DOMAINS

### DIFF
--- a/website/src/app/access/AccessForm.tsx
+++ b/website/src/app/access/AccessForm.tsx
@@ -1,7 +1,18 @@
 "use client";
 
-import { useActionState } from "react";
+import { useActionState, useEffect, useState } from "react";
 import { submitAccessRequest, type AccessResult } from "./actions";
+
+/**
+ * Recognized `?source=` values surfaced in the form submission so
+ * the inbound email tells Junaid which offer the visitor came in
+ * on. Values not in this map are dropped (defense against random
+ * URL-injected source strings landing in inboxes).
+ */
+const SOURCE_LABELS: Record<string, string> = {
+  "founding-10": "Founding 10 (apex.founding)",
+  "mini-audit": "ΩF Mini-Audit (apex.audit)",
+};
 
 const DOMAINS = [
   { value: "", label: "Select a domain (optional)" },
@@ -20,6 +31,25 @@ export default function AccessForm() {
     submitAccessRequest,
     null,
   );
+
+  // Read `?source=` from the URL on mount and stash it in a hidden
+  // input below. Server action picks it up and includes it in the
+  // email body so we know whether the visitor came in via /founding,
+  // /audit, or directly. Whitelist-validated against SOURCE_LABELS
+  // so random / injected values don't propagate.
+  const [source, setSource] = useState<string>("");
+  const [sourceLabel, setSourceLabel] = useState<string>("");
+  useEffect(() => {
+    try {
+      const raw = new URLSearchParams(window.location.search).get("source") ?? "";
+      if (raw && SOURCE_LABELS[raw]) {
+        setSource(raw);
+        setSourceLabel(SOURCE_LABELS[raw]);
+      }
+    } catch {
+      /* SSR / no-window — leave empty. */
+    }
+  }, []);
 
   if (state?.ok) {
     return (
@@ -44,6 +74,25 @@ export default function AccessForm() {
 
   return (
     <form action={formAction} className="space-y-5" noValidate>
+      {/* Source hidden field — captured from ?source= URL param above
+          and posted with the form so the email tells Junaid which
+          offer brought the visitor in (Founding 10, Mini-Audit). */}
+      <input type="hidden" name="source" value={source} />
+
+      {/* Visible source banner — confirms to the visitor that we
+          know they came in from the offer they clicked, so the form
+          doesn't feel like a generic dead-end. */}
+      {sourceLabel && (
+        <div className="flex items-center gap-2 px-3 py-2 border border-accent-cyan/30 bg-accent-cyan/5 rounded">
+          <span className="h-1.5 w-1.5 rounded-full bg-accent-cyan" />
+          <span className="font-mono text-[11px] text-accent-cyan/90 leading-tight">
+            Coming in from{" "}
+            <span className="text-accent-cyan">{sourceLabel}</span> — we&apos;ll
+            handle the next step manually until checkout is wired.
+          </span>
+        </div>
+      )}
+
       {/* Honeypot — hidden from humans, bots fill it in */}
       <div aria-hidden className="hidden" style={{ display: "none" }}>
         <label>

--- a/website/src/app/access/actions.ts
+++ b/website/src/app/access/actions.ts
@@ -25,6 +25,18 @@ const DOMAIN_OPTIONS = new Set([
   "other",
 ]);
 
+/**
+ * Recognized `source` values forwarded from the form's hidden field
+ * (populated client-side from `?source=` in the URL on /founding +
+ * /audit pages). Used to flag the email subject + body so Junaid
+ * can immediately see which offer the request came from. Mirrors
+ * SOURCE_LABELS in AccessForm.tsx — keep in sync.
+ */
+const SOURCE_LABELS: Record<string, string> = {
+  "founding-10": "Founding 10",
+  "mini-audit": "ΩF Mini-Audit",
+};
+
 function s(value: FormDataEntryValue | null, max = 2000): string {
   if (typeof value !== "string") return "";
   return value.trim().slice(0, max);
@@ -46,6 +58,8 @@ export async function submitAccessRequest(
   const org = s(formData.get("org"), 200);
   const domain = s(formData.get("domain"), 64).toLowerCase();
   const useCase = s(formData.get("useCase"), 4000);
+  const sourceRaw = s(formData.get("source"), 64);
+  const sourceLabel = SOURCE_LABELS[sourceRaw] ?? "";
 
   if (!name) return { ok: false, error: "Please enter your name." };
   if (!email || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
@@ -57,7 +71,7 @@ export async function submitAccessRequest(
   if (!apiKey) {
     console.error(
       "[access] RESEND_API_KEY not set — email NOT sent. Submission:",
-      { name, email, org, domain: safeDomain, useCase },
+      { name, email, org, domain: safeDomain, useCase, source: sourceLabel || sourceRaw },
     );
     return {
       ok: false,
@@ -65,8 +79,17 @@ export async function submitAccessRequest(
     };
   }
 
-  const subject = `[Manifold] Access request — ${org || name}`;
+  // Subject line gets a [Founding 10] / [ΩF Mini-Audit] prefix when
+  // the visitor came in via one of those offer pages, so the inbox
+  // sorts cleanly without having to read the body.
+  const subjectPrefix = sourceLabel ? `[${sourceLabel}] ` : "[Manifold] ";
+  const subject = `${subjectPrefix}Access request — ${org || name}`;
+
   const lines = [
+    sourceLabel
+      ? `>> ROUTING: ${sourceLabel} (visitor clicked the primary CTA on /${sourceRaw === "founding-10" ? "founding" : "audit"})`
+      : "",
+    sourceLabel ? "" : null,
     `Name: ${name}`,
     `Email: ${email}`,
     `Organization: ${org || "(not provided)"}`,
@@ -76,8 +99,10 @@ export async function submitAccessRequest(
     useCase || "(not provided)",
     "",
     "—",
-    `Submitted via ${SITE.platformUrl} access form.`,
-  ];
+    sourceLabel
+      ? `Submitted via the ${sourceLabel} order CTA on apexanalytica.co. Stripe checkout for this offer is not yet wired — handle this submission manually (send Stripe invoice or similar).`
+      : `Submitted via ${SITE.platformUrl} access form.`,
+  ].filter((line): line is string => line !== null);
 
   try {
     const res = await fetch("https://api.resend.com/emails", {

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -213,7 +213,13 @@ export default function Home() {
           for it — in plain terms, before any of the math.
         </p>
 
-        <div className="grid gap-3 grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-7">
+        {/* 8 tiles in 2 rows of 4 at lg (was lg:grid-cols-7 with 7
+            tiles — now we have 8 with insurance added, so the
+            7-col layout was wrapping the 8th tile to a row of its
+            own AND squeezing every tile to ~167px which clipped the
+            longer labels MANUFACTURING / INFRASTRUCTURE). 4 cols
+            gives each tile ~290px and the labels breathe. */}
+        <div className="grid gap-3 grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-4">
           {DOMAINS.map((d) => (
             <Link
               key={d.label}


### PR DESCRIPTION
## Summary

Two follow-ups on top of the just-merged #269.

### 1. Source-tracking on /access

While Stripe is unwired, primary CTAs on /founding and /audit route to `/access?source=founding-10` (or `mini-audit`) via `offerCheckoutHref()`. The form was *receiving* the source param in the URL but not *propagating* it into the email — Junaid had no way to tell whether an inbound submission came from a Founding 10 click, a Mini-Audit click, or a generic access request.

This patch:

- **Client** (`AccessForm.tsx`): on mount, read `?source=` from `window.location.search`, validate against a `SOURCE_LABELS` whitelist, populate a hidden `<input name="source">` plus a visible cyan banner: "Coming in from Founding 10 (apex.founding) — we'll handle the next step manually until checkout is wired."
- **Server** (`actions.ts`): pick up `source` from formData, validate against the same whitelist. Subject line gets a `[Founding 10]` / `[ΩF Mini-Audit]` prefix; body gets a `>> ROUTING:` flag at the top + a closing line flagging that the submission needs manual Stripe-invoice fulfillment.
- Whitelist-only — any random / injected source value is rejected silently.

### 2. Homepage // DOMAINS goes 4-col at lg

Two stacked issues:
- Grid was `lg:grid-cols-7` from when there were 7 domains. Insurance was added in #257, so 8 tiles in 7 columns left the 8th wrapping to a row by itself.
- Each tile was ~167px wide, clipping `MANUFACTURING` and `INFRASTRUCTURE` even with the tightened tracking from `2d98076`.

Fix: `lg:grid-cols-7` → `lg:grid-cols-4`. 8 tiles in 2 rows of 4 at lg, ~290px per tile, labels fit cleanly.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `/access?source=founding-10` renders the cyan source banner with 'Founding 10' label; hidden input value `founding-10`
- [x] `/access?source=mini-audit` same with the audit label
- [x] `/access?source=hax0r-injection` shows no banner, hidden input empty (whitelist worked)
- [x] `/access` plain (no param) renders the form unchanged
- [x] Homepage // DOMAINS: 8 tiles, all-same width, MANUFACTURING + INFRASTRUCTURE not clipping (`scrollWidth === clientWidth`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)