### PR TITLE
feat(ux): χ★ drill-downs on EdgeInspector + NodeInspector + LEGEND

### DIFF
--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -254,16 +254,28 @@ function CausalNode2D({ data, selected, id }: NodeProps) {
   );
 }
 
+// Per-edge χ★ context for the inspector — see EdgeInspector.tsx's
+// ChiStarEdgeInfo for the canonical definition. Local copy here so
+// the 2D canvas's locally-defined inspector stays self-contained.
+interface ChiStarEdgeInfo {
+  isBridge: boolean;
+  bes: number;
+  rank: number | null;
+  totalEdges: number;
+}
+
 function EdgeInspector({
   edge,
   sourceLabel,
   targetLabel,
   onClose,
+  chiStarInfo,
 }: {
   edge: CausalEdge;
   sourceLabel: string;
   targetLabel: string;
   onClose: () => void;
+  chiStarInfo?: ChiStarEdgeInfo | null;
 }) {
   const typeColor =
     edge.type === "temporal"
@@ -369,6 +381,45 @@ function EdgeInspector({
             />
           </div>
         </div>
+
+        {/* χ★ membership — same render as EdgeInspector.tsx; kept
+            in sync manually since 2D defines its own inspector. */}
+        {chiStarInfo && (
+          <div className="pt-2 border-t border-border/50">
+            <div className="flex items-center justify-between mb-1">
+              <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted">
+                χ★ BRIDGE SET
+              </div>
+              <div
+                className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider tabular-nums"
+                style={{ color: "#7B68EE" }}
+              >
+                {chiStarInfo.isBridge ? "STRICT BRIDGE" : "TOP-BES"}
+              </div>
+            </div>
+            <div className="text-[10px] font-mono text-foreground/90 leading-relaxed">
+              {chiStarInfo.isBridge
+                ? "Removing this edge disconnects the (undirected) graph — every cascade path between the two resulting components must traverse it."
+                : "High Bridge-Edge Strength — participates in many shortest paths even though removing it doesn't formally disconnect the graph."}
+            </div>
+            <div className="mt-1.5 flex gap-4 text-[10px] font-mono tabular-nums">
+              <div>
+                <span className="text-text-muted">BES </span>
+                <span style={{ color: "#7B68EE" }}>
+                  {chiStarInfo.bes.toFixed(3)}
+                </span>
+              </div>
+              {chiStarInfo.rank !== null && chiStarInfo.totalEdges > 0 && (
+                <div>
+                  <span className="text-text-muted">RANK </span>
+                  <span className="text-foreground">
+                    {chiStarInfo.rank + 1} / {chiStarInfo.totalEdges}
+                  </span>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
       </div>
     </motion.div>
   );
@@ -807,20 +858,35 @@ function CausalDAG2DInner() {
     return nodes.filter((n) => selSet.has(n.id));
   }, [nodes, isolateSelection, multiSelectedNodes]);
 
-  // χ★ bridge-set membership per edge id. Computed once per graph
-  // structure and consumed by the edges memo below — gates the violet
-  // halo rendered behind χ★ edges in EmphasizedEdge. Brandes' BES is
-  // O(V·E); this memo runs only when graphData changes (not on every
-  // selection / hover).
-  const chiStarSet = useMemo(() => {
-    if (graphData.edges.length === 0) return new Set<string>();
+  // χ★ result on the live filtered graph. Powers (a) the violet halo
+  // behind χ★ edges in EmphasizedEdge below, and (b) the per-edge
+  // BES + bridge-vs-top-k context surfaced by the EdgeInspector.
+  // Brandes' BES is O(V·E); memoised on graphData so it runs only
+  // when the graph changes, not on selection / hover.
+  const chiStarInfo = useMemo(() => {
+    if (graphData.edges.length === 0) {
+      return {
+        chiStarSet: new Set<string>(),
+        bridgeSet: new Set<string>(),
+        bes: new Map<string, number>(),
+        rank: new Map<string, number>(),
+      };
+    }
     const r = chiStar({
       nodes: graphData.nodes,
       edges: graphData.edges.filter((e) => !e.isSevered),
       metadata: graphData.metadata,
     });
-    return new Set(r.chiStar);
+    const rank = new Map<string, number>();
+    r.besRanking.forEach((entry, idx) => rank.set(entry.edgeId, idx));
+    return {
+      chiStarSet: new Set(r.chiStar),
+      bridgeSet: new Set(r.bridges),
+      bes: r.bes,
+      rank,
+    };
   }, [graphData]);
+  const chiStarSet = chiStarInfo.chiStarSet;
 
   // Edges carry only structural / replay / truth-filter state. Hover and
   // single-select emphasis are computed inside `EmphasizedEdge` itself, so
@@ -1151,6 +1217,16 @@ function CausalDAG2DInner() {
             sourceLabel={selectedSourceLabel}
             targetLabel={selectedTargetLabel}
             onClose={() => setSelectedEdge(null)}
+            chiStarInfo={
+              chiStarInfo.chiStarSet.has(selectedEdge.id)
+                ? {
+                    isBridge: chiStarInfo.bridgeSet.has(selectedEdge.id),
+                    bes: chiStarInfo.bes.get(selectedEdge.id) ?? 0,
+                    rank: chiStarInfo.rank.get(selectedEdge.id) ?? null,
+                    totalEdges: chiStarInfo.bes.size,
+                  }
+                : null
+            }
           />
         )}
       </AnimatePresence>

--- a/src/components/CausalDAG3D.tsx
+++ b/src/components/CausalDAG3D.tsx
@@ -615,22 +615,37 @@ export default function CausalDAG3D() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [topologyKey]);
 
-  // χ★ bridge-set membership per edge id. Lets the renderer highlight
-  // the load-bearing skeleton of the live filtered graph without each
-  // DAGEdge3D having to know about the topology computation. Memoised
-  // on topologyKey so it only recomputes when the graph structure
-  // actually changes — Brandes' BES is O(V·E) and re-running every
-  // render would be wasteful.
-  const chiStarSet = useMemo(() => {
-    if (graphData.edges.length === 0) return new Set<string>();
+  // χ★ result on the live filtered graph. Lets the renderer highlight
+  // the load-bearing skeleton AND lets the EdgeInspector surface
+  // per-edge BES + bridge / top-k membership without recomputing.
+  // Memoised on topologyKey so it only recomputes when the graph
+  // structure actually changes — Brandes' BES is O(V·E) and
+  // re-running every render would be wasteful.
+  const chiStarInfo = useMemo(() => {
+    if (graphData.edges.length === 0) {
+      return {
+        chiStarSet: new Set<string>(),
+        bridgeSet: new Set<string>(),
+        bes: new Map<string, number>(),
+        rank: new Map<string, number>(),
+      };
+    }
     const r = chiStar({
       nodes: graphData.nodes,
       edges: graphData.edges.filter((e) => !e.isSevered),
       metadata: graphData.metadata,
     });
-    return new Set(r.chiStar);
+    const rank = new Map<string, number>();
+    r.besRanking.forEach((entry, idx) => rank.set(entry.edgeId, idx));
+    return {
+      chiStarSet: new Set(r.chiStar),
+      bridgeSet: new Set(r.bridges),
+      bes: r.bes,
+      rank,
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [topologyKey]);
+  const chiStarSet = chiStarInfo.chiStarSet;
 
   // Store baseline omega scores (live/initial values) as a reference point.
   // Movement during scrubbing is driven by the DELTA from baseline, not absolute omega.
@@ -1188,6 +1203,16 @@ export default function CausalDAG3D() {
             sourceLabel={selectedEdgeSourceLabel}
             targetLabel={selectedEdgeTargetLabel}
             onClose={() => setSelectedEdge(null)}
+            chiStarInfo={
+              chiStarInfo.chiStarSet.has(selectedEdge.id)
+                ? {
+                    isBridge: chiStarInfo.bridgeSet.has(selectedEdge.id),
+                    bes: chiStarInfo.bes.get(selectedEdge.id) ?? 0,
+                    rank: chiStarInfo.rank.get(selectedEdge.id) ?? null,
+                    totalEdges: chiStarInfo.bes.size,
+                  }
+                : null
+            }
           />
         )}
       </AnimatePresence>

--- a/src/components/EdgeInspector.tsx
+++ b/src/components/EdgeInspector.tsx
@@ -4,6 +4,23 @@ import { motion } from "framer-motion";
 import type { CausalEdge } from "@/lib/types";
 
 /**
+ * Per-edge χ★ context — when present, the edge is in the χ★ set
+ * (Tarjan strict bridges ∪ top-k Bridge-Edge Strength). Surfaces
+ * BES + bridge / top-k membership inline so users can answer "why
+ * is this edge highlighted with the violet halo?" without leaving
+ * the inspector. Computed once at the canvas level — see
+ * CausalDAG3D's chiStarInfo useMemo.
+ */
+export interface ChiStarEdgeInfo {
+  isBridge: boolean;
+  bes: number;
+  /** 0-indexed BES rank (0 = highest BES). null if not ranked. */
+  rank: number | null;
+  /** Total edges in the BES ranking — context for the rank value. */
+  totalEdges: number;
+}
+
+/**
  * Shared edge inspector popup — used by 2D, 3D, and Map views.
  * Shows causal link details when an edge is clicked.
  */
@@ -12,11 +29,13 @@ export default function EdgeInspector({
   sourceLabel,
   targetLabel,
   onClose,
+  chiStarInfo,
 }: {
   edge: CausalEdge;
   sourceLabel: string;
   targetLabel: string;
   onClose: () => void;
+  chiStarInfo?: ChiStarEdgeInfo | null;
 }) {
   const typeColor =
     edge.type === "temporal"
@@ -124,6 +143,46 @@ export default function EdgeInspector({
             />
           </div>
         </div>
+
+        {/* χ★ membership — only rendered when this edge is in χ★.
+            The violet color (#7B68EE) matches the canvas halo + the
+            chi-star color in the criticality registry. */}
+        {chiStarInfo && (
+          <div className="pt-2 border-t border-border/50">
+            <div className="flex items-center justify-between mb-1">
+              <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted">
+                χ★ BRIDGE SET
+              </div>
+              <div
+                className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider tabular-nums"
+                style={{ color: "#7B68EE" }}
+              >
+                {chiStarInfo.isBridge ? "STRICT BRIDGE" : "TOP-BES"}
+              </div>
+            </div>
+            <div className="text-[10px] font-mono text-foreground/90 leading-relaxed">
+              {chiStarInfo.isBridge
+                ? "Removing this edge disconnects the (undirected) graph — every cascade path between the two resulting components must traverse it."
+                : "High Bridge-Edge Strength — participates in many shortest paths even though removing it doesn't formally disconnect the graph."}
+            </div>
+            <div className="mt-1.5 flex gap-4 text-[10px] font-mono tabular-nums">
+              <div>
+                <span className="text-text-muted">BES </span>
+                <span style={{ color: "#7B68EE" }}>
+                  {chiStarInfo.bes.toFixed(3)}
+                </span>
+              </div>
+              {chiStarInfo.rank !== null && chiStarInfo.totalEdges > 0 && (
+                <div>
+                  <span className="text-text-muted">RANK </span>
+                  <span className="text-foreground">
+                    {chiStarInfo.rank + 1} / {chiStarInfo.totalEdges}
+                  </span>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
       </div>
     </motion.div>
   );

--- a/src/components/NodeInspector.tsx
+++ b/src/components/NodeInspector.tsx
@@ -8,6 +8,7 @@ import { useTemporalGraph } from "@/hooks/useTemporalGraph";
 import type { NodeTemporalState } from "@/lib/temporal-data";
 import { getNodeDataDescription } from "@/lib/real-timeseries";
 import { resolveDomainProfile, type PillarKey } from "@/lib/domain-profiles";
+import { chiStar } from "@/lib/estimators/chi-star";
 
 function getBarColor(value: number): string {
   if (value > 9) return "#ff1744";
@@ -210,6 +211,25 @@ export default function NodeInspector() {
       (e) => e.source === selectedNode || e.target === selectedNode
     );
   }, [selectedNode, graphData.edges]);
+
+  // χ★ bridge-set membership for the live graph. Bridge-centrality
+  // = how many of this node's edges are in χ★ — answers "is this
+  // node embedded in the load-bearing skeleton?". Computed once
+  // per graph (Brandes O(V·E)), independent of which node is
+  // selected, so node-flip is free.
+  const chiStarSet = useMemo(() => {
+    if (graphData.edges.length === 0) return new Set<string>();
+    const r = chiStar({
+      nodes: graphData.nodes,
+      edges: graphData.edges.filter((e) => !e.isSevered),
+      metadata: graphData.metadata,
+    });
+    return new Set(r.chiStar);
+  }, [graphData]);
+  const bridgeCentrality = useMemo(
+    () => connectedEdges.filter((e) => chiStarSet.has(e.id)).length,
+    [connectedEdges, chiStarSet],
+  );
 
   // Get temporal history for this node (for data context)
   const nodeHistory = useMemo<NodeTemporalState[]>(() => {
@@ -532,6 +552,19 @@ export default function NodeInspector() {
                   RESTRICTED
                 </span>
               )}
+              {bridgeCentrality > 0 && (
+                <span
+                  className="text-[7px] px-1.5 py-0.5 rounded font-mono"
+                  style={{
+                    color: "#7B68EE",
+                    backgroundColor: "rgba(123,104,238,0.08)",
+                    border: "1px solid rgba(123,104,238,0.30)",
+                  }}
+                  title={`${bridgeCentrality} of ${connectedEdges.length} edges from this node are in χ★ (Tarjan strict bridges ∪ top-k Bridge-Edge Strength). High bridge-centrality means this node sits on the load-bearing skeleton.`}
+                >
+                  χ★ × {bridgeCentrality}
+                </span>
+              )}
             </div>
 
             {/* Connected Edges */}
@@ -546,10 +579,19 @@ export default function NodeInspector() {
                     const otherNode = graphData.nodes.find(
                       (n) => n.id === (isSource ? edge.target : edge.source)
                     );
+                    const isInChiStar = chiStarSet.has(edge.id);
                     return (
                       <div
                         key={edge.id}
-                        className="edge-card text-[8px] font-mono p-1.5 rounded border border-border bg-surface-elevated min-w-0"
+                        className="edge-card text-[8px] font-mono p-1.5 rounded border bg-surface-elevated min-w-0"
+                        style={{
+                          borderColor: isInChiStar
+                            ? "rgba(123,104,238,0.45)"
+                            : "var(--border)",
+                          boxShadow: isInChiStar
+                            ? "inset 0 0 0 1px rgba(123,104,238,0.12)"
+                            : undefined,
+                        }}
                       >
                         <div className="flex items-start gap-1">
                           <span className="text-text-muted">
@@ -558,6 +600,15 @@ export default function NodeInspector() {
                           <span className="text-foreground truncate flex-1">
                             {otherNode?.shortLabel ?? "?"}
                           </span>
+                          {isInChiStar && (
+                            <span
+                              className="text-[7px] tracking-wider flex-shrink-0"
+                              style={{ color: "#7B68EE" }}
+                              title="Edge is in \u03c7\u2605 \u2014 strict bridge or top-k Bridge-Edge Strength"
+                            >
+                              \u03c7\u2605
+                            </span>
+                          )}
                         </div>
                         <span className="edge-meta-hidden text-text-muted text-[7px] min-w-0 break-words block mt-0.5">
                           {edge.physicalMechanism}

--- a/src/components/dag3d/DAGOverlay.tsx
+++ b/src/components/dag3d/DAGOverlay.tsx
@@ -216,6 +216,22 @@ function EncodingLegend({
             </div>
           }
         />
+        <LegendRow
+          label="χ★ BRIDGE (violet halo)"
+          help="Edge sits in the χ★ bridge set: either a strict bridge (removing it disconnects the graph) or a top-k Bridge-Edge Strength edge (high shortest-path load). Click any haloed edge for the BES value + bridge / top-k status. Source: Ghauri 2025 D.Eng."
+          swatch={
+            <div className="flex items-center gap-0.5">
+              <span
+                className="h-1.5 w-6 rounded-sm"
+                style={{
+                  backgroundColor: "#7B68EE",
+                  opacity: 0.45,
+                }}
+              />
+              <span className="h-0.5 w-6 -ml-6" style={{ backgroundColor: "#00e5ff" }} />
+            </div>
+          }
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Closes the deferred drill-down work from PR [#318](https://github.com/ApexAnalytica/apex-terminal/pull/318). Users can now answer "why is this edge highlighted with the violet halo?" without leaving the inspector, and the LEGEND popover documents the encoding.

## What changed

### EdgeInspector
When the selected edge is in χ★, a new section below the confidence bar shows:

- **STRICT BRIDGE** or **TOP-BES** tag in violet (`#7B68EE`)
- One-line explanation appropriate to membership type:
  - strict bridge → removing it disconnects the graph
  - top-BES → high shortest-path load even though removal doesn't formally disconnect
- BES value + descending-rank position (e.g. `3 / 348`)

Shared inspector (`src/components/EdgeInspector.tsx`, used by 3D + Map) and 2D's locally-defined inspector (`CausalDAG2D.tsx`) both render this — kept in sync manually since they're parallel components serving different canvases. Section is suppressed when `chiStarInfo` is null so non-bridge edges keep their existing layout.

### NodeInspector
- **Bridge-centrality badge**: `χ★ × N` in the badges row, showing how many of the node's connected edges are in χ★. Tooltip explains: "high bridge-centrality means this node sits on the load-bearing skeleton."
- **Connected-edges list**: χ★-edge cards now have a violet border + interior glow + small χ★ marker, so users can see which specific connections are load-bearing without needing to click each one.

### LEGEND popover (DAGOverlay)
New "χ★ BRIDGE (violet halo)" row between INCONSISTENT and the existing edge-type swatches. Swatch shows the violet halo behind the cyan baseline, mirroring the canvas treatment. Help text covers both strict-bridge and top-BES cases plus a pointer to click for details.

## Implementation choices

**Per-edge data via canvas-side memo.** CausalDAG3D and CausalDAG2D each build a `chiStarInfo` object (`chiStarSet` + `bridgeSet` + `bes` + `rank`) once per graph and pass per-edge entries down to the EdgeInspector. Brandes runs once; the inspector just looks up. Same memoisation key (`topologyKey` for 3D, `graphData` for 2D) the halo rendering already uses, so no extra cost.

**Per-node bridge-centrality recomputes χ★ inside NodeInspector** rather than threading data down through canvas → store → inspector. Defensible because the node inspector already does its own connected-edge filtering and the `chiStar` memo is keyed on `graphData`, so node-flip is free; graph-swap pays one Brandes pass which is amortised across however many nodes the user inspects in that session.

**Map view's EdgeInspector usage in `CausalDAGMap.tsx` unchanged.** Map doesn't render the halo today (deferred separately) so surfacing per-edge BES there before the visual lands would be misleading. Will wire when Map halo work picks up.

## Test plan

- [x] `vitest run`: **976 passing**, no regressions.
- [x] `tsc --noEmit` clean for touched files.
- [x] Manual flow:
  - Click a haloed edge in 3D or 2D → EdgeInspector shows χ★ BRIDGE SET section with STRICT BRIDGE or TOP-BES tag, explanation, BES, rank.
  - Click a node sitting on χ★ edges → NodeInspector shows χ★ × N badge in the badges row + tints those specific connections in the connected-edges list.
  - Open LEGEND → new χ★ row with violet swatch describes the encoding alongside the existing edge-type rows.

## Phase 1 χ★ status — fully closed across math + every UX surface

| Surface | Status |
|---|---|
| Math (chiStar, BES, OBD) | ✅ #287 / #294 |
| Registry + AI Safety profile | ✅ #289 / #318 (architecture) |
| SnapshotDiagnostics panel | ✅ #318 |
| System-metrics strip (Ω-Bridge Density) | ✅ #297 |
| 3D canvas halo | ✅ #313 |
| 2D canvas halo | ✅ #316 |
| **EdgeInspector BES + bridge tag** | ✅ this PR |
| **NodeInspector bridge-centrality** | ✅ this PR |
| **LEGEND χ★ row** | ✅ this PR |
| Map view halo | deferred (different rendering paradigm) |
| Relief view overlay | deferred |

🤖 Generated with [Claude Code](https://claude.com/claude-code)