### PR TITLE
feat(criticality): wire CVaR-W₁ into registry + AI Safety profile

### DIFF
--- a/src/lib/criticality-registry.ts
+++ b/src/lib/criticality-registry.ts
@@ -107,6 +107,28 @@ const REGISTRY: Record<EstimatorId, EstimatorMeta> = {
       "STABLE REGIME — posterior is concentrated on the current run; no recent change-point activity above floor.",
     defaultAvailability: "ready",
   },
+
+  // ── Distributionally-robust risk (Ghauri 2025 Ω-Robustness, from-spec) ──
+  "cvar-w1": {
+    id: "cvar-w1",
+    abbrev: "CVAR-W₁",
+    fullName: "CVaR — WASSERSTEIN-1 AMBIGUITY",
+    shortDesc:
+      "Distributionally-robust α-CVaR over a W₁ ball — quantifies tail loss with a calibrated ambiguity premium",
+    color: "#7B68EE",
+    methodology: [
+      "Conditional Value-at-Risk (CVaR_α) is the standard coherent risk measure for the upper-α tail of a loss distribution: the expected loss conditional on being in the worst (1−α) fraction of outcomes. For a sorted sample {x_(1) ≤ … ≤ x_(n)} and k = ⌈αn⌉ the empirical estimator is CVaR_α = (1 / ((1−α)n)) · [(k − αn) · x_(k) + Σ_{i>k} x_(i)]. The (k − αn) factor redistributes the boundary order statistic when αn isn't an integer.",
+      "Wasserstein-1 ambiguity hedges against the empirical distribution being wrong. Define a W₁-ball B_ε(P̂_n) of radius ε around the empirical measure; the worst-case CVaR over that ball admits a closed form (Mohajerin Esfahani & Kuhn 2018, Theorem 6.3, specialised to the ReLU envelope (·)_+ that defines CVaR via Rockafellar-Uryasev): sup_{Q ∈ B_ε} CVaR_α(ℓ; Q) = CVaR_α(ℓ; P̂_n) + (L_ℓ · ε) / (1−α). The ambiguity term is a deterministic premium proportional to ε and inversely proportional to (1−α) — it grows as you demand more tail confidence.",
+      "Implementation at src/lib/estimators/cvar-w1.ts. From-spec, derived directly from Ghauri 2025 (D.Eng., Ch. 4 §3 — Ω-Robustness framework). No Python reference exists because the dissertation closed form is the canonical specification. Calibration of ε is domain-specific — typical practice is ε = c · n^{−1/d} where d is the loss dimensionality and c is tuned by cross-validation on a held-out window.",
+    ],
+    formula: "CVaR_α^{W₁}(X) = CVaR_α(X̂) + L · ε / (1 − α)",
+    placeholderAssessment:
+      "AWAITING DATA — needs a numeric loss sample (per-node failure cost, per-incident cascade depth, per-attack-class observed harm). Once a sample is wired the card reports empirical CVaR, robust CVaR, and the W₁ ambiguity premium.",
+    defaultAvailability: "awaiting-data",
+    requiredInputs:
+      "A loss sample {x_1, …, x_n} (n ≥ ~30 for stable boundary interpolation). One scalar per observation; the loss transform should be applied upstream so the sample is already on the right scale. Plus α ∈ (0, 1) and a W₁ radius ε ≥ 0 chosen via cross-validation.",
+  },
+
   "transfer-entropy": {
     id: "transfer-entropy",
     abbrev: "TE",

--- a/src/lib/domain-profiles.ts
+++ b/src/lib/domain-profiles.ts
@@ -19,6 +19,8 @@ export type EstimatorId =
   | "transfer-entropy"
   | "moran"
   | "takens"
+  // Distributionally-robust risk estimators (from-spec, Ghauri 2025)
+  | "cvar-w1"
   // Clinical / trial estimators (Python reference canonical)
   | "hte-meta"
   | "cox-ph"
@@ -386,10 +388,18 @@ export const AI_SAFETY_PROFILE: DomainProfile = {
   pillarLabels: AI_SAFETY_PILLARS,
   pillarDetails: AI_SAFETY_PILLAR_DETAILS,
   compositeMethodology: AI_SAFETY_METHODOLOGY,
-  // v1 reuses geopolitical's criticality estimator set as a working fallback.
-  // AI-domain-specific estimators (FR, BES temporal monitoring) arrive in
-  // Phase 3 once Pearl session wires them up.
-  criticalityEstimators: ["csd", "ph", "lppls", "bocpd"],
+  // Five tabs:
+  //   csd / ph / lppls / bocpd — graph-Ω-trajectory estimators inherited
+  //     from the geopolitical fallback. Sharp transitions in the GAT's
+  //     ΩF trajectory under catastrophic-forgetting events are exactly
+  //     the regime they were designed for.
+  //   cvar-w1 — canonical Tail Depth pillar estimator (Ghauri 2025
+  //     Ch. 4 §3 Ω-Robustness). Renders as "awaiting-data" until a loss
+  //     sample (per-attack-class observed harm, per-incident cascade
+  //     depth, etc.) is wired into the store.
+  // FR + BES temporal monitoring arrive in Phase 3 once the Pearl
+  // session wires them up.
+  criticalityEstimators: ["csd", "ph", "lppls", "bocpd", "cvar-w1"],
 };
 
 // ─── Resolution ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Follow-on to [#279](https://github.com/ApexAnalytica/apex-terminal/pull/279) (CVaR-W₁ math core, merged). Surfaces the distributionally-robust Tail Depth estimator in the criticality runner so it appears as a tab in the Pareto card under the AI Safety profile.

## What changed

### `src/lib/domain-profiles.ts`
- `EstimatorId` union extended with `"cvar-w1"`. Slotted under a new group comment **"Distributionally-robust risk estimators (from-spec, Ghauri 2025)"** between the patient-trace estimators and the clinical estimators.
- `AI_SAFETY_PROFILE.criticalityEstimators` becomes `["csd", "ph", "lppls", "bocpd", "cvar-w1"]` — five tabs. Comment rewritten to explain the surface (graph-Ω-trajectory estimators ⊕ the canonical Tail Depth estimator) and what's still deferred to Phase 3 (FR + BES temporal monitoring).

### `src/lib/criticality-registry.ts`
- New `REGISTRY` entry for `"cvar-w1"`. Three-paragraph methodology copy following the registry's existing style:
  1. **Empirical CVaR**: the canonical interpolated formula with the boundary-redistribution factor explained.
  2. **W₁ ambiguity**: the Mohajerin Esfahani & Kuhn (2018) Theorem 6.3 closed form, derived via the Rockafellar-Uryasev representation specialised to the ReLU envelope `(·)_+` that defines CVaR.
  3. **Provenance + calibration**: from-spec from Ghauri 2025 (Ch. 4 §3, Ω-Robustness framework) — no Python reference because the dissertation closed form is the canonical specification. ε calibration practice via `c · n^{−1/d}` with cross-validation.
- Color `#7B68EE` matches the AI Safety domain color.
- Formula line: `CVaR_α^{W₁}(X) = CVaR_α(X̂) + L · ε / (1 − α)`.

## Why `defaultAvailability: "awaiting-data"` (not `"ready"`)

The registry-profile coverage test ([#254](https://github.com/ApexAnalytica/apex-terminal/pull/254)) enforces:

> Every `"ready"` estimator must appear in at least one production profile (or be exempted with a reason).

The math core from #279 is fully ready — but no AI-Safety loss sample is wired into the store yet, so a `"ready"` card would render empty. `"awaiting-data"` is the honest state: full methodology copy renders, runtime suppresses time series + confidence panels until a sample lands upstream. Same pattern as `transfer-entropy` / `moran` / `takens` (TS implementations exist, awaiting their input data).

When a real loss sample is wired (per-attack-class observed harm, per-node cascade depth, etc.) the flip from `"awaiting-data"` → `"ready"` is one-line; the coverage test will then confirm `AI_SAFETY_PROFILE` already lists the estimator.

## What this PR does NOT do

- Doesn't wire a loss sample into the store. That requires a data-side decision about which signal to emit and at what cadence — separate concern.
- Doesn't add cvar-w1 to GEOPOLITICAL or T1D profiles. Tail Depth is profile-specific; revisit per-domain when there's a meaningful loss sample for each.

## Test plan

- [x] `vitest run`: **833 passing**, no regressions.
- [x] `registry-profile-coverage` test: green. cvar-w1 is `"awaiting-data"` so the "ready needs profile" rule doesn't apply; `AI_SAFETY_PROFILE`'s reference to `"cvar-w1"` resolves to the new registry entry; no orphan profile entries.
- [x] `tsc --noEmit` clean for the edited files.

## Sequence

PR [#279](https://github.com/ApexAnalytica/apex-terminal/pull/279) ✅ math core (`cvarW1`, `tailDepthScore`, 20 tests).
**This PR — registry wiring + AI_SAFETY_PROFILE entry.**
Future — wire a real loss sample into the store; flip availability to `"ready"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
