### PR TITLE
feat(estimators): add Ω-Bridge Density — system-level diagnostic metric

### DIFF
--- a/src/lib/__tests__/estimators/omega-bridge-density.test.ts
+++ b/src/lib/__tests__/estimators/omega-bridge-density.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect } from "vitest";
+import { omegaBridgeDensity } from "@/lib/estimators/omega-bridge-density";
+import type { CausalGraph } from "@/lib/types";
+import { makeNode, makeEdge } from "../fixtures/graph-fixtures";
+
+// Tests cover:
+//   1. The canonical |χ★| / |E| identity on hand-computable fixtures.
+//   2. Endpoint behaviour: density ∈ [0, 1] always.
+//   3. Tree → density 1; large highly-connected graph → small density.
+//   4. Empty graph: 0 (defined, not NaN).
+//   5. Pass-through of chiStar options (topK control).
+//   6. bridgeFraction subset relationship.
+
+function makeGraph(
+  nodeIds: string[],
+  edgeSpecs: { id: string; source: string; target: string }[],
+): CausalGraph {
+  return {
+    nodes: nodeIds.map((id) => makeNode({ id })),
+    edges: edgeSpecs.map((s) => makeEdge(s)),
+    metadata: {
+      density: 0,
+      constraintType: "",
+      verificationStatus: "UNVERIFIED",
+      totalNodes: nodeIds.length,
+      totalEdges: edgeSpecs.length,
+      inconsistentEdges: 0,
+      restrictedNodes: 0,
+    },
+  };
+}
+
+describe("omegaBridgeDensity — canonical |χ★| / |E|", () => {
+  it("path graph: every edge is a bridge → density = 1", () => {
+    // 3-edge path. χ★ = all 3 edges. |E| = 3. Density = 1.
+    const g = makeGraph(
+      ["a", "b", "c", "d"],
+      [
+        { id: "ab", source: "a", target: "b" },
+        { id: "bc", source: "b", target: "c" },
+        { id: "cd", source: "c", target: "d" },
+      ],
+    );
+    const r = omegaBridgeDensity(g);
+    expect(r.density).toBe(1);
+    expect(r.chiStarSize).toBe(3);
+    expect(r.edgeCount).toBe(3);
+    expect(r.bridgeFraction).toBe(1);
+  });
+
+  it("triangle: no bridges, but auto topK = max(1, ⌊0.1·3⌋) = 1, so density = 1/3", () => {
+    const g = makeGraph(
+      ["a", "b", "c"],
+      [
+        { id: "ab", source: "a", target: "b" },
+        { id: "bc", source: "b", target: "c" },
+        { id: "ca", source: "c", target: "a" },
+      ],
+    );
+    const r = omegaBridgeDensity(g);
+    expect(r.bridgeFraction).toBe(0); // no strict bridges in a cycle
+    expect(r.density).toBeCloseTo(1 / 3, 12); // 1 top-BES edge
+    expect(r.chiStarSize).toBe(1);
+    expect(r.edgeCount).toBe(3);
+  });
+
+  it("two triangles + bridge: bridge plus auto topK = 1 → density = 1/7", () => {
+    // 7 edges total; 1 strict bridge ("cf"). Auto topK = max(1, ⌊0.1·7⌋) = 1.
+    // Top-BES is also "cf" (carries every cross-component shortest path).
+    // χ★ = {cf}. Density = 1/7 ≈ 0.143.
+    const g = makeGraph(
+      ["a", "b", "c", "d", "e", "f"],
+      [
+        { id: "ab", source: "a", target: "b" },
+        { id: "bc", source: "b", target: "c" },
+        { id: "ca", source: "c", target: "a" },
+        { id: "de", source: "d", target: "e" },
+        { id: "ef", source: "e", target: "f" },
+        { id: "fd", source: "f", target: "d" },
+        { id: "cf", source: "c", target: "f" },
+      ],
+    );
+    const r = omegaBridgeDensity(g);
+    expect(r.chiStarSize).toBe(1);
+    expect(r.edgeCount).toBe(7);
+    expect(r.density).toBeCloseTo(1 / 7, 12);
+    expect(r.bridgeFraction).toBeCloseTo(1 / 7, 12);
+  });
+
+  it("complete K4 with topK=0: no bridges, no BES additions → density = 0", () => {
+    const g = makeGraph(
+      ["a", "b", "c", "d"],
+      [
+        { id: "ab", source: "a", target: "b" },
+        { id: "ac", source: "a", target: "c" },
+        { id: "ad", source: "a", target: "d" },
+        { id: "bc", source: "b", target: "c" },
+        { id: "bd", source: "b", target: "d" },
+        { id: "cd", source: "c", target: "d" },
+      ],
+    );
+    const r = omegaBridgeDensity(g, { topK: 0 });
+    expect(r.density).toBe(0);
+    expect(r.bridgeFraction).toBe(0);
+    expect(r.edgeCount).toBe(6);
+  });
+
+  it("star graph: every spoke is a bridge → density = 1", () => {
+    const g = makeGraph(
+      ["hub", "l1", "l2", "l3", "l4"],
+      [
+        { id: "s1", source: "hub", target: "l1" },
+        { id: "s2", source: "hub", target: "l2" },
+        { id: "s3", source: "hub", target: "l3" },
+        { id: "s4", source: "hub", target: "l4" },
+      ],
+    );
+    const r = omegaBridgeDensity(g);
+    expect(r.density).toBe(1);
+    expect(r.bridgeFraction).toBe(1);
+  });
+
+  it("density is always in [0, 1]", () => {
+    const fixtures: CausalGraph[] = [
+      makeGraph([], []),
+      makeGraph(["a"], []),
+      makeGraph(
+        ["a", "b"],
+        [{ id: "ab", source: "a", target: "b" }],
+      ),
+      makeGraph(
+        ["a", "b", "c", "d"],
+        [
+          { id: "ab", source: "a", target: "b" },
+          { id: "bc", source: "b", target: "c" },
+          { id: "cd", source: "c", target: "d" },
+          { id: "ad", source: "a", target: "d" },
+        ],
+      ),
+    ];
+    for (const g of fixtures) {
+      const r = omegaBridgeDensity(g);
+      expect(r.density).toBeGreaterThanOrEqual(0);
+      expect(r.density).toBeLessThanOrEqual(1);
+      expect(r.bridgeFraction).toBeGreaterThanOrEqual(0);
+      expect(r.bridgeFraction).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe("omegaBridgeDensity — bridgeFraction is a subset of density", () => {
+  it("strict bridges are a subset of χ★, so bridgeFraction ≤ density", () => {
+    // Mixed graph: triangle attached to a tail.
+    //   a—b—c—a (triangle)
+    //   c—d (bridge to tail)
+    //   d—e (bridge to leaf)
+    const g = makeGraph(
+      ["a", "b", "c", "d", "e"],
+      [
+        { id: "ab", source: "a", target: "b" },
+        { id: "bc", source: "b", target: "c" },
+        { id: "ca", source: "c", target: "a" },
+        { id: "cd", source: "c", target: "d" },
+        { id: "de", source: "d", target: "e" },
+      ],
+    );
+    const r = omegaBridgeDensity(g);
+    expect(r.bridgeFraction).toBeLessThanOrEqual(r.density);
+    // 2 strict bridges (cd, de), 5 edges.
+    expect(r.bridgeFraction).toBeCloseTo(2 / 5, 12);
+  });
+});
+
+describe("omegaBridgeDensity — empty / degenerate graphs", () => {
+  it("empty graph: density 0 (defined, not NaN)", () => {
+    const g = makeGraph([], []);
+    const r = omegaBridgeDensity(g);
+    expect(r.density).toBe(0);
+    expect(r.chiStarSize).toBe(0);
+    expect(r.edgeCount).toBe(0);
+    expect(Number.isNaN(r.density)).toBe(false);
+  });
+
+  it("single isolated node: density 0", () => {
+    const g = makeGraph(["a"], []);
+    const r = omegaBridgeDensity(g);
+    expect(r.density).toBe(0);
+  });
+
+  it("single edge: density 1", () => {
+    const g = makeGraph(
+      ["a", "b"],
+      [{ id: "ab", source: "a", target: "b" }],
+    );
+    const r = omegaBridgeDensity(g);
+    expect(r.density).toBe(1);
+    expect(r.bridgeFraction).toBe(1);
+  });
+});
+
+describe("omegaBridgeDensity — option pass-through", () => {
+  it("topK=0 reduces density to bridges-only", () => {
+    // Triangle has 0 bridges but auto topK = 1, so default density > 0.
+    // topK = 0 forces density = 0.
+    const g = makeGraph(
+      ["a", "b", "c"],
+      [
+        { id: "ab", source: "a", target: "b" },
+        { id: "bc", source: "b", target: "c" },
+        { id: "ca", source: "c", target: "a" },
+      ],
+    );
+    const auto = omegaBridgeDensity(g);
+    const zero = omegaBridgeDensity(g, { topK: 0 });
+    expect(auto.density).toBeGreaterThan(0);
+    expect(zero.density).toBe(0);
+  });
+
+  it("larger topK increases (or holds) density monotonically", () => {
+    // 20-node cycle: 0 bridges. As topK grows, more BES edges are
+    // included; density can only rise.
+    const ids: string[] = [];
+    const edges: { id: string; source: string; target: string }[] = [];
+    for (let i = 0; i < 20; i++) ids.push(`n${i}`);
+    for (let i = 0; i < 20; i++) {
+      edges.push({
+        id: `e${i}`,
+        source: `n${i}`,
+        target: `n${(i + 1) % 20}`,
+      });
+    }
+    const g = makeGraph(ids, edges);
+    let prev = -1;
+    for (const k of [0, 1, 2, 5, 10, 20]) {
+      const d = omegaBridgeDensity(g, { topK: k }).density;
+      expect(d).toBeGreaterThanOrEqual(prev);
+      prev = d;
+    }
+  });
+
+  it("returns the underlying chiStar result for further inspection", () => {
+    const g = makeGraph(
+      ["a", "b", "c", "d"],
+      [
+        { id: "ab", source: "a", target: "b" },
+        { id: "bc", source: "b", target: "c" },
+        { id: "cd", source: "c", target: "d" },
+      ],
+    );
+    const r = omegaBridgeDensity(g);
+    expect(r.chiStar.bridges.sort()).toEqual(["ab", "bc", "cd"]);
+    expect(r.chiStar.besRanking.length).toBe(3);
+    expect(r.chiStar.bes.size).toBe(3);
+  });
+});

--- a/src/lib/estimators/index.ts
+++ b/src/lib/estimators/index.ts
@@ -49,3 +49,9 @@ export {
   resolveChiStarEdges,
 } from "./chi-star";
 export type { ChiStarOptions, ChiStarResult } from "./chi-star";
+
+export { omegaBridgeDensity } from "./omega-bridge-density";
+export type {
+  OmegaBridgeDensityOptions,
+  OmegaBridgeDensityResult,
+} from "./omega-bridge-density";

--- a/src/lib/estimators/omega-bridge-density.ts
+++ b/src/lib/estimators/omega-bridge-density.ts
@@ -1,0 +1,76 @@
+// Ω-Bridge Density — system-level diagnostic metric.
+//
+// Defined in the dissertation integration plan as:
+//
+//   Ω-Bridge Density = |χ★(G)| / |E(G)|
+//
+// (Ghauri 2025 framework integration, 2026-05-07 handoff). The fraction
+// of the graph's edges that participate in the load-bearing skeleton.
+//
+// Interpretation:
+//   - 0       → no bridge structure at all (graph is highly redundant;
+//               every edge has many shortest-path alternates and no
+//               edge is a strict bridge).
+//   - 1       → every edge is in χ★ (graph is a tree or near-tree;
+//               removing any single edge disconnects something or
+//               severely cuts shortest-path flow).
+//   - typical → 0.05 ≲ density ≲ 0.30 for "well-connected with some
+//               critical chokepoints" — common in real causal graphs.
+//
+// Defined for all domains (not just AI Safety): it's a property of the
+// graph topology, independent of the domain profile. Surfaces in the
+// system-metrics dashboard as a single scalar diagnostic.
+//
+// Computed by delegation to `chiStar` from `./chi-star.ts` — same topK
+// convention (default 10% of edges).
+//
+// O(V · E) dominated by the underlying Brandes step in chiStar.
+
+import type { CausalGraph } from "@/lib/types";
+import { chiStar } from "./chi-star";
+import type { ChiStarOptions, ChiStarResult } from "./chi-star";
+
+export interface OmegaBridgeDensityOptions extends ChiStarOptions {}
+
+export interface OmegaBridgeDensityResult {
+  /** Density = |χ★| / |E|. Scalar in [0, 1]. */
+  density: number;
+  /** Size of the χ★ set (numerator). */
+  chiStarSize: number;
+  /** Total edge count in the graph (denominator). */
+  edgeCount: number;
+  /** Strict-bridges-only fraction = |bridges| / |E|. */
+  bridgeFraction: number;
+  /**
+   * The full χ★ result (bridges, BES map, χ★ list, BES ranking).
+   * Returned alongside so callers don't need a second computation if
+   * they want to render the breakdown.
+   */
+  chiStar: ChiStarResult;
+}
+
+/**
+ * Compute the Ω-Bridge Density of a causal graph.
+ *
+ * Returns 0 (with `chiStarSize: 0`, `edgeCount: 0`) when the graph has
+ * no edges — explicitly defined rather than NaN so the metric is
+ * always renderable. Empty-graph density is a meaningful "no bridge
+ * structure to measure" reading.
+ */
+export function omegaBridgeDensity(
+  graph: CausalGraph,
+  options: OmegaBridgeDensityOptions = {},
+): OmegaBridgeDensityResult {
+  const result = chiStar(graph, options);
+  const edgeCount = graph.edges.length;
+  const chiStarSize = result.chiStar.length;
+  const bridgeCount = result.bridges.length;
+
+  return {
+    density: edgeCount === 0 ? 0 : chiStarSize / edgeCount,
+    chiStarSize,
+    edgeCount,
+    bridgeFraction: edgeCount === 0 ? 0 : bridgeCount / edgeCount,
+    chiStar: result,
+  };
+}


### PR DESCRIPTION
## Summary

**Third and final Phase 1 dissertation contribution** (Ghauri 2025 framework integration plan, 2026-05-07 handoff). Adds the canonical system-level diagnostic metric:

> **Ω-Bridge Density** = `|χ★(G)| / |E(G)|`

A single scalar in [0, 1] summarising how concentrated the graph's load-bearing skeleton is. Defined for **all domains** (not just AI Safety) — it's a property of graph topology, independent of any pillar weighting.

This closes Phase 1 of the dissertation integration: CVaR-W₁ for the Tail Depth pillar, χ★ as the cascade artefact, and Ω-Bridge Density as the topology-summary metric.

## Public API

```ts
omegaBridgeDensity(graph, options?) -> {
  density,         // |χ★| / |E|, scalar in [0, 1]
  chiStarSize,     // numerator
  edgeCount,       // denominator
  bridgeFraction,  // |bridges| / |E| — strict-bridges-only subset
  chiStar,         // full ChiStarResult for callers wanting the breakdown
}
```

`options` extends `ChiStarOptions` directly — pass-through to the underlying `chiStar` call. Default `topK` matches χ★'s: `max(1, ⌊0.1·|E|⌋)`.

## Interpretation

From the dissertation framework:
- **0** — no bridge structure at all (highly redundant, cycle-rich graph; every edge has shortest-path alternates)
- **1** — every edge is in χ★ (tree or near-tree topology; remove any edge and the graph splinters)
- **0.05–0.30** — typical "well-connected with some critical chokepoints" regime for real causal graphs

`bridgeFraction` is the strictly-stronger reading — fraction of edges whose removal *literally* disconnects the graph. Always `≤ density` since strict bridges are a subset of χ★.

## Why this lives at system-metrics rather than per-node

`density` is a global graph property. Per-node criticality is already covered by the Pareto card (CSD/PH/LPPLS/BOCPD) and the per-edge BES from PR [#287](https://github.com/ApexAnalytica/apex-terminal/pull/287). What was missing was a single number that tells you "how chokepoint-y is this entire system?" — useful as a comparison across persona / domain / time-window selections, and as a sanity gauge ("density jumped from 0.12 to 0.40 after that edge set was added — did we introduce a fragile bottleneck?").

The dissertation UX spec routes this to the system-metrics dashboard, which reads `graph.chiStarSet`. That wiring is a follow-on PR.

## Test plan

- [x] 13 new tests under `src/lib/__tests__/estimators/omega-bridge-density.test.ts`:
  - Canonical `|χ★|/|E|` identity on hand-computable fixtures:
    - 3-edge path → 1
    - Triangle with auto-topK=1 → 1/3
    - Two-triangles + bridge → 1/7
    - K4 with `topK: 0` → 0
    - Star with 4 leaves → 1
  - `density ∈ [0, 1]` invariant across diverse fixtures
  - `bridgeFraction ≤ density` invariant (strict bridges ⊆ χ★)
  - Empty / single-node / single-edge endpoint cases (density 0 defined, not NaN)
  - `topK: 0` reduces density to bridges-only
  - Monotone non-decrease in topK (`0 → 1 → 2 → 5 → 10 → 20` on a 20-cycle, density only rises)
  - Full `chiStar` breakdown returned for caller inspection
- [x] `vitest run`: **909 passing** (was 869 after #289; +13 new + ~27 from sibling sessions in parallel). No regressions.
- [x] `tsc --noEmit` clean for the new files.

## Scope discipline

Math core only — same pattern as the previous five PRs in the Phase 1 series:

- **Does not** wire into the system-metrics dashboard.
- **Does not** add to any DomainProfile (it's a system-level metric, not a per-domain pillar estimator — different surface).
- **Does not** change `criticality-registry.ts` (registry is for the Pareto-card per-pillar estimators; Ω-Bridge Density renders elsewhere).

## Phase 1 sequence — complete after this PR

| PR | Status | Contribution |
|---|---|---|
| [#279](https://github.com/ApexAnalytica/apex-terminal/pull/279) | ✅ merged | CVaR-W₁ math core (Tail Depth pillar) |
| [#282](https://github.com/ApexAnalytica/apex-terminal/pull/282) | ✅ merged | CVaR-W₁ registry + AI Safety entry |
| [#287](https://github.com/ApexAnalytica/apex-terminal/pull/287) | ✅ merged | χ★ math core (bridges + BES) |
| [#289](https://github.com/ApexAnalytica/apex-terminal/pull/289) | ✅ merged | χ★ registry + AI Safety entry |
| **this** | 🟡 open | Ω-Bridge Density math core |

After this lands, all three Phase 1 estimators have shipped math + tests. Remaining is UI surfacing — separate concern, separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
