### PR TITLE
fix(copilot): populate dataset on traces — closes #251 TODO

### DIFF
--- a/src/components/SystemCopilot.tsx
+++ b/src/components/SystemCopilot.tsx
@@ -15,8 +15,10 @@ import {
   logTurnTrace,
   hashPrompt,
   newConversationId,
+  resolveActiveDataset,
   type TurnTrace,
 } from "@/lib/copilot/trace-logger";
+import { DOMAIN_CARDS } from "@/lib/domains";
 import { CopilotMessage } from "@/lib/types";
 import { getModelsForProvider, type LLMProvider } from "@/lib/llm-providers";
 import { serializeGraphContext, serializeSnapshotContext, serializeTimeWindowContext } from "@/lib/copilot-context";
@@ -496,9 +498,12 @@ export default function SystemCopilot() {
             model_id: copilotModel,
             system_prompt_hash: hashPrompt(systemPromptText),
             system_prompt_size: systemPromptText.length,
-            // dataset routing isn't in the store yet (PR3 candidate);
-            // leave null so the column is still queryable when added.
-            dataset: null,
+            // Resolved from selectedDomains via the domain catalog.
+            // Null when no domains selected (pre-onboarding).
+            dataset: resolveActiveDataset(
+              useApexStore.getState().selectedDomains,
+              DOMAIN_CARDS,
+            ),
             active_module: activeModule,
             selected_node: selectedNode,
             active_shock_count: shocks.length,

--- a/src/lib/__tests__/copilot-trace-logger.test.ts
+++ b/src/lib/__tests__/copilot-trace-logger.test.ts
@@ -6,7 +6,7 @@ import {
   __resetRegistryForTests,
   type ToolCallTrace,
 } from "@/lib/copilot/tool-registry";
-import { hashPrompt, newConversationId, logTurnTrace } from "@/lib/copilot/trace-logger";
+import { hashPrompt, newConversationId, logTurnTrace, resolveActiveDataset } from "@/lib/copilot/trace-logger";
 import type { ApexState } from "@/stores/useApexStore";
 
 // ─── Registry trace shape ───────────────────────────────────────
@@ -203,5 +203,51 @@ describe("logTurnTrace — fail-safe semantics", () => {
     expect(JSON.parse(callArgs.body as string)).toEqual(validTrace);
 
     vi.unstubAllGlobals();
+  });
+});
+
+// ─── resolveActiveDataset ───────────────────────────────────────
+
+describe("resolveActiveDataset", () => {
+  const cards = [
+    { id: "energy-systems", dataset: "main" },
+    { id: "fx-stress", dataset: "main" },
+    { id: "defense-supply", dataset: "athena" },
+    { id: "t1d-mech", dataset: "t1d" },
+    { id: "vx880-trial", dataset: "vx880" },
+  ];
+
+  it("returns null when no domains are selected", () => {
+    expect(resolveActiveDataset([], cards)).toBeNull();
+  });
+
+  it("returns 'main' for a generic geopolitical selection", () => {
+    expect(resolveActiveDataset(["energy-systems", "fx-stress"], cards)).toBe("main");
+  });
+
+  it("returns the only dataset when one domain is selected", () => {
+    expect(resolveActiveDataset(["t1d-mech"], cards)).toBe("t1d");
+  });
+
+  it("prefers t1d > vx880 > athena > main when domains span datasets", () => {
+    // t1d wins over vx880 wins over athena wins over main
+    expect(
+      resolveActiveDataset(["energy-systems", "vx880-trial", "t1d-mech"], cards),
+    ).toBe("t1d");
+    expect(
+      resolveActiveDataset(["energy-systems", "defense-supply", "vx880-trial"], cards),
+    ).toBe("vx880");
+    expect(
+      resolveActiveDataset(["energy-systems", "defense-supply"], cards),
+    ).toBe("athena");
+  });
+
+  it("returns null if every selected id is unknown", () => {
+    expect(resolveActiveDataset(["does-not-exist"], cards)).toBeNull();
+  });
+
+  it("falls back to the first dataset for unrecognized dataset values", () => {
+    const customCards = [{ id: "future-domain", dataset: "future-dataset" }];
+    expect(resolveActiveDataset(["future-domain"], customCards)).toBe("future-dataset");
   });
 });

