### PR TITLE
feat(copilot): + EVAL CASE exporter — turn a trace into a seed.ts snippet

### DIFF
--- a/src/components/CopilotEvalCaseExporter.tsx
+++ b/src/components/CopilotEvalCaseExporter.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+// ─── Eval Case Exporter ────────────────────────────────────────
+//
+// Inline form rendered beneath an expanded trace row. Lets the
+// user turn a captured turn into a TestCase TS snippet they can
+// paste into src/lib/copilot/eval/cases/seed.ts.
+//
+// Why TS-snippet-to-clipboard, not DB-backed cases:
+//   - Keeps the eval reviewable in PRs (the case lands as code)
+//   - CI gate doesn't depend on prod data — no dev/prod skew
+//   - Clear ownership: the seed set is curated, not a free-for-all
+//
+// Long-term we may add a DB-backed flow for bulk capture, but the
+// canonical eval set should live in code.
+
+import { useMemo, useState } from "react";
+import {
+  buildCaseSnippet,
+  defaultFormFromTrace,
+  type CaseSeedForm,
+  type CaseSeedInput,
+} from "@/lib/copilot/eval/case-snippet";
+
+interface Props {
+  trace: CaseSeedInput;
+  onClose: () => void;
+}
+
+export default function CopilotEvalCaseExporter({ trace, onClose }: Props) {
+  const [form, setForm] = useState<CaseSeedForm>(() => defaultFormFromTrace(trace));
+  const [copied, setCopied] = useState(false);
+
+  const snippet = useMemo(() => buildCaseSnippet(trace, form), [trace, form]);
+
+  const update = <K extends keyof CaseSeedForm>(k: K, v: CaseSeedForm[K]) =>
+    setForm((prev) => ({ ...prev, [k]: v }));
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(snippet);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    } catch {
+      // clipboard write blocked (no HTTPS in dev sometimes) — user
+      // can select-all + copy manually from the textarea.
+    }
+  };
+
+  return (
+    <div className="mt-2 pt-2 border-t border-border space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-accent-cyan">
+          ADD AS EVAL CASE
+        </span>
+        <button
+          onClick={onClose}
+          className="text-[10px] text-text-muted hover:text-foreground transition-colors"
+          title="Cancel"
+        >
+          ✕
+        </button>
+      </div>
+
+      <div className="grid grid-cols-2 gap-1.5">
+        <Field label="ID" hint="snake_case; unique within seed.ts">
+          <input
+            value={form.id}
+            onChange={(e) => update("id", e.target.value)}
+            spellCheck={false}
+            className={inputClass}
+          />
+        </Field>
+        <Field label="GRAPH FIXTURE" hint="see seed.ts buildFixture">
+          <select
+            value={form.graph_fixture}
+            onChange={(e) => update("graph_fixture", e.target.value)}
+            className={inputClass}
+          >
+            <option value="geopolitical_main">geopolitical_main</option>
+            <option value="small_energy">small_energy</option>
+            <option value="empty">empty</option>
+          </select>
+        </Field>
+      </div>
+
+      <Field label="DESCRIPTION" hint="one line; what the case tests">
+        <textarea
+          value={form.description}
+          onChange={(e) => update("description", e.target.value)}
+          rows={2}
+          className={inputClass}
+        />
+      </Field>
+
+      <Field label="TAGS" hint="comma-separated">
+        <input
+          value={form.tags ?? ""}
+          onChange={(e) => update("tags", e.target.value)}
+          spellCheck={false}
+          className={inputClass}
+        />
+      </Field>
+
+      <div className="grid grid-cols-2 gap-1.5">
+        <Field label="REQUIRED IN RESPONSE" hint="one regex per line">
+          <textarea
+            value={form.required_in_response ?? ""}
+            onChange={(e) => update("required_in_response", e.target.value)}
+            rows={2}
+            placeholder="e.g.  energy"
+            className={inputClass}
+          />
+        </Field>
+        <Field label="FORBIDDEN IN RESPONSE" hint="one regex per line">
+          <textarea
+            value={form.forbidden_in_response ?? ""}
+            onChange={(e) => update("forbidden_in_response", e.target.value)}
+            rows={2}
+            placeholder="e.g.  cannot|refuse"
+            className={inputClass}
+          />
+        </Field>
+      </div>
+
+      <label className="flex items-center gap-1.5 text-[10px] font-mono text-text-muted">
+        <input
+          type="checkbox"
+          checked={form.forbid_tool_calls ?? false}
+          onChange={(e) => update("forbid_tool_calls", e.target.checked)}
+        />
+        forbid_tool_calls (assert no tool was emitted)
+      </label>
+
+      <div className="space-y-1">
+        <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted">
+          GENERATED SNIPPET — paste into <span className="text-accent-cyan">src/lib/copilot/eval/cases/seed.ts</span>
+        </div>
+        <textarea
+          readOnly
+          value={snippet}
+          rows={Math.min(14, snippet.split("\n").length + 1)}
+          className="w-full bg-surface-elevated font-mono text-[9px] text-foreground outline-none px-2 py-1 rounded border border-border resize-none"
+          onFocus={(e) => e.currentTarget.select()}
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button
+          onClick={handleCopy}
+          className="flex-1 text-[9px] font-[family-name:var(--font-michroma)] tracking-wider px-2 py-1.5 rounded border border-accent-cyan text-accent-cyan hover:bg-accent-cyan/10 transition-all"
+        >
+          {copied ? "✓ COPIED" : "COPY TO CLIPBOARD"}
+        </button>
+        <a
+          href="https://github.com/ApexAnalytica/apex-terminal/blob/main/src/lib/copilot/eval/cases/seed.ts"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-[9px] font-mono text-text-muted hover:text-accent-cyan transition-colors"
+        >
+          open seed.ts ↗
+        </a>
+      </div>
+    </div>
+  );
+}
+
+// ─── Internals ─────────────────────────────────────────────────
+
+const inputClass =
+  "w-full bg-surface font-mono text-[10px] text-foreground outline-none px-2 py-1 rounded border border-border placeholder:text-text-muted/60 focus:border-accent-cyan/50 transition-colors";
+
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-0.5">
+      <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted flex items-baseline gap-1.5">
+        <span>{label}</span>
+        {hint && <span className="text-text-muted/60 normal-case tracking-normal">— {hint}</span>}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/components/CopilotTraceHistory.tsx
+++ b/src/components/CopilotTraceHistory.tsx
@@ -14,6 +14,7 @@
 import { useEffect, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import type { TraceListRow } from "@/app/api/copilot/traces/route";
+import CopilotEvalCaseExporter from "@/components/CopilotEvalCaseExporter";
 
 interface Props {
   /** When true, fetch fresh on mount and on every reopen. */
@@ -114,6 +115,7 @@ function TraceRow({
   expanded: boolean;
   onToggle: () => void;
 }) {
+  const [exporting, setExporting] = useState(false);
   const ts = new Date(trace.created_at);
   const tsLabel = `${ts.toLocaleDateString("en-US", { month: "short", day: "numeric" })} ${ts.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`;
   const userPreview = (trace.user_message ?? "").slice(0, 80) || "(no user message)";
@@ -178,11 +180,31 @@ function TraceRow({
                   </ul>
                 </div>
               )}
-              <div className="flex gap-3 text-[9px] text-text-muted/60 pt-1">
+              <div className="flex gap-3 text-[9px] text-text-muted/60 pt-1 items-center">
                 {trace.model_id && <span>{trace.model_id}</span>}
                 {trace.dataset && <span>dataset: {trace.dataset}</span>}
                 {trace.active_module && <span>module: {trace.active_module}</span>}
+                <span className="flex-1" />
+                {!exporting && (
+                  <button
+                    onClick={() => setExporting(true)}
+                    className="text-[9px] font-[family-name:var(--font-michroma)] tracking-wider text-accent-cyan hover:text-foreground transition-colors"
+                    title="Generate a TestCase TS snippet for src/lib/copilot/eval/cases/seed.ts"
+                  >
+                    + EVAL CASE
+                  </button>
+                )}
               </div>
+
+              {exporting && (
+                <CopilotEvalCaseExporter
+                  trace={{
+                    user_message: trace.user_message,
+                    tool_calls: trace.tool_calls,
+                  }}
+                  onClose={() => setExporting(false)}
+                />
+              )}
             </div>
           </motion.div>
         )}

--- a/src/lib/__tests__/copilot-eval-case-snippet.test.ts
+++ b/src/lib/__tests__/copilot-eval-case-snippet.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildCaseSnippet,
+  defaultFormFromTrace,
+} from "@/lib/copilot/eval/case-snippet";
+import type { ObservedToolCall } from "@/lib/copilot/eval/types";
+
+// ─── defaultFormFromTrace ───────────────────────────────────────
+
+describe("defaultFormFromTrace", () => {
+  it("slugifies the user message into the id", () => {
+    const form = defaultFormFromTrace({
+      user_message: "Show me only the energy stuff!",
+      tool_calls: [],
+    });
+    expect(form.id).toBe("show_me_only_the_energy_stuff");
+  });
+
+  it("falls back to 'untitled_case' on empty / non-alpha input", () => {
+    expect(defaultFormFromTrace({ user_message: null, tool_calls: [] }).id).toBe(
+      "untitled_case",
+    );
+    expect(defaultFormFromTrace({ user_message: "!?@#$", tool_calls: [] }).id).toBe(
+      "untitled_case",
+    );
+  });
+
+  it("sets forbid_tool_calls=true when no tools were emitted", () => {
+    const form = defaultFormFromTrace({ user_message: "hi", tool_calls: [] });
+    expect(form.forbid_tool_calls).toBe(true);
+  });
+
+  it("sets forbid_tool_calls=false when tools were emitted", () => {
+    const form = defaultFormFromTrace({
+      user_message: "show me energy",
+      tool_calls: [tc("isolate_nodes", { query: "energy" })],
+    });
+    expect(form.forbid_tool_calls).toBe(false);
+  });
+
+  it("derives tags from tool names — single tool", () => {
+    const form = defaultFormFromTrace({
+      user_message: "isolate nodes",
+      tool_calls: [tc("isolate_nodes", { query: "x" })],
+    });
+    expect(form.tags).toContain("isolate_nodes");
+  });
+
+  it("uses 'multi-tool' tag when multiple tools fired", () => {
+    const form = defaultFormFromTrace({
+      user_message: "do both",
+      tool_calls: [tc("a", {}), tc("b", {})],
+    });
+    expect(form.tags).toContain("multi-tool");
+  });
+});
+
+// ─── buildCaseSnippet ───────────────────────────────────────────
+
+describe("buildCaseSnippet", () => {
+  it("emits a complete TestCase literal for a tool-emitting trace", () => {
+    const snippet = buildCaseSnippet(
+      {
+        user_message: "show me only the energy stuff",
+        tool_calls: [tc("isolate_nodes", { query: "energy" })],
+      },
+      {
+        id: "isolate_energy",
+        description: "User wants only energy nodes visible.",
+        graph_fixture: "geopolitical_main",
+        tags: "tool-selection, filtering",
+      },
+    );
+    expect(snippet).toContain('id: "isolate_energy"');
+    expect(snippet).toContain('user_message: "show me only the energy stuff"');
+    expect(snippet).toContain('graph_fixture: "geopolitical_main"');
+    expect(snippet).toContain("accepted_tool_calls:");
+    expect(snippet).toContain('name: "isolate_nodes"');
+    expect(snippet).toContain('query: { includes: "energy" }');
+    expect(snippet).toContain('tags: ["tool-selection", "filtering"]');
+  });
+
+  it("emits forbid_tool_calls and skips accepted_tool_calls when forbid is set", () => {
+    const snippet = buildCaseSnippet(
+      { user_message: "what is omega-fragility?", tool_calls: [] },
+      {
+        id: "qa_omega",
+        description: "Definitional question.",
+        graph_fixture: "geopolitical_main",
+        forbid_tool_calls: true,
+      },
+    );
+    expect(snippet).toContain("forbid_tool_calls: true");
+    expect(snippet).not.toContain("accepted_tool_calls:");
+  });
+
+  it("renders required and forbidden response regexes correctly", () => {
+    const snippet = buildCaseSnippet(
+      { user_message: "x", tool_calls: [] },
+      {
+        id: "test",
+        description: "test",
+        graph_fixture: "geopolitical_main",
+        required_in_response: "energy\ngrid",
+        forbidden_in_response: "cannot|refuse",
+      },
+    );
+    expect(snippet).toMatch(/required_in_response: \[\/energy\/i, \/grid\/i\]/);
+    expect(snippet).toContain("forbidden_in_response: [/cannot|refuse/i]");
+  });
+
+  it("respects pre-flagged regex literals (e.g. /pattern/g) verbatim", () => {
+    const snippet = buildCaseSnippet(
+      { user_message: "x", tool_calls: [] },
+      {
+        id: "test",
+        description: "test",
+        graph_fixture: "geopolitical_main",
+        required_in_response: "/Ω.{0,40}fragility/i",
+      },
+    );
+    expect(snippet).toContain("required_in_response: [/Ω.{0,40}fragility/i]");
+  });
+
+  it("uses array_includes for array params and exact match for numbers", () => {
+    const snippet = buildCaseSnippet(
+      {
+        user_message: "x",
+        tool_calls: [tc("solve_interdiction", { budget: 3, mode: "edge" }), tc("set_domains", { domains: ["energy-systems", "finance"] })],
+      },
+      { id: "t", description: "t", graph_fixture: "geopolitical_main" },
+    );
+    expect(snippet).toContain("budget: 3");
+    expect(snippet).toContain('mode: { includes: "edge" }');
+    expect(snippet).toContain('domains: { array_includes: "energy-systems" }');
+  });
+
+  it("emits a name-only assertion when the tool has no params", () => {
+    const snippet = buildCaseSnippet(
+      { user_message: "x", tool_calls: [tc("start_replay", {})] },
+      { id: "t", description: "t", graph_fixture: "geopolitical_main" },
+    );
+    expect(snippet).toMatch(/{ name: "start_replay" }/);
+    expect(snippet).not.toContain("params_match");
+  });
+
+  it("escapes quotes correctly in user_message", () => {
+    const snippet = buildCaseSnippet(
+      { user_message: 'he said "hello"', tool_calls: [] },
+      { id: "t", description: "t", graph_fixture: "geopolitical_main" },
+    );
+    // JSON.stringify produces \"…\" — so the literal in the snippet
+    // ends up as user_message: "he said \"hello\""
+    expect(snippet).toContain('user_message: "he said \\"hello\\""');
+  });
+});
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+function tc(name: string, params: Record<string, unknown>): ObservedToolCall {
+  return { name, params, result: "" };
+}

