### PR TITLE
feat(copilot): trace browser — your conversations panel in the chat

### DIFF
--- a/src/app/api/copilot/traces/__tests__/route.test.ts
+++ b/src/app/api/copilot/traces/__tests__/route.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment node
+//
+// Tests for GET /api/copilot/traces. We mock @/lib/supabase/server
+// at the module level — the route never touches a real Supabase
+// instance during tests. This validates:
+//   - Anonymous callers get an empty list, not a 401
+//   - Authenticated callers get filtered rows
+//   - Bad limits clamp to safe range
+//   - Server-client init failures return 503
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mock the supabase server client ───────────────────────────
+//
+// The route does: supabase.from("copilot_traces").select(...).order(...).limit(N)
+// The mock's select/order both return the same chainable object, and
+// limit resolves the final promise.
+
+let mockUser: { id: string } | null = null;
+let mockRows: unknown[] = [];
+let mockError: { message: string } | null = null;
+let mockClientThrows: boolean = false;
+let lastFromCalledWith: string | undefined;
+let lastLimitCalledWith: number | undefined;
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => {
+    if (mockClientThrows) throw new Error("supabase client init failed");
+    return {
+      auth: {
+        getUser: async () => ({ data: { user: mockUser } }),
+      },
+      from: (table: string) => {
+        lastFromCalledWith = table;
+        const chain = {
+          select: () => chain,
+          order: () => chain,
+          limit: (n: number) => {
+            lastLimitCalledWith = n;
+            return Promise.resolve({ data: mockRows, error: mockError });
+          },
+        };
+        return chain;
+      },
+    };
+  },
+}));
+
+// Import AFTER the mock is registered.
+const { GET } = await import("@/app/api/copilot/traces/route");
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+function req(url = "http://localhost/api/copilot/traces"): NextRequest {
+  return new NextRequest(url, { method: "GET" });
+}
+
+beforeEach(() => {
+  mockUser = null;
+  mockRows = [];
+  mockError = null;
+  mockClientThrows = false;
+  lastFromCalledWith = undefined;
+  lastLimitCalledWith = undefined;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ─── Tests ──────────────────────────────────────────────────────
+
+describe("GET /api/copilot/traces", () => {
+  it("returns empty list (200) for anonymous callers — never 401", async () => {
+    mockUser = null;
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { traces: unknown[] };
+    expect(body.traces).toEqual([]);
+  });
+
+  it("returns rows for authenticated callers", async () => {
+    mockUser = { id: "user-1" };
+    mockRows = [
+      {
+        id: "t1",
+        created_at: "2026-05-08T00:00:00Z",
+        conversation_id: "c1",
+        turn_index: 0,
+        user_message: "hello",
+        assistant_message: "hi",
+        display_text: "hi",
+        tool_calls: [],
+        model_provider: "gemini",
+        model_id: "gemini-2.5-flash",
+        dataset: null,
+        active_module: "spirtes",
+      },
+    ];
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { traces: { id: string }[] };
+    expect(body.traces).toHaveLength(1);
+    expect(body.traces[0].id).toBe("t1");
+    expect(lastFromCalledWith).toBe("copilot_traces");
+  });
+
+  it("clamps the limit to MAX_LIMIT (200)", async () => {
+    mockUser = { id: "user-1" };
+    await GET(req("http://localhost/api/copilot/traces?limit=999"));
+    expect(lastLimitCalledWith).toBe(200);
+  });
+
+  it("clamps a negative or zero limit to a minimum of 1", async () => {
+    mockUser = { id: "user-1" };
+    await GET(req("http://localhost/api/copilot/traces?limit=0"));
+    expect(lastLimitCalledWith).toBe(1);
+    await GET(req("http://localhost/api/copilot/traces?limit=-5"));
+    expect(lastLimitCalledWith).toBe(1);
+  });
+
+  it("falls back to default limit (50) when ?limit is missing or non-numeric", async () => {
+    mockUser = { id: "user-1" };
+    await GET(req("http://localhost/api/copilot/traces"));
+    expect(lastLimitCalledWith).toBe(50);
+    await GET(req("http://localhost/api/copilot/traces?limit=abc"));
+    expect(lastLimitCalledWith).toBe(50);
+  });
+
+  it("returns 503 when the supabase server client fails to init", async () => {
+    mockClientThrows = true;
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await GET(req());
+    expect(res.status).toBe(503);
+    consoleSpy.mockRestore();
+  });
+
+  it("returns 500 when the select itself errors", async () => {
+    mockUser = { id: "user-1" };
+    mockError = { message: "boom" };
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await GET(req());
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/Failed to load traces/);
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/app/api/copilot/traces/route.ts
+++ b/src/app/api/copilot/traces/route.ts
@@ -1,0 +1,83 @@
+// ─── GET /api/copilot/traces ────────────────────────────────────
+//
+// Returns the authenticated user's recent copilot turns. RLS on
+// public.copilot_traces (Users read own copilot traces) does the
+// security work — we just need to use the auth-aware server
+// client (NOT the service-role client) so auth.uid() is bound to
+// the caller.
+//
+// Anonymous callers see an empty list, not a 401: production has
+// some pre-auth surfaces and we don't want noise in the logs.
+
+import { NextRequest, NextResponse } from "next/server";
+import { createClient as createServerClient } from "@/lib/supabase/server";
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+export interface TraceListRow {
+  id: string;
+  created_at: string;
+  conversation_id: string;
+  turn_index: number;
+  user_message: string | null;
+  assistant_message: string | null;
+  display_text: string | null;
+  tool_calls: Array<{
+    name: string;
+    params: Record<string, unknown>;
+    result: string;
+    error: string | null;
+    latency_ms: number;
+  }>;
+  model_provider: string | null;
+  model_id: string | null;
+  dataset: string | null;
+  active_module: string | null;
+}
+
+export async function GET(request: NextRequest) {
+  const limitParam = request.nextUrl.searchParams.get("limit");
+  const requestedLimit = limitParam ? parseInt(limitParam, 10) : DEFAULT_LIMIT;
+  const limit = Math.min(
+    MAX_LIMIT,
+    Math.max(1, Number.isFinite(requestedLimit) ? requestedLimit : DEFAULT_LIMIT),
+  );
+
+  let supabase;
+  try {
+    supabase = await createServerClient();
+  } catch (err) {
+    console.error("[copilot-traces] failed to create server client:", err);
+    return NextResponse.json(
+      { error: "Supabase server client unavailable" },
+      { status: 503 },
+    );
+  }
+
+  // RLS will filter to auth.uid() = user_id automatically. The
+  // explicit auth check here is defense-in-depth so anonymous
+  // callers see a clean empty list rather than a Postgres error.
+  const { data: userData } = await supabase.auth.getUser();
+  if (!userData.user) {
+    return NextResponse.json({ traces: [] satisfies TraceListRow[] });
+  }
+
+  const { data, error } = await supabase
+    .from("copilot_traces")
+    .select(
+      "id, created_at, conversation_id, turn_index, user_message, assistant_message, display_text, tool_calls, model_provider, model_id, dataset, active_module",
+    )
+    .order("created_at", { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    console.error("[copilot-traces] select failed:", error);
+    return NextResponse.json(
+      { error: "Failed to load traces" },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ traces: (data ?? []) as TraceListRow[] });
+}

--- a/src/components/CopilotTraceHistory.tsx
+++ b/src/components/CopilotTraceHistory.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+// ─── Copilot Trace History ──────────────────────────────────────
+//
+// Browse the authenticated user's recent copilot turns. Reads
+// from /api/copilot/traces, which is RLS-protected — the server
+// route only ever returns rows where auth.uid() = user_id.
+//
+// Surface goal: close the loop on the trace store. Today the data
+// exists but you can only see it via SQL. With this panel you can
+// scan recent turns, expand to see params + results, and (in a
+// follow-up) one-click a turn into the eval seed set.
+
+import { useEffect, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import type { TraceListRow } from "@/app/api/copilot/traces/route";
+
+interface Props {
+  /** When true, fetch fresh on mount and on every reopen. */
+  open: boolean;
+}
+
+type LoadState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "loaded"; traces: TraceListRow[] }
+  | { kind: "error"; message: string };
+
+export default function CopilotTraceHistory({ open }: Props) {
+  const [state, setState] = useState<LoadState>({ kind: "idle" });
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    // Wrap in an async IIFE so all setState calls happen inside
+    // the awaited microtask, never synchronously in the effect
+    // body (react-hooks/set-state-in-effect).
+    void (async () => {
+      setState({ kind: "loading" });
+      try {
+        const res = await fetch("/api/copilot/traces", {
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = (await res.json()) as { traces: TraceListRow[] };
+        if (!cancelled) setState({ kind: "loaded", traces: data.traces });
+      } catch (err) {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : String(err);
+        setState({ kind: "error", message });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div className="mt-2 pt-2 border-t border-border space-y-2">
+      <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted flex items-center justify-between">
+        <span>YOUR CONVERSATIONS</span>
+        {state.kind === "loaded" && (
+          <span className="text-text-muted/60">
+            {state.traces.length === 0
+              ? "no rows"
+              : `${state.traces.length} turn${state.traces.length === 1 ? "" : "s"}`}
+          </span>
+        )}
+      </div>
+
+      {state.kind === "loading" && (
+        <div className="text-[10px] font-mono text-text-muted">Loading…</div>
+      )}
+
+      {state.kind === "error" && (
+        <div className="text-[10px] font-mono text-accent-amber">
+          Couldn&apos;t load history: {state.message}
+        </div>
+      )}
+
+      {state.kind === "loaded" && state.traces.length === 0 && (
+        <div className="text-[10px] font-mono text-text-muted leading-relaxed">
+          No turns yet. Send a message to the copilot — it&apos;ll appear here.
+        </div>
+      )}
+
+      {state.kind === "loaded" && state.traces.length > 0 && (
+        <div className="space-y-1 max-h-[60vh] overflow-y-auto">
+          {state.traces.map((trace) => (
+            <TraceRow
+              key={trace.id}
+              trace={trace}
+              expanded={expanded === trace.id}
+              onToggle={() => setExpanded(expanded === trace.id ? null : trace.id)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Single row ─────────────────────────────────────────────────
+
+function TraceRow({
+  trace,
+  expanded,
+  onToggle,
+}: {
+  trace: TraceListRow;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const ts = new Date(trace.created_at);
+  const tsLabel = `${ts.toLocaleDateString("en-US", { month: "short", day: "numeric" })} ${ts.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`;
+  const userPreview = (trace.user_message ?? "").slice(0, 80) || "(no user message)";
+  const nTools = trace.tool_calls.length;
+  const provider = trace.model_provider ?? "?";
+
+  return (
+    <div className="rounded border border-border bg-surface text-[10px] font-mono">
+      <button
+        onClick={onToggle}
+        className="w-full text-left px-2 py-1.5 flex items-start gap-2 hover:bg-surface-elevated transition-colors"
+      >
+        <span className="text-text-muted/60 shrink-0 w-[72px]">{tsLabel}</span>
+        <span className="flex-1 text-foreground leading-snug truncate">{userPreview}</span>
+        <span className="shrink-0 text-text-muted/60 flex items-center gap-1">
+          <span className="text-accent-cyan">{provider}</span>
+          {nTools > 0 && <span className="text-accent-green">·{nTools}🔧</span>}
+        </span>
+      </button>
+
+      <AnimatePresence>
+        {expanded && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.12 }}
+            className="overflow-hidden"
+          >
+            <div className="px-2 py-1.5 border-t border-border space-y-1.5">
+              <Block label="user">{trace.user_message ?? "(none)"}</Block>
+              <Block label="assistant">
+                {(trace.display_text ?? trace.assistant_message ?? "(none)").slice(0, 800)}
+                {(trace.display_text ?? trace.assistant_message ?? "").length > 800 && "…"}
+              </Block>
+              {trace.tool_calls.length > 0 && (
+                <div>
+                  <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted mb-0.5">
+                    TOOL CALLS
+                  </div>
+                  <ul className="space-y-1">
+                    {trace.tool_calls.map((tc, i) => (
+                      <li key={i} className="bg-surface-elevated rounded px-1.5 py-1">
+                        <div className="flex items-center justify-between">
+                          <span className={tc.error ? "text-accent-amber" : "text-accent-green"}>
+                            {tc.name}
+                          </span>
+                          <span className="text-text-muted/60 text-[9px]">
+                            {tc.latency_ms}ms
+                          </span>
+                        </div>
+                        {Object.keys(tc.params).length > 0 && (
+                          <div className="text-text-muted/80 text-[9px] truncate">
+                            {JSON.stringify(tc.params)}
+                          </div>
+                        )}
+                        {tc.error && (
+                          <div className="text-accent-amber text-[9px] truncate">{tc.error}</div>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              <div className="flex gap-3 text-[9px] text-text-muted/60 pt-1">
+                {trace.model_id && <span>{trace.model_id}</span>}
+                {trace.dataset && <span>dataset: {trace.dataset}</span>}
+                {trace.active_module && <span>module: {trace.active_module}</span>}
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+function Block({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted mb-0.5">
+        {label.toUpperCase()}
+      </div>
+      <div className="text-text-muted leading-snug whitespace-pre-wrap">{children}</div>
+    </div>
+  );
+}

--- a/src/components/SystemCopilot.tsx
+++ b/src/components/SystemCopilot.tsx
@@ -21,6 +21,7 @@ import { CopilotMessage } from "@/lib/types";
 import { getModelsForProvider, type LLMProvider } from "@/lib/llm-providers";
 import { serializeGraphContext, serializeSnapshotContext, serializeTimeWindowContext } from "@/lib/copilot-context";
 import { buildSnapshot } from "@/lib/snapshots/serializer";
+import CopilotTraceHistory from "@/components/CopilotTraceHistory";
 
 const ACTIONS: { label: string; action: CopilotAction; color: string }[] = [
   { label: "DISCOVER STRUCTURE", action: "DISCOVER_STRUCTURE", color: "var(--accent-cyan)" },
@@ -137,6 +138,7 @@ export default function SystemCopilot() {
   const inputRef = useRef<HTMLInputElement>(null);
   const [showSettings, setShowSettings] = useState(false);
   const [showDatasets, setShowDatasets] = useState(false);
+  const [showHistory, setShowHistory] = useState(false);
   const [contextBadge, setContextBadge] = useState<string | null>(null);
   const [isListening, setIsListening] = useState(false);
   const [ttsEnabled, setTtsEnabled] = useState(false);
@@ -844,7 +846,7 @@ export default function SystemCopilot() {
             </button>
             {importedDatasets.length > 0 && (
               <button
-                onClick={() => { setShowDatasets(!showDatasets); if (!showDatasets) setShowSettings(false); }}
+                onClick={() => { setShowDatasets(!showDatasets); if (!showDatasets) { setShowSettings(false); setShowHistory(false); } }}
                 className={`text-[11px] transition-colors p-1 ${
                   showDatasets ? "text-accent-amber" : "text-text-muted hover:text-accent-amber"
                 }`}
@@ -854,7 +856,16 @@ export default function SystemCopilot() {
               </button>
             )}
             <button
-              onClick={() => { setShowSettings(!showSettings); if (!showSettings) setShowDatasets(false); }}
+              onClick={() => { setShowHistory(!showHistory); if (!showHistory) { setShowSettings(false); setShowDatasets(false); } }}
+              className={`text-[11px] transition-colors p-1 ${
+                showHistory ? "text-accent-green" : "text-text-muted hover:text-accent-green"
+              }`}
+              title="Your Conversation History"
+            >
+              {showHistory ? "\u2715" : "\u29C9"}
+            </button>
+            <button
+              onClick={() => { setShowSettings(!showSettings); if (!showSettings) { setShowDatasets(false); setShowHistory(false); } }}
               className="text-[11px] text-text-muted hover:text-accent-cyan transition-colors p-1"
               title="LLM Settings"
             >
@@ -1020,6 +1031,21 @@ export default function SystemCopilot() {
                   )}
                 </div>
               </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {/* Trace history panel — opens via the ⧉ icon next to settings */}
+        <AnimatePresence>
+          {showHistory && (
+            <motion.div
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: "auto", opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={{ duration: 0.15 }}
+              className="overflow-hidden"
+            >
+              <CopilotTraceHistory open={showHistory} />
             </motion.div>
           )}
         </AnimatePresence>


### PR DESCRIPTION
## Summary

Closes the user-facing loop on the trace store. Today the trace data lives in `copilot_traces` but you can only see it via SQL. This PR adds an in-chat panel that lists your recent turns with full structured tool-call drill-in.

## What you'll see

A new ⧉ button appears in the chat header alongside ⚙ (settings) and ▤ (datasets). Click it → a collapsible panel opens beneath the header showing your last 50 turns:

```
YOUR CONVERSATIONS                                   12 turns

May 8 18:55  show me only the energy stuff           gemini ·1🔧
May 8 18:50  what is omega-fragility?                gemini
May 8 18:47  compare TSMC and ASML                   gemini ·1🔧
            ↳ click a row to expand:

            USER
            compare TSMC and ASML

            ASSISTANT
            [ANALYSIS] Both nodes are critical chokepoints…

            TOOL CALLS
            ┌───────────────────────────────────────────────┐
            │ compare_nodes                          22ms   │
            │ {"ids":["FAB_TW","ASML_NL"]}                  │
            └───────────────────────────────────────────────┘

            gemini-2.5-flash · dataset: main · module: spirtes
```

## How

- **`GET /api/copilot/traces`** uses the auth-aware server client (`createClient` from `@/lib/supabase/server`) — **never** the service-role client. The existing RLS policy `Users read own copilot traces` filters automatically to `auth.uid() = user_id`. The route never queries with elevated privileges; the database itself enforces the boundary.
- **Anonymous callers** get `{ traces: [] }` at 200, not 401. Production has pre-auth surfaces and we don't want noise in the logs.
- **`?limit=` query param** clamped to `[1, 200]`, default 50.
- **`<CopilotTraceHistory />`** state machine: `idle → loading → loaded | error`. The fetch runs inside an async IIFE so `setState` calls happen in the microtask queue, not the effect's synchronous body (resolves a `react-hooks/set-state-in-effect` lint violation that the first draft hit).

## Files

| File | Lines | What |
|---|---|---|
| `src/app/api/copilot/traces/route.ts` | new (88) | The API route. RLS-protected. |
| `src/app/api/copilot/traces/__tests__/route.test.ts` | new (155) | 7 unit tests — anon empty list, authenticated returns rows, limit clamping, init failure → 503, query failure → 500. |
| `src/components/CopilotTraceHistory.tsx` | new (180) | The panel + per-row expand UI. |
| `src/components/SystemCopilot.tsx` | +28 | New `showHistory` state, ⧉ button in header, mounted panel. Mutually exclusive with settings + datasets. |

## RLS demo

Open the panel as User A → you see User A's rows. Sign out and hit the API (or run `curl /api/copilot/traces`) → empty list. The route doesn't have a fallback to service-role for the read path; the database refuses to surface other users' rows because RLS evaluates `auth.uid() = user_id` at every query.

## Why now

1. **Visible proof the trace store is working.** Today: SQL-only. Most users won't open SQL.
2. **Bootstraps the eval-set growth loop.** Future "lock as eval case" button per row would let you curate the seed test cases from production traffic with one click. That's how the eval set goes from 7 → 30+ organically.
3. **Debug surface** — diagnose *why* a turn produced a specific tool call by inspecting full params + result + latency.

## Test plan

- [x] `vitest run` — **966/966 pass** (7 new in the route test)
- [x] `tsc --noEmit` clean on touched files
- [x] `eslint` clean (only pre-existing `currentSnapshot` warning in SystemCopilot.tsx)
- [x] `next build` passes with dummy env
- [ ] Manual on Vercel preview: send a chat message, click the ⧉ icon, verify your turn appears
- [ ] Manual: click a row, verify expand shows the full message + tool calls
- [ ] Manual: in an Incognito window with a different user, confirm you can't see User A's rows
- [ ] Manual: log out, hit `/api/copilot/traces` directly — should return `{ traces: [] }`

## Roadmap status

```
[1]   Tool registry             ✅ #249
[2]   Trace store                ✅ #251
[3.1] Provider abstraction       ✅ #296
[3.2] Model picker UI            ✅ #298
[4]   Eval harness               ✅ #302  (7/7 PASS on Gemini Flash)
[—]   Dataset routing TODO       ✅ #310 (open)
[—]   Trace browser UI           ◀ this PR
[—]   Eval CI gate               next (wait for eval set ≥ 20 cases)
[—]   Conversation memory        queued
[3.3] Native tool_use            queued (lower priority)
[5]   Distillation               unblocked when traces ≥ 10K + eval set ≥ 30 cases
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
