### PR TITLE
feat(website): remove Brynna from /team, rename CORE TEAM → LEADERSHIP

### DIFF
--- a/website/src/app/team/page.tsx
+++ b/website/src/app/team/page.tsx
@@ -33,19 +33,6 @@ const TEAM = [
     education:
       "Ph.D. in Mathematics, Trinity College Dublin. Visiting Ph.D. Scholar at Stanford University.",
   },
-  {
-    name: "Brynna Shale",
-    role: "Head of Operations",
-    color: "purple",
-    initials: "BS",
-    photo: "/team/brynna.png",
-    linkedin: null,
-    scholar: null,
-    expertise: "Business strategy, data analytics, and operational efficiency.",
-    background:
-      "Goldman Sachs Analyst in Capital Reporting. Background in business, computer science, and data analytics.",
-    education: "NYU Stern School of Business — Business and Data Science.",
-  },
 ] as const;
 
 const ADVISORS = [
@@ -135,7 +122,7 @@ export default function TeamPage() {
       {/* Core team — mosaic grid */}
       <Section className="py-10 md:py-14 border-t border-border">
         <TerminalHeader
-          label="// CORE TEAM"
+          label="// LEADERSHIP"
           path="apex.team"
           right={`${TEAM.length} MEMBERS`}
           color="cyan"


### PR DESCRIPTION
## Summary

- Drops the Brynna Shale entry from the `TEAM` array in `website/src/app/team/page.tsx`. One fewer person renders in the leadership grid; everything else unchanged.
- Renames `// CORE TEAM` → `// LEADERSHIP` on the section header. Right-side meta auto-updates from `3 MEMBERS` → `2 MEMBERS` (uses `TEAM.length`).

## Left intentionally

- `website/public/team/brynna.png` stays on disk (not referenced by any page now, cheap to keep).
- `contact/page.tsx` still routes ACCESS · INVITE inquiries to `brynna@apexanalytica.co` — surfacing this as a follow-up question rather than changing it without explicit direction.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `/team` renders 2 leadership tiles (Junaid + Georgios), no Brynna, header reads // LEADERSHIP, right-side meta '2 MEMBERS'

🤖 Generated with [Claude Code](https://claude.com/claude-code)