### PR TITLE
feat(estimators): add χ★ bridge sets — topology-aware criticality artefact

### DIFF
--- a/src/lib/__tests__/estimators/chi-star.test.ts
+++ b/src/lib/__tests__/estimators/chi-star.test.ts
@@ -1,0 +1,438 @@
+import { describe, it, expect } from "vitest";
+import {
+  findBridges,
+  edgeBetweenness,
+  bridgeEdgeStrength,
+  chiStar,
+  resolveChiStarEdges,
+} from "@/lib/estimators/chi-star";
+import type { CausalGraph } from "@/lib/types";
+import { makeNode, makeEdge } from "../fixtures/graph-fixtures";
+
+// Tests cover:
+//   1. Tarjan bridge detection on canonical graphs (path, cycle, star,
+//      two-triangles-by-bridge, K4, multi-edge).
+//   2. Brandes edge betweenness on graphs with hand-computable values.
+//   3. χ★ set composition (bridges ∪ top-k BES).
+//   4. Edge cases: empty graph, single node, disconnected components.
+//
+// Uses the existing makeNode / makeEdge fixture builders. The χ★
+// algorithms only read id, source, target (and treat the graph as
+// undirected for connectivity / shortest-path purposes).
+
+function makeGraph(
+  nodeIds: string[],
+  edgeSpecs: { id: string; source: string; target: string }[],
+): CausalGraph {
+  return {
+    nodes: nodeIds.map((id) => makeNode({ id })),
+    edges: edgeSpecs.map((s) => makeEdge(s)),
+    metadata: {
+      density: 0,
+      constraintType: "",
+      verificationStatus: "UNVERIFIED",
+      totalNodes: nodeIds.length,
+      totalEdges: edgeSpecs.length,
+      inconsistentEdges: 0,
+      restrictedNodes: 0,
+    },
+  };
+}
+
+describe("findBridges (Tarjan)", () => {
+  it("path graph: every edge is a bridge", () => {
+    // a — b — c — d
+    const g = makeGraph(
+      ["a", "b", "c", "d"],
+      [
+        { id: "e1", source: "a", target: "b" },
+        { id: "e2", source: "b", target: "c" },
+        { id: "e3", source: "c", target: "d" },
+      ],
+    );
+    expect(findBridges(g).sort()).toEqual(["e1", "e2", "e3"]);
+  });
+
+  it("cycle graph: no bridges", () => {
+    // a — b — c — a
+    const g = makeGraph(
+      ["a", "b", "c"],
+      [
+        { id: "e1", source: "a", target: "b" },
+        { id: "e2", source: "b", target: "c" },
+        { id: "e3", source: "c", target: "a" },
+      ],
+    );
+    expect(findBridges(g)).toEqual([]);
+  });
+
+  it("two triangles connected by a single edge: only the connector is a bridge", () => {
+    //   a — b      d — e
+    //    \ /        \ /
+    //     c — — — — f
+    const g = makeGraph(
+      ["a", "b", "c", "d", "e", "f"],
+      [
+        { id: "ab", source: "a", target: "b" },
+        { id: "bc", source: "b", target: "c" },
+        { id: "ca", source: "c", target: "a" },
+        { id: "de", source: "d", target: "e" },
+        { id: "ef", source: "e", target: "f" },
+        { id: "fd", source: "f", target: "d" },
+        { id: "cf", source: "c", target: "f" }, // bridge
+      ],
+    );
+    expect(findBridges(g)).toEqual(["cf"]);
+  });
+
+  it("star graph: every spoke is a bridge", () => {
+    // hub connected to 4 leaves
+    const g = makeGraph(
+      ["hub", "l1", "l2", "l3", "l4"],
+      [
+        { id: "s1", source: "hub", target: "l1" },
+        { id: "s2", source: "hub", target: "l2" },
+        { id: "s3", source: "hub", target: "l3" },
+        { id: "s4", source: "hub", target: "l4" },
+      ],
+    );
+    expect(findBridges(g).sort()).toEqual(["s1", "s2", "s3", "s4"]);
+  });
+
+  it("complete K4: no bridges", () => {
+    const g = makeGraph(
+      ["a", "b", "c", "d"],
+      [
+        { id: "ab", source: "a", target: "b" },
+        { id: "ac", source: "a", target: "c" },
+        { id: "ad", source: "a", target: "d" },
+        { id: "bc", source: "b", target: "c" },
+        { id: "bd", source: "b", target: "d" },
+        { id: "cd", source: "c", target: "d" },
+      ],
+    );
+    expect(findBridges(g)).toEqual([]);
+  });
+
+  it("multi-edge between two nodes: neither is a bridge", () => {
+    // Parallel edges form a 2-edge cycle, so removing either leaves
+    // the graph connected. Tarjan must use parent-EDGE not parent-NODE
+    // bookkeeping for this to work.
+    const g = makeGraph(
+      ["a", "b"],
+      [
+        { id: "e1", source: "a", target: "b" },
+        { id: "e2", source: "a", target: "b" },
+      ],
+    );
+    expect(findBridges(g)).toEqual([]);
+  });
+
+  it("disconnected components: bridges found within each component", () => {
+    // Component 1: a—b—c (path, both edges bridges)
+    // Component 2: d—e—f—d (cycle, no bridges)
+    const g = makeGraph(
+      ["a", "b", "c", "d", "e", "f"],
+      [
+        { id: "ab", source: "a", target: "b" },
+        { id: "bc", source: "b", target: "c" },
+        { id: "de", source: "d", target: "e" },
+        { id: "ef", source: "e", target: "f" },
+        { id: "fd", source: "f", target: "d" },
+      ],
+    );
+    expect(findBridges(g).sort()).toEqual(["ab", "bc"]);
+  });
+
+  it("empty graph", () => {
+    const g = makeGraph([], []);
+    expect(findBridges(g)).toEqual([]);
+  });
+
+  it("single node, no edges", () => {
+    const g = makeGraph(["a"], []);
+    expect(findBridges(g)).toEqual([]);
+  });
+});
+
+describe("edgeBetweenness (Brandes)", () => {
+  it("path graph: middle edge has highest betweenness", () => {
+    // a — b — c — d
+    // Shortest paths through each edge (undirected, n=4):
+    //   ab carries: {a-b, a-c, a-d}                 → 3
+    //   bc carries: {a-c, a-d, b-c, b-d}            → 4
+    //   cd carries: {a-d, b-d, c-d}                 → 3
+    const g = makeGraph(
+      ["a", "b", "c", "d"],
+      [
+        { id: "ab", source: "a", target: "b" },
+        { id: "bc", source: "b", target: "c" },
+        { id: "cd", source: "c", target: "d" },
+      ],
+    );
+    const eb = edgeBetweenness(g);
+    expect(eb.get("ab")).toBeCloseTo(3, 12);
+    expect(eb.get("bc")).toBeCloseTo(4, 12);
+    expect(eb.get("cd")).toBeCloseTo(3, 12);
+  });
+
+  it("triangle: all edges equal by symmetry", () => {
+    // a—b—c—a, every pair has 2 shortest paths of length 1; each pair
+    // contributes 1/2 to each of the two edges on its path — but wait,
+    // pairs at distance 1 have a single shortest path (the direct edge).
+    // So each edge carries betweenness = 1 (its endpoints' pair).
+    const g = makeGraph(
+      ["a", "b", "c"],
+      [
+        { id: "ab", source: "a", target: "b" },
+        { id: "bc", source: "b", target: "c" },
+        { id: "ca", source: "c", target: "a" },
+      ],
+    );
+    const eb = edgeBetweenness(g);
+    expect(eb.get("ab")).toBeCloseTo(1, 12);
+    expect(eb.get("bc")).toBeCloseTo(1, 12);
+    expect(eb.get("ca")).toBeCloseTo(1, 12);
+  });
+
+  it("star graph: every spoke equally betwixt", () => {
+    // hub—l1, hub—l2, hub—l3, hub—l4
+    // Pairs of leaves (li, lj) each have one shortest path through hub
+    // using two edges; each leaf-pair contributes 1 to each of its 2
+    // spoke edges. Pairs (hub, li) contribute 1 to spoke i.
+    // Spoke i's betweenness = 1 (hub-li pair) + 3 (other 3 leaves
+    // connecting to li through the spoke) = 4.
+    const g = makeGraph(
+      ["hub", "l1", "l2", "l3", "l4"],
+      [
+        { id: "s1", source: "hub", target: "l1" },
+        { id: "s2", source: "hub", target: "l2" },
+        { id: "s3", source: "hub", target: "l3" },
+        { id: "s4", source: "hub", target: "l4" },
+      ],
+    );
+    const eb = edgeBetweenness(g);
+    expect(eb.get("s1")).toBeCloseTo(4, 12);
+    expect(eb.get("s2")).toBeCloseTo(4, 12);
+    expect(eb.get("s3")).toBeCloseTo(4, 12);
+    expect(eb.get("s4")).toBeCloseTo(4, 12);
+  });
+
+  it("bridge between two triangles has highest betweenness", () => {
+    // Same fixture as bridge test. The connector cf carries every
+    // shortest path between the two triangle components.
+    const g = makeGraph(
+      ["a", "b", "c", "d", "e", "f"],
+      [
+        { id: "ab", source: "a", target: "b" },
+        { id: "bc", source: "b", target: "c" },
+        { id: "ca", source: "c", target: "a" },
+        { id: "de", source: "d", target: "e" },
+        { id: "ef", source: "e", target: "f" },
+        { id: "fd", source: "f", target: "d" },
+        { id: "cf", source: "c", target: "f" },
+      ],
+    );
+    const eb = edgeBetweenness(g);
+    // 3 nodes on each side; 3·3 = 9 cross-pairs all routing through cf.
+    expect(eb.get("cf")).toBeCloseTo(9, 12);
+    // Internal triangle edges carry strictly less.
+    for (const eid of ["ab", "bc", "ca", "de", "ef", "fd"]) {
+      expect(eb.get(eid)!).toBeLessThan(eb.get("cf")!);
+    }
+  });
+
+  it("disconnected components: betweenness only counts within-component pairs", () => {
+    // Two separate paths: a—b and c—d. Each edge carries one pair.
+    const g = makeGraph(
+      ["a", "b", "c", "d"],
+      [
+        { id: "ab", source: "a", target: "b" },
+        { id: "cd", source: "c", target: "d" },
+      ],
+    );
+    const eb = edgeBetweenness(g);
+    expect(eb.get("ab")).toBeCloseTo(1, 12);
+    expect(eb.get("cd")).toBeCloseTo(1, 12);
+  });
+});
+
+describe("bridgeEdgeStrength", () => {
+  it("normalises to [0, 1] with max = 1", () => {
+    const g = makeGraph(
+      ["a", "b", "c", "d"],
+      [
+        { id: "ab", source: "a", target: "b" },
+        { id: "bc", source: "b", target: "c" },
+        { id: "cd", source: "c", target: "d" },
+      ],
+    );
+    const bes = bridgeEdgeStrength(g);
+    let maxBes = 0;
+    for (const v of bes.values()) {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(1);
+      if (v > maxBes) maxBes = v;
+    }
+    expect(maxBes).toBeCloseTo(1, 12);
+    // Middle edge should be the max.
+    expect(bes.get("bc")).toBeCloseTo(1, 12);
+    expect(bes.get("ab")).toBeCloseTo(0.75, 12); // 3 / 4
+    expect(bes.get("cd")).toBeCloseTo(0.75, 12);
+  });
+
+  it("returns all zeros for a single isolated node", () => {
+    const g = makeGraph(["a"], []);
+    const bes = bridgeEdgeStrength(g);
+    expect(bes.size).toBe(0);
+  });
+});
+
+describe("chiStar", () => {
+  it("path graph: bridges cover every edge, χ★ = all edges", () => {
+    const g = makeGraph(
+      ["a", "b", "c", "d"],
+      [
+        { id: "ab", source: "a", target: "b" },
+        { id: "bc", source: "b", target: "c" },
+        { id: "cd", source: "c", target: "d" },
+      ],
+    );
+    const r = chiStar(g);
+    expect(r.bridges.sort()).toEqual(["ab", "bc", "cd"]);
+    expect([...r.chiStar].sort()).toEqual(["ab", "bc", "cd"]);
+  });
+
+  it("two triangles + bridge: χ★ contains the bridge plus top-k BES", () => {
+    const g = makeGraph(
+      ["a", "b", "c", "d", "e", "f"],
+      [
+        { id: "ab", source: "a", target: "b" },
+        { id: "bc", source: "b", target: "c" },
+        { id: "ca", source: "c", target: "a" },
+        { id: "de", source: "d", target: "e" },
+        { id: "ef", source: "e", target: "f" },
+        { id: "fd", source: "f", target: "d" },
+        { id: "cf", source: "c", target: "f" },
+      ],
+    );
+    const r = chiStar(g, { topK: 1 });
+    expect(r.bridges).toEqual(["cf"]);
+    // topK=1 → top BES edge is cf (betweenness 9, the max).
+    // χ★ = {cf} ∪ {cf} = {cf}.
+    expect(r.chiStar).toEqual(["cf"]);
+  });
+
+  it("topK can be larger than bridges, adds top-BES edges", () => {
+    const g = makeGraph(
+      ["a", "b", "c", "d"],
+      [
+        { id: "ab", source: "a", target: "b" },
+        { id: "bc", source: "b", target: "c" },
+        { id: "cd", source: "c", target: "d" },
+      ],
+    );
+    // All three are bridges. topK=2 picks top-2 BES (bc, then a tie
+    // between ab/cd resolved by Map insertion order).
+    const r = chiStar(g, { topK: 2 });
+    expect(r.bridges.sort()).toEqual(["ab", "bc", "cd"]);
+    expect(r.chiStar.length).toBe(3); // bridges already cover everything
+  });
+
+  it("topK = 0 returns only strict bridges", () => {
+    const g = makeGraph(
+      ["a", "b", "c", "d"],
+      [
+        { id: "ab", source: "a", target: "b" },
+        { id: "bc", source: "b", target: "c" },
+        { id: "ca", source: "c", target: "a" },
+        { id: "cd", source: "c", target: "d" }, // bridge
+      ],
+    );
+    const r = chiStar(g, { topK: 0 });
+    expect(r.bridges).toEqual(["cd"]);
+    expect(r.chiStar).toEqual(["cd"]);
+  });
+
+  it("auto topK defaults to ~10% of edges, minimum 1 edge", () => {
+    // 20-edge cycle has no bridges; auto topK = max(1, floor(0.1 · 20)) = 2.
+    const ids: string[] = [];
+    const edges: { id: string; source: string; target: string }[] = [];
+    for (let i = 0; i < 20; i++) ids.push(`n${i}`);
+    for (let i = 0; i < 20; i++) {
+      edges.push({
+        id: `e${i}`,
+        source: `n${i}`,
+        target: `n${(i + 1) % 20}`,
+      });
+    }
+    const g = makeGraph(ids, edges);
+    const r = chiStar(g);
+    expect(r.bridges).toEqual([]);
+    expect(r.topK).toBe(2);
+    expect(r.chiStar.length).toBe(2);
+  });
+
+  it("besRanking is sorted descending", () => {
+    const g = makeGraph(
+      ["a", "b", "c", "d"],
+      [
+        { id: "ab", source: "a", target: "b" },
+        { id: "bc", source: "b", target: "c" },
+        { id: "cd", source: "c", target: "d" },
+      ],
+    );
+    const r = chiStar(g);
+    for (let i = 1; i < r.besRanking.length; i++) {
+      expect(r.besRanking[i].bes).toBeLessThanOrEqual(
+        r.besRanking[i - 1].bes,
+      );
+    }
+  });
+
+  it("rejects negative or non-finite topK", () => {
+    const g = makeGraph(
+      ["a", "b"],
+      [{ id: "ab", source: "a", target: "b" }],
+    );
+    expect(() => chiStar(g, { topK: -1 })).toThrow(/topK/);
+    expect(() => chiStar(g, { topK: NaN })).toThrow(/topK/);
+    expect(() => chiStar(g, { topK: Infinity })).toThrow(/topK/);
+  });
+
+  it("empty graph: empty result", () => {
+    const g = makeGraph([], []);
+    const r = chiStar(g);
+    expect(r.bridges).toEqual([]);
+    expect(r.chiStar).toEqual([]);
+    expect(r.bes.size).toBe(0);
+  });
+});
+
+describe("resolveChiStarEdges", () => {
+  it("returns the original CausalEdge objects in χ★ order", () => {
+    const g = makeGraph(
+      ["a", "b", "c"],
+      [
+        { id: "ab", source: "a", target: "b" },
+        { id: "bc", source: "b", target: "c" },
+      ],
+    );
+    const r = chiStar(g);
+    const edges = resolveChiStarEdges(g, r);
+    expect(edges.map((e) => e.id).sort()).toEqual(["ab", "bc"]);
+    expect(edges[0]).toMatchObject({ source: expect.any(String), target: expect.any(String) });
+  });
+
+  it("skips edge ids not present in the graph (defensive)", () => {
+    const g = makeGraph(
+      ["a", "b"],
+      [{ id: "ab", source: "a", target: "b" }],
+    );
+    const r = chiStar(g);
+    // Manually inject a phantom id — resolver should skip it.
+    const fakeResult = { ...r, chiStar: [...r.chiStar, "ghost"] };
+    const edges = resolveChiStarEdges(g, fakeResult);
+    expect(edges.map((e) => e.id)).toEqual(["ab"]);
+  });
+});

