### PR TITLE
fix(perf): stop CausalDAG2D from running its layout sim on launch

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -839,6 +839,21 @@ The full GPU compute-shader port is still queued — if real-time scrub still dr
 
 **Verification.** `tsc --noEmit` clean; vitest 918/918 pass (22 of which are relief-field-specific).
 
+### 2026-05-07 — Shipped: stop CausalDAG2D from running its layout sim on launch
+
+**PR:** TBD (about to open).
+
+**Trigger.** User: *"still keeps freezing"* after the previous launch-workspace fix. Identified the remaining sync hog: `CausalDAG2D` was statically imported and always-mounted (with `visibility: hidden` for instant view-switching), so its `compute2DForceLayout` + `computeNetworkMetrics` ran *in parallel* with the 3D path's equivalents on every launch — even though the user lands on 3D and the 2D canvas is hidden.
+
+The always-mount pattern was in place to keep the 3D WebGL context alive across view switches (the browser's GPU process can deallocate it on remount). 2D doesn't carry a WebGL context — it renders through React Flow — so the rationale doesn't apply to it.
+
+**What shipped.** `CausalDAG2D` converted to `next/dynamic` (matching Map / Relief) and conditionally rendered only when `viewMode === "2d"`. 3D stays always-mounted with the `visibility: hidden` toggle. Trade-off: first switch from 3D → 2D pays a chunk-load + layout-compute beat (~300-500ms on a 500-node CROSS-DOMAIN workspace), same shape as the existing first-Map and first-Relief switch.
+
+**Files.**
+- `src/app/page.tsx` — `CausalDAG2D` static import → `dynamic`; render block wrapped in `viewMode === "2d"` gate.
+
+**Verification.** `tsc --noEmit` clean; vitest 918/918 pass.
+
 ---
 
 ## How a fresh session resumes

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,6 @@ import SystemCopilot from "@/components/SystemCopilot";
 import RiskPropagationFlow from "@/components/RiskPropagationFlow";
 import ModulePanel from "@/components/ModulePanel";
 import StructuralMetrics from "@/components/StructuralMetrics";
-import CausalDAG2D from "@/components/CausalDAG2D";
 import TimeDial from "@/components/TimeDial";
 import FeedbackWidget from "@/components/FeedbackWidget";
 import TimeSeriesOverlay from "@/components/TimeSeriesOverlay";
@@ -56,6 +55,30 @@ const CausalDAG3D = dynamic(() => import("@/components/CausalDAG3D"), {
     <div className="w-full h-full flex items-center justify-center bg-background">
       <div className="text-[10px] font-mono text-text-muted animate-pulse">
         INITIALIZING WEBGL_3D RENDERER...
+      </div>
+    </div>
+  ),
+});
+
+// CausalDAG2D was previously statically imported and rendered alongside
+// CausalDAG3D with `visibility: hidden` so view switches were instant.
+// Cost: on launch the 2D layout sim + Brandes' centrality ran in parallel
+// with the 3D ones, doubling the work in the launch frame. User reports
+// of "manifold keeps freezing on LAUNCH WORKSPACE" came back even after
+// the omega-pillar O(N×E) fix and the metric deferrals — this was the
+// remaining sync budget hog. 2D doesn't carry a WebGL context (it uses
+// React Flow), so the comment about GPU-context preservation that
+// motivated the always-mount pattern doesn't apply to 2D.
+//
+// Trade-off: first switch from 3D → 2D incurs chunk-load + layout
+// compute (~300-500ms on a 500-node CROSS-DOMAIN workspace), same shape
+// as the existing first-switch latency for Map / Relief.
+const CausalDAG2D = dynamic(() => import("@/components/CausalDAG2D"), {
+  ssr: false,
+  loading: () => (
+    <div className="w-full h-full flex items-center justify-center bg-background">
+      <div className="text-[10px] font-mono text-text-muted animate-pulse">
+        INITIALIZING 2D RENDERER...
       </div>
     </div>
   ),
@@ -147,8 +170,13 @@ export default function Home() {
           {/* DAG Canvas — relative container with explicit flex sizing,
                children use absolute positioning to fill */}
           <div className="flex-1 relative min-h-0" data-tour="dag-canvas" style={{ contain: "strict" }}>
-            {/* Keep both views mounted — use visibility:hidden instead of display:none
-                to prevent WebGL context deallocation by the browser GPU process */}
+            {/* 3D stays always-mounted with visibility:hidden so the WebGL
+                context isn't torn down on view switches (the browser's GPU
+                process can deallocate it across remounts). 2D / Map / Relief
+                are conditionally rendered — they don't carry a WebGL context
+                that needs preserving (2D uses React Flow), so paying first-
+                switch chunk-load latency once is cheaper than running their
+                layout sims on every page launch. */}
             <div
               className="absolute inset-0"
               style={{
@@ -159,16 +187,11 @@ export default function Home() {
             >
               <CausalDAG3D />
             </div>
-            <div
-              className="absolute inset-0"
-              style={{
-                visibility: viewMode === "2d" ? "visible" : "hidden",
-                pointerEvents: viewMode === "2d" ? "auto" : "none",
-                zIndex: viewMode === "2d" ? 1 : 0,
-              }}
-            >
-              <CausalDAG2D />
-            </div>
+            {viewMode === "2d" && (
+              <div className="absolute inset-0" style={{ zIndex: 1 }}>
+                <CausalDAG2D />
+              </div>
+            )}
             {viewMode === "map" && (
               <div className="absolute inset-0" style={{ zIndex: 1 }}>
                 <CausalDAGMap />


### PR DESCRIPTION
## Summary

User: *"still keeps freezing"* after the previous launch-workspace fixes.

The remaining sync hog: `CausalDAG2D` was statically imported and always-mounted (with `visibility: hidden` for instant view-switching), so its `compute2DForceLayout` + `computeNetworkMetrics` ran *in parallel* with the 3D path's equivalents on every launch — even though the user lands on 3D and the 2D canvas is hidden.

The always-mount pattern was in place to keep the 3D WebGL context alive across view switches (the browser's GPU process can deallocate it on remount). 2D doesn't carry a WebGL context — it renders through React Flow — so the rationale doesn't apply to it.

Converted `CausalDAG2D` to `next/dynamic` (matching Map / Relief) and gated the render block on `viewMode === "2d"`. 3D stays always-mounted with the `visibility: hidden` toggle.

**Trade-off.** First switch from 3D → 2D pays a chunk-load + layout-compute beat (~300-500ms on a 500-node CROSS-DOMAIN workspace), same shape as the existing first-Map and first-Relief switch.

## Test plan

- [ ] Pick CROSS-DOMAIN persona + every available card, click LAUNCH WORKSPACE — confirm the page becomes interactive without a multi-second hang. The default 3D canvas should mount with its `INITIALIZING WEBGL_3D RENDERER…` placeholder, then resolve.
- [ ] Click "2D" tab — confirm the new `INITIALIZING 2D RENDERER…` placeholder appears for a beat, then the React Flow graph mounts with the layout settled.
- [ ] Switch back to 3D — confirm it's instant (3D's chunk + WebGL context remain alive).
- [ ] Switch to 2D again — confirm it's now instant on subsequent visits (chunk is cached, but the layout sim still re-runs since the component remounts each visit; verify the perceived latency is acceptable).

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_