### PR TITLE
feat(estimators): add CVaR-W₁ — canonical Tail Depth pillar estimator

### DIFF
--- a/src/lib/__tests__/estimators/cvar-w1.test.ts
+++ b/src/lib/__tests__/estimators/cvar-w1.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import { cvarW1, tailDepthScore } from "@/lib/estimators/cvar-w1";
+
+// Tests cover:
+//   1. Closed-form analytic cases (uniform sample, single-tail spike).
+//   2. The Mohajerin Esfahani & Kuhn (2018) W₁ adjustment identity:
+//        robust = empirical + L · ε / (1 − α).
+//   3. Edge handling (αn integer vs non-integer, k clamps, lipschitz).
+//   4. Argument validation (empty, NaN, out-of-range α / radius).
+
+describe("cvarW1 — empirical CVaR closed form", () => {
+  it("uniform 1..10, α=0.9 → tail mean of {10}", () => {
+    const samples = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    // αn = 9, k = ⌈9⌉ = 9, x_(9) = 9, tailSum = x_(10) = 10.
+    // CVaR = ((9 − 9) · 9 + 10) / ((1 − 0.9) · 10) = 10 / 1 = 10.
+    const r = cvarW1(samples, { alpha: 0.9 });
+    expect(r.empirical).toBeCloseTo(10, 12);
+    expect(r.varEmpirical).toBe(9);
+    expect(r.n).toBe(10);
+  });
+
+  it("uniform 1..10, α=0.8 → mean of strict upper tail {9, 10}", () => {
+    const samples = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    // αn = 8, k = 8. (k − αn) = 0. tailSum = 9 + 10 = 19. CVaR = 19/2 = 9.5.
+    const r = cvarW1(samples, { alpha: 0.8 });
+    expect(r.empirical).toBeCloseTo(9.5, 12);
+    expect(r.varEmpirical).toBe(8);
+  });
+
+  it("non-integer αn interpolates the boundary order statistic", () => {
+    const samples = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    // α = 0.85, αn = 8.5, k = 9, x_(9) = 9. tailSum = 10.
+    // CVaR = ((9 − 8.5) · 9 + 10) / ((1 − 0.85) · 10) = (4.5 + 10) / 1.5
+    //      = 14.5 / 1.5 ≈ 9.6667.
+    const r = cvarW1(samples, { alpha: 0.85 });
+    expect(r.empirical).toBeCloseTo(14.5 / 1.5, 12);
+    expect(r.varEmpirical).toBe(9);
+  });
+
+  it("CVaR ≥ VaR always", () => {
+    // Random-ish but deterministic sample.
+    const samples = [3.2, -1.1, 5.7, 0.4, 9.8, 2.0, 4.6, -0.3, 7.1, 6.5];
+    for (const a of [0.5, 0.75, 0.9, 0.95]) {
+      const r = cvarW1(samples, { alpha: a });
+      expect(r.empirical).toBeGreaterThanOrEqual(r.varEmpirical - 1e-12);
+    }
+  });
+
+  it("CVaR is monotone non-decreasing in α", () => {
+    const samples = [-2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    let prev = -Infinity;
+    for (const a of [0.5, 0.6, 0.7, 0.8, 0.9, 0.95]) {
+      const r = cvarW1(samples, { alpha: a });
+      expect(r.empirical).toBeGreaterThanOrEqual(prev - 1e-12);
+      prev = r.empirical;
+    }
+  });
+
+  it("does not mutate the input array", () => {
+    const samples = [3, 1, 4, 1, 5, 9, 2, 6, 5, 3];
+    const copy = samples.slice();
+    cvarW1(samples, { alpha: 0.9 });
+    expect(samples).toEqual(copy);
+  });
+});
+
+describe("cvarW1 — W₁ ambiguity adjustment (Mohajerin Esfahani & Kuhn 2018)", () => {
+  const samples = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+  it("radius = 0 → robust equals empirical", () => {
+    const r = cvarW1(samples, { alpha: 0.9, radius: 0 });
+    expect(r.robust).toBe(r.empirical);
+  });
+
+  it("robust = empirical + ε / (1 − α) when L = 1", () => {
+    const a = 0.9;
+    const eps = 0.5;
+    const r = cvarW1(samples, { alpha: a, radius: eps });
+    expect(r.robust - r.empirical).toBeCloseTo(eps / (1 - a), 12);
+  });
+
+  it("robust scales linearly with the Lipschitz constant", () => {
+    const a = 0.95;
+    const eps = 0.25;
+    const r1 = cvarW1(samples, { alpha: a, radius: eps, lipschitz: 1 });
+    const r3 = cvarW1(samples, { alpha: a, radius: eps, lipschitz: 3 });
+    expect(r3.robust - r1.robust).toBeCloseTo(
+      (2 * eps) / (1 - a),
+      12,
+    );
+  });
+
+  it("ambiguity term blows up as α → 1", () => {
+    const eps = 0.1;
+    const a09 = cvarW1(samples, { alpha: 0.9, radius: eps });
+    const a099 = cvarW1(samples, { alpha: 0.99, radius: eps });
+    const term09 = a09.robust - a09.empirical;
+    const term099 = a099.robust - a099.empirical;
+    expect(term099).toBeGreaterThan(term09);
+    expect(term099 / term09).toBeCloseTo((1 - 0.9) / (1 - 0.99), 8);
+  });
+});
+
+describe("cvarW1 — argument validation", () => {
+  it("rejects empty samples", () => {
+    expect(() => cvarW1([], { alpha: 0.9 })).toThrow(/empty/);
+  });
+
+  it("rejects α outside (0, 1)", () => {
+    expect(() => cvarW1([1, 2, 3], { alpha: 0 })).toThrow(/alpha/);
+    expect(() => cvarW1([1, 2, 3], { alpha: 1 })).toThrow(/alpha/);
+    expect(() => cvarW1([1, 2, 3], { alpha: -0.1 })).toThrow(/alpha/);
+    expect(() => cvarW1([1, 2, 3], { alpha: 1.5 })).toThrow(/alpha/);
+  });
+
+  it("rejects negative radius", () => {
+    expect(() =>
+      cvarW1([1, 2, 3], { alpha: 0.9, radius: -0.01 }),
+    ).toThrow(/radius/);
+  });
+
+  it("rejects non-positive Lipschitz constant", () => {
+    expect(() =>
+      cvarW1([1, 2, 3], { alpha: 0.9, lipschitz: 0 }),
+    ).toThrow(/lipschitz/);
+    expect(() =>
+      cvarW1([1, 2, 3], { alpha: 0.9, lipschitz: -1 }),
+    ).toThrow(/lipschitz/);
+  });
+
+  it("rejects NaN samples", () => {
+    expect(() =>
+      cvarW1([1, 2, NaN, 4], { alpha: 0.9 }),
+    ).toThrow(/NaN/);
+  });
+});
+
+describe("tailDepthScore", () => {
+  it("clamps below floor to 0", () => {
+    expect(tailDepthScore(-5, 0, 10)).toBe(0);
+    expect(tailDepthScore(0, 0, 10)).toBe(0);
+  });
+
+  it("clamps above ceiling to 10", () => {
+    expect(tailDepthScore(15, 0, 10)).toBe(10);
+    expect(tailDepthScore(10, 0, 10)).toBe(10);
+  });
+
+  it("interpolates linearly inside the interval", () => {
+    expect(tailDepthScore(5, 0, 10)).toBeCloseTo(5, 12);
+    expect(tailDepthScore(2.5, 0, 10)).toBeCloseTo(2.5, 12);
+    expect(tailDepthScore(7.5, 0, 10)).toBeCloseTo(7.5, 12);
+  });
+
+  it("works on shifted scales", () => {
+    expect(tailDepthScore(0, -10, 10)).toBeCloseTo(5, 12);
+    expect(tailDepthScore(-5, -10, 10)).toBeCloseTo(2.5, 12);
+  });
+
+  it("rejects degenerate ranges", () => {
+    expect(() => tailDepthScore(5, 10, 0)).toThrow(/ceiling/);
+    expect(() => tailDepthScore(5, 5, 5)).toThrow(/ceiling/);
+  });
+});

--- a/src/lib/estimators/cvar-w1.ts
+++ b/src/lib/estimators/cvar-w1.ts
@@ -1,0 +1,175 @@
+// CVaR-W₁ — Conditional Value-at-Risk under Wasserstein-1 ambiguity.
+// Canonical Tail Depth pillar estimator for the Ω-Robustness framework
+// (Ghauri 2025, D.Eng. dissertation, Ch. 4 §3).
+//
+// Empirical α-CVaR of a loss sample {x_1, …, x_n} (sorted ascending,
+// k = ⌈αn⌉):
+//
+//   CVaR_α(X̂) = (1 / ((1−α) n)) · [(k − αn) · x_(k) + Σ_{i=k+1}^n x_(i)]
+//
+// Robust CVaR over a W₁ ambiguity ball of radius ε around the empirical
+// distribution — Mohajerin Esfahani & Kuhn (2018), Theorem 6.3 closed
+// form, specialised to the ReLU envelope (·)_+ that defines CVaR. For a
+// loss with Lipschitz constant L_ℓ:
+//
+//   sup_{Q ∈ B_ε^{W₁}(P̂_n)} CVaR_α(ℓ; Q)
+//     = CVaR_α(ℓ; P̂_n) + (L_ℓ · ε) / (1 − α)
+//
+// Identity loss (L_ℓ = 1) is the default — caller passes in samples that
+// already have the loss applied. For non-identity ℓ, pass `lipschitz` so
+// the ambiguity term scales correctly. Setting `radius = 0` reduces to
+// the empirical estimator.
+//
+// Why it sits at the Tail Depth pillar: ΩF's T pillar measures
+// adversarial / worst-case loss in the tail, and CVaR is the standard
+// coherent risk measure for that. The W₁ ball is the canonical way to
+// hedge against the empirical distribution being wrong by a bounded
+// amount in transport cost — the ε term is the "ambiguity premium" that
+// converts a sample-CVaR into a distributionally-robust one.
+//
+// No external deps. O(n log n) from the sort.
+
+export interface CvarW1Options {
+  /**
+   * Confidence level α ∈ (0, 1). Conventional choices: 0.95 (95% tail),
+   * 0.99 (deeper / more conservative).
+   */
+  alpha: number;
+  /**
+   * W₁ ambiguity-ball radius ε ≥ 0. Set to 0 to recover the pure
+   * empirical CVaR. Calibration is domain-specific — typical practice
+   * is ε = c · n^{-1/d} where d is sample dimension and c is tuned by
+   * cross-validation on a held-out window.
+   */
+  radius?: number;
+  /**
+   * Lipschitz constant L_ℓ of the loss function applied to raw samples.
+   * Defaults to 1 (identity loss — caller has already applied any
+   * transform). Only affects the ambiguity term; empirical CVaR is
+   * computed on the samples as given.
+   */
+  lipschitz?: number;
+}
+
+export interface CvarW1Result {
+  /** Empirical α-CVaR of the input sample. */
+  empirical: number;
+  /**
+   * Distributionally-robust α-CVaR under a W₁ ambiguity ball of radius
+   * `options.radius`. Equals `empirical + lipschitz · radius / (1 − α)`.
+   */
+  robust: number;
+  /**
+   * Empirical α-VaR — the α-quantile of the sample. Returned alongside
+   * for downstream callers that want both quantile and tail mean.
+   */
+  varEmpirical: number;
+  /** Echo of the resolved options after defaulting. */
+  alpha: number;
+  radius: number;
+  lipschitz: number;
+  /** Sample size used. */
+  n: number;
+}
+
+/**
+ * Compute the empirical α-CVaR of a sample, plus its W₁-robust
+ * counterpart under an ambiguity ball of the given radius.
+ *
+ * Throws on degenerate inputs (empty sample, α outside (0, 1), negative
+ * radius, non-positive Lipschitz) — the caller should validate upstream
+ * rather than swallow a silent NaN.
+ */
+export function cvarW1(
+  samples: ArrayLike<number>,
+  options: CvarW1Options,
+): CvarW1Result {
+  const { alpha } = options;
+  const radius = options.radius ?? 0;
+  const lipschitz = options.lipschitz ?? 1;
+  const n = samples.length;
+
+  if (n === 0) {
+    throw new Error("cvarW1: sample is empty");
+  }
+  if (!(alpha > 0 && alpha < 1)) {
+    throw new Error(`cvarW1: alpha must be in (0, 1), got ${alpha}`);
+  }
+  if (!(radius >= 0)) {
+    throw new Error(`cvarW1: radius must be ≥ 0, got ${radius}`);
+  }
+  if (!(lipschitz > 0)) {
+    throw new Error(`cvarW1: lipschitz must be > 0, got ${lipschitz}`);
+  }
+
+  // Sort ascending. Copy into a typed array — keeps callers free to
+  // pass plain arrays without us mutating their input.
+  const sorted = new Float64Array(n);
+  for (let i = 0; i < n; i++) sorted[i] = samples[i] as number;
+  sorted.sort();
+
+  // Reject NaN — would silently sort to the end and corrupt the tail.
+  if (Number.isNaN(sorted[n - 1])) {
+    throw new Error("cvarW1: sample contains NaN");
+  }
+
+  // k = ⌈α n⌉, clamped so 1 ≤ k ≤ n.
+  const aN = alpha * n;
+  let k = Math.ceil(aN);
+  if (k < 1) k = 1;
+  if (k > n) k = n;
+
+  // VaR — the α-quantile, taken at the k-th order statistic (1-indexed).
+  const varEmpirical = sorted[k - 1];
+
+  // CVaR via the canonical interpolated formula:
+  //   CVaR = (1 / ((1-α) n)) · [(k - αn) · x_(k) + Σ_{i=k+1}^n x_(i)]
+  // The leading (k - αn) term redistributes the boundary mass when αn
+  // isn't an integer; the second term is the strict upper tail.
+  let tailSum = 0;
+  for (let i = k; i < n; i++) tailSum += sorted[i];
+  const denom = (1 - alpha) * n;
+  // (k - αn) is in [0, 1) by construction unless k was clamped to n;
+  // when k = n the first term carries the entire tail mass.
+  const empirical =
+    ((k - aN) * varEmpirical + tailSum) / Math.max(denom, Number.EPSILON);
+
+  // Robust CVaR: closed-form W₁ adjustment.
+  const robust = empirical + (lipschitz * radius) / (1 - alpha);
+
+  return {
+    empirical,
+    robust,
+    varEmpirical,
+    alpha,
+    radius,
+    lipschitz,
+    n,
+  };
+}
+
+/**
+ * Pillar-T scoring helper. Maps a robust CVaR value into the [0, 10]
+ * pillar scale used by the ΩF composite, given a domain-specific
+ * reference scale `floor` (CVaR considered low-risk, scored 0) and
+ * `ceiling` (CVaR considered saturating, scored 10). Linear in the
+ * interior, clamped at the endpoints.
+ *
+ * Calibration belongs in the DomainProfile, not here — this is just
+ * the deterministic mapping.
+ */
+export function tailDepthScore(
+  robustCvar: number,
+  floor: number,
+  ceiling: number,
+): number {
+  if (!(ceiling > floor)) {
+    throw new Error(
+      `tailDepthScore: ceiling (${ceiling}) must be > floor (${floor})`,
+    );
+  }
+  const t = (robustCvar - floor) / (ceiling - floor);
+  if (t <= 0) return 0;
+  if (t >= 1) return 10;
+  return 10 * t;
+}

--- a/src/lib/estimators/index.ts
+++ b/src/lib/estimators/index.ts
@@ -37,3 +37,6 @@ export type {
   BettiAtEpsilon,
   PersistenceBar,
 } from "./persistent-homology";
+
+export { cvarW1, tailDepthScore } from "./cvar-w1";
+export type { CvarW1Options, CvarW1Result } from "./cvar-w1";


### PR DESCRIPTION
## Summary

First TS implementation derived directly from the **Ghauri 2025 D.Eng. dissertation** (Ch. 4 §3 — Ω-Robustness framework). Adds the canonical **Tail Depth (T-pillar)** estimator: empirical CVaR with a closed-form W₁-Wasserstein ambiguity adjustment.

This unblocks the ΩF composite's T pillar: until now T was scored heuristically per-profile. With this in the registry, any profile can opt into a principled, distributionally-robust CVaR scoring that's well-defined whether you have 30 samples or 30,000.

## What's in the box

```ts
cvarW1(samples, { alpha, radius?, lipschitz? }) -> {
  empirical,    // standard interpolated empirical α-CVaR
  robust,       // = empirical + L · ε / (1 − α)  (W₁ closed form)
  varEmpirical, // α-quantile (returned for downstream use)
  alpha, radius, lipschitz, n,
}

tailDepthScore(robustCvar, floor, ceiling) -> [0, 10]
```

## The math, briefly

**Empirical α-CVaR** (sorted ascending, k = ⌈αn⌉):

```
CVaR_α(X̂) = (1 / ((1−α) n)) · [(k − αn) · x_(k) + Σ_{i=k+1}^n x_(i)]
```

Standard interpolated form — the (k − αn) factor redistributes the boundary order statistic when αn isn't an integer.

**W₁-robust CVaR** — Mohajerin Esfahani & Kuhn (2018) Theorem 6.3, specialised to the ReLU envelope `(·)_+` that defines CVaR via Rockafellar-Uryasev:

```
sup_{Q ∈ B_ε^{W₁}(P̂_n)} CVaR_α(ℓ; Q)  =  CVaR_α(ℓ; P̂_n) + (L_ℓ · ε) / (1 − α)
```

The Lipschitz constant of `(·)_+` is 1, so for identity loss this is just `+ ε / (1 − α)`. The `lipschitz` option scales it for non-identity transforms applied before sampling.

`tailDepthScore` is a deterministic linear map into `[0, 10]` — domain calibration of `floor` / `ceiling` belongs in the `DomainProfile`, not in the estimator core.

## What this PR does NOT do

- **Doesn't wire into `criticality-registry.ts`** — that's the next PR. This is the math core only.
- **Doesn't add `"cvar-w1"` to any DomainProfile's `criticalityEstimators`** — also next PR.
- **No Python reference** — this estimator is from-spec, derived directly from the dissertation. The TS implementation is the canonical one.

Splitting math from wiring keeps the review tight: this PR is 1 small file + tests, the next PR is the registry / profile wiring.

## Why no Python parity test?

Most existing estimators (`bocpd`, `transfer-entropy`, `moran`, `persistent-homology`) are TS ports of `research/estimators/*.py` so they need parity tests against fixtures. CVaR-W₁ has no Python reference because the dissertation closed form is the canonical specification — there's nothing to be parity-checked against. Tests instead cover:

1. **Closed-form analytic cases** (uniform 1..10 at α=0.8, 0.85, 0.9 — every CVaR value computed by hand and matched to <1e-12).
2. **The MEK identity** (`robust − empirical == L · ε / (1 − α)` to machine precision).
3. **Monotonicity properties** (CVaR ≥ VaR; CVaR non-decreasing in α).
4. **Argument validation** (empty / NaN samples, α ∉ (0, 1), negative radius, non-positive Lipschitz — all throw).

## Test plan

- [x] `vitest run`: **818 passing** (was 798; +20 new tests).
- [x] `tsc --noEmit` clean for the new files.
- [x] Input-array immutability covered (sort happens on a copy).

## Sequence

PR (this) — math core: `cvarW1` + `tailDepthScore` + tests.
Follow-on PR — wire into `criticality-registry.ts` with full methodology copy + register `"cvar-w1"` as a `criticalityEstimators` entry on AI Safety / IDS, replacing one of the v1 fallback entries.
Later — Spirtes+Pareto χ★ artifact (next dissertation contribution to land).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
