### PR TITLE
feat(ui): surface Ω-Bridge Density on the system-metrics strip

### DIFF
--- a/src/components/StructuralMetrics.tsx
+++ b/src/components/StructuralMetrics.tsx
@@ -4,9 +4,12 @@ import { useMemo } from "react";
 import { useApexStore } from "@/stores/useApexStore";
 import { useFilteredGraph } from "@/hooks/useFilteredGraph";
 import { computeOmegaState, computeDoomsdayState } from "@/lib/omega-engine";
+import { omegaBridgeDensity } from "@/lib/estimators";
+import { bridgeDensityBand } from "@/lib/omega-bridge-density-display";
 
 export default function StructuralMetrics() {
-  const meta = useFilteredGraph().metadata;
+  const graph = useFilteredGraph();
+  const meta = graph.metadata;
   const shocks = useApexStore((s) => s.shocks);
 
   const omegaState = useMemo(() => computeOmegaState(shocks), [shocks]);
@@ -14,12 +17,23 @@ export default function StructuralMetrics() {
     () => computeDoomsdayState(shocks, omegaState.buffer),
     [shocks, omegaState.buffer]
   );
+  // Ω-Bridge Density (Ghauri 2025, system-level diagnostic). Recomputes
+  // on filtered-graph changes — same cadence as DISCOVERY DENSITY.
+  const bridgeDensity = useMemo(() => omegaBridgeDensity(graph), [graph]);
+  const band = bridgeDensityBand(bridgeDensity.density);
 
   return (
     <div className="flex items-center gap-4 px-4 py-1.5 border-t border-border bg-surface text-[9px] font-mono text-text-muted">
       <span>
         DISCOVERY DENSITY:{" "}
         <span className="text-foreground">{meta.density.toFixed(2)}</span>
+      </span>
+      <span className="text-border">|</span>
+      <span title={band.tooltip}>
+        Ω-BRIDGE DENSITY:{" "}
+        <span style={{ color: band.color }}>
+          {bridgeDensity.density.toFixed(3)}
+        </span>
       </span>
       <span className="text-border">|</span>
       <span>

--- a/src/lib/__tests__/omega-bridge-density-display.test.ts
+++ b/src/lib/__tests__/omega-bridge-density-display.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { bridgeDensityBand } from "@/lib/omega-bridge-density-display";
+
+// Display-band tests — verifies the threshold mapping is exhaustive
+// and matches the documented bands. The math itself is covered by
+// src/lib/__tests__/estimators/omega-bridge-density.test.ts.
+
+describe("bridgeDensityBand — threshold coverage", () => {
+  it("density > 0.60 → FRAGILE (red)", () => {
+    expect(bridgeDensityBand(0.61).band).toBe("fragile");
+    expect(bridgeDensityBand(0.8).band).toBe("fragile");
+    expect(bridgeDensityBand(1.0).band).toBe("fragile");
+  });
+
+  it("0.30 < density ≤ 0.60 → ELEVATED (amber)", () => {
+    expect(bridgeDensityBand(0.31).band).toBe("elevated");
+    expect(bridgeDensityBand(0.45).band).toBe("elevated");
+    expect(bridgeDensityBand(0.6).band).toBe("elevated");
+  });
+
+  it("0.05 ≤ density ≤ 0.30 → NOMINAL (green)", () => {
+    expect(bridgeDensityBand(0.05).band).toBe("nominal");
+    expect(bridgeDensityBand(0.1).band).toBe("nominal");
+    expect(bridgeDensityBand(0.15).band).toBe("nominal");
+    expect(bridgeDensityBand(0.3).band).toBe("nominal");
+  });
+
+  it("density < 0.05 → REDUNDANT (green)", () => {
+    expect(bridgeDensityBand(0).band).toBe("redundant");
+    expect(bridgeDensityBand(0.01).band).toBe("redundant");
+    expect(bridgeDensityBand(0.049).band).toBe("redundant");
+  });
+});
+
+describe("bridgeDensityBand — degenerate inputs", () => {
+  it("NaN → nominal placeholder with em-dash", () => {
+    const r = bridgeDensityBand(Number.NaN);
+    expect(r.band).toBe("nominal");
+    expect(r.label).toBe("—");
+  });
+
+  it("negative → nominal placeholder", () => {
+    const r = bridgeDensityBand(-0.1);
+    expect(r.label).toBe("—");
+  });
+
+  it("Infinity → nominal placeholder (not finite)", () => {
+    const r = bridgeDensityBand(Number.POSITIVE_INFINITY);
+    expect(r.label).toBe("—");
+  });
+});
+
+describe("bridgeDensityBand — band record completeness", () => {
+  it("every band returns a non-empty label, color, and tooltip", () => {
+    const samples = [0, 0.02, 0.1, 0.3, 0.45, 0.7];
+    for (const d of samples) {
+      const r = bridgeDensityBand(d);
+      expect(r.label.length).toBeGreaterThan(0);
+      expect(r.color.length).toBeGreaterThan(0);
+      expect(r.tooltip.length).toBeGreaterThan(10);
+    }
+  });
+
+  it("FRAGILE / ELEVATED bands use distinct warning colors", () => {
+    const fragile = bridgeDensityBand(0.8);
+    const elevated = bridgeDensityBand(0.45);
+    const nominal = bridgeDensityBand(0.15);
+    expect(fragile.color).not.toBe(elevated.color);
+    expect(fragile.color).not.toBe(nominal.color);
+    expect(elevated.color).not.toBe(nominal.color);
+  });
+});

--- a/src/lib/omega-bridge-density-display.ts
+++ b/src/lib/omega-bridge-density-display.ts
@@ -1,0 +1,79 @@
+// Display helpers for Ω-Bridge Density on the system-metrics surface.
+//
+// The math lives in src/lib/estimators/omega-bridge-density.ts. This
+// file is the UI concern: mapping the [0, 1] scalar to a color band +
+// human-readable label that surfaces the dissertation's interpretation:
+//
+//   0.05 ≲ density ≲ 0.30 — "well-connected with some critical
+//                            chokepoints", the typical regime for real
+//                            causal graphs (NOMINAL).
+//   density > 0.30        — elevated chokepoint concentration; the
+//                            graph has more bridge-like structure than
+//                            usual (ELEVATED).
+//   density > 0.60        — tree-like topology, removing any of many
+//                            edges would fragment cascade pathways
+//                            (FRAGILE).
+//   density < 0.05        — almost no bridge structure; cycle-rich,
+//                            highly redundant. Not a fragility flag —
+//                            shown the same as nominal.
+
+export interface BridgeDensityBand {
+  /** Discrete band identifier. */
+  band: "redundant" | "nominal" | "elevated" | "fragile";
+  /** Short human-readable label suitable for a status badge. */
+  label: string;
+  /** CSS color (uses the project's accent CSS variables). */
+  color: string;
+  /** Hover-tooltip text explaining the reading + band threshold. */
+  tooltip: string;
+}
+
+/**
+ * Map an Ω-Bridge Density value into the display band the system-
+ * metrics strip uses. Pure function — no React or DOM access; safe to
+ * unit-test directly.
+ */
+export function bridgeDensityBand(density: number): BridgeDensityBand {
+  if (!Number.isFinite(density) || density < 0) {
+    return {
+      band: "nominal",
+      label: "—",
+      color: "var(--text-muted)",
+      tooltip: "Ω-Bridge Density unavailable for the current selection.",
+    };
+  }
+  if (density > 0.6) {
+    return {
+      band: "fragile",
+      label: "FRAGILE",
+      color: "#ff1744",
+      tooltip:
+        "Ω-Bridge Density > 0.60 — near-tree topology. Most edges sit in χ★, so removing any of them fragments the cascade pathways. Investigate redundancy.",
+    };
+  }
+  if (density > 0.3) {
+    return {
+      band: "elevated",
+      label: "ELEVATED",
+      color: "var(--accent-amber)",
+      tooltip:
+        "Ω-Bridge Density 0.30–0.60 — elevated chokepoint concentration. More edges than typical fall in χ★; the graph has bridge-like structure to monitor.",
+    };
+  }
+  if (density < 0.05) {
+    return {
+      band: "redundant",
+      label: "REDUNDANT",
+      color: "var(--accent-green)",
+      tooltip:
+        "Ω-Bridge Density < 0.05 — cycle-rich, highly redundant graph. Few edges sit in χ★. Not a fragility flag — alternate paths absorb most disruptions.",
+    };
+  }
+  return {
+    band: "nominal",
+    label: "NOMINAL",
+    color: "var(--accent-green)",
+    tooltip:
+      "Ω-Bridge Density 0.05–0.30 — well-connected with some critical chokepoints. Typical regime for real causal graphs.",
+  };
+}


### PR DESCRIPTION
## Summary

Wires the Ω-Bridge Density math from PR [#294](https://github.com/ApexAnalytica/apex-terminal/pull/294) onto the bottom system-metrics strip so users can actually see it. Closes the UX half of the third Phase 1 dissertation contribution per the [dissertation UX spec](https://docs.google.com/document/d/1dFSyeZ8TnisYFl27mnLZ1xnCJjYlAP0cPh5dhVqwRXA/edit).

## What changed

### `src/components/StructuralMetrics.tsx`
Added new segment between `DISCOVERY DENSITY` and `CONSTRAINT`:

```
Ω-BRIDGE DENSITY: 0.143
```

- Recomputes via `useMemo` on filtered-graph changes — same cadence as `DISCOVERY DENSITY` which already lived here, so no perf regression.
- Color reflects the band; hover-tooltip explains the reading + threshold.

### `src/lib/omega-bridge-density-display.ts` (new)

```ts
bridgeDensityBand(density) -> { band, label, color, tooltip }
```

Pure function — extracts threshold logic from the component so it's directly unit-testable. Bands match the dissertation's interpretation:

| density | band | color | meaning |
|---|---|---|---|
| > 0.60 | FRAGILE | red | near-tree topology, removing any of many edges fragments cascade pathways |
| 0.30–0.60 | ELEVATED | amber | more bridge-like structure than typical — monitor |
| 0.05–0.30 | NOMINAL | green | well-connected with some critical chokepoints (typical regime) |
| < 0.05 | REDUNDANT | green | cycle-rich, highly redundant; not a fragility flag |

NaN / negative / Infinity inputs return a `—` placeholder so the strip never renders garbage on degenerate selections.

### `src/lib/__tests__/omega-bridge-density-display.test.ts` (new)

9 tests covering:
- Band thresholds — boundary values (0, 0.049, 0.05, 0.30, 0.31, 0.60, 0.61) plus interior samples
- Degenerate input handling (NaN, negative, Infinity)
- Band-record completeness invariant — every band returns a non-empty label, color, and tooltip; warning bands use distinct colors

## Why a separate display helper

Matches the project's existing "logic in libs, render in components" split. Keeps the threshold mapping testable without a render harness, and lets the component stay presentational. Same shape as how `computeOmegaState` / `computeDoomsdayState` are extracted from `StructuralMetrics`.

## Test plan

- [x] `vitest run`: **918 passing** (was 909 after PR #294; +9 new). No regressions.
- [x] `tsc --noEmit` clean for the new files.
- [x] Manual review: the strip already lives at the bottom of every main view (DISCOVERY DENSITY is already there). Ω-BRIDGE DENSITY sits next to it with the same visual weight — same font size, same separator pipes.

## Phase 1 status after this PR

| PR | Status | Contribution |
|---|---|---|
| [#279](https://github.com/ApexAnalytica/apex-terminal/pull/279) | ✅ merged | CVaR-W₁ math core |
| [#282](https://github.com/ApexAnalytica/apex-terminal/pull/282) | ✅ merged | CVaR-W₁ registry + AI Safety entry |
| [#287](https://github.com/ApexAnalytica/apex-terminal/pull/287) | ✅ merged | χ★ math core (bridges + BES) |
| [#289](https://github.com/ApexAnalytica/apex-terminal/pull/289) | ✅ merged | χ★ registry + AI Safety entry |
| [#294](https://github.com/ApexAnalytica/apex-terminal/pull/294) | ✅ merged | Ω-Bridge Density math core |
| **this** | 🟡 open | Ω-Bridge Density UI surface |

After this lands, all three Phase 1 dissertation contributions have shipped math + (where applicable) registry wiring + UI surface. The remaining UI work is per-pillar Pareto-card integration for χ★ (highlight on graph + per-edge BES color ramp), which is a more involved 3D-rendering decision deferred to its own session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