--- a/src/lib/estimators/chi-star.ts
+++ b/src/lib/estimators/chi-star.ts
@@ -1,0 +1,305 @@
+// χ★ (chi-star) bridge sets — topology-aware criticality on the causal
+// graph. Canonical artefact from Ghauri 2025 (D.Eng., Ch. 5–8 — IDS
+// substrate + topology-aware replay).
+//
+// The χ★ set is the union of:
+//
+//   1. Strict bridges. Edges whose removal disconnects the underlying
+//      graph (treating directed edges as undirected for connectivity).
+//      Computed via Tarjan's DFS-based algorithm in O(V + E). These are
+//      the topological single-points-of-failure — every cascade path
+//      between the two components must traverse them.
+//
+//   2. Top-k edges by Bridge-Edge Strength (BES). BES is a continuous
+//      measure of how much each edge participates in shortest paths
+//      across the graph: high BES = high information-flow funnel.
+//      Implemented as edge betweenness centrality (Brandes 2008,
+//      unweighted O(V·E)) normalised to [0, 1]. The dissertation's
+//      attention-head layer reads BES to bias the replay buffer
+//      toward high-bridge edges (Ch. 8 §6, "topology-aware rehearsal").
+//
+// Strict bridges and high-BES edges together give a structural picture
+// of the graph's load-bearing skeleton — the edges most worth hardening,
+// monitoring, or preserving in replay against catastrophic forgetting.
+//
+// All algorithms operate on the undirected version of the graph for
+// connectivity / shortest-path purposes. Edge IDs are preserved
+// throughout so callers can map BES scores and bridge membership back
+// to the original directed edges.
+//
+// No external deps. Tarjan: O(V + E). Brandes: O(V · E) (unweighted
+// shortest paths via BFS, accumulating dependency over edges).
+
+import type { CausalGraph, CausalEdge } from "@/lib/types";
+
+export interface ChiStarOptions {
+  /**
+   * Number of top-BES edges to include in the χ★ set on top of the
+   * strict bridges. If null, an automatic threshold is used:
+   * floor(max(1, 0.1 · |E|)) — ten percent of edges, minimum one.
+   */
+  topK?: number | null;
+}
+
+export interface ChiStarResult {
+  /** Edge IDs whose removal disconnects the (undirected) graph. */
+  bridges: string[];
+  /** Per-edge BES ∈ [0, 1] (normalised edge betweenness). */
+  bes: Map<string, number>;
+  /** Edge IDs in the χ★ set: bridges ∪ top-k BES. */
+  chiStar: string[];
+  /** Edge IDs ranked descending by BES (full ranking, not just top-k). */
+  besRanking: { edgeId: string; bes: number }[];
+  /** Echo of resolved options after defaulting. */
+  topK: number;
+}
+
+/**
+ * Build adjacency list (undirected) keyed by node id. Each adjacency
+ * entry carries the original edge id and the neighbour. Multi-edges
+ * are preserved — Tarjan and Brandes both need to see them.
+ */
+function buildUndirectedAdjacency(
+  graph: CausalGraph,
+): Map<string, { neighbour: string; edgeId: string }[]> {
+  const adj = new Map<string, { neighbour: string; edgeId: string }[]>();
+  for (const node of graph.nodes) adj.set(node.id, []);
+  for (const edge of graph.edges) {
+    if (!adj.has(edge.source) || !adj.has(edge.target)) continue;
+    adj.get(edge.source)!.push({ neighbour: edge.target, edgeId: edge.id });
+    adj.get(edge.target)!.push({ neighbour: edge.source, edgeId: edge.id });
+  }
+  return adj;
+}
+
+/**
+ * Tarjan's DFS-based bridge-finding. An edge (u, v) is a bridge iff
+ * low[v] > disc[u] for the tree edge (u, v) — i.e. v's subtree has no
+ * back-edge climbing above u. Multi-edges between the same pair are
+ * never bridges (one of them provides an alternate path), so we
+ * track parent edge id rather than parent node id to handle this
+ * correctly.
+ */
+export function findBridges(graph: CausalGraph): string[] {
+  const adj = buildUndirectedAdjacency(graph);
+  const disc = new Map<string, number>();
+  const low = new Map<string, number>();
+  const bridgeIds: string[] = [];
+  let timer = 0;
+
+  // Iterative DFS to avoid stack overflow on large graphs.
+  for (const start of adj.keys()) {
+    if (disc.has(start)) continue;
+    type Frame = { node: string; parentEdge: string | null; iterIdx: number };
+    const stack: Frame[] = [{ node: start, parentEdge: null, iterIdx: 0 }];
+    disc.set(start, timer);
+    low.set(start, timer);
+    timer++;
+
+    while (stack.length > 0) {
+      const frame = stack[stack.length - 1];
+      const neighbours = adj.get(frame.node)!;
+
+      if (frame.iterIdx < neighbours.length) {
+        const { neighbour, edgeId } = neighbours[frame.iterIdx];
+        frame.iterIdx++;
+        if (edgeId === frame.parentEdge) continue;
+
+        if (!disc.has(neighbour)) {
+          disc.set(neighbour, timer);
+          low.set(neighbour, timer);
+          timer++;
+          stack.push({ node: neighbour, parentEdge: edgeId, iterIdx: 0 });
+        } else {
+          // Back edge: update low[frame.node].
+          const lo = low.get(frame.node)!;
+          const d = disc.get(neighbour)!;
+          if (d < lo) low.set(frame.node, d);
+        }
+      } else {
+        // Done with this node — propagate low up to parent.
+        stack.pop();
+        if (stack.length > 0) {
+          const parent = stack[stack.length - 1];
+          const childLow = low.get(frame.node)!;
+          const parentLow = low.get(parent.node)!;
+          if (childLow < parentLow) low.set(parent.node, childLow);
+          // Bridge test: child subtree's low > parent's discovery time.
+          if (childLow > disc.get(parent.node)!) {
+            bridgeIds.push(frame.parentEdge!);
+          }
+        }
+      }
+    }
+  }
+
+  return bridgeIds;
+}
+
+/**
+ * Edge betweenness via Brandes (2008), unweighted variant.
+ *
+ *   For every source s ∈ V:
+ *     1. BFS from s — compute σ(s, v) = #shortest paths and the BFS
+ *        predecessor multiset Pred[v].
+ *     2. Accumulate δ(v) = Σ_{w in succ(v)} (σ(s,v)/σ(s,w)) · (1 + δ(w))
+ *        in reverse BFS order. Each tree edge (v, w) contributes
+ *        (σ(s,v)/σ(s,w)) · (1 + δ(w)) to its betweenness.
+ *
+ * The result is summed across all sources. For an undirected graph the
+ * standard Brandes formulation double-counts (s→t and t→s share a
+ * shortest path), so we divide the final sum by 2.
+ *
+ * Returns RAW betweenness counts. Use {@link bridgeEdgeStrength} to
+ * normalise to [0, 1].
+ */
+export function edgeBetweenness(graph: CausalGraph): Map<string, number> {
+  const adj = buildUndirectedAdjacency(graph);
+  const nodes = [...adj.keys()];
+  const betweenness = new Map<string, number>();
+  for (const e of graph.edges) betweenness.set(e.id, 0);
+
+  for (const s of nodes) {
+    // BFS from s.
+    const sigma = new Map<string, number>(); // # shortest paths
+    const dist = new Map<string, number>();
+    const pred = new Map<string, { node: string; edgeId: string }[]>();
+    for (const n of nodes) {
+      sigma.set(n, 0);
+      dist.set(n, -1);
+      pred.set(n, []);
+    }
+    sigma.set(s, 1);
+    dist.set(s, 0);
+
+    const queue: string[] = [s];
+    const order: string[] = []; // BFS visit order (for reverse accumulation)
+    let head = 0;
+    while (head < queue.length) {
+      const v = queue[head++];
+      order.push(v);
+      const dv = dist.get(v)!;
+      for (const { neighbour: w, edgeId } of adj.get(v)!) {
+        if (dist.get(w) === -1) {
+          dist.set(w, dv + 1);
+          queue.push(w);
+        }
+        if (dist.get(w) === dv + 1) {
+          sigma.set(w, sigma.get(w)! + sigma.get(v)!);
+          pred.get(w)!.push({ node: v, edgeId });
+        }
+      }
+    }
+
+    // Accumulation in reverse BFS order.
+    const delta = new Map<string, number>();
+    for (const n of nodes) delta.set(n, 0);
+    for (let i = order.length - 1; i >= 0; i--) {
+      const w = order[i];
+      const dw = delta.get(w)!;
+      const sw = sigma.get(w)!;
+      for (const { node: v, edgeId } of pred.get(w)!) {
+        const sv = sigma.get(v)!;
+        const contribution = (sv / sw) * (1 + dw);
+        delta.set(v, delta.get(v)! + contribution);
+        betweenness.set(edgeId, betweenness.get(edgeId)! + contribution);
+      }
+    }
+  }
+
+  // Undirected double-count correction.
+  for (const [eid, b] of betweenness) betweenness.set(eid, b / 2);
+  return betweenness;
+}
+
+/**
+ * Bridge-Edge Strength: edge betweenness normalised to [0, 1] by the
+ * maximum across the graph. If max is zero (graph has no shortest
+ * paths through any edge — degenerate, e.g. single isolated node),
+ * returns all zeros.
+ */
+export function bridgeEdgeStrength(graph: CausalGraph): Map<string, number> {
+  const raw = edgeBetweenness(graph);
+  let max = 0;
+  for (const v of raw.values()) if (v > max) max = v;
+  const bes = new Map<string, number>();
+  if (max === 0) {
+    for (const k of raw.keys()) bes.set(k, 0);
+    return bes;
+  }
+  for (const [k, v] of raw) bes.set(k, v / max);
+  return bes;
+}
+
+/**
+ * Compute the χ★ bridge set: strict bridges ∪ top-k BES edges.
+ *
+ * Returns the edge ids in both groups along with the full BES ranking,
+ * so downstream callers can render the score distribution rather than
+ * just the binary membership.
+ */
+export function chiStar(
+  graph: CausalGraph,
+  options: ChiStarOptions = {},
+): ChiStarResult {
+  const bridges = findBridges(graph);
+  const bes = bridgeEdgeStrength(graph);
+
+  const besRanking = [...bes.entries()]
+    .map(([edgeId, b]) => ({ edgeId, bes: b }))
+    .sort((a, b) => b.bes - a.bes);
+
+  const nE = graph.edges.length;
+  const requestedK = options.topK;
+  let topK: number;
+  if (requestedK === undefined || requestedK === null) {
+    topK = Math.max(1, Math.floor(0.1 * nE));
+    if (nE === 0) topK = 0;
+  } else {
+    if (!Number.isFinite(requestedK) || requestedK < 0) {
+      throw new Error(
+        `chiStar: topK must be a non-negative integer, got ${requestedK}`,
+      );
+    }
+    topK = Math.min(Math.floor(requestedK), nE);
+  }
+
+  const topByBes = new Set<string>();
+  for (let i = 0; i < topK; i++) {
+    if (i >= besRanking.length) break;
+    topByBes.add(besRanking[i].edgeId);
+  }
+
+  // χ★ = bridges ∪ top-k BES. Preserve order: bridges first (in
+  // discovery order), then any additional top-k entries not already
+  // included.
+  const chiStarSet = new Set<string>(bridges);
+  for (const eid of topByBes) chiStarSet.add(eid);
+
+  return {
+    bridges,
+    bes,
+    chiStar: [...chiStarSet],
+    besRanking,
+    topK,
+  };
+}
+
+/**
+ * Convenience: extract the original `CausalEdge` objects matching a
+ * χ★ result's edge ids. Returns them in the order they appear in
+ * `chiStar.chiStar` (bridges first, then top-k BES additions).
+ */
+export function resolveChiStarEdges(
+  graph: CausalGraph,
+  result: ChiStarResult,
+): CausalEdge[] {
+  const byId = new Map<string, CausalEdge>();
+  for (const e of graph.edges) byId.set(e.id, e);
+  const out: CausalEdge[] = [];
+  for (const eid of result.chiStar) {
+    const e = byId.get(eid);
+    if (e) out.push(e);
+  }
+  return out;
+}

