### PR TITLE
feat(canvas): startTransition on ISOLATE + TOPO shift-lasso

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -712,6 +712,25 @@ A `draggedRef` tracks whether motion fired between drag start/stop.
 
 **Verification.** `tsc --noEmit` clean; lint clean (pre-existing `ablationMode` warning unchanged); vitest 793/793 pass.
 
+### 2026-05-07 — Shipped: ISOLATE freeze unblocked + TOPO shift-lasso
+
+**PR:** TBD (about to open).
+
+**Trigger.** Two-item batch:
+1. *"On the bottom-left domains panel, if I click [a domain row] and then click ISOLATE, it kinda slows down and freezes. … If I use lasso, it doesn't do that."* — clicking ISOLATE after a multi-domain pick blocked the main thread while React unmounted ~150 DAGNode3D + ~270 DAGEdge3D children in a single render cycle (and rebuilt 4 GeoJSON FCs in the Map view). Lasso selections were typically smaller, but the real perceptual difference was that lasso users had already paid the multi-select cost during the drag — the ISOLATE click only triggered the re-render at peak fan-out.
+2. *"For the topological [view], a user should be able to select specific parts of the topology using the shift-lasso feature you have across the other views."* — TOPO had no marquee.
+
+**What shipped.**
+
+- **`startTransition` around the ISOLATE toggle.** `setIsolateSelection(...)` now runs inside `startTransition`, marking the resulting re-render as non-urgent. React keeps the current UI interactive while it computes the new tree (and processes the unmount cascade) in the background. The actual switch still takes its full ~150-300ms in the worst case, but the click feels instant — the button highlights immediately and the user can keep interacting with other controls. No data-shape changes; just a render-priority hint.
+- **TOPO shift+drag lasso.** New `TopoShiftMarquee` component inside the relief Canvas (mirrors the 3D `ShiftMarquee` pattern). Listens on `gl.domElement` for `pointerdown/move/up`, gates on `e.shiftKey`, tracks a screen-space rect, and on release projects each node's ground-plane position (`layout.x - field.cx`, `0`, `layout.y - field.cy` — same translation `SelectionMarkers` uses) into screen coords for hit-testing. OrbitControls disabled during the drag so the camera doesn't rotate. DOM rect overlay rendered outside the Canvas, identical class set to 2D / 3D / Map for visual consistency.
+
+**Files.**
+- `src/components/dag3d/DAGOverlay.tsx` — `startTransition(() => setIsolateSelection(...))`.
+- `src/components/CausalDAGRelief.tsx` — new `TopoShiftMarquee`; `selectionBoxRef`, `selectionRect`, `shiftDragging`, `handleShiftSelect` state in parent; OrbitControls.enabled bound to `!shiftDragging`; DOM overlay for the rect.
+
+**Verification.** `tsc --noEmit` clean (modulo pre-existing `onboarding-metrics.test.ts` strictness errors inherited from main); lint clean; vitest 833/833 pass.
+
 ---
 
 ## How a fresh session resumes

