### PR TITLE
refactor(pareto): split snapshot estimators out of the time-series strip

### DIFF
--- a/src/components/ModulePanel.tsx
+++ b/src/components/ModulePanel.tsx
@@ -9,11 +9,6 @@ import { AXIOM_LIBRARY, scoreAxiomRelevance, type ScoredAxiom } from "@/lib/tars
 import { resolveDomainProfile, type EstimatorId } from "@/lib/domain-profiles";
 import { getEstimatorMeta } from "@/lib/criticality-registry";
 import { moransI } from "@/lib/estimators/moran";
-// omegaBridgeDensity wraps chiStar (Tarjan + Brandes BES) and surfaces
-// the |χ★| / |E| scalar plus the full ChiStarResult — used by the
-// chi-star Pareto-card branch and the system-metrics strip.
-import { omegaBridgeDensity } from "@/lib/estimators/omega-bridge-density";
-import { cvarW1, tailDepthScore } from "@/lib/estimators/cvar-w1";
 import { extractT1DSeries, T1D_NODE_IDS } from "@/lib/t1d-estimator-inputs";
 import {
   bocpdRegimeGate,
@@ -36,6 +31,7 @@ import TrinityPanel from "./TrinityPanel";
 import DiscoveryRunsPanel from "./DiscoveryRunsPanel";
 import NewsInterpreterPanel from "./NewsInterpreterPanel";
 import NodeInspector from "./NodeInspector";
+import SnapshotDiagnostics from "./SnapshotDiagnostics";
 
 // Tab-gated sub-panels lazy-loaded so the default Spirtes tab doesn't
 // pull their JS on first paint:
@@ -1599,175 +1595,6 @@ function ParetoPanel({
               };
             }
           }