--- a/src/lib/estimators/index.ts
+++ b/src/lib/estimators/index.ts
@@ -40,3 +40,12 @@ export type {
 
 export { cvarW1, tailDepthScore } from "./cvar-w1";
 export type { CvarW1Options, CvarW1Result } from "./cvar-w1";
+
+export {
+  findBridges,
+  edgeBetweenness,
+  bridgeEdgeStrength,
+  chiStar,
+  resolveChiStarEdges,
+} from "./chi-star";
+export type { ChiStarOptions, ChiStarResult } from "./chi-star";


### PR DESCRIPTION
## Summary

Second from-spec dissertation port (Ghauri 2025, D.Eng., Ch. 5–8 — IDS substrate + topology-aware replay). Adds the canonical **χ★ (chi-star) bridge set** artefact: the load-bearing skeleton of a graph, computed as **strict bridges ∪ top-k Bridge-Edge Strength edges**.

The dissertation uses χ★ to bias the GAT replay buffer toward high-bridge edges (Ch. 8 §6, "topology-aware rehearsal"). For Manifold's purposes, it gives the runtime a principled "edges most worth hardening / monitoring / preserving" set on any graph — useful well beyond AI Safety.

## Public API

```ts
findBridges(graph) -> string[]
edgeBetweenness(graph) -> Map<edgeId, number>
bridgeEdgeStrength(graph) -> Map<edgeId, number>   // BES ∈ [0, 1]
chiStar(graph, { topK? }) -> ChiStarResult
resolveChiStarEdges(graph, result) -> CausalEdge[]
```

## What's in each piece

### `findBridges` — Tarjan's DFS, O(V + E)
Edges whose removal disconnects the (undirected) graph. Iterative DFS to avoid stack overflow on large graphs. Tracks **parent edge id** (not parent node id) so multi-edges between the same pair are correctly NOT flagged as bridges — important for graphs with parallel feedback loops like the AI Safety GAT ↔ replay buffer pair.

### `edgeBetweenness` — Brandes (2008), unweighted, O(V · E)
Per-source BFS + reverse-order dependency accumulation. Returns raw betweenness counts. Divided by 2 at the end to correct for the undirected double-count.

### `bridgeEdgeStrength` — BES ∈ [0, 1]
Edge betweenness normalised by the graph's max. This is what the dissertation's attention-head layer reads to score bridge-likelihood per edge.

### `chiStar`
Returns:
- `bridges`: edge ids from Tarjan
- `bes`: per-edge BES map
- `chiStar`: edge ids in `bridges ∪ top-k BES`
- `besRanking`: full descending-BES list (so the runtime can render distributions, not just binary membership)
- `topK`: resolved value (defaults to `max(1, ⌊0.1·|E|⌋)`)

### `resolveChiStarEdges`
Convenience helper to pull the original `CausalEdge` objects in χ★ order.

## Why these specific algorithms

**Tarjan for strict bridges** is canonical, O(V+E), and the parent-edge bookkeeping cleanly handles multi-edges that show up in real graphs (e.g. the parallel temporal feedback loops `ais_replay_buffer → ais_gat` and `ais_eval_harness → ais_replay_buffer` in the AI Safety subgraph from PR #275).

**Brandes for BES** is the standard betweenness algorithm. Weighted variants would require Dijkstra plus a domain-specific weight semantics decision (do we weight by `edge.weight`? `confidence`? `lag`?). Defer that to a follow-on PR — unweighted is defensible for v1 since χ★ is fundamentally a topological artefact.

## Test plan

- [x] 26 new tests under `src/lib/__tests__/estimators/chi-star.test.ts`.
- [x] **Tarjan**: path / cycle / star / two-triangles-by-bridge / K4 / multi-edge / disconnected-components / empty / single-node.
- [x] **Brandes** with hand-computed values:
  - Path `a—b—c—d`: betweenness `(3, 4, 3)` for `(ab, bc, cd)`
  - Triangle: `(1, 1, 1)` (every pair distance-1 has a single shortest path)
  - Star with 4 leaves: every spoke = 4
  - Two triangles + bridge: connector = 9 = 3·3 cross-pairs
  - Disconnected components: only within-component pairs counted
- [x] **χ★**: bridges-cover-all path / two-triangles + topK=1 / topK=0 bridges-only / auto-topK = 10% of edges with min 1 / besRanking sorted desc / topK validation (NaN, Infinity, negative all throw).
- [x] Uses existing `makeNode` / `makeEdge` factories from `src/lib/__tests__/fixtures/graph-fixtures.ts`.
- [x] `vitest run`: **869 passing** (was 833 before this PR — +26 new + ~10 from sibling sessions in parallel).
- [x] `tsc --noEmit` clean for the new files.

## Scope discipline

Math core only, matching the [#279](https://github.com/ApexAnalytica/apex-terminal/pull/279) / [#282](https://github.com/ApexAnalytica/apex-terminal/pull/282) pattern:

- **Does not** add to `criticality-registry.ts`.
- **Does not** add `"chi-star"` to any `DomainProfile`.
- **Does not** wire into any UI surface.

Follow-on PR will register it (the runtime decision — "compute on the live graph or the scoped subgraph?" — deserves its own discussion) and add an AI Safety profile entry.

## Sequence (Phase 1 from-spec dissertation work)

PR [#279](https://github.com/ApexAnalytica/apex-terminal/pull/279) ✅ CVaR-W₁ math core (Tail Depth pillar).
PR [#282](https://github.com/ApexAnalytica/apex-terminal/pull/282) ✅ CVaR-W₁ registry + AI Safety entry.
**This PR — χ★ bridge sets math core.**
Follow-on — χ★ registry + AI Safety entry.
Later — UX Ω-Bridge Density metric (third Phase 1 contribution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
