### PR TITLE
feat(dag2d): highlight χ★ edges with a violet halo on the 2D canvas

### DIFF
--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -27,6 +27,7 @@ import { useApexStore } from "@/stores/useApexStore";
 import { useFilteredGraph } from "@/hooks/useFilteredGraph";
 import { getCategoryColor, getDomainColor } from "@/lib/graph-data";
 import { getDomainCardColor } from "@/lib/domains";
+import { chiStar } from "@/lib/estimators/chi-star";
 import DAGOverlay from "./dag3d/DAGOverlay";
 import CanvasWatermark from "./CanvasWatermark";
 import { useReplayTickDOM } from "@/lib/useReplayTick";
@@ -394,6 +395,13 @@ interface EmphasizedEdgeData {
   isSelected: boolean;
   propagationSignal: number;
   showArrow: boolean;
+  /**
+   * Edge is in the χ★ bridge set (Tarjan strict bridges ∪ top-k BES).
+   * EmphasizedEdge renders a wider violet path behind the main edge
+   * so the load-bearing skeleton is visible at a glance — same
+   * treatment as the 3D canvas, adapted to ReactFlow's SVG layer.
+   */
+  isChiStar: boolean;
 }
 
 function EmphasizedEdge(props: EdgeProps<EmphasizedEdgeData>) {
@@ -500,18 +508,36 @@ function EmphasizedEdge(props: EdgeProps<EmphasizedEdgeData>) {
   void adjacency;
 
   return (
-    <BaseEdge
-      id={id}
-      path={edgePath}
-      markerEnd={markerEnd}
-      style={{
-        stroke,
-        strokeWidth,
-        strokeDasharray,
-        opacity,
-        transition: "opacity 180ms ease-out",
-      }}
-    />
+    <>
+      {/* χ★ halo — wider violet path behind the main edge, matching
+          the 3D canvas treatment (DAGEdge3D). Skipped when the
+          element-specific overrides (selection, propagation flash)
+          are active so they remain unambiguous. Halo opacity scales
+          with the edge's overall opacity so a dimmed χ★ edge stays
+          visually consistent with its main line. */}
+      {d.isChiStar && !isThisSelected && d.propagationSignal === 0 && (
+        <path
+          d={edgePath}
+          stroke="#7B68EE"
+          strokeWidth={strokeWidth + 3}
+          fill="none"
+          opacity={opacity * 0.45}
+          style={{ transition: "opacity 180ms ease-out", pointerEvents: "none" }}
+        />
+      )}
+      <BaseEdge
+        id={id}
+        path={edgePath}
+        markerEnd={markerEnd}
+        style={{
+          stroke,
+          strokeWidth,
+          strokeDasharray,
+          opacity,
+          transition: "opacity 180ms ease-out",
+        }}
+      />
+    </>
   );
 }
 
@@ -781,6 +807,21 @@ function CausalDAG2DInner() {
     return nodes.filter((n) => selSet.has(n.id));
   }, [nodes, isolateSelection, multiSelectedNodes]);
 
+  // χ★ bridge-set membership per edge id. Computed once per graph
+  // structure and consumed by the edges memo below — gates the violet
+  // halo rendered behind χ★ edges in EmphasizedEdge. Brandes' BES is
+  // O(V·E); this memo runs only when graphData changes (not on every
+  // selection / hover).
+  const chiStarSet = useMemo(() => {
+    if (graphData.edges.length === 0) return new Set<string>();
+    const r = chiStar({
+      nodes: graphData.nodes,
+      edges: graphData.edges.filter((e) => !e.isSevered),
+      metadata: graphData.metadata,
+    });
+    return new Set(r.chiStar);
+  }, [graphData]);
+
   // Edges carry only structural / replay / truth-filter state. Hover and
   // single-select emphasis are computed inside `EmphasizedEdge` itself, so
   // this useMemo doesn't depend on hoveredNodeId or selectedNode — and
@@ -833,10 +874,11 @@ function CausalDAG2DInner() {
             isSelected,
             propagationSignal,
             showArrow,
+            isChiStar: chiStarSet.has(e.id),
           },
         };
       }),
-    [graphData, truthFilter, currentSnapshot, selectedEdge]
+    [graphData, truthFilter, currentSnapshot, selectedEdge, chiStarSet]
   );
 
   // Filter edges for isolation mode


### PR DESCRIPTION
## Summary

Mirrors the 3D treatment from PR [#313](https://github.com/ApexAnalytica/apex-terminal/pull/313) on the 2D ReactFlow canvas. Math, registry, Pareto card, system-metrics strip, and 3D canvas all surface χ★ today; this PR extends the visual halo to the 2D view so the load-bearing skeleton reads consistently across both topology canvases.

## Implementation

**`CausalDAG2D`** — new `useMemo` computes `chiStar()` once per `graphData` and exposes the χ★ edge ids as a Set. Same memoisation pattern as the 3D canvas — recomputes only when graphData changes, not on every selection / hover.

**`EmphasizedEdgeData`** — new `isChiStar` boolean field.

**`EmphasizedEdge`** — renders a wider violet `<path>` behind the BaseEdge when `isChiStar` is true:

| Property | Value |
|---|---|
| Stroke | `#7B68EE` (matches AI Safety / chi-star palette) |
| Stroke-width | `strokeWidth + 3` |
| Opacity | `opacity * 0.45` (scales with the edge's overall opacity, so a dimmed χ★ edge stays consistent with its main line) |
| pointerEvents | `none` (visual-only; click/hover targeting unchanged) |

Skipped when `isThisSelected` or `propagationSignal > 0` so element-specific overrides (selection ring, amber propagation flash) remain unambiguous.

## Why a raw `<path>` not a second BaseEdge

`BaseEdge` carries ReactFlow's edge selection / interaction wiring that we don't want for a visual-only halo. A plain SVG path is the minimal surface — no event handlers, no edge-state coupling.

## Why behind, not in front

The existing edge-type palette (cyan / amber / orange / red, dashed for confounded / inconsistent) is the primary signal. Halo behind, lower opacity, lets χ★ membership read as supplementary context — same priority hierarchy as the 3D canvas treatment.

## Visual χ★ status after this PR

| Surface | Status |
|---|---|
| 3D canvas | ✅ #313 |
| 2D canvas | ✅ this PR |
| Relief view | deferred (scalar field is a fundamentally different rendering paradigm — needs its own design pass) |

## Test plan

- [x] `vitest run`: **959 passing**, no regressions.
- [x] `tsc --noEmit` clean for `CausalDAG2D.tsx`.
- [x] Manual: select AI Safety / Endogenous Catastrophe → 2D view → χ★ edges in the IDS substrate render with a violet halo behind the cyan baseline; selection / hover / propagation behaviour unchanged; severed / ablated edges retain their existing visual identities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)