-          // ── CVaR-W₁ (canonical Tail Depth pillar estimator) ───────
-          // Loss sample = per-node ΩF composite values across the
-          // filtered graph. Profile-agnostic: every CausalNode carries
-          // omegaFragility.composite, so wherever the user has
-          // selected, this estimator has a sample to work with.
-          //
-          // α = 0.9 standard. W₁ ambiguity radius ε = 0 — until a
-          // calibrated radius lands per profile (cross-validation on
-          // historical incidents would set it), the robust value
-          // collapses to the empirical CVaR. Documented in the
-          // methodology so the user knows what's missing.
-          if (id === "cvar-w1") {
-            const samples = graphData.nodes
-              .map((n) => n.omegaFragility?.composite)
-              .filter(
-                (v): v is number => typeof v === "number" && !Number.isNaN(v),
-              );
-            if (samples.length < 5) {
-              return {
-                key: "cvar-w1",
-                abbrev: meta.abbrev,
-                fullName: meta.fullName,
-                epochs: 0,
-                maxEpochs: 100,
-                color: meta.color,
-                confidence: 0,
-                timeSeries: [],
-                modelSeries: undefined,
-                shortDesc: meta.shortDesc,
-                methodology: meta.methodology,
-                formula: meta.formula,
-                assessment: `INSUFFICIENT DATA — only ${samples.length} ΩF composite value(s) in the current filtered graph. CVaR's boundary interpolation needs ≥5 samples to be stable.`,
-                emptyState: {
-                  kind: "awaiting-data" as const,
-                  inputs:
-                    "At least 5 nodes with omegaFragility.composite values in the filtered graph. Widen the domain selection or load a domain with more nodes.",
-                },
-              };
-            }
-            const alpha = 0.9;
-            const result = cvarW1(samples, { alpha, radius: 0 });
-            // Pillar score in [0, 10] using the conventional ΩF range
-            // (composites are 0–10 by construction). High CVaR → high
-            // tail depth → high pillar score.
-            const pillarScore = tailDepthScore(result.empirical, 0, 10);
-            // Sort descending so the chart shows the upper tail's
-            // shape rather than the cumulative distribution. Same
-            // convention as the chi-star BES ranking.
-            const sorted = [...samples].sort((a, b) => b - a);
-            // Epochs: low pillar score → far from critical (high T-);
-            // high pillar score → close to critical (low T-). Mirrors
-            // the direction csd / lppls / chi-star use.
-            const epochs = Math.max(
-              0,
-              Math.round((1 - pillarScore / 10) * 100),
-            );
-            return {
-              key: "cvar-w1",
-              abbrev: meta.abbrev,
-              fullName: meta.fullName,
-              epochs,
-              maxEpochs: 100,
-              color: meta.color,
-              // pillarScore / 10 lands in [0, 1] — same shape as the
-              // other estimators' confidence values. High = elevated
-              // tail risk.
-              confidence: pillarScore / 10,
-              timeSeries: sorted,
-              modelSeries: undefined,
-              shortDesc: meta.shortDesc,
-              methodology: [
-                `Empirical α-CVaR on n=${samples.length} ΩF composite values across the live filtered graph (${graphData.nodes.length} nodes total). α = ${alpha}, so CVaR_α is the expected ΩF in the worst ${((1 - alpha) * 100).toFixed(0)}% tail.`,
-                `α-VaR (${alpha}-quantile) = ${result.varEmpirical.toFixed(3)}. Empirical CVaR = ${result.empirical.toFixed(3)}. Robust CVaR = ${result.robust.toFixed(3)} (W₁ ambiguity radius ε = ${result.radius} — no calibrated radius wired upstream yet, so robust collapses to empirical for now).`,
-                meta.methodology[0] ?? "",
-              ],
-              formula: `α = ${alpha} | n = ${samples.length} | VaR = ${result.varEmpirical.toFixed(3)} | empirical CVaR = ${result.empirical.toFixed(3)} | pillar = ${pillarScore.toFixed(2)}/10`,
-              assessment:
-                pillarScore >= 8
-                  ? `CRITICAL TAIL — empirical CVaR_${alpha} = ${result.empirical.toFixed(2)} on n=${samples.length}. Expected ΩF in the worst ${((1 - alpha) * 100).toFixed(0)}% tail is in the high-fragility band. Pillar score ${pillarScore.toFixed(1)}/10.`
-                  : pillarScore >= 5
-                    ? `ELEVATED TAIL — empirical CVaR_${alpha} = ${result.empirical.toFixed(2)} on n=${samples.length}. Worst-${((1 - alpha) * 100).toFixed(0)}% tail sits above the median fragility. Pillar score ${pillarScore.toFixed(1)}/10.`
-                    : `CONTAINED TAIL — empirical CVaR_${alpha} = ${result.empirical.toFixed(2)} on n=${samples.length}. Worst-${((1 - alpha) * 100).toFixed(0)}% tail stays in the lower-fragility regime. Pillar score ${pillarScore.toFixed(1)}/10.`,
-            };
-          }
-          // ── χ★ BRIDGE SETS (live on filtered graph topology) ──────
-          // Snapshot estimator: no time-series, no observed-vs-model
-          // fit. Computes Tarjan strict bridges + Brandes BES on the
-          // current filtered graph and renders the live numerics.
-          // The chart shows the descending-BES distribution as a
-          // Pareto-shape curve — informative as a "concentration"
-          // visualisation even though the x-axis is rank not time.
-          if (id === "chi-star") {
-            const liveEdgeCount = graphData.edges.filter((e) => !e.isSevered).length;
-            if (liveEdgeCount === 0) {
-              return {
-                key: "chi-star",
-                abbrev: meta.abbrev,
-                fullName: meta.fullName,
-                epochs: 0,
-                maxEpochs: 100,
-                color: meta.color,
-                confidence: 0,
-                timeSeries: [],
-                modelSeries: undefined,
-                shortDesc: meta.shortDesc,
-                methodology: meta.methodology,
-                formula: meta.formula,
-                assessment:
-                  "INSUFFICIENT GRAPH STRUCTURE — no live edges in the current filtered graph. χ★ requires edges to compute strict bridges and Bridge-Edge Strength.",
-                emptyState: {
-                  kind: "awaiting-data" as const,
-                  inputs:
-                    "At least one edge in the current filtered graph. Select a domain that contains edges (or widen the filter).",
-                },
-              };
-            }
-            const obd = omegaBridgeDensity({
-              ...graphData,
-              edges: graphData.edges.filter((e) => !e.isSevered),
-            });
-            const density = obd.density;
-            const bridgeFraction = obd.bridgeFraction;
-            const chiStarSize = obd.chiStarSize;
-            const bridgeCount = obd.chiStar.bridges.length;
-            const topBesAdds = chiStarSize - bridgeCount;
-            const topBesEdge = obd.chiStar.besRanking[0];
-            // BES descending series — informative shape for the chart
-            // (Pareto-style fall-off when one edge dominates, flat
-            // when betweenness is evenly distributed). Not a time
-            // axis — labelled in the methodology copy.
-            const besSeries = obd.chiStar.besRanking.map((r) => r.bes);
-            // Bridge-fraction is the natural [0, 1] confidence proxy:
-            // 0 means "no strict chokepoints, alternate paths
-            // everywhere"; 1 means "tree topology, every edge load-
-            // bearing." Higher = more critical.
-            const confidence = bridgeFraction;
-            // Epochs gauge: invert density so high-density (near-tree)
-            // graphs show a low T- value (closer to critical), and
-            // redundant graphs show high T- (far from critical).
-            // Same direction as csd/lppls semantics ("epochs to
-            // critical").
-            const epochs = Math.max(0, Math.round((1 - density) * 100));
-            return {
-              key: "chi-star",
-              abbrev: meta.abbrev,
-              fullName: meta.fullName,
-              epochs,
-              maxEpochs: 100,
-              color: meta.color,
-              confidence,
-              timeSeries: besSeries,
-              modelSeries: undefined,
-              shortDesc: meta.shortDesc,
-              methodology: [
-                `Tarjan strict bridges + Brandes Bridge-Edge Strength (BES) on the live filtered graph (${graphData.nodes.length} nodes, ${liveEdgeCount} non-severed edges). Found ${bridgeCount} strict bridges (edges whose removal disconnects the graph) and ${topBesAdds} top-BES additions, for a χ★ size of ${chiStarSize}.`,
-                `Ω-Bridge Density = |χ★| / |E| = ${chiStarSize} / ${liveEdgeCount} = ${density.toFixed(3)}. Strict-bridges-only fraction = ${bridgeFraction.toFixed(3)}. Top BES = ${topBesEdge ? topBesEdge.bes.toFixed(3) : "—"} on edge ${topBesEdge ? topBesEdge.edgeId : "—"}.`,
-                meta.methodology[0] ?? "",
-              ],
-              formula: `|χ★| = ${chiStarSize} | bridges = ${bridgeCount} | density = ${density.toFixed(3)} | top BES = ${topBesEdge ? topBesEdge.bes.toFixed(3) : "—"}`,
-              assessment:
-                density > 0.6
-                  ? `FRAGILE — Ω-Bridge Density ${density.toFixed(3)} > 0.60. Near-tree topology; ${chiStarSize} χ★ edges (${bridgeCount} strict bridges) carry the cascade pathways. Removing any of them fragments the graph.`
-                  : density > 0.3
-                    ? `ELEVATED — Ω-Bridge Density ${density.toFixed(3)} ∈ (0.30, 0.60]. ${chiStarSize} edges form the load-bearing skeleton; more bridge-like structure than typical for real causal graphs.`
-                    : density < 0.05
-                      ? `REDUNDANT — Ω-Bridge Density ${density.toFixed(3)} < 0.05. Cycle-rich; few chokepoints. Alternate paths absorb most disruptions; ${bridgeCount} strict bridges in ${liveEdgeCount} edges.`
-                      : `NOMINAL — Ω-Bridge Density ${density.toFixed(3)} ∈ [0.05, 0.30]. Well-connected with ${chiStarSize} chokepoint edges (${bridgeCount} strict bridges, ${topBesAdds} top-BES). Typical regime for real causal graphs.`,
-            };
-          }
           // Estimator has a static-registry entry with no live runtime yet:
           // render the card in an empty state that still teaches what the
           // method does and which inputs it needs.
