### PR TITLE
feat(tour): instrument onboarding metrics at phase boundaries

### DIFF
--- a/src/app/api/tour/event/__tests__/route.test.ts
+++ b/src/app/api/tour/event/__tests__/route.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment node
+//
+// Tests the tour-event server route. Validation only — the sink is a
+// console.log and we don't assert on stdout shape (Vercel logs do that
+// for us at runtime). Mirrors the d1namo-ingester / api-routes test
+// pattern with the `node` env override (happy-dom doesn't have NextRequest).
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/tour/event/route";
+
+function reqJson(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/tour/event", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const validBody = {
+  event: "tour_started",
+  stepId: null,
+  phase: "first-run",
+  track: "analyst",
+  persona: "macro",
+  tourSessionId: "ts_xxxxxxxx",
+  elapsedMs: 0,
+};
+
+describe("POST /api/tour/event", () => {
+  // Silence the [tour-event] log line so test output stays clean.
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("accepts a well-formed event and returns ok", async () => {
+    const res = await POST(reqJson(validBody));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean };
+    expect(body.ok).toBe(true);
+  });
+
+  it("rejects malformed JSON", async () => {
+    const req = new NextRequest("http://localhost/api/tour/event", {
+      method: "POST",
+      body: "{ not json",
+      headers: { "content-type": "application/json" },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects unknown event types", async () => {
+    const res = await POST(reqJson({ ...validBody, event: "bogus" }));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/event/);
+  });
+
+  it("rejects unknown phases", async () => {
+    const res = await POST(reqJson({ ...validBody, phase: "ridiculous" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects events with no tourSessionId", async () => {
+    const res = await POST(reqJson({ ...validBody, tourSessionId: null }));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/tourSessionId/);
+  });
+
+  it("accepts every valid event type", async () => {
+    for (const event of [
+      "tour_started",
+      "first_run_completed",
+      "deep_dive_launched",
+      "deep_dive_completed",
+      "tour_closed",
+    ] as const) {
+      const res = await POST(reqJson({ ...validBody, event }));
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it("clamps elapsedMs to a non-negative integer", async () => {
+    // Negative / NaN / huge floats all sanitise to a safe integer.
+    const res1 = await POST(reqJson({ ...validBody, elapsedMs: -5 }));
+    expect(res1.status).toBe(200);
+    const res2 = await POST(reqJson({ ...validBody, elapsedMs: "twelve" }));
+    expect(res2.status).toBe(200);
+  });
+
+  it("survives oversized clientMeta without erroring (drops extras)", async () => {
+    const big: Record<string, string> = {};
+    for (let i = 0; i < 100; i++) big[`k${i}`] = `value-${i}`;
+    const res = await POST(reqJson({ ...validBody, clientMeta: big }));
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/app/api/tour/event/route.ts
+++ b/src/app/api/tour/event/route.ts
@@ -1,0 +1,122 @@
+// ─── POST /api/tour/event ───────────────────────────────────────
+//
+// Receives a TourEvent from the browser and emits it to the
+// request log. Today the sink is `console.log` (visible in Vercel
+// runtime logs as structured JSON); a future PR can wire it to
+// Supabase / Tinybird / wherever the analytics pipeline lands.
+//
+// Logging is best-effort. Failures here MUST NOT cascade into the
+// user's tour experience — this route returns 4xx/5xx but the
+// client treats logging as fire-and-forget and ignores the result.
+//
+// PRIVACY: events are tour-session-scoped (random uuid per open).
+// We never receive a user id here. Persona / track / step id are
+// product analytics, not user identifiers.
+
+import { NextRequest, NextResponse } from "next/server";
+
+// ─── Validation ─────────────────────────────────────────────────
+
+const ALLOWED_EVENTS = new Set([
+  "tour_started",
+  "first_run_completed",
+  "deep_dive_launched",
+  "deep_dive_completed",
+  "tour_closed",
+]);
+
+const ALLOWED_PHASES = new Set(["first-run", "deep-dive", "menu"]);
+
+interface IncomingEvent {
+  event?: unknown;
+  stepId?: unknown;
+  phase?: unknown;
+  track?: unknown;
+  persona?: unknown;
+  tourSessionId?: unknown;
+  elapsedMs?: unknown;
+  clientMeta?: unknown;
+}
+
+// Hard caps so a misbehaving client can't fill the log with
+// gigabyte rows. Generous for legitimate use.
+const MAX_STR = 200;
+const MAX_META_KEYS = 20;
+const MAX_META_VAL = 500;
+
+function isString(v: unknown): v is string {
+  return typeof v === "string";
+}
+
+function clampStr(v: unknown, max: number): string | null {
+  if (!isString(v)) return null;
+  return v.length > max ? v.slice(0, max) : v;
+}
+
+function sanitizeClientMeta(input: unknown): Record<string, unknown> | undefined {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) return undefined;
+  const src = input as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  let n = 0;
+  for (const k of Object.keys(src)) {
+    if (n >= MAX_META_KEYS) break;
+    if (k.length > 50) continue;
+    const v = src[k];
+    if (v === null || v === undefined) continue;
+    if (typeof v === "number" || typeof v === "boolean") {
+      out[k] = v;
+      n += 1;
+      continue;
+    }
+    if (typeof v === "string") {
+      out[k] = v.length > MAX_META_VAL ? v.slice(0, MAX_META_VAL) : v;
+      n += 1;
+      continue;
+    }
+    // Drop anything else (objects, arrays) — keep payload bounded.
+  }
+  return out;
+}
+
+export async function POST(request: NextRequest) {
+  let raw: IncomingEvent;
+  try {
+    raw = (await request.json()) as IncomingEvent;
+  } catch {
+    return NextResponse.json({ error: "invalid json" }, { status: 400 });
+  }
+
+  if (!isString(raw.event) || !ALLOWED_EVENTS.has(raw.event)) {
+    return NextResponse.json({ error: "unknown event type" }, { status: 400 });
+  }
+  if (!isString(raw.phase) || !ALLOWED_PHASES.has(raw.phase)) {
+    return NextResponse.json({ error: "unknown phase" }, { status: 400 });
+  }
+  const tourSessionId = clampStr(raw.tourSessionId, MAX_STR);
+  if (!tourSessionId) {
+    return NextResponse.json({ error: "missing tourSessionId" }, { status: 400 });
+  }
+  const elapsedMs =
+    typeof raw.elapsedMs === "number" && Number.isFinite(raw.elapsedMs) && raw.elapsedMs >= 0
+      ? Math.floor(raw.elapsedMs)
+      : 0;
+
+  const sanitized = {
+    event: raw.event,
+    stepId: clampStr(raw.stepId, MAX_STR),
+    phase: raw.phase,
+    track: clampStr(raw.track, MAX_STR),
+    persona: clampStr(raw.persona, MAX_STR),
+    tourSessionId,
+    elapsedMs,
+    clientMeta: sanitizeClientMeta(raw.clientMeta),
+  };
+
+  // Sink: structured stdout so Vercel runtime logs can be queried.
+  // To wire to Supabase / Tinybird later, replace this with the
+  // appropriate client call — the validated payload is exactly the
+  // shape the sink will need.
+  console.log("[tour-event]", JSON.stringify(sanitized));
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/components/SpotlightTour.tsx
+++ b/src/components/SpotlightTour.tsx
@@ -14,6 +14,7 @@ import {
   type TourStep,
   type DeepDiveTrack,
 } from "@/lib/tour-steps";
+import { logTourEvent, newTourSessionId } from "@/lib/onboarding/metrics";
 import TTSControls from "@/components/TTSControls";
 
 // ─── Constants ──────────────────────────────────────────────────────────
@@ -197,6 +198,13 @@ export default function SpotlightTour() {
   const tooltipHeightRef = useRef(200);
   const preTourModuleRef = useRef<string | null>(null);
 
+  // Telemetry. tourSessionId is a fresh uuid per tour-open, reused
+  // across all events inside that open. tourSessionStartRef gives us
+  // an elapsedMs base for funnel analysis. Both reset on the rising
+  // edge of tourActive — see the effect a few blocks below.
+  const tourSessionIdRef = useRef<string>("");
+  const tourSessionStartRef = useRef<number>(0);
+
   const track = trackForPersona(activePersona);
 
   // Active step list driven by mode. Memoized so step indices stay stable.
@@ -269,15 +277,27 @@ export default function SpotlightTour() {
 
   // When the tour is re-opened externally (the "?" button), reset to first-run.
   // Without this, re-opening after a deep-dive ended in the same session would
-  // start mid-track.
+  // start mid-track. Also fires the `tour_started` telemetry event and stamps
+  // a fresh tourSessionId for downstream events to share.
   const prevActiveRef = useRef(tourActive);
   useEffect(() => {
     if (tourActive && !prevActiveRef.current) {
       setMode("first-run");
       setTourStep(0);
+      tourSessionIdRef.current = newTourSessionId();
+      tourSessionStartRef.current = Date.now();
+      void logTourEvent({
+        event: "tour_started",
+        stepId: null,
+        phase: "first-run",
+        track,
+        persona: activePersona ?? null,
+        tourSessionId: tourSessionIdRef.current,
+        elapsedMs: 0,
+      });
     }
     prevActiveRef.current = tourActive;
-  }, [tourActive, setTourStep]);
+  }, [tourActive, setTourStep, track, activePersona]);
 
   // Run a step's onEnter side effect (e.g. switch active module).
   useEffect(() => {
@@ -391,6 +411,23 @@ export default function SpotlightTour() {
   // ─── Navigation ──────────────────────────────────────────────────────
 
   const close = useCallback(() => {
+    // Fire BEFORE we wipe state so phase / step are still meaningful.
+    if (tourSessionIdRef.current) {
+      void logTourEvent({
+        event: "tour_closed",
+        stepId: step?.id ?? null,
+        phase: mode === "first-run" ? "first-run" : mode === "deep-dive-menu" ? "menu" : "deep-dive",
+        track:
+          mode === "first-run"
+            ? track
+            : mode === "deep-dive-menu"
+              ? null
+              : (mode as DeepDiveTrack),
+        persona: activePersona ?? null,
+        tourSessionId: tourSessionIdRef.current,
+        elapsedMs: Date.now() - tourSessionStartRef.current,
+      });
+    }
     if (preTourModuleRef.current) {
       useApexStore.getState().setActiveModule(preTourModuleRef.current as "spirtes" | "tarski" | "pearl" | "pareto");
     }
@@ -402,7 +439,7 @@ export default function SpotlightTour() {
     setMode("first-run");
     setTourStep(0);
     setTourActive(false);
-  }, [setTourActive, setTourStep]);
+  }, [setTourActive, setTourStep, step, mode, track, activePersona]);
 
   const next = useCallback(() => {
     if (step?.id === "welcome-and-domain") {
@@ -427,11 +464,34 @@ export default function SpotlightTour() {
     }
     if (step?.id === "first-run-finish") {
       // First-run done → show the deep-dive menu instead of closing.
+      void logTourEvent({
+        event: "first_run_completed",
+        stepId: step.id,
+        phase: "first-run",
+        track,
+        persona: activePersona ?? null,
+        tourSessionId: tourSessionIdRef.current,
+        elapsedMs: Date.now() - tourSessionStartRef.current,
+      });
       setMode("deep-dive-menu");
       setTourStep(0);
       return;
     }
     if (isLast) {
+      // Last step of a deep-dive track. Fire deep_dive_completed before
+      // close() fires its own tour_closed — funnel readers can tell whether
+      // the user finished the track or bailed mid-track from the pair.
+      if (mode !== "first-run" && mode !== "deep-dive-menu") {
+        void logTourEvent({
+          event: "deep_dive_completed",
+          stepId: step?.id ?? null,
+          phase: "deep-dive",
+          track: mode as DeepDiveTrack,
+          persona: activePersona ?? null,
+          tourSessionId: tourSessionIdRef.current,
+          elapsedMs: Date.now() - tourSessionStartRef.current,
+        });
+      }
       close();
     } else {
       setTourStep(tourStep + 1);
@@ -445,6 +505,9 @@ export default function SpotlightTour() {
     close,
     setTourStep,
     tourStep,
+    mode,
+    track,
+    activePersona,
   ]);
 
   const back = useCallback(() => {
@@ -452,11 +515,20 @@ export default function SpotlightTour() {
   }, [isFirst, setTourStep, tourStep]);
 
   const launchDeepDive = useCallback(
-    (track: DeepDiveTrack) => {
-      setMode(track);
+    (deepDiveTrack: DeepDiveTrack) => {
+      void logTourEvent({
+        event: "deep_dive_launched",
+        stepId: null,
+        phase: "deep-dive",
+        track: deepDiveTrack,
+        persona: activePersona ?? null,
+        tourSessionId: tourSessionIdRef.current,
+        elapsedMs: Date.now() - tourSessionStartRef.current,
+      });
+      setMode(deepDiveTrack);
       setTourStep(0);
     },
-    [setTourStep],
+    [setTourStep, activePersona],
   );
 
   // Keyboard navigation. Disabled on the menu (no step to advance).

--- a/src/lib/__tests__/onboarding-metrics.test.ts
+++ b/src/lib/__tests__/onboarding-metrics.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import {
+  logTourEvent,
+  newTourSessionId,
+  type TourEvent,
+} from "../onboarding/metrics";
+
+const sampleEvent = (overrides: Partial<TourEvent> = {}): TourEvent => ({
+  event: "tour_started",
+  stepId: null,
+  phase: "first-run",
+  track: "analyst",
+  persona: "macro",
+  tourSessionId: "ts_test_session",
+  elapsedMs: 0,
+  ...overrides,
+});
+
+describe("newTourSessionId", () => {
+  it("returns a non-empty string", () => {
+    const id = newTourSessionId();
+    expect(typeof id).toBe("string");
+    expect(id.length).toBeGreaterThan(8);
+  });
+
+  it("returns a different value each call (collision-resistant)", () => {
+    const ids = new Set(Array.from({ length: 50 }, () => newTourSessionId()));
+    expect(ids.size).toBe(50);
+  });
+});
+
+describe("logTourEvent", () => {
+  let originalFetch: typeof globalThis.fetch | undefined;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    if (originalFetch) globalThis.fetch = originalFetch;
+    else delete (globalThis as { fetch?: typeof fetch }).fetch;
+    vi.restoreAllMocks();
+  });
+
+  it("returns false when fetch is unavailable (SSR / test env)", async () => {
+    delete (globalThis as { fetch?: typeof fetch }).fetch;
+    const ok = await logTourEvent(sampleEvent());
+    expect(ok).toBe(false);
+  });
+
+  it("posts to /api/tour/event with the JSON-serialised event", async () => {
+    const fetchSpy = vi.fn(async () =>
+      new Response('{"ok":true}', { status: 200 }),
+    );
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const ev = sampleEvent({ event: "first_run_completed", stepId: "first-run-finish" });
+    const ok = await logTourEvent(ev);
+
+    expect(ok).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("/api/tour/event");
+    expect((init as RequestInit).method).toBe("POST");
+    const body = JSON.parse(((init as RequestInit).body as string));
+    expect(body).toMatchObject({
+      event: "first_run_completed",
+      stepId: "first-run-finish",
+      phase: "first-run",
+      track: "analyst",
+      tourSessionId: "ts_test_session",
+    });
+  });
+
+  it("returns false on non-2xx response", async () => {
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    globalThis.fetch = (async () =>
+      new Response('{"error":"bad"}', { status: 400 })) as unknown as typeof fetch;
+    const ok = await logTourEvent(sampleEvent());
+    expect(ok).toBe(false);
+    consoleSpy.mockRestore();
+  });
+
+  it("returns false (and never throws) when fetch rejects", async () => {
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    globalThis.fetch = (async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    const ok = await logTourEvent(sampleEvent());
+    expect(ok).toBe(false);
+    consoleSpy.mockRestore();
+  });
+
+  it("uses keepalive so a tab-close on tour_closed still flushes", async () => {
+    const fetchSpy = vi.fn(async () =>
+      new Response("{}", { status: 200 }),
+    );
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    await logTourEvent(sampleEvent({ event: "tour_closed" }));
+    const [, init] = fetchSpy.mock.calls[0];
+    expect((init as RequestInit & { keepalive?: boolean }).keepalive).toBe(true);
+  });
+});

--- a/src/lib/onboarding/metrics.ts
+++ b/src/lib/onboarding/metrics.ts
@@ -1,0 +1,98 @@
+// ─── Onboarding tour metrics ─────────────────────────────────────
+//
+// Fire-and-forget client logger for tour boundary events. Mirrors the
+// copilot trace-logger pattern (src/lib/copilot/trace-logger.ts):
+// best-effort POST to a server route, never blocks the UI, never
+// throws upward. The server side currently logs to stdout (Vercel
+// request logs); a future PR can swap that for a Supabase table or
+// a Tinybird sink without changing this module.
+//
+// Why this exists: the 2026-05-03..04 onboarding overhaul restructured
+// the tour into clean phase boundaries (first-run / deep-dive / per-
+// track), but no telemetry was wired. Without metrics we don't know
+// what fraction of users finish first-run, which deep-dive track they
+// pick, or where they bail. This module instruments those answers.
+//
+// Cardinality is deliberately low: ~5 events per tour-open. Per-step
+// telemetry is intentionally not instrumented at the boundary level
+// to keep the volume small; if step-level granularity is needed
+// later, add it as a separate `step_advanced` event with sampling.
+
+// ─── Types ──────────────────────────────────────────────────────
+
+export type TourEventType =
+  | "tour_started"            // tour opened — auto (first visit) or manual ("?" button)
+  | "first_run_completed"     // user advanced past the final first-run step
+  | "deep_dive_launched"      // user picked a track from the deep-dive menu
+  | "deep_dive_completed"     // user advanced past the final step of a deep-dive track
+  | "tour_closed";            // user closed the tour at any point (Esc / X / outside-click)
+
+export interface TourEvent {
+  event: TourEventType;
+  /** Step id at the moment of the event. Null for tour_started before the first step renders. */
+  stepId: string | null;
+  /** "first-run" | "deep-dive" | "menu" — the macro phase the tour was in. */
+  phase: "first-run" | "deep-dive" | "menu";
+  /**
+   * For first-run: the persona track ("analyst" | "scientist").
+   * For deep-dive: the track id ("engines" | "loop" | "customization").
+   * For menu / unset: null.
+   */
+  track: string | null;
+  /** Snapshot of the active persona at event time, if known. */
+  persona: string | null;
+  /** Stable id for the duration of one tour-open. Lets the server reconstruct
+   *  per-session funnels without identifying users. */
+  tourSessionId: string;
+  /** ms since tour-session start. tour_started carries 0. */
+  elapsedMs: number;
+  /** Open-ended client metadata bag. Keep it small. */
+  clientMeta?: Record<string, unknown>;
+}
+
+// ─── Public API ─────────────────────────────────────────────────
+
+/**
+ * POST a tour event to the server. Fire-and-forget. Returns true on
+ * 2xx, false on any failure or environment without `fetch`. Callers
+ * MUST NOT await this from interaction-hot paths — logging failures
+ * never block tour state.
+ */
+export async function logTourEvent(event: TourEvent): Promise<boolean> {
+  if (typeof fetch === "undefined") return false;
+  try {
+    const res = await fetch("/api/tour/event", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(event),
+      // Bounded budget so logging can never hang a tab.
+      signal: AbortSignal.timeout(5000),
+      // Send in the background so a tab close on tour_closed doesn't
+      // lose the funnel-end event.
+      keepalive: true,
+    });
+    if (!res.ok) {
+      console.warn(`[tour-metrics] log failed: HTTP ${res.status}`);
+      return false;
+    }
+    return true;
+  } catch (err) {
+    console.warn("[tour-metrics] log failed:", err);
+    return false;
+  }
+}
+
+/**
+ * Generate a fresh tour-session id. SpotlightTour creates one when
+ * the tour opens (auto or manual) and reuses it across all events
+ * inside that open until close. A re-launch from the "?" button
+ * starts a new session id.
+ */
+export function newTourSessionId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  // Fallback for very old runtimes — sufficient entropy for our
+  // analytics use case (collisions don't matter).
+  return `ts_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}


### PR DESCRIPTION
## Summary

Closes the open thread *"Onboarding completion metrics — never instrumented; tour now has clean phase boundaries so it's a tidy place to add telemetry."*

The 2026-05-03..04 tour overhaul gave us clean phase boundaries (first-run / deep-dive / per-track) but no telemetry on them. We don't know what fraction of users finish first-run, which deep-dive track they pick, or where they bail. This PR wires fire-and-forget telemetry at the five boundary points that matter for funnel analysis.

## Five events

| Event | When it fires |
|---|---|
| `tour_started` | tour opens (auto-launch on first visit OR "?" button) |
| `first_run_completed` | user advances past the final first-run step |
| `deep_dive_launched` | user picks a track from the deep-dive menu |
| `deep_dive_completed` | user advances past the final step of a deep-dive track |
| `tour_closed` | tour closed at any point (Esc / X / outside-click) |

Cardinality: ~5 events per tour open. Per-step instrumentation is **deliberately not added** to keep volume small. Step-level granularity can be added later as a separate `step_advanced` event with sampling.

## Architecture (mirrors copilot trace-logger pattern)

| File | What it does |
|------|--------|
| `src/lib/onboarding/metrics.ts` | `logTourEvent(event)` fire-and-forget client logger. `keepalive: true` so a tab-close on `tour_closed` still flushes. Bounded 5s timeout so logging can never hang. |
| `src/app/api/tour/event/route.ts` | Receives event, validates shape (event type / phase allow-lists, required tourSessionId, clamped strings, sanitised clientMeta with key + value caps), emits structured JSON via `console.log` so Vercel request logs become the analytics sink. Future Supabase / Tinybird wire-in is a one-line swap. |
| `src/components/SpotlightTour.tsx` | `tourSessionIdRef` captures a fresh uuid per tour-open via `newTourSessionId()` on the rising edge of `tourActive`. Each event fires at its natural transition point. `tour_closed` fires BEFORE state wipe so phase / step are still meaningful. `deep_dive_completed` fires before `close()` so funnel readers can tell "completed track" from "bailed track" by the pair. |

## Privacy

- Tour-session ids are random uuids, not user ids. No user identifier crosses the wire.
- Persona / track / step id are product analytics, not user identifiers.
- `clientMeta` is sanitised server-side: max 20 keys, max 50-char keys, max 500-char string values, no nested objects. A misbehaving client can't fill the log with gigabyte rows.

## Tests (15 new)

`src/lib/__tests__/onboarding-metrics.test.ts` — 7 tests:
- `newTourSessionId` returns a non-empty string + collision-resistant across 50 calls
- `logTourEvent` returns false when `fetch` is unavailable (SSR / test env)
- POSTs to `/api/tour/event` with the JSON-serialised event
- Returns false on non-2xx; never throws on fetch reject
- Uses `keepalive: true`

`src/app/api/tour/event/__tests__/route.test.ts` — 8 tests:
- Accepts well-formed event (200 ok)
- Rejects malformed JSON (400)
- Rejects unknown event types
- Rejects unknown phases
- Rejects missing `tourSessionId`
- Accepts every valid event type
- Sanitises `elapsedMs` (negative / non-numeric → 0, no 400)
- Survives oversized `clientMeta` without erroring

Total: 798 → 813. Build green.

## Backwards compat

Tour state machine and UX are unchanged. `logTourEvent` failures are silent (`console.warn` only); the tour never blocks on telemetry. If the new route is unreachable, the tour continues normally.

## How to read the metrics today

Vercel runtime logs:

```bash
vercel logs --follow | grep "\[tour-event\]"
```

Each line is structured JSON with the event payload. A first cut at funnel analysis: count `tour_started`, `first_run_completed`, `deep_dive_launched` (per track), `deep_dive_completed` (per track) over a window. The drop-off between adjacent stages is the funnel.

## Test plan

- [x] 15 new tests pass
- [x] Full vitest suite green: 813 / 813
- [x] `npm run build` passes locally
- [ ] PR-validate workflow green
- [ ] Vercel preview eyeball: open the tour, walk through, hit Esc → check `vercel logs` for the `[tour-event]` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
