### PR TITLE
feat(relief): opt-in χ★ chokepoint markers (default off)

### DIFF
--- a/src/components/CausalDAGRelief.tsx
+++ b/src/components/CausalDAGRelief.tsx
@@ -17,6 +17,7 @@ import {
   type NodeAnchor,
   type ReliefField,
 } from "@/lib/graph-relief-field";
+import { chiStar } from "@/lib/estimators/chi-star";
 
 /* ─── Topo shader ──────────────────────────────────────────────────
  *
@@ -800,11 +801,62 @@ export default function CausalDAGRelief() {
   );
 }
 
+/**
+ * χ★ midpoint markers — small violet octahedral pips at each χ★
+ * edge midpoint, opt-in (default off; toggled on via the Relief
+ * canvas's "χ★" button). Stays out of the way by default because
+ * Relief's job is the fragility heatmap; this overlay answers the
+ * separate question "where do critical chokepoints sit relative to
+ * those fragility regions?".
+ *
+ * Translation matches SelectionMarkers — layout (x, y) in the 2D
+ * plane → scene (x, y_height, z) with field.cx / cy subtracted.
+ * Markers float at a fixed height above the 0-plane so they read
+ * over peaks AND valleys.
+ */
+function ChiStarMidpointMarkers({
+  midpoints,
+}: {
+  midpoints: { id: string; x: number; z: number }[];
+}) {
+  if (midpoints.length === 0) return null;
+  const HOVER_Y = 60;
+  const PIP_RADIUS = 1.6;
+  return (
+    <group>
+      {midpoints.map((m) => (
+        <group key={`chi-${m.id}`} position={[m.x, HOVER_Y, m.z]}>
+          {/* Outer halo — soft violet glow */}
+          <mesh>
+            <sphereGeometry args={[PIP_RADIUS * 2.2, 12, 12]} />
+            <meshBasicMaterial color="#7B68EE" transparent opacity={0.18} />
+          </mesh>
+          {/* Inner pip — sharper violet octahedron, distinguishable
+              from spherical SelectionMarkers caps and node labels. */}
+          <mesh rotation={[Math.PI / 4, 0, Math.PI / 4]}>
+            <octahedronGeometry args={[PIP_RADIUS, 0]} />
+            <meshBasicMaterial color="#7B68EE" transparent opacity={0.85} />
+          </mesh>
+        </group>
+      ))}
+    </group>
+  );
+}
+
 function CausalDAGReliefInner() {
   const graphData = useFilteredGraph();
   const setSelectedNode = useApexStore((s) => s.setSelectedNode);
   const setSelectedNodes = useApexStore((s) => s.setSelectedNodes);
   const [pickHint, setPickHint] = useState<string | null>(null);
+  // χ★ overlay toggle. Default OFF: Relief is for the fragility heat
+  // distribution; the chokepoint structure is a separate question
+  // best surfaced in 3D / 2D / Map where edges are the rendering
+  // primitive. When the user opts in, octahedral pips render at χ★
+  // edge midpoints to answer "do my hottest fragility regions sit on
+  // top of the load-bearing skeleton?". State is local — the toggle
+  // doesn't need to persist across view swaps and other views don't
+  // read it.
+  const [chiStarOverlayOn, setChiStarOverlayOn] = useState(false);
 
   // Shift+drag marquee state — mirrors the pattern in CausalDAG3D /
   // CausalDAG2D / CausalDAGMap so the user can lasso a region of the
@@ -960,6 +1012,43 @@ function CausalDAGReliefInner() {
     return computeNodeAnchors(fieldNodes, layout, activeField, {}, 40);
   }, [activeField, isEmpty, fieldNodes, layout]);
 
+  // χ★ midpoints (scene-local). Brandes O(V·E) keyed on the same
+  // graph signature the layout uses, so it doesn't recompute on
+  // replay scrub ticks — only on real graph-structure changes.
+  // Severed edges excluded so user-driven cuts reflect immediately.
+  const chiStarMidpoints = useMemo(() => {
+    if (!activeField || isEmpty || graphData.edges.length === 0) return [];
+    const r = chiStar({
+      nodes: graphData.nodes,
+      edges: graphData.edges.filter((e) => !e.isSevered),
+      metadata: graphData.metadata,
+    });
+    const chiSet = new Set(r.chiStar);
+    const out: { id: string; x: number; z: number }[] = [];
+    for (const e of graphData.edges) {
+      if (e.isSevered) continue;
+      if (!chiSet.has(e.id)) continue;
+      const a = layout.get(e.source);
+      const b = layout.get(e.target);
+      if (
+        !a || !b ||
+        !Number.isFinite(a.x) || !Number.isFinite(a.y) ||
+        !Number.isFinite(b.x) || !Number.isFinite(b.y)
+      ) {
+        continue;
+      }
+      const mx = (a.x + b.x) / 2;
+      const my = (a.y + b.y) / 2;
+      out.push({
+        id: e.id,
+        x: mx - activeField.cx,
+        z: my - activeField.cy,
+      });
+    }
+    return out;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sig, activeField, isEmpty, layout]);
+
   // Click handler — convert the mesh-local hit point to nearest node id
   // and dispatch into the store. Same selection signal the rest of the app
   // already listens to (3D pillars, 2D React Flow, ModulePanel, etc.).
