### PR TITLE
ci(copilot): eval gate runs on every copilot PR

### DIFF
--- a/.github/workflows/copilot-eval.yml
+++ b/.github/workflows/copilot-eval.yml
@@ -1,0 +1,125 @@
+# ─── Copilot eval gate ────────────────────────────────────────────────
+#
+# Runs `npm run eval:copilot` against Gemini Flash on every PR that
+# touches the copilot surface. Catches regressions in tool-selection
+# accuracy and response shape before they ship.
+#
+# Path filter is intentionally narrow: this is a paid LLM call (~$0.02
+# per run, ~30s wall time), not a free unit test. We only spend on it
+# when copilot code actually changed.
+#
+# Secret required: GEMINI_API_KEY. Add it in repo Settings → Secrets
+# and variables → Actions. If the secret is missing (e.g. PR from a
+# fork, Dependabot run), the job exits 0 with a clear "skipped" line
+# so we don't fail every external PR for an unrelated reason.
+#
+# Flake handling: Gemini at temperature 0 is empirically not fully
+# deterministic — observed during the eval seed expansion. We do a
+# single retry on first failure to absorb that noise without doubling
+# the cost in the common (passing) case.
+
+name: Copilot eval
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/lib/copilot/**"
+      - "src/app/api/copilot/**"
+      - "src/components/SystemCopilot.tsx"
+      - "src/components/CopilotTraceHistory.tsx"
+      - "src/lib/copilot-actions.ts"
+      - "src/lib/copilot-context.ts"
+      - "src/lib/copilot-engine.ts"
+      - "scripts/eval-copilot.ts"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/copilot-eval.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/lib/copilot/**"
+      - "src/app/api/copilot/**"
+      - "src/components/SystemCopilot.tsx"
+      - "src/components/CopilotTraceHistory.tsx"
+      - "src/lib/copilot-actions.ts"
+      - "src/lib/copilot-context.ts"
+      - "src/lib/copilot-engine.ts"
+      - "scripts/eval-copilot.ts"
+
+concurrency:
+  group: copilot-eval-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  eval:
+    name: copilot · eval
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Skip cleanly when the secret isn't available (fork PRs,
+      # Dependabot, etc). Fail-open for those — we don't want
+      # unrelated PRs to be blocked by a missing key.
+      - name: Check API key availability
+        id: keycheck
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          if [ -z "$GEMINI_API_KEY" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning ::GEMINI_API_KEY not set in repo secrets — skipping eval. Add it in Settings → Secrets and variables → Actions to enable this gate."
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run eval (with one retry on flake)
+        if: steps.keycheck.outputs.available == 'true'
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          set +e
+          npm run eval:copilot -- --json eval-report.json | tee eval-output.txt
+          STATUS=$?
+          if [ "$STATUS" -ne 0 ]; then
+            echo ""
+            echo "::warning ::First eval pass had failures — retrying once to absorb Gemini's mild non-determinism at temperature 0."
+            echo ""
+            npm run eval:copilot -- --json eval-report.json | tee eval-output.txt
+            STATUS=$?
+          fi
+          exit $STATUS
+
+      - name: Append eval rollup to step summary
+        if: always() && steps.keycheck.outputs.available == 'true'
+        run: |
+          if [ -f eval-output.txt ]; then
+            {
+              echo "## Copilot eval result"
+              echo ""
+              echo '```'
+              # Only the final report block (after the per-case stream).
+              tail -n 30 eval-output.txt
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload eval JSON report
+        if: always() && steps.keycheck.outputs.available == 'true' && hashFiles('eval-report.json') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: copilot-eval-report
+          path: eval-report.json
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,11 @@ yarn-error.log*
 # vercel
 .vercel
 
+# copilot eval — local artifacts from `npm run eval:copilot`
+eval-report.json
+eval-output.txt
+baseline-*.json
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts


### PR DESCRIPTION
## Summary

Adds `.github/workflows/copilot-eval.yml` — runs `npm run eval:copilot` against `gemini-2.5-flash` on every PR that touches the copilot surface. Catches tool-selection regressions before they ship. Builds on the 20-case seed set ([#317](https://github.com/ApexAnalytica/apex-terminal/pull/317)).

## ⚠️ User action required

After merge, add **`GEMINI_API_KEY`** as a GitHub repo secret:

> **Settings** → **Secrets and variables** → **Actions** → **New repository secret**
> Name: `GEMINI_API_KEY`
> Value: same key that's in your local `.env.local`

Until you do, the workflow runs but emits a `::warning::` and exits 0 (fail-open — see "Defensive design" below).

## When does it run?

Path-filtered narrow — only runs when copilot code actually changed:

```yaml
- src/lib/copilot/**
- src/app/api/copilot/**
- src/components/SystemCopilot.tsx
- src/components/CopilotTraceHistory.tsx
- src/lib/copilot-actions.ts
- src/lib/copilot-context.ts
- src/lib/copilot-engine.ts
- scripts/eval-copilot.ts
- package.json / package-lock.json
- .github/workflows/copilot-eval.yml
```

This is a paid LLM call (~$0.02 per run, ~30-40s wall time). The narrow filter keeps cost trivial — typical week is a handful of copilot PRs, so total spend is pennies.

## Flake handling

Gemini at `temperature: 0` is empirically not fully deterministic — confirmed during the 7→20 seed expansion (one case passed, then failed, then passed across runs). The workflow does a **single retry on first failure** to absorb that noise without doubling cost in the common (passing) case.

If both runs fail, the gate fails the PR.

## Defensive design

The job uses an explicit key-availability check before running the eval. When `GEMINI_API_KEY` is missing (fork PRs, Dependabot, repos cloned without the secret), the job emits a `::warning::` and exits 0 — **doesn't block unrelated PRs**. This is the right tradeoff: a broken eval gate that blocks every external PR is worse than a missing eval gate that we know is missing.

## Output for failure diagnosis

When the eval runs:

1. **Step summary** — the eval rollup (pass/fail counts, mean latency, per-case results) is written to `$GITHUB_STEP_SUMMARY` so it shows up in the PR check details.
2. **JSON artifact** — full `eval-report.json` uploaded for 30 days. Download it to inspect exactly what each case produced (raw assistant message, tool calls, latency).

## Files

| File | Lines | What |
|---|---|---|
| `.github/workflows/copilot-eval.yml` | new (125) | The workflow itself |
| `.gitignore` | +5 | Excludes local eval artifacts (`eval-report.json`, `eval-output.txt`, `baseline-*.json`) so they don't accidentally land in commits |

No source-code changes. No test changes. The eval-runner code already existed (PR #302 + #317).

## Test plan

- [x] `vitest run` — 976/976 (no regressions; nothing in src/* changed)
- [x] YAML syntax sanity-checked
- [x] Path filter verified by listing the touched files this PR contains (only `.github/workflows/copilot-eval.yml` matches the workflow's own filter — the workflow will run against itself)
- [ ] After merge: verify the workflow runs on the next copilot PR (or push a dummy change to a copilot file)
- [ ] After secret added: verify a real eval result appears in the step summary

## Roadmap

```
[1]   Tool registry             ✅ #249
[2]   Trace store                ✅ #251
[3.1] Provider abstraction       ✅ #296
[3.2] Model picker UI            ✅ #298
[4]   Eval harness               ✅ #302
[—]   Dataset routing TODO       ✅ #310
[—]   Trace browser UI           ✅ #315
[—]   Eval seed 7 → 20           ✅ #317
[—]   Eval CI gate               ◀ this PR
[—]   "Save as eval case" button next — closes the trace→eval bootstrap loop
[—]   Conversation memory        queued
[3.3] Native tool_use            queued (lower priority)
[5]   Distillation               unblocked when traces ≥ 10K
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
