### PR TITLE
fix(platform): swap vercel.app hrefs to apexanalytica.co + add nav banner to /request-access

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -38,14 +38,16 @@ export default function LoginPage() {
     <div className="min-h-screen flex flex-col bg-background">
       {/* Marketing-site nav so visitors landing on the login page can
           still navigate back to /product, /framework, /domains, etc.
-          on the public site. Brand mark goes to the new marketing
-          site (apex-analytica-website.vercel.app); other nav items
-          point at subpages on the same. Login + Request Access are
-          intentionally omitted — visitor is already on /login. */}
+          on the public site at apexanalytica.co. Login + Request
+          Access are intentionally omitted — visitor is already on
+          /login. (Hrefs used to point at the .vercel.app deploy
+          while DNS for apexanalytica.co was on the legacy Netlify
+          Vite SPA; switched to the canonical domain post-cutover
+          on 2026-05-05.) */}
       <header className="border-b border-border">
         <div className="mx-auto flex h-[68px] max-w-7xl items-center justify-between px-4 md:px-6">
           <a
-            href="https://apex-analytica-website.vercel.app/"
+            href="https://apexanalytica.co/"
             className="group flex items-center gap-2.5"
           >
             <Image
@@ -62,31 +64,31 @@ export default function LoginPage() {
           </a>
           <nav className="hidden md:flex items-center gap-7">
             <a
-              href="https://apex-analytica-website.vercel.app/product"
+              href="https://apexanalytica.co/product"
               className="font-[family-name:var(--font-michroma)] text-[10px] tracking-[0.25em] text-text-muted hover:text-accent-cyan transition-colors"
             >
               PRODUCT
             </a>
             <a
-              href="https://apex-analytica-website.vercel.app/framework"
+              href="https://apexanalytica.co/framework"
               className="font-[family-name:var(--font-michroma)] text-[10px] tracking-[0.25em] text-text-muted hover:text-accent-cyan transition-colors"
             >
               FRAMEWORK
             </a>
             <a
-              href="https://apex-analytica-website.vercel.app/domains"
+              href="https://apexanalytica.co/domains"
               className="font-[family-name:var(--font-michroma)] text-[10px] tracking-[0.25em] text-text-muted hover:text-accent-cyan transition-colors"
             >
               DOMAINS
             </a>
             <a
-              href="https://apex-analytica-website.vercel.app/team"
+              href="https://apexanalytica.co/team"
               className="font-[family-name:var(--font-michroma)] text-[10px] tracking-[0.25em] text-text-muted hover:text-accent-cyan transition-colors"
             >
               TEAM
             </a>
             <a
-              href="https://apex-analytica-website.vercel.app/contact"
+              href="https://apexanalytica.co/contact"
               className="font-[family-name:var(--font-michroma)] text-[10px] tracking-[0.25em] text-text-muted hover:text-accent-cyan transition-colors"
             >
               CONTACT

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -24,18 +24,15 @@ export default function PricingPage() {
 
       <header className="relative border-b border-border">
         <div className="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
-          {/* Brand mark on /pricing routes back to the new marketing
-              site (apex-analytica-website.vercel.app), NOT to the
-              platform root or the legacy apexanalytica.co Vite SPA.
-              Visitors landing here are evaluating the product, so
-              "home" means the new public marketing site we're
-              building, not the platform dashboard.
-
-              TODO when DNS for apexanalytica.co cuts over to this
-              new website (the Vercel project apex-analytica-website),
-              swap this href to https://apexanalytica.co/ so the
-              brand mark uses the canonical domain. */}
-          <a href="https://apex-analytica-website.vercel.app/" className="flex items-center gap-3">
+          {/* Brand mark on /pricing routes back to apexanalytica.co —
+              the public marketing site. Visitors landing here are
+              evaluating the product, so "home" means the marketing
+              site, NOT the platform root. (DNS for apexanalytica.co
+              was cut over from the legacy Netlify Vite SPA to the
+              apex-analytica-website Vercel project on 2026-05-05;
+              this href used to point at the .vercel.app deploy URL
+              while DNS was still on Netlify.) */}
+          <a href="https://apexanalytica.co/" className="flex items-center gap-3">
             <Image src="/logo.png" alt="Apex Analytica" width={36} height={36} />
             <div className="leading-tight">
               <div className="text-[12px] font-[family-name:var(--font-michroma)] tracking-[0.25em] text-accent-cyan">

--- a/src/app/request-access/page.tsx
+++ b/src/app/request-access/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 import Image from "next/image";
+import Link from "next/link";
 import RequestAccessForm from "./RequestAccessForm";
 
 export const metadata = {
@@ -8,38 +9,105 @@ export const metadata = {
 
 export default function RequestAccessPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background px-4 py-12">
-      <div className="w-full max-w-md space-y-7">
-        <div className="text-center space-y-2">
-          <Image
-            src="/logo.png"
-            alt="Manifold"
-            width={120}
-            height={120}
-            className="mx-auto object-contain"
-            priority
-          />
-          <h1 className="text-xl font-[family-name:var(--font-michroma)] tracking-[0.3em] text-accent-cyan">
-            MANIFOLD
-          </h1>
-          <span className="font-[family-name:var(--font-michroma)] text-[8px] tracking-[0.25em] text-text-muted">
-            by APEX ANALYTICA
-          </span>
-          <div className="text-[10px] font-mono text-text-muted tracking-wider mt-1">
-            REQUEST ACCESS
-          </div>
-          <div className="w-16 h-px bg-accent-cyan/40 mx-auto mt-3" />
+    <div className="min-h-screen flex flex-col bg-background">
+      {/* Marketing-site nav so visitors landing here can still
+          navigate back to /product, /framework, /domains, etc.
+          on the public site at apexanalytica.co. Same pattern as
+          /login (PR #239). Login + Request Access intentionally
+          omitted from the nav — visitor is already on the
+          request-access flow. */}
+      <header className="border-b border-border">
+        <div className="mx-auto flex h-[68px] max-w-7xl items-center justify-between px-4 md:px-6">
+          <a
+            href="https://apexanalytica.co/"
+            className="group flex items-center gap-2.5"
+          >
+            <Image
+              src="/logo.png"
+              alt="Apex Analytica"
+              width={44}
+              height={54}
+              className="object-contain shrink-0"
+              priority
+            />
+            <span className="font-[family-name:var(--font-michroma)] text-[12px] tracking-[0.3em] text-foreground group-hover:text-accent-cyan transition-colors">
+              APEX ANALYTICA
+            </span>
+          </a>
+          <nav className="hidden md:flex items-center gap-7">
+            <a
+              href="https://apexanalytica.co/product"
+              className="font-[family-name:var(--font-michroma)] text-[10px] tracking-[0.25em] text-text-muted hover:text-accent-cyan transition-colors"
+            >
+              PRODUCT
+            </a>
+            <a
+              href="https://apexanalytica.co/framework"
+              className="font-[family-name:var(--font-michroma)] text-[10px] tracking-[0.25em] text-text-muted hover:text-accent-cyan transition-colors"
+            >
+              FRAMEWORK
+            </a>
+            <a
+              href="https://apexanalytica.co/domains"
+              className="font-[family-name:var(--font-michroma)] text-[10px] tracking-[0.25em] text-text-muted hover:text-accent-cyan transition-colors"
+            >
+              DOMAINS
+            </a>
+            <a
+              href="https://apexanalytica.co/team"
+              className="font-[family-name:var(--font-michroma)] text-[10px] tracking-[0.25em] text-text-muted hover:text-accent-cyan transition-colors"
+            >
+              TEAM
+            </a>
+            <a
+              href="https://apexanalytica.co/contact"
+              className="font-[family-name:var(--font-michroma)] text-[10px] tracking-[0.25em] text-text-muted hover:text-accent-cyan transition-colors"
+            >
+              CONTACT
+            </a>
+          </nav>
+          <Link
+            href="/login"
+            className="font-[family-name:var(--font-michroma)] text-[10px] tracking-[0.25em] text-text-muted hover:text-foreground transition-colors"
+          >
+            SIGN IN
+          </Link>
         </div>
+      </header>
 
-        <Suspense
-          fallback={
-            <div className="text-center text-[10px] font-mono text-text-muted">
-              Loading…
+      <div className="flex-1 flex items-center justify-center px-4 py-10">
+        <div className="w-full max-w-md space-y-7">
+          <div className="text-center space-y-2">
+            <Image
+              src="/logo.png"
+              alt="Manifold"
+              width={120}
+              height={120}
+              className="mx-auto object-contain"
+              priority
+            />
+            <h1 className="text-xl font-[family-name:var(--font-michroma)] tracking-[0.3em] text-accent-cyan">
+              MANIFOLD
+            </h1>
+            <span className="font-[family-name:var(--font-michroma)] text-[8px] tracking-[0.25em] text-text-muted">
+              by APEX ANALYTICA
+            </span>
+            <div className="text-[10px] font-mono text-text-muted tracking-wider mt-1">
+              REQUEST ACCESS
             </div>
-          }
-        >
-          <RequestAccessForm />
-        </Suspense>
+            <div className="w-16 h-px bg-accent-cyan/40 mx-auto mt-3" />
+          </div>
+
+          <Suspense
+            fallback={
+              <div className="text-center text-[10px] font-mono text-text-muted">
+                Loading…
+              </div>
+            }
+          >
+            <RequestAccessForm />
+          </Suspense>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Two related cleanups on the platform side now that DNS for apexanalytica.co has cut over to the new website:

### 1. Cross-origin hrefs swapped to apexanalytica.co

PRs #237 (/pricing brand link) and #239 (/login nav) were written before the 2026-05-05 DNS cutover and pointed at `https://apex-analytica-website.vercel.app/` since apexanalytica.co was still serving the legacy Netlify Vite SPA. With the canonical domain now on the new Next.js site, those should use `https://apexanalytica.co/`.

User flagged: *"if i click the login page on the top right of the website and then click on the top left apex analytica, it goes back to the vercel link rather than the main domain."*

- `src/app/login/page.tsx`: brand-mark href + 5 nav items
- `src/app/pricing/page.tsx`: brand-mark href + comment cleanup

### 2. Marketing nav banner on /request-access

User flagged: *"i think the request access page should have the banner with the different pages on the top like the rest of the pages."*

The platform's `/request-access` page (publicly reachable, used by "Request Access" CTAs from across the platform) was a centered card with no marketing nav. Same treatment as #239 (/login):

- `src/app/request-access/page.tsx`: added the marketing-site nav header. 44×54 mantis brand mark + APEX ANALYTICA wordmark on the left (links to apexanalytica.co); PRODUCT / FRAMEWORK / DOMAINS / TEAM / CONTACT nav items (md+) cross-origin to apexanalytica.co subpages; SIGN IN on the right (next/link, platform-internal). Login + Request Access intentionally omitted from the nav — visitor is already on this flow. Existing centered request-access card unchanged underneath.

## Test plan

- [x] `tsc --noEmit` clean for the modified files (pre-existing `resend` module error in `api/request-access/route.ts` is unrelated and on main)
- [ ] Post-merge: brand mark on /login, /pricing, /request-access routes to apexanalytica.co
- [ ] Post-merge: /request-access page shows the new marketing nav header

🤖 Generated with [Claude Code](https://claude.com/claude-code)