@@ -1860,6 +1687,13 @@ function ParetoPanel({
           </>
         );
       })()}
+
+      {/* Snapshot Diagnostics — Tail (CVaR-W₁) + Topology (χ★).
+          Whole-system readouts on the live filtered graph, separate
+          from the time-series criticality strip above. */}
+      <div className="mt-3 pt-3 border-t border-border/50">
+        <SnapshotDiagnostics />
+      </div>
 
       {/* Ω-Fragility Ranking — collapsible, default closed */}
       <div className="mt-3">

--- a/src/components/SnapshotDiagnostics.tsx
+++ b/src/components/SnapshotDiagnostics.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+// Snapshot Diagnostics panel — surfaces the dissertation's two
+// non-temporal estimators side-by-side, both reading the live
+// filtered graph that the canvas + the system-metrics strip already
+// share.
+//
+// Why a separate panel from the Pareto criticality strip: the four
+// strip estimators (CSD / PH / LPPLS / BOCPD) all fit the same shape
+// — observed-vs-model fit on a Ω-trajectory with an "epochs to
+// critical" reading. CVaR-W₁ and χ★ are SNAPSHOT estimators; they
+// read the per-node ΩF distribution / graph topology in one shot,
+// with no time axis and no model fit. Forcing them into the same
+// strip required synthesising fake "epochs" readings (the T-77
+// reading users were seeing on the χ★ tab was just `(1 - density)
+// × 100` — not a meaningful time-to-critical, just a topology
+// summary stretched into the wrong UI mold).
+//
+// Whole-system primary readout for both, matching what the math
+// estimators actually compute. Per-node drill-downs live in the
+// node / edge inspectors.
+
+import { useMemo, useState } from "react";
+import { useFilteredGraph } from "@/hooks/useFilteredGraph";
+import { cvarW1, tailDepthScore } from "@/lib/estimators/cvar-w1";
+import { omegaBridgeDensity } from "@/lib/estimators/omega-bridge-density";
+
+type Band = {
+  label: string;
+  color: string;
+  description: string;
+};
+
+function tailBand(pillarScore: number): Band {
+  if (pillarScore >= 8)
+    return {
+      label: "CRITICAL TAIL",
+      color: "#ff1744",
+      description:
+        "Worst-α tail in the high-fragility band. Significant probability mass on outcomes that would dominate ΩF.",
+    };
+  if (pillarScore >= 5)
+    return {
+      label: "ELEVATED TAIL",
+      color: "var(--accent-amber)",
+      description:
+        "Worst-α tail sits above the median ΩF. Worth monitoring; the tail is not yet critical but it's not contained either.",
+    };
+  return {
+    label: "CONTAINED TAIL",
+    color: "var(--accent-green)",
+    description:
+      "Worst-α tail stays in the lower-fragility regime. Tail risk is bounded for the current configuration.",
+  };
+}
+
+function topologyBand(density: number): Band {
+  if (density > 0.6)
+    return {
+      label: "FRAGILE",
+      color: "#ff1744",
+      description:
+        "Near-tree topology. Most edges sit in χ★, so removing any of them fragments cascade pathways. Investigate redundancy.",
+    };
+  if (density > 0.3)
+    return {
+      label: "ELEVATED",
+      color: "var(--accent-amber)",
+      description:
+        "Elevated chokepoint concentration. More edges than typical fall in χ★; the graph has bridge-like structure to monitor.",
+    };
+  if (density < 0.05)
+    return {
+      label: "REDUNDANT",
+      color: "var(--accent-green)",
+      description:
+        "Cycle-rich, highly redundant. Few chokepoints; alternate paths absorb most disruptions.",
+    };
+  return {
+    label: "NOMINAL",
+    color: "var(--accent-green)",
+    description:
+      "Well-connected with some critical chokepoints. Typical regime for real causal graphs.",
+  };
+}
+
+export default function SnapshotDiagnostics() {
+  const graph = useFilteredGraph();
+  const [expanded, setExpanded] = useState<"tail" | "topology" | null>(null);
+
+  // Tail Depth — empirical α-CVaR over the per-node ΩF composite
+  // distribution of the live filtered graph. α = 0.9 standard.
+  const tail = useMemo(() => {
+    const samples = graph.nodes
+      .map((n) => n.omegaFragility?.composite)
+      .filter(
+        (v): v is number => typeof v === "number" && !Number.isNaN(v),
+      );
+    if (samples.length < 5) return { ok: false as const, n: samples.length };
+    const alpha = 0.9;
+    const r = cvarW1(samples, { alpha, radius: 0 });
+    const pillarScore = tailDepthScore(r.empirical, 0, 10);
+    return {
+      ok: true as const,
+      alpha,
+      n: samples.length,
+      varEmpirical: r.varEmpirical,
+      empirical: r.empirical,
+      robust: r.robust,
+      pillarScore,
+      band: tailBand(pillarScore),
+    };
+  }, [graph]);
+
+  // Topology — χ★ on the live filtered graph (severed edges
+  // excluded so user-driven cuts are reflected immediately).
+  const topo = useMemo(() => {
+    const liveEdges = graph.edges.filter((e) => !e.isSevered);
+    if (liveEdges.length === 0) return { ok: false as const, edgeCount: 0 };
+    const obd = omegaBridgeDensity({ ...graph, edges: liveEdges });
+    const top = obd.chiStar.besRanking[0];
+    return {
+      ok: true as const,
+      edgeCount: liveEdges.length,
+      chiStarSize: obd.chiStarSize,
+      bridgeCount: obd.chiStar.bridges.length,
+      density: obd.density,
+      bridgeFraction: obd.bridgeFraction,
+      topBes: top,
+      band: topologyBand(obd.density),
+    };
+  }, [graph]);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-baseline justify-between gap-2">
+        <div className="font-[family-name:var(--font-michroma)] text-[10px] tracking-wider text-text-muted">
+          SNAPSHOT DIAGNOSTICS
+        </div>
+        <div className="font-mono text-[8px] text-text-muted/70">
+          Ghauri 2025 · whole-system
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        {/* ── Tail Depth (CVaR-W₁) ─────────────────────────── */}
+        <button
+          onClick={() => setExpanded(expanded === "tail" ? null : "tail")}
+          className="text-left p-2 rounded border transition-all"
+          style={{
+            borderColor:
+              expanded === "tail"
+                ? tail.ok
+                  ? tail.band.color
+                  : "var(--border)"
+                : "var(--border)",
+            backgroundColor: "var(--surface)",
+          }}
+        >
+          <div className="flex items-center justify-between gap-1">
+            <span className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted">
+              TAIL · CVaR-W₁
+            </span>
+            {tail.ok && (
+              <span
+                className="text-[8px] font-[family-name:var(--font-michroma)] tabular-nums font-bold"
+                style={{ color: tail.band.color }}
+              >
+                {tail.band.label}
+              </span>
+            )}
+          </div>
+          <div className="mt-1.5 flex items-baseline gap-2">
+            {tail.ok ? (
+              <>
+                <span
+                  className="text-[20px] font-[family-name:var(--font-michroma)] tabular-nums leading-none"
+                  style={{ color: tail.band.color }}
+                >
+                  {tail.pillarScore.toFixed(1)}
+                </span>
+                <span className="text-[9px] font-mono text-text-muted/70">
+                  / 10 · α={tail.alpha} · n={tail.n}
+                </span>
+              </>
+            ) : (
+              <span className="text-[10px] font-mono text-text-muted">
+                INSUFFICIENT DATA · n={tail.n} (need ≥ 5)
+              </span>
+            )}
+          </div>
+        </button>
+
+        {/* ── Topology (χ★) ────────────────────────────────── */}
+        <button
+          onClick={() => setExpanded(expanded === "topology" ? null : "topology")}
+          className="text-left p-2 rounded border transition-all"
+          style={{
+            borderColor:
+              expanded === "topology"
+                ? topo.ok
+                  ? topo.band.color
+                  : "var(--border)"
+                : "var(--border)",
+            backgroundColor: "var(--surface)",
+          }}
+        >
+          <div className="flex items-center justify-between gap-1">
+            <span className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted">
+              TOPOLOGY · χ★
+            </span>
+            {topo.ok && (
+              <span
+                className="text-[8px] font-[family-name:var(--font-michroma)] tabular-nums font-bold"
+                style={{ color: topo.band.color }}
+              >
+                {topo.band.label}
+              </span>
+            )}
+          </div>
+          <div className="mt-1.5 flex items-baseline gap-2">
+            {topo.ok ? (
+              <>
+                <span
+                  className="text-[20px] font-[family-name:var(--font-michroma)] tabular-nums leading-none"
+                  style={{ color: topo.band.color }}
+                >
+                  {topo.density.toFixed(3)}
+                </span>
+                <span className="text-[9px] font-mono text-text-muted/70">
+                  |χ★| = {topo.chiStarSize} / {topo.edgeCount}
+                </span>
+              </>
+            ) : (
+              <span className="text-[10px] font-mono text-text-muted">
+                NO LIVE EDGES
+              </span>
+            )}
+          </div>
+        </button>
+      </div>
+
+      {/* Expanded detail ─────────────────────────────────────── */}
+      {expanded === "tail" && tail.ok && (
+        <div className="p-3 rounded border border-border bg-surface space-y-2">
+          <div className="text-[9px] font-mono text-text-muted leading-relaxed">
+            <span className="text-foreground">{tail.band.description}</span>
+          </div>
+          <div className="text-[9px] font-mono text-text-muted leading-relaxed">
+            Empirical α-CVaR on n={tail.n} ΩF composite values across
+            the live filtered graph. α = {tail.alpha}, so CVaR_α is the
+            expected ΩF in the worst {((1 - tail.alpha) * 100).toFixed(0)}% tail.
+          </div>
+          <div className="font-mono text-[9px] text-foreground tabular-nums">
+            α-VaR = {tail.varEmpirical.toFixed(3)} · empirical CVaR ={" "}
+            {tail.empirical.toFixed(3)} · robust CVaR ={" "}
+            {tail.robust.toFixed(3)} · pillar = {tail.pillarScore.toFixed(2)}/10
+          </div>
+          <div className="text-[8px] font-mono text-text-muted/70 leading-relaxed">
+            W₁ ambiguity radius ε = 0 — no calibrated radius wired
+            upstream yet, so robust collapses to empirical for now.
+            Source: Ghauri 2025 (D.Eng., Ch. 4 §3 — Ω-Robustness).
+          </div>
+        </div>
+      )}
+
+      {expanded === "topology" && topo.ok && (
+        <div className="p-3 rounded border border-border bg-surface space-y-2">
+          <div className="text-[9px] font-mono text-text-muted leading-relaxed">
+            <span className="text-foreground">{topo.band.description}</span>
+          </div>
+          <div className="text-[9px] font-mono text-text-muted leading-relaxed">
+            χ★ = strict bridges (Tarjan) ∪ top-k Bridge-Edge Strength
+            (Brandes) on {graph.nodes.length} nodes / {topo.edgeCount}{" "}
+            non-severed edges. Found {topo.bridgeCount} strict bridges
+            and {topo.chiStarSize - topo.bridgeCount} top-BES additions.
+          </div>
+          <div className="font-mono text-[9px] text-foreground tabular-nums">
+            density = {topo.density.toFixed(3)} · bridge-fraction ={" "}
+            {topo.bridgeFraction.toFixed(3)} · top BES ={" "}
+            {topo.topBes ? topo.topBes.bes.toFixed(3) : "—"}
+            {topo.topBes && (
+              <>
+                {" "}on <span className="text-text-muted">{topo.topBes.edgeId}</span>
+              </>
+            )}
+          </div>
+          <div className="text-[8px] font-mono text-text-muted/70 leading-relaxed">
+            χ★ edges render with a violet halo on the 3D / 2D canvas.
+            Source: Ghauri 2025 (D.Eng., Ch. 5–8 — IDS substrate +
+            topology-aware replay).
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/__tests__/ai-safety-domain-render.test.ts
+++ b/src/lib/__tests__/ai-safety-domain-render.test.ts
@@ -41,8 +41,12 @@ describe("AI Safety / IDS — end-to-end domain render", () => {
     const p = resolveDomainProfile(["ai-safety-ids"]);
     expect(p.id).toBe("ai-safety");
     expect(p.displayName).toBe("AI Safety / Endogenous Catastrophe");
-    expect(p.criticalityEstimators).toContain("chi-star");
-    expect(p.criticalityEstimators).toContain("cvar-w1");
+    // Pareto criticality strip = four time-series estimators only.
+    // The dissertation's snapshot estimators (cvar-w1, chi-star) are
+    // surfaced in SnapshotDiagnostics + canvas halos + the system-
+    // metrics strip — see registry-profile-coverage's
+    // EXEMPT_READY_ESTIMATORS for the rationale.
+    expect(p.criticalityEstimators).toEqual(["csd", "ph", "lppls", "bocpd"]);
   });
 
   it("internal AI Safety edges all resolve when filtered to ai-safety-ids only", () => {

--- a/src/lib/__tests__/registry-profile-coverage.test.ts
+++ b/src/lib/__tests__/registry-profile-coverage.test.ts
@@ -38,9 +38,16 @@ const PRODUCTION_PROFILES = [
  * entry needs a one-line justification.
  */
 const EXEMPT_READY_ESTIMATORS: Partial<Record<EstimatorId, string>> = {
-  // No exemptions today. Add entries here only when an estimator is
-  // genuinely ready but intentionally not surfaced in any default
-  // profile (e.g. a flagship-feature gated behind a paid tier).
+  // Snapshot estimators (Ghauri 2025 — distributionally-robust risk
+  // and topology-aware criticality). Live-computable but they don't
+  // share the time-series-criticality shape the Pareto strip is built
+  // around (observed vs model fit on a Ω-trajectory). Surfaced in the
+  // SnapshotDiagnostics panel instead, plus the canvas halos and
+  // system-metrics strip — none of those go through criticalityEstimators.
+  "cvar-w1":
+    "Snapshot Tail Depth diagnostic — surfaced in SnapshotDiagnostics, not the Pareto criticality strip.",
+  "chi-star":
+    "Snapshot topology diagnostic — surfaced in SnapshotDiagnostics + canvas halos + system-metrics strip, not the Pareto criticality strip.",
 };
 
 describe("criticality-registry × domain-profile coverage", () => {

--- a/src/lib/domain-profiles.ts
+++ b/src/lib/domain-profiles.ts
@@ -390,23 +390,16 @@ export const AI_SAFETY_PROFILE: DomainProfile = {
   pillarLabels: AI_SAFETY_PILLARS,
   pillarDetails: AI_SAFETY_PILLAR_DETAILS,
   compositeMethodology: AI_SAFETY_METHODOLOGY,
-  // Six tabs:
-  //   csd / ph / lppls / bocpd — graph-Ω-trajectory estimators inherited
-  //     from the geopolitical fallback. Sharp transitions in the GAT's
-  //     ΩF trajectory under catastrophic-forgetting events are exactly
-  //     the regime they were designed for.
-  //   cvar-w1 — canonical Tail Depth pillar estimator (Ghauri 2025
-  //     Ch. 4 §3 Ω-Robustness). Renders as "awaiting-data" until a loss
-  //     sample (per-attack-class observed harm, per-incident cascade
-  //     depth, etc.) is wired into the store.
-  //   chi-star — topology-aware criticality artefact (Ghauri 2025
-  //     Ch. 5–8 — IDS substrate + topology-aware replay). Computes
-  //     strict bridges (Tarjan) ∪ top-k Bridge-Edge Strength (Brandes)
-  //     on the live graph. Ready out of the box — operates on the
-  //     graph topology directly.
-  // FR + BES temporal monitoring arrive in Phase 3 once the Pearl
-  // session wires them up.
-  criticalityEstimators: ["csd", "ph", "lppls", "bocpd", "cvar-w1", "chi-star"],
+  // Pareto criticality strip = four time-series estimators that share
+  // a common shape (observed-vs-model fit on a Ω-trajectory, with an
+  // "epochs to critical" reading). cvar-w1 and chi-star are SNAPSHOT
+  // estimators — they read the per-node ΩF distribution / graph
+  // topology in one shot, with no time axis and no observed-vs-model
+  // fit. Forcing them into this strip required synthesising a fake
+  // "epochs" reading and confused users about what they were looking
+  // at, so they live in the SnapshotDiagnostics panel instead.
+  // FR + BES temporal monitoring arrive in Phase 3.
+  criticalityEstimators: ["csd", "ph", "lppls", "bocpd"],
 };
 
 // ─── Resolution ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Live UX feedback flagged that surfacing **CVaR-W₁ and χ★** as tabs in the Pareto criticality strip alongside CSD / PH / LPPLS / BOCPD was conceptually wrong and visibly confusing. This PR fixes the architecture.

## The problem

The Pareto strip is a **time-series** criticality suite — every estimator in it answers "how many epochs until the system tips?" with an observed-vs-model fit on a Ω-trajectory. CVaR-W₁ and χ★ are **snapshot** estimators:
- CVaR-W₁ reads the per-node ΩF distribution in one shot
- χ★ reads the graph topology in one shot

Neither has a time axis or a model fit. Forcing them into the same strip required synthesising fake "epochs" readings:
- `chi-star: epochs = (1 - density) × 100` → user saw `T-77` on the strip
- `cvar-w1:  epochs = (1 - pillarScore/10) × 100` → user saw `T-18`

Those numbers don't mean what the strip's other tabs claim — they're topology / distribution summaries dressed up as time-to-critical.

**Real bug too**: the Pareto-card branches read `graphData` (full main graph) while the system-metrics strip read `useFilteredGraph` (filtered by domain selection). Same Ω-Bridge Density metric, two different numbers visible on screen, no explanation. Density 0.722 on the strip vs. T-77 (~0.23) on the Pareto tab.

## The fix

### Pareto strip back to 4 time-series estimators
`AI_SAFETY_PROFILE.criticalityEstimators` trimmed to `["csd", "ph", "lppls", "bocpd"]`. Comment rewritten to explain why cvar-w1 and chi-star aren't here.

### New `SnapshotDiagnostics` panel below the Pareto strip
Two side-by-side cards:

| Card | Headline | Detail (click to expand) |
|---|---|---|
| **TAIL · CVaR-W₁** | Pillar score X.X / 10 + band (CRITICAL / ELEVATED / CONTAINED) | α-VaR · empirical CVaR · robust CVaR · pillar score + Ghauri 2025 Ch. 4 §3 provenance |
| **TOPOLOGY · χ★** | Density 0.XXX + `|χ★| = N / E` + band (FRAGILE / ELEVATED / NOMINAL / REDUNDANT) | bridge-fraction · top BES + edge id + Ghauri 2025 Ch. 5–8 provenance |

Both read `useFilteredGraph()` — same scope as the system-metrics strip, **fixing the cross-surface mismatch**. Severed edges excluded so user-driven cuts reflect immediately.

### Coverage test exemption
`cvar-w1` and `chi-star` added to `EXEMPT_READY_ESTIMATORS` in `registry-profile-coverage.test.ts` with explicit reasons (surfaced in SnapshotDiagnostics + canvas halos + system-metrics strip; not gated by `criticalityEstimators`).

## What this PR does NOT do

**Per-node / per-edge drill-downs deferred to a follow-on PR.** The user's feedback included three additional UX gaps:
- LEGEND popover should explain the χ★ violet halo
- EdgeInspector should show BES + bridge / top-k membership when you click an edge
- NodeInspector should show "sits on N χ★ edges" (bridge-centrality)

Those are independent UX additions — keeping them out of this architectural PR so the diff stays reviewable.

## Test plan

- [x] `vitest run`: **976 passing** (was 959 + 17 from sibling sessions). No regressions.
- [x] `registry-profile-coverage` gate green via the new exemptions.
- [x] `ai-safety-domain-render` test updated to assert the new 4-tab strip composition.
- [x] `tsc --noEmit` clean for the touched files.
- [x] Manual: AI Safety profile's Pareto card now shows the original four-tab strip; below it, the SnapshotDiagnostics panel renders Tail and Topology cards with band-coded values matching the system-metrics strip's Ω-Bridge Density readout (single source of truth on the filtered graph).

🤖 Generated with [Claude Code](https://claude.com/claude-code)