--- a/src/lib/copilot/eval/case-snippet.ts
+++ b/src/lib/copilot/eval/case-snippet.ts
@@ -1,0 +1,185 @@
+// ─── Eval Case Snippet Generator ────────────────────────────────
+//
+// Takes a captured trace + minimal user input and produces a
+// `TestCase` TS literal the user can paste into seed.ts. Pure
+// function, no I/O. The button-driven UX in CopilotTraceHistory
+// is a thin shell around this.
+//
+// Why TS-snippet-to-clipboard, not DB-backed cases:
+//   - Code-as-cases keeps the eval reviewable in PRs (you can see
+//     exactly which case was added; reviewer can sanity-check it)
+//   - CI gate doesn't depend on prod data — no dev/prod skew
+//   - Clear ownership: the seed set is a curated artifact, not a
+//     free-for-all production dump.
+//
+// We may add a DB-backed flow later (auto-suggest cases from
+// surprising traces, etc), but the canonical eval set should stay
+// in code.
+
+import type { ObservedToolCall } from "./types";
+
+// ─── Input shapes ──────────────────────────────────────────────
+
+/** Subset of TraceListRow that we actually need. Decoupled from
+ *  the API route so this module isn't pulled into the client
+ *  bundle's API-route dependency graph. */
+export interface CaseSeedInput {
+  user_message: string | null;
+  tool_calls: ObservedToolCall[];
+}
+
+/** User-editable fields on top of the captured trace. */
+export interface CaseSeedForm {
+  /** Stable case id (snake_case-ish; deduped against existing seed). */
+  id: string;
+  /** Human-readable description shown in console output. */
+  description: string;
+  /** Graph fixture name from seed.ts. Default geopolitical_main. */
+  graph_fixture: string;
+  /** Comma-separated tags (UI-friendly; we split + trim). */
+  tags?: string;
+  /** Free-form regex sources (one per line). */
+  required_in_response?: string;
+  forbidden_in_response?: string;
+  /** When true, the generated case asserts no tools were called. */
+  forbid_tool_calls?: boolean;
+}
+
+// ─── Public API ────────────────────────────────────────────────
+
+/**
+ * Build a TestCase TS literal that the user can paste into
+ * `src/lib/copilot/eval/cases/seed.ts`. The output is hand-edited-
+ * shaped (multi-line, matching the surrounding style) so a paste
+ * fits in alongside the existing cases without reformatting.
+ */
+export function buildCaseSnippet(input: CaseSeedInput, form: CaseSeedForm): string {
+  const lines: string[] = [];
+  lines.push("{");
+  lines.push(`  id: ${jsString(form.id)},`);
+  lines.push(`  description:`);
+  lines.push(`    ${jsString(form.description)},`);
+  lines.push(`  user_message: ${jsString(input.user_message ?? "")},`);
+  lines.push(`  graph_fixture: ${jsString(form.graph_fixture)},`);
+
+  if (form.forbid_tool_calls) {
+    lines.push(`  forbid_tool_calls: true,`);
+  } else if (input.tool_calls.length > 0) {
+    lines.push(`  accepted_tool_calls: [`);
+    for (const tc of input.tool_calls) {
+      lines.push(`    ${renderToolCallAssertion(tc)},`);
+    }
+    lines.push(`  ],`);
+  }
+
+  const required = parseRegexLines(form.required_in_response);
+  if (required.length > 0) {
+    lines.push(`  required_in_response: [${required.map(renderRegexLiteral).join(", ")}],`);
+  }
+  const forbidden = parseRegexLines(form.forbidden_in_response);
+  if (forbidden.length > 0) {
+    lines.push(`  forbidden_in_response: [${forbidden.map(renderRegexLiteral).join(", ")}],`);
+  }
+
+  const tags = parseTags(form.tags);
+  if (tags.length > 0) {
+    lines.push(`  tags: [${tags.map(jsString).join(", ")}],`);
+  }
+  lines.push("},");
+  return lines.join("\n");
+}
+
+/**
+ * Pre-fill the form from a trace. The user can edit anything
+ * before exporting. We bias toward minimal-but-useful defaults:
+ *   - id: slug from the user message
+ *   - description: a stub the user should rewrite
+ *   - graph_fixture: geopolitical_main (the most common)
+ *   - tags: derived from the tool names involved
+ */
+export function defaultFormFromTrace(input: CaseSeedInput): CaseSeedForm {
+  const slug = slugify(input.user_message ?? "", 32);
+  const toolNames = input.tool_calls.map((tc) => tc.name);
+  const toolTag =
+    toolNames.length === 0 ? "no-tool" : toolNames.length === 1 ? toolNames[0] : "multi-tool";
+  return {
+    id: slug || "untitled_case",
+    description:
+      input.tool_calls.length === 0
+        ? "User asked a definitional question — model should respond without tools."
+        : `User intent → fires ${toolNames.join(" + ")}.`,
+    graph_fixture: "geopolitical_main",
+    tags: ["tool-selection", toolTag].join(", "),
+    required_in_response: "",
+    forbidden_in_response: "",
+    forbid_tool_calls: input.tool_calls.length === 0,
+  };
+}
+
+// ─── Internals ─────────────────────────────────────────────────
+
+/** Render a single ObservedToolCall as a ToolCallAssertion literal.
+ *  Auto-converts string params into `{ includes: ... }` matchers
+ *  (more permissive — exact strings are brittle for natural-text
+ *  fields like queries). Numbers and booleans match exactly. */
+function renderToolCallAssertion(tc: ObservedToolCall): string {
+  if (Object.keys(tc.params).length === 0) {
+    return `{ name: ${jsString(tc.name)} }`;
+  }
+  const matchers = Object.entries(tc.params).map(([k, v]) => {
+    if (typeof v === "string") {
+      return `${k}: { includes: ${jsString(v)} }`;
+    }
+    if (Array.isArray(v) && v.length > 0 && typeof v[0] === "string") {
+      // Permissive: only assert one element is present.
+      return `${k}: { array_includes: ${jsString(v[0] as string)} }`;
+    }
+    return `${k}: ${JSON.stringify(v)}`;
+  });
+  return (
+    `{ name: ${jsString(tc.name)}, params_match: { ${matchers.join(", ")} } }`
+  );
+}
+
+/** Convert a free-form line of text into a /regex/i. We bias to
+ *  case-insensitive because the eval is matching response text,
+ *  not code. The user can edit afterward if they want stricter. */
+function renderRegexLiteral(source: string): string {
+  // If the user already wrote /…/flags, respect it.
+  const slashed = source.match(/^\/(.+)\/([a-z]*)$/);
+  if (slashed) {
+    return `/${slashed[1]}/${slashed[2]}`;
+  }
+  return `/${source.replace(/\//g, "\\/")}/i`;
+}
+
+function parseRegexLines(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function parseTags(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function slugify(text: string, max: number): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9_\s-]/g, "")
+    .trim()
+    .replace(/[\s-]+/g, "_")
+    .slice(0, max);
+}
+
+/** JSON.stringify produces double-quoted JS-compatible string
+ *  literals; that's exactly what we want in the snippet. */
+function jsString(s: string): string {
+  return JSON.stringify(s);
+}