--- a/src/lib/copilot/trace-logger.ts
+++ b/src/lib/copilot/trace-logger.ts
@@ -75,6 +75,40 @@ export async function logTurnTrace(trace: TurnTrace): Promise<boolean> {
 // ─── Helpers ────────────────────────────────────────────────────
 
 /**
+ * Resolve which dataset is "active" given a list of selected
+ * domain ids. Used to populate `TurnTrace.dataset` so analytics
+ * can slice traces by dataset (`select * from copilot_traces
+ * where dataset = 't1d'` etc).
+ *
+ * Resolution rule when domains span multiple datasets (only
+ * possible in CROSS persona): prefer the most specialized
+ * dataset over the generic "main" — t1d > vx880 > athena > main.
+ * That better reflects what graph the user is reasoning over.
+ *
+ * Returns null when no domains are selected (pre-onboarding,
+ * or after a reset). Callers should pass null through to the
+ * trace row in that case.
+ */
+export function resolveActiveDataset(
+  selectedDomains: string[],
+  domainCards: ReadonlyArray<{ id: string; dataset: string }>,
+): string | null {
+  if (selectedDomains.length === 0) return null;
+  const datasets = new Set(
+    selectedDomains
+      .map((id) => domainCards.find((c) => c.id === id)?.dataset)
+      .filter((d): d is string => d !== undefined),
+  );
+  if (datasets.size === 0) return null;
+  // Specialization order — most specific wins.
+  for (const candidate of ["t1d", "vx880", "athena", "main"]) {
+    if (datasets.has(candidate)) return candidate;
+  }
+  // Fallback: arbitrary first dataset for any unknown identifier.
+  return [...datasets][0];
+}
+
+/**
  * Cheap, deterministic, non-cryptographic hash of a string. Used
  * as the system_prompt_hash so we can tell whether two turns
  * shared a prompt without storing the prompt itself. djb2 is


### PR DESCRIPTION
## Summary

Closes the `dataset: null` TODO from [PR #251](https://github.com/ApexAnalytica/apex-terminal/pull/251). Trace rows now carry the active dataset (`main` / `athena` / `t1d` / `vx880`) so analytics queries can slice traces by dataset:

```sql
-- Now possible — was always null before this PR:
select dataset, count(*) from copilot_traces group by 1;
select * from copilot_traces where dataset = 't1d' order by created_at desc limit 10;
```

## How

No store changes. Each `DomainCard` in `src/lib/domains.ts` already declares its `dataset`. New helper `resolveActiveDataset(selectedDomains, DOMAIN_CARDS)` returns the active dataset from those:

```ts
resolveActiveDataset([], cards)                         // → null
resolveActiveDataset(["energy-systems"], cards)          // → "main"
resolveActiveDataset(["t1d-mech"], cards)                // → "t1d"
resolveActiveDataset(["energy-systems", "t1d-mech"], cards) // → "t1d" (specialization wins)
```

**Specialization rule for cross-domain selections:** `t1d > vx880 > athena > main`. Only possible in CROSS persona where users select across datasets. The more specialized dataset better reflects what graph the user is reasoning over.

The trace builder in `SystemCopilot.tsx` reads `selectedDomains` from the store at trace-build time and passes it through the helper.

## Files

| File | Change |
|---|---|
| `src/lib/copilot/trace-logger.ts` | New `resolveActiveDataset` helper. ~30 lines. |
| `src/components/SystemCopilot.tsx` | `dataset: null` → `dataset: resolveActiveDataset(...)`. Plus `DOMAIN_CARDS` import. |
| `src/lib/__tests__/copilot-trace-logger.test.ts` | 6 new unit tests covering empty/single/cross/unknown cases. |

## Test plan

- [x] `vitest run` — 953/953 pass (6 new)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean (only pre-existing `currentSnapshot` warning)
- [ ] After merge, send a chat message in production and check:
  ```sql
  select dataset, conversation_id, created_at
  from copilot_traces
  order by created_at desc
  limit 3;
  ```
  Should show non-null dataset matching whichever domains you have loaded.

## Roadmap

```
[1]   Tool registry             ✅ #249
[2]   Trace store                ✅ #251
[3.1] Provider abstraction       ✅ #296
[3.2] Model picker UI            ✅ #298
[4]   Eval harness               ✅ #302  (7/7 pass on Gemini Flash)
[—]   Dataset routing TODO       ◀ this PR  (closes #251 follow-up)
[3.3] Native tool_use            queued (lower priority)
[5]   Distillation               unblocked when traces ≥ 10K + eval set ≥ 30 cases
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
