### PR TITLE
perf(bundle): defer four tab-gated ModulePanel sub-panels via next/dynamic

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -776,6 +776,29 @@ Net effect: per-frame work shrinks from "render + diff + reconcile + setData" to
 
 **Verification.** `tsc --noEmit` clean; lint clean on touched file; vitest 843/843 pass.
 
+### 2026-05-07 — Shipped: defer tab-gated ModulePanel sub-panels via next/dynamic
+
+**PR:** TBD (about to open).
+
+**Trigger.** Backlog: bundle-analyzer perf sweep (PR #222 wired the tooling). Sandbox can't run `ANALYZE=true npx next build` end-to-end — Google Fonts blocked + `ai`/`@ai-sdk/*` not installed — so I switched to static analysis. The ModulePanel mounts on first paint (right pane is the default), and it statically imports a swarm of sub-panels gated on the active module tab. Spirtes is the default tab; users on Spirtes were paying for the JS of every other tab's sub-panel.
+
+**What shipped.** Four tab-gated sub-panels converted to `next/dynamic` with `ssr: false`:
+- `MonteCarloForecast` (~714 LOC, Pearl tab)
+- `VX880TrialPanel` (~910 LOC, Pearl tab)
+- `InterdictionPanel` (~191 LOC, Pareto tab)
+- `TissueCohortView` (~504 LOC, Spirtes tab but only when `isT1DDomain`)
+
+Common loading hint (`<div>LOADING…</div>`) sized to the panel padding so the layout doesn't jump when the chunk lands. Inline panels (`TarskiPanel`, `ParetoPanel`, `CopilotInterdictionResults`, `SnapshotIndicator`) live as functions inside `ModulePanel.tsx` itself, so I'd need to extract them before they could be deferred — out of scope for a perf sweep, queued for later.
+
+The Spirtes-tab default sub-panels (`TrinityPanel`, `DiscoveryRunsPanel`) stay static since they're on the critical path; `TrinityPanel` already lazy-loads its three Trinity graphs internally so there's no double-defer to chase.
+
+**Files.**
+- `src/components/ModulePanel.tsx` — four `dynamic()` declarations replacing the static imports.
+
+**Notes for future sweep.** When the analyzer can be run end-to-end on a real env, things to look at next: the `tarski-data` axiom library size; estimator libs (`lppls-fit`, `ph-fit`, `pareto-relevance-bootstrap`) imported at module top-level — could be deferred to first-use; `framer-motion` is everywhere and probably unavoidable but worth confirming we're tree-shaking.
+
+**Verification.** `tsc --noEmit` clean (modulo pre-existing inherited errors from `ai`-SDK types missing in sandbox + a known fci.test endpointMarks drift); lint pre-existing errors only (2 errors on lines 81 + 1806, both confirmed on main pre-merge); vitest 909/909 pass.
+
 ---
 
 ## How a fresh session resumes

--- a/src/components/ModulePanel.tsx
+++ b/src/components/ModulePanel.tsx
@@ -26,14 +26,42 @@ import { fitLppls, lpplsSeries } from "@/lib/estimators/lppls-fit";
 import { fitBettiTemplate } from "@/lib/estimators/ph-fit";
 import { detectCommunities } from "@/lib/community-detection";
 import { summarizeDiscoveryUncertainty } from "@/lib/discovery-uncertainty";
+import dynamic from "next/dynamic";
 import TrinityPanel from "./TrinityPanel";
 import DiscoveryRunsPanel from "./DiscoveryRunsPanel";
-import TissueCohortView from "./scientist/TissueCohortView";
-import MonteCarloForecast from "./MonteCarloForecast";
-import InterdictionPanel from "./InterdictionPanel";
 import NewsInterpreterPanel from "./NewsInterpreterPanel";
 import NodeInspector from "./NodeInspector";
-import VX880TrialPanel from "./VX880TrialPanel";
+
+// Tab-gated sub-panels lazy-loaded so the default Spirtes tab doesn't
+// pull their JS on first paint:
+//   - MonteCarloForecast (714 LOC + simulation helpers)  → Pearl tab
+//   - VX880TrialPanel (910 LOC + cohort helpers)         → Pearl tab
+//   - InterdictionPanel (191 LOC)                        → Pareto tab
+//   - TissueCohortView (504 LOC + d1namo cohort data)    → Spirtes tab
+//     but only when isT1DDomain is true, so worth deferring
+// Each has a small loading hint that matches the panel padding so the
+// layout doesn't jump when the chunk lands.
+const PANEL_LOADER = (
+  <div className="p-4 text-[8px] font-mono text-text-muted/60 animate-pulse">
+    LOADING…
+  </div>
+);
+const TissueCohortView = dynamic(
+  () => import("./scientist/TissueCohortView"),
+  { ssr: false, loading: () => PANEL_LOADER },
+);
+const MonteCarloForecast = dynamic(
+  () => import("./MonteCarloForecast"),
+  { ssr: false, loading: () => PANEL_LOADER },
+);
+const InterdictionPanel = dynamic(
+  () => import("./InterdictionPanel"),
+  { ssr: false, loading: () => PANEL_LOADER },
+);
+const VX880TrialPanel = dynamic(
+  () => import("./VX880TrialPanel"),
+  { ssr: false, loading: () => PANEL_LOADER },
+);
 
 export default function ModulePanel() {
   const activeModule = useApexStore((s) => s.activeModule);


### PR DESCRIPTION
## Summary

Bundle-analyzer perf sweep (the analyzer can't run end-to-end in this sandbox — Google Fonts blocked + AI SDK packages not installed — so this is the static-analysis pass).

`ModulePanel` mounts on first paint (right pane default) and statically imports a swarm of sub-panels each gated on the active module tab. Spirtes is the default tab; users on Spirtes were paying for every other tab's JS on first load.

Converted four tab-gated sub-panels to `next/dynamic` with `ssr: false`:
- `MonteCarloForecast` (~714 LOC, Pearl tab)
- `VX880TrialPanel` (~910 LOC, Pearl tab)
- `InterdictionPanel` (~191 LOC, Pareto tab)
- `TissueCohortView` (~504 LOC, Spirtes tab gated on `isT1DDomain`)

Common `LOADING…` hint sized to the panel padding so the layout doesn't jump when the chunk lands.

**Why these four and not the others.** `TarskiPanel`, `ParetoPanel`, `CopilotInterdictionResults`, `SnapshotIndicator` live as inline functions inside `ModulePanel.tsx`, so they'd need extraction before they could be deferred — out of scope for a perf sweep, noted as a follow-up. `TrinityPanel` + `DiscoveryRunsPanel` stay static because they're on the Spirtes critical path; `TrinityPanel` already lazy-loads its three Trinity graphs internally.

## Test plan

- [ ] Open the app, land on the default Spirtes tab — confirm the panel renders normally (no `LOADING…` flash unless `isT1DDomain`, in which case `TissueCohortView` momentarily shows the loader).
- [ ] Switch to Pearl tab — confirm `LOADING…` flashes briefly the first time, then `VX880TrialPanel` + `MonteCarloForecast` render.
- [ ] Switch back to Spirtes, then Pearl again — confirm the chunks are cached (no second loader flash).
- [ ] Switch to Pareto — confirm `InterdictionPanel` lazy-loads on first visit.
- [ ] In a T1D-domain workspace, confirm `TissueCohortView` lazy-loads on Spirtes when active.

## Notes for the next sweep (when the analyzer can actually run)

- `tarski-data` axiom library size — likely candidate for a one-time module-level review.
- Estimator libs (`lppls-fit`, `ph-fit`, `pareto-relevance-bootstrap`) currently imported at module top-level — could defer to first-use behind dynamic.
- `framer-motion` is widespread; worth confirming the tree-shaking is doing its job.

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_