### PR DESCRIPTION
## Summary

Closes the **trace → eval** bootstrap loop. Today the eval seed set grows by hand: notice a turn that should be tested → write the `TestCase` by hand → commit. This PR replaces "write by hand" with **click button, fill 3 fields, paste**.

## What you'll see

In the trace browser ([#315](https://github.com/ApexAnalytica/apex-terminal/pull/315)), every expanded row now has a **`+ EVAL CASE`** button next to the model/dataset/module footer. Click it → an inline form opens beneath the row, auto-filled from the captured turn:

```
+ EVAL CASE                                            ✕

ID                            GRAPH FIXTURE
[ show_me_only_the_energy_… ] [ geopolitical_main ▾ ]

DESCRIPTION
[ User intent → fires set_domains.                  ]

TAGS
[ tool-selection, set_domains                        ]

REQUIRED IN RESPONSE          FORBIDDEN IN RESPONSE
[ energy                    ] [                      ]

[ ] forbid_tool_calls

GENERATED SNIPPET — paste into src/lib/copilot/eval/cases/seed.ts
{
  id: "show_me_only_the_energy_stuff",
  description:
    "User intent → fires set_domains.",
  user_message: "show me only the energy stuff",
  graph_fixture: "geopolitical_main",
  accepted_tool_calls: [
    { name: "set_domains", params_match: { domains: { array_includes: "energy-systems" } } },
  ],
  required_in_response: [/energy/i],
  tags: ["tool-selection", "set_domains"],
},

[ COPY TO CLIPBOARD ]            open seed.ts ↗
```

User edits any field, the snippet updates live, copies, pastes into seed.ts. Done.

## Auto-population rules

| Captured | → | Generated |
|---|---|---|
| `user_message: "show me only the energy stuff"` | | `id: "show_me_only_the_energy_stuff"` (slugified, capped at 32 chars) |
| `tool_calls: [{ name: "set_domains", params: { domains: ["energy-systems"] } }]` | | `accepted_tool_calls: [{ name: "set_domains", params_match: { domains: { array_includes: "energy-systems" } } }]` |
| String params | | `{ includes: "..." }` matchers (permissive — exact match is brittle for natural-text queries) |
| Array params | | `{ array_includes: "first-element" }` |
| Numbers + booleans | | exact match |
| Empty `tool_calls` | | `forbid_tool_calls: true` (good default for definitional Q&A) |
| Tool names | | `tags: ["tool-selection", "<tool-name>"]` (or "no-tool" / "multi-tool") |

## Why TS-snippet-to-clipboard, not DB-backed cases

- **Code-as-cases keeps the eval reviewable in PRs.** The reviewer sees exactly what case was added and can sanity-check it.
- **CI gate doesn't depend on prod data.** No dev/prod skew, no flaky tests because production rows changed.
- **Clear ownership.** The seed set is a curated artifact, not a free-for-all production dump.

DB-backed eval cases (auto-suggest from surprising traces, etc.) is a possible later move, but the **canonical** eval set should stay in code.

## Files

| File | Lines | What |
|---|---|---|
| `src/lib/copilot/eval/case-snippet.ts` | new (~150) | Pure function: `buildCaseSnippet(input, form) → string` + `defaultFormFromTrace(input)` for the auto-fill defaults. |
| `src/components/CopilotEvalCaseExporter.tsx` | new (~145) | Inline form component, thin shell around the generator. |
| `src/components/CopilotTraceHistory.tsx` | +24 | Wires the button + per-row toggle state. |
| `src/lib/__tests__/copilot-eval-case-snippet.test.ts` | new (~150) | 13 unit tests for the pure generator (no UI tests needed — the component is a thin shell). |

## Test plan

- [x] `vitest run` — **989/989 pass** (13 new)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `next build` passes with dummy env
- [ ] Manual on Vercel preview: open the chat, send a message, open trace browser (⧉), click a row, click `+ EVAL CASE`, verify the form auto-fills sensibly
- [ ] Manual: edit a field, verify the snippet textarea updates live
- [ ] Manual: click `COPY TO CLIPBOARD`, paste into seed.ts, verify it parses + the eval picks it up

## Roadmap

```
[1]   Tool registry              ✅ #249
[2]   Trace store                 ✅ #251
[3.1] Provider abstraction        ✅ #296
[3.2] Model picker UI             ✅ #298
[4]   Eval harness                ✅ #302
[—]   Dataset routing TODO        ✅ #310
[—]   Trace browser UI            ✅ #315
[—]   Eval seed 7 → 20            ✅ #317
[—]   Eval CI gate                ✅ #319
[—]   "+ EVAL CASE" exporter      ◀ this PR
[—]   Conversation memory         queued
[3.3] Native tool_use             queued (lower priority)
[5]   Distillation                unblocked when traces ≥ 10K
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