@@ -1033,6 +1122,9 @@ function CausalDAGReliefInner() {
           />
         )}
         {!isEmpty && <NodeLabels anchors={anchors} />}
+        {!isEmpty && chiStarOverlayOn && (
+          <ChiStarMidpointMarkers midpoints={chiStarMidpoints} />
+        )}
         {!isEmpty && activeField && (
           <CameraSetup
             width={activeField.width}
@@ -1079,6 +1171,36 @@ function CausalDAGReliefInner() {
       )}
       {!isEmpty && multilayer && fusedField && (
         <DomainLegend field={fusedField} />
+      )}
+      {/* χ★ overlay toggle. Default off — Relief's primary purpose
+          is the fragility heat distribution; the chokepoint
+          structure is opt-in supplementary context. Pip count in
+          the label tells the user what to expect before they enable. */}
+      {!isEmpty && chiStarMidpoints.length > 0 && (
+        <button
+          type="button"
+          onClick={() => setChiStarOverlayOn((v) => !v)}
+          title={
+            chiStarOverlayOn
+              ? "Hide χ★ chokepoint markers"
+              : "Show χ★ chokepoint markers (violet pips at edge midpoints)"
+          }
+          className="absolute bottom-4 right-4 z-10 px-2.5 py-1.5 rounded border backdrop-blur-sm transition-colors"
+          style={{
+            borderColor: chiStarOverlayOn ? "#7B68EE" : "var(--border)",
+            backgroundColor: chiStarOverlayOn
+              ? "rgba(123,104,238,0.10)"
+              : "var(--surface-elevated)",
+            color: chiStarOverlayOn ? "#7B68EE" : "var(--text-muted)",
+          }}
+        >
+          <span className="text-[9px] font-[family-name:var(--font-michroma)] tracking-wider">
+            χ★ {chiStarOverlayOn ? "ON" : "OFF"}
+          </span>
+          <span className="ml-1.5 text-[8px] font-mono opacity-70 tabular-nums">
+            ({chiStarMidpoints.length})
+          </span>
+        </button>
       )}
       {/* ElevationLegend (DOM, right edge) has been replaced by
           InSceneElevationLegend, which renders a vertical column


### PR DESCRIPTION
## Summary

Closes the χ★ visual story across **all four canvases**. The 3D / 2D / Map views render χ★ as edge halos because they draw edges as their primary artifact; Relief is fundamentally different — a scalar fragility heatmap that strips the discrete graph structure out, so a halo treatment doesn't fit.

Per the design discussion, this PR adopts the **D + B-as-toggle** compromise:

- **Default (D)**: NO χ★ rendering on Relief. The view stays focused on the fragility distribution — the question it was built to answer.
- **Opt-in (B)**: a small "χ★ OFF / ON" pill in the bottom-right of the canvas. When on, octahedral violet pips render at each χ★ edge midpoint, hovering above the 0-plane so they read over peaks AND valleys. Toggle label includes the χ★ count (`χ★ OFF (13)`) so the user knows what to expect before flipping it on.

## Why this shape

**Default off** because Relief's value-add is precisely that it strips topology out and shows fragility intensity continuously. Adding χ★ unconditionally would dilute that purpose without giving the user something they can't get more clearly on the other three canvases.

**Toggle for the alternative reading** — "do my hottest fragility regions sit on top of the load-bearing skeleton?" — for the user who wants to overlay topology on the heat.

**Octahedrons not spheres**: visually distinguishable from SelectionMarkers' spherical caps and NodeLabels' tick markers. Same color (`#7B68EE`) and the same inner-pip + soft-outer-halo opacity logic as the canvas halos on the other three views, so the encoding is consistent.

## Implementation

- `chiStar()` runs once per graph signature (Brandes O(V·E), memoised on the same key the layout uses), so replay scrub ticks don't recompute it.
- Severed edges excluded so user-driven cuts reflect immediately.
- Toggle is local component state — doesn't need to persist across view swaps; other views ignore it.
- Button only renders when `chiStarMidpoints.length > 0` so empty graphs don't surface a meaningless toggle.
- Markers are non-clickable in this PR (no hit testing) — keeps scope tight; could add inspector linkage in a follow-on.

## Phase 1 χ★ visual coverage

| Canvas | Treatment | Status |
|---|---|---|
| 3D | always-on edge halo | ✅ #313 |
| 2D | always-on edge halo | ✅ #316 |
| Map | always-on edge halo | ✅ #322 |
| Relief | opt-in midpoint pips | ✅ this PR |
| LEGEND popover | violet halo row | ✅ #320 |
| EdgeInspector | BES + bridge / top-k drill-down | ✅ #320 + #322 |
| NodeInspector | bridge-centrality badge + tinted edge cards | ✅ #320 |

## Test plan

- [x] `vitest run`: **976 passing**, no regressions.
- [x] `tsc --noEmit` clean for `CausalDAGRelief.tsx`.
- [x] Manual: open Relief view → button reads `χ★ OFF (N)` with the χ★ count. Click → label flips to `χ★ ON` in violet, pips appear at chokepoint locations. Click again → pips disappear, view returns to pure heat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)