### PR TITLE
fix(timeseries): canvas selection drives the bottom-panel comparison chart

### DIFF
--- a/src/components/TimeSeriesOverlay.tsx
+++ b/src/components/TimeSeriesOverlay.tsx
@@ -20,6 +20,40 @@ const PAD = { top: 12, bottom: 20, left: 32, right: 12 };
 const SPARSE_POINT_THRESHOLD = 20;
 
 /**
+ * Derive the ordered list of nodes the comparison panel should plot. The
+ * panel unions canvas selection with manual pins so clicking a node on the
+ * canvas surfaces its series automatically — selection leads (single focus
+ * first, then multi-select), manual pins follow, duplicates are dropped.
+ *
+ * Exported for unit testing. Pure: same inputs always yield the same array.
+ */
+export function deriveVisibleNodeIds(
+  selectedNode: string | null,
+  selectedNodes: readonly string[],
+  manuallyPinned: readonly string[],
+): string[] {
+  const ordered: string[] = [];
+  const seen = new Set<string>();
+  if (selectedNode && !seen.has(selectedNode)) {
+    ordered.push(selectedNode);
+    seen.add(selectedNode);
+  }
+  for (const id of selectedNodes) {
+    if (!seen.has(id)) {
+      ordered.push(id);
+      seen.add(id);
+    }
+  }
+  for (const id of manuallyPinned) {
+    if (!seen.has(id)) {
+      ordered.push(id);
+      seen.add(id);
+    }
+  }
+  return ordered;
+}
+
+/**
  * Build a hold-forward step-line path string for the given history,
  * extended to xEnd. For each segment [i, i+1] the value is held at
  * history[i].omegaComposite until history[i+1].timestamp. After the
@@ -105,15 +139,55 @@ function formatRawValue(value: number): string {
 }
 
 export default function TimeSeriesOverlay() {
-  const pinnedNodes = useApexStore((s) => s.pinnedTimeSeriesNodes);
+  const manuallyPinned = useApexStore((s) => s.pinnedTimeSeriesNodes);
   const togglePinned = useApexStore((s) => s.togglePinnedTimeSeries);
   const clearPinned = useApexStore((s) => s.clearPinnedTimeSeries);
+  const selectedNode = useApexStore((s) => s.selectedNode);
+  const selectedNodes = useApexStore((s) => s.selectedNodes);
+  const setSelectedNode = useApexStore((s) => s.setSelectedNode);
+  const setSelectedNodes = useApexStore((s) => s.setSelectedNodes);
   const temporalData = useApexStore((s) => s.temporalData);
   const graphData = useApexStore((s) => s.graphData);
   const timelineRange = useApexStore((s) => s.timelineRange);
   const timelinePosition = useApexStore((s) => s.timelinePosition);
   const isLive = useApexStore((s) => s.isLive);
   const timelineDragging = useApexStore((s) => s.timelineDragging);
+
+  // Comparison panel renders the union of canvas selection + manual pins.
+  // Selecting a node on the canvas now auto-shows its series — without this
+  // the user had to find the pin button on the per-node card to ever see
+  // the bottom-panel chart. Manual pins still persist across selection
+  // changes so the user can build durable comparisons.
+  const pinnedNodes = useMemo(
+    () => deriveVisibleNodeIds(selectedNode, selectedNodes, manuallyPinned),
+    [selectedNode, selectedNodes, manuallyPinned],
+  );
+
+  // Removing a chip in the legend has different semantics depending on why
+  // the curve is on screen. Manual pins → unpin. Selection-driven rows →
+  // clear that node from the selection so the canvas no longer marks it
+  // active. Without this branch the X on a selection-driven chip would
+  // toggle a pin the user never created (silent state surprise).
+  const removeFromPanel = useCallback(
+    (nodeId: string) => {
+      if (manuallyPinned.includes(nodeId)) {
+        togglePinned(nodeId);
+        return;
+      }
+      if (selectedNode === nodeId) setSelectedNode(null);
+      if (selectedNodes.includes(nodeId)) {
+        setSelectedNodes(selectedNodes.filter((id) => id !== nodeId));
+      }
+    },
+    [
+      manuallyPinned,
+      togglePinned,
+      selectedNode,
+      setSelectedNode,
+      selectedNodes,
+      setSelectedNodes,
+    ],
+  );
 
   const [hoverX, setHoverX] = useState<number | null>(null);
   const svgRef = useRef<SVGSVGElement>(null);
@@ -767,7 +841,7 @@ export default function TimeSeriesOverlay() {
               return (
                 <button
                   key={curve.nodeId}
-                  onClick={() => togglePinned(curve.nodeId)}
+                  onClick={() => removeFromPanel(curve.nodeId)}
                   className="flex items-center gap-1.5 px-2 py-0.5 rounded border border-border hover:border-accent-red/40 transition-colors group"
                   title={tooltipParts.join(" · ")}
                 >
@@ -823,7 +897,7 @@ export default function TimeSeriesOverlay() {
             {noDataNodes.map((nd) => (
               <button
                 key={nd.nodeId}
-                onClick={() => togglePinned(nd.nodeId)}
+                onClick={() => removeFromPanel(nd.nodeId)}
                 className="flex items-center gap-1.5 px-2 py-0.5 rounded border border-border/50 hover:border-accent-red/40 transition-colors group opacity-50"
                 title={`${nd.label} — no time series data available`}
               >

--- a/src/lib/__tests__/timeseries-overlay-selection.test.ts
+++ b/src/lib/__tests__/timeseries-overlay-selection.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { deriveVisibleNodeIds } from "@/components/TimeSeriesOverlay";
+
+describe("TimeSeriesOverlay — deriveVisibleNodeIds", () => {
+  it("returns empty when nothing is selected or pinned", () => {
+    expect(deriveVisibleNodeIds(null, [], [])).toEqual([]);
+  });
+
+  it("shows the single-selected node when nothing is pinned", () => {
+    expect(deriveVisibleNodeIds("a", [], [])).toEqual(["a"]);
+  });
+
+  it("shows multi-select nodes alongside the single-select focus", () => {
+    expect(deriveVisibleNodeIds("a", ["b", "c"], [])).toEqual(["a", "b", "c"]);
+  });
+
+  it("dedupes when single-select is also in multi-select", () => {
+    expect(deriveVisibleNodeIds("a", ["a", "b"], [])).toEqual(["a", "b"]);
+  });
+
+  it("keeps manual pins visible when nothing is selected", () => {
+    expect(deriveVisibleNodeIds(null, [], ["x", "y"])).toEqual(["x", "y"]);
+  });
+
+  it("orders selection before manual pins", () => {
+    expect(deriveVisibleNodeIds("a", ["b"], ["x", "y"])).toEqual([
+      "a",
+      "b",
+      "x",
+      "y",
+    ]);
+  });
+
+  it("dedupes when a selected node is also manually pinned", () => {
+    // Pinned node stays visible after deselection — no duplicate row while
+    // it's both selected and pinned.
+    expect(deriveVisibleNodeIds("x", [], ["x", "y"])).toEqual(["x", "y"]);
+  });
+
+  it("preserves the user-supplied order of manual pins", () => {
+    // Pin order is the order the user pinned in; selection-prefix doesn't
+    // reorder the rest.
+    expect(deriveVisibleNodeIds(null, [], ["c", "a", "b"])).toEqual([
+      "c",
+      "a",
+      "b",
+    ]);
+  });
+
+  it("handles a deselected user with surviving multi-select", () => {
+    // setSelectedNode(null) clears the single focus; multi-select rows
+    // (e.g. shift+drag set) should still drive the chart.
+    expect(deriveVisibleNodeIds(null, ["b", "c"], [])).toEqual(["b", "c"]);
+  });
+});


### PR DESCRIPTION
## Summary

- Clicking a node on the canvas now auto-shows its series in the ΩF-comparison overlay. Previously the chart only rendered for nodes the user had explicitly pinned via the small dot button on the per-node risk card, so most users never saw the bottom panel at all.
- Pinned-node list is derived from `selectedNode + selectedNodes + pinnedTimeSeriesNodes` (deduped, selection rows leading). Manual pins still persist across selection changes — durable comparisons aren't lost when the user clicks elsewhere.
- Legend X is split: removing a manually-pinned chip unpins (existing); removing a selection-driven chip clears that node from the selection so the canvas no longer marks it active. Avoids silently toggling a pin the user never created.

Closes Asana [1213910663098428](https://app.asana.com/1/1170302368162172/task/1213910663098428).

## Scope notes

The Asana spec also lists "Omega criticality variables should recalculate per time step" and "Distance measures should update accordingly." The bottom panel itself is already timestep-aware (cyan playhead + tooltip values index into history at `timelinePosition`), but `NodeInspector` still reads `node.omegaFragility.*` statically rather than indexing `temporalData` at the dial position. That's a NodeInspector rewrite that touches every pillar card — left out of this PR so the headline "selecting a node renders its series" fix can land cleanly. Worth a follow-up.

## Test plan

- [x] `vitest run` — 985 pass / 985 (87 files), including 9 new tests on `deriveVisibleNodeIds`
- [x] `tsc --noEmit` — no new errors (pre-existing ones in `resend`, `@vercel/speed-insights`, `ai`, `onboarding-metrics.test.ts`, `fci.test.ts` are untouched)
- [x] `eslint` clean on changed files
- [ ] Click a single node on the 3D canvas → comparison chart appears with that node's series
- [ ] Shift+click to multi-select → all selected nodes overlay together
- [ ] Click a different node → previous selection-driven row goes away unless it was manually pinned
- [ ] Pin a node via the per-card pin button → row persists when you click elsewhere
- [ ] Click a chip's X for a manually-pinned node → unpin (existing); for a selection-driven chip → clears from selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)