--- a/src/components/CausalDAGRelief.tsx
+++ b/src/components/CausalDAGRelief.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Component, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { Component, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { Canvas, useThree, type ThreeEvent } from "@react-three/fiber";
 import { Html, OrbitControls } from "@react-three/drei";
 import * as THREE from "three";
@@ -683,6 +683,115 @@ function SelectionMarkers({
   );
 }
 
+/**
+ * Shift+drag lasso for the topology canvas. Same pattern as the 3D and
+ * 2D views: attach pointer listeners on the WebGL canvas DOM element,
+ * track a screen-space rect, project each node's ground-plane position
+ * (layout.xy minus the field origin offset) into screen coordinates on
+ * release, and hit-test against the rect.
+ *
+ * Lives inside the Canvas so it can grab `useThree` (camera + canvas
+ * size). Renders nothing — selection rect is drawn as a DOM overlay by
+ * the parent.
+ */
+function TopoShiftMarquee({
+  layout,
+  field,
+  graphNodes,
+  selectionBoxRef,
+  setSelectionRect,
+  setShiftDragging,
+  onSelect,
+}: {
+  layout: Map<string, { x: number; y: number }>;
+  field: ReliefField | null | undefined;
+  graphNodes: { id: string }[];
+  selectionBoxRef: React.MutableRefObject<{ x1: number; y1: number; x2: number; y2: number } | null>;
+  setSelectionRect: (r: { x1: number; y1: number; x2: number; y2: number } | null) => void;
+  setShiftDragging: (b: boolean) => void;
+  onSelect: (ids: string[]) => void;
+}) {
+  const { camera, gl, size: canvasSize } = useThree();
+  const dragging = useRef(false);
+  const startRef = useRef({ x: 0, y: 0 });
+
+  useEffect(() => {
+    const canvas = gl.domElement;
+
+    const onDown = (e: PointerEvent) => {
+      if (!e.shiftKey) return;
+      dragging.current = true;
+      setShiftDragging(true);
+      const rect = canvas.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      startRef.current = { x, y };
+      selectionBoxRef.current = { x1: x, y1: y, x2: x, y2: y };
+      setSelectionRect({ x1: x, y1: y, x2: x, y2: y });
+    };
+
+    const onMove = (e: PointerEvent) => {
+      if (!dragging.current) return;
+      const rect = canvas.getBoundingClientRect();
+      const x2 = e.clientX - rect.left;
+      const y2 = e.clientY - rect.top;
+      const box = { x1: startRef.current.x, y1: startRef.current.y, x2, y2 };
+      selectionBoxRef.current = box;
+      setSelectionRect(box);
+    };
+
+    const onUp = () => {
+      if (!dragging.current) return;
+      dragging.current = false;
+      setShiftDragging(false);
+      const b = selectionBoxRef.current;
+      if (!b) return;
+
+      const minX = Math.min(b.x1, b.x2);
+      const maxX = Math.max(b.x1, b.x2);
+      const minY = Math.min(b.y1, b.y2);
+      const maxY = Math.max(b.y1, b.y2);
+
+      selectionBoxRef.current = null;
+      setSelectionRect(null);
+
+      // Ignore tiny drags so a normal shift-click doesn't clobber state.
+      if (maxX - minX < 5 && maxY - minY < 5) return;
+      if (!field) return;
+
+      // Project each node's ground-plane position to NDC, then to pixels.
+      // The TOPO scene places nodes at (layout.x - field.cx, 0, layout.y -
+      // field.cy) — same translation `SelectionMarkers` uses — so peaks
+      // rise vertically above their xz base. We hit-test the base, which
+      // is what the user visually associates with the node.
+      const ids: string[] = [];
+      const vec = new THREE.Vector3();
+      for (const node of graphNodes) {
+        const p = layout.get(node.id);
+        if (!p || !Number.isFinite(p.x) || !Number.isFinite(p.y)) continue;
+        vec.set(p.x - field.cx, 0, p.y - field.cy).project(camera);
+        const sx = ((vec.x + 1) / 2) * canvasSize.width;
+        const sy = ((-vec.y + 1) / 2) * canvasSize.height;
+        if (sx >= minX && sx <= maxX && sy >= minY && sy <= maxY) {
+          ids.push(node.id);
+        }
+      }
+      onSelect(ids);
+    };
+
+    canvas.addEventListener("pointerdown", onDown);
+    canvas.addEventListener("pointermove", onMove);
+    canvas.addEventListener("pointerup", onUp);
+    return () => {
+      canvas.removeEventListener("pointerdown", onDown);
+      canvas.removeEventListener("pointermove", onMove);
+      canvas.removeEventListener("pointerup", onUp);
+    };
+  }, [gl, layout, field, graphNodes, camera, canvasSize, onSelect, selectionBoxRef, setSelectionRect, setShiftDragging]);
+
+  return null;
+}
+
 export default function CausalDAGRelief() {
   return (
     <ReliefErrorBoundary>
@@ -694,7 +803,22 @@ export default function CausalDAGRelief() {
 function CausalDAGReliefInner() {
   const graphData = useFilteredGraph();
   const setSelectedNode = useApexStore((s) => s.setSelectedNode);
+  const setSelectedNodes = useApexStore((s) => s.setSelectedNodes);
   const [pickHint, setPickHint] = useState<string | null>(null);
+
+  // Shift+drag marquee state — mirrors the pattern in CausalDAG3D /
+  // CausalDAG2D / CausalDAGMap so the user can lasso a region of the
+  // topology and have those nodes selected across views (2D / 3D /
+  // TOPO / Map all read the same `selectedNodes` slice in the store).
+  const selectionBoxRef = useRef<{ x1: number; y1: number; x2: number; y2: number } | null>(null);
+  const [selectionRect, setSelectionRect] = useState<{ x1: number; y1: number; x2: number; y2: number } | null>(null);
+  const [shiftDragging, setShiftDragging] = useState(false);
+  const handleShiftSelect = useCallback(
+    (ids: string[]) => {
+      if (ids.length > 0) setSelectedNodes(ids);
+    },
+    [setSelectedNodes],
+  );
 
   // Replay state — when a cascade is being scrubbed, the current epoch's
   // snapshot drives the topo's height field instead of the static node
@@ -926,8 +1050,33 @@ function CausalDAGReliefInner() {
           minDistance={20}
           maxDistance={3000}
           maxPolarAngle={Math.PI * 0.49}
+          // Disable orbit while shift-dragging so the camera doesn't
+          // rotate alongside the marquee gesture.
+          enabled={!shiftDragging}
         />
+        {!isEmpty && activeField && (
+          <TopoShiftMarquee
+            layout={layout}
+            field={activeField}
+            graphNodes={graphData.nodes}
+            selectionBoxRef={selectionBoxRef}
+            setSelectionRect={setSelectionRect}
+            setShiftDragging={setShiftDragging}
+            onSelect={handleShiftSelect}
+          />
+        )}
       </Canvas>
+      {selectionRect && (
+        <div
+          className="absolute pointer-events-none border border-accent-cyan/80 bg-accent-cyan/10 z-50"
+          style={{
+            left: Math.min(selectionRect.x1, selectionRect.x2),
+            top: Math.min(selectionRect.y1, selectionRect.y2),
+            width: Math.abs(selectionRect.x2 - selectionRect.x1),
+            height: Math.abs(selectionRect.y2 - selectionRect.y1),
+          }}
+        />
+      )}
       {!isEmpty && multilayer && fusedField && (
         <DomainLegend field={fusedField} />
       )}

--- a/src/components/dag3d/DAGOverlay.tsx
+++ b/src/components/dag3d/DAGOverlay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { startTransition, useEffect, useMemo, useRef, useState } from "react";
 import { useApexStore } from "@/stores/useApexStore";
 import { getDomainColor } from "@/lib/graph-data";
 import { useTemporalGraph } from "@/hooks/useTemporalGraph";
@@ -572,7 +572,18 @@ export default function DAGOverlay() {
             {/* Action buttons */}
             <div className="flex gap-1 mt-1.5 pt-1.5 border-t border-border/50">
               <button
-                onClick={() => setIsolateSelection(!isolateSelection)}
+                // ISOLATE flips the selection-only filter across every
+                // canvas surface — 2D / 3D / Map / TOPO. With ~200 nodes
+                // and ~330 edges, the resulting re-render cascade
+                // (especially the 3D scene-tree where non-selected nodes
+                // unmount in a single frame) was reading as a freeze
+                // for ~150-300ms when triggered from a multi-domain
+                // selection. `startTransition` marks the resulting work
+                // as non-urgent: React keeps the current UI interactive
+                // and computes the new tree in the background, so the
+                // click feels instant even if the actual switch lands
+                // ~150ms later.
+                onClick={() => startTransition(() => setIsolateSelection(!isolateSelection))}
                 className={`flex-1 text-[7px] font-[family-name:var(--font-michroma)] tracking-wider px-1.5 py-1 rounded border transition-colors ${
                   isolateSelection
                     ? "border-accent-amber/60 text-accent-amber bg-accent-amber/10"


### PR DESCRIPTION
## Summary

Two-item batch:

- **ISOLATE freeze unblocked.** Clicking ISOLATE after a multi-domain panel pick caused ~150 `DAGNode3D` + ~270 `DAGEdge3D` children to unmount in a single render cycle (plus 4 Map GeoJSON FC rebuilds), blocking the main thread for ~150-300ms. Wrapping the toggle in `startTransition` marks the resulting re-render as non-urgent so React processes the unmount cascade in the background while the UI stays interactive. The actual switch still costs the same; it just no longer reads as a freeze.
- **TOPO shift+drag lasso.** Mirrors the 3D `ShiftMarquee` pattern: new `TopoShiftMarquee` inside the relief Canvas listens on `gl.domElement` for pointer events gated on `e.shiftKey`, tracks a screen-space rect, and on release projects each node's ground-plane position (`layout.xy − field.cxcy`) into screen coords for hit-testing. OrbitControls disabled during the drag. DOM rect overlay matches the visual style used by the other views.

## Test plan

- [ ] Open the 3D / 2D / Map view, click a row in the bottom-left DOMAINS panel, then click ISOLATE — confirm the click feels instant (UI doesn't lock up). The actual visual switch may take a beat but the click feedback should be immediate.
- [ ] In TOPO, hold Shift and drag across a region of the surface — confirm a cyan rect overlay appears, OrbitControls stops rotating, and on release the nodes whose base falls inside the rect get selected (`selectedNodes` in store).
- [ ] Confirm a normal Shift-click (or tiny drag < 5px) does NOT clobber `selectedNodes` (the marquee is gated to non-trivial drags).
- [ ] Confirm tooltips / pillars in TOPO update to reflect the lassoed multi-selection.

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_