### PR TITLE
fix(map): edge color/dash/width align to 3D conventions

### DIFF
--- a/src/components/CausalDAGMap.tsx
+++ b/src/components/CausalDAGMap.tsx
@@ -11,6 +11,7 @@ import { getDomainColor } from "@/lib/graph-data";
 import { getDomainCardColor } from "@/lib/domains";
 import { getNodeCoordinates } from "@/lib/geo-coordinates";
 import { chiStar } from "@/lib/estimators/chi-star";
+import { deriveEdgeAppearance } from "@/lib/edge-styling";
 import { useFilteredGraph } from "@/hooks/useFilteredGraph";
 import DAGOverlay from "@/components/dag3d/DAGOverlay";
 import EdgeInspector from "@/components/EdgeInspector";
@@ -60,6 +61,8 @@ function CausalDAGMapInner() {
     selectedNodes,
     setSelectedNodes,
     isolateSelection,
+    truthFilter,
+    ablatedEdgeIds,
   } = useApexStore();
   // Use the same filtered graph as 2D and 3D views for consistent data
   const activeGraph = useFilteredGraph();
@@ -244,6 +247,8 @@ function CausalDAGMapInner() {
     };
   }, [activeGraph]);
 
+  const ablatedEdgeSet = useMemo(() => new Set(ablatedEdgeIds), [ablatedEdgeIds]);
+
   const { solidEdgeGeoJSON, dashedEdgeGeoJSON, chiStarHaloGeoJSON } = useMemo(() => {
     const nodeMap = new Map<string, [number, number]>();
     activeGraph.nodes.forEach((node) => {
@@ -266,20 +271,28 @@ function CausalDAGMapInner() {
       const target = nodeMap.get(edge.target);
       if (!source || !target) return;
 
-      // Three modes for edges when a multi-selection is active:
-      //  - isolate ON   → cull edges that don't connect two selected nodes
-      //  - isolate OFF  → render but dim edges with no selected endpoint
-      //                   (matches 2D's `multiInScope` spotlight)
-      //  - no selection → render normally
-      const inScope =
+      // Selection-driven dimming. Mirrors 3D (`CausalDAG3D.tsx` →
+      // `DAGEdge3D` `selectionDim` + multi-select scoping).
+      //  - multi-select isolate ON   → cull edges not bridging two selected
+      //  - multi-select isolate OFF  → dim edges with no selected endpoint
+      //  - single-select (no multi)  → dim edges not touching the selection
+      //  - no selection              → render normally
+      const inMultiScope =
         selectedSet.size === 0 ||
         selectedSet.has(edge.source) ||
         selectedSet.has(edge.target);
-      const fullScope =
+      const fullMultiScope =
         selectedSet.size === 0 ||
         (selectedSet.has(edge.source) && selectedSet.has(edge.target));
-      if (isolateSelection && selectedSet.size > 0 && !fullScope) return;
-      const edgeIsDimmed = !isolateSelection && selectedSet.size > 0 && !inScope;
+      if (isolateSelection && selectedSet.size > 0 && !fullMultiScope) return;
+      const dimmedByMulti =
+        !isolateSelection && selectedSet.size > 0 && !inMultiScope;
+      const dimmedBySingle =
+        selectedSet.size === 0 &&
+        selectedNode !== null &&
+        edge.source !== selectedNode &&
+        edge.target !== selectedNode;
+      const edgeIsDimmed = dimmedByMulti || dimmedBySingle;
 
       // Curved line via midpoint offset (MapLibre renders LineStrings as
       // straight segments between vertices, so we sample the quadratic
@@ -316,23 +329,25 @@ function CausalDAGMapInner() {
         }
       }
 
-      // Edge color — matches 3D exactly. Severed gets a distinct slate color
-      // so Pearl link-breaks don't look like Tarski-inconsistent edges.
+      // Color / dash / width come from the shared helper that mirrors 3D's
+      // edge styling. Keeps the four mismatches the Asana ticket called out
+      // (ablation magenta, gated inconsistent red, consequence-edge orange,
+      // power-scaled width) in sync without each view drifting on its own.
       const isSevered = edge.isSevered ?? false;
-      const edgeColor = isSevered
-        ? "#78909c"
-        : edge.isInconsistent
-          ? "#ff1744"
-          : edge.type === "temporal"
-            ? "#ffab00"
-            : edge.type === "confounded"
-              ? "#ff6d00"
-              : "#00e5ff";
+      const isAblated = ablatedEdgeSet.has(edge.id);
+      const { color: edgeColor, isDashed, widthFactor } = deriveEdgeAppearance({
+        edge,
+        truthFilter,
+        isAblated,
+      });
 
-      // Dashed: confounded, inconsistent, or severed (matches 3D isDashed logic)
-      const isDashed = edge.type === "confounded" || edge.isInconsistent || isSevered;
+      // Map screen-space scale: the helper returns a 0.7–4.0 factor; the
+      // map's previous mapping was `weight * 2 + 1.5` (≈1.5–3.5). Multiplying
+      // by ~0.9 keeps the absolute pixel range comparable while restoring
+      // the perceptual contrast 3D / 2D already use.
+      const widthPx = widthFactor * 0.9 + 0.3;
 
-      const baseOpacity = isSevered ? 0.45 : 0.5;
+      const baseOpacity = isSevered || isAblated ? 0.45 : 0.5;
       const opacity = edgeIsDimmed ? 0.08 : baseOpacity;
 
       const feature: Feature<LineString> = {
@@ -347,7 +362,7 @@ function CausalDAGMapInner() {
           type: edge.type,
           opacity,
           color: edgeColor,
-          width: edge.weight * 2 + 1.5,
+          width: widthPx,
         },
       };
 
@@ -358,10 +373,14 @@ function CausalDAGMapInner() {
       }
 
       // Halo: rendered behind the main edge for any edge in χ★.
-      // Skipped on severed (their slate styling takes priority) and
-      // on dimmed multi-selection out-of-scope edges (would compete
-      // with the dim treatment).
-      if (chiStarInfo.chiStarSet.has(edge.id) && !isSevered && !edgeIsDimmed) {
+      // Skipped on severed/ablated (their styling takes priority) and on
+      // dimmed out-of-scope edges (would compete with the dim treatment).
+      if (
+        chiStarInfo.chiStarSet.has(edge.id) &&
+        !isSevered &&
+        !isAblated &&
+        !edgeIsDimmed
+      ) {
         haloFeatures.push({
           type: "Feature",
           geometry: { type: "LineString", coordinates },
@@ -369,7 +388,7 @@ function CausalDAGMapInner() {
             id: `${edge.id}-halo`,
             // Halo width scales with the edge's width so thin and
             // thick edges both read as having a halo.
-            width: edge.weight * 2 + 4.5,
+            width: widthPx + 3,
           },
         });
       }
@@ -380,7 +399,16 @@ function CausalDAGMapInner() {
       dashedEdgeGeoJSON: { type: "FeatureCollection" as const, features: dashedFeatures },
       chiStarHaloGeoJSON: { type: "FeatureCollection" as const, features: haloFeatures },
     };
-  }, [activeGraph.nodes, activeGraph.edges, selectedNodes, isolateSelection, chiStarInfo]);
+  }, [
+    activeGraph.nodes,
+    activeGraph.edges,
+    selectedNode,
+    selectedNodes,
+    isolateSelection,
+    chiStarInfo,
+    truthFilter,
+    ablatedEdgeSet,
+  ]);
 
   // Extract temporal edge paths directly from the solid edge GeoJSON features
   // so particles follow the exact same sampled bezier polyline as the

--- a/src/lib/__tests__/edge-styling.test.ts
+++ b/src/lib/__tests__/edge-styling.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveEdgeAppearance,
+  edgeWidthFactor,
+} from "@/lib/edge-styling";
+import type { CausalEdge } from "@/lib/types";
+
+function mkEdge(overrides: Partial<CausalEdge> = {}): CausalEdge {
+  return {
+    id: "e1",
+    source: "a",
+    target: "b",
+    weight: 0.5,
+    lag: 0,
+    type: "directed",
+    confidence: 0.9,
+    isInconsistent: false,
+    physicalMechanism: "test",
+    ...overrides,
+  };
+}
+
+describe("deriveEdgeAppearance — color tier precedence", () => {
+  it("ablated overrides everything (magenta + dashed)", () => {
+    // Even a severed inconsistent confounded edge becomes magenta+dashed
+    // when ablated — Pearl do(X) supremacy.
+    const out = deriveEdgeAppearance({
+      edge: mkEdge({
+        type: "confounded",
+        isInconsistent: true,
+        isSevered: true,
+      }),
+      truthFilter: "verified",
+      isAblated: true,
+    });
+    expect(out.color).toBe("#e040fb");
+    expect(out.isDashed).toBe(true);
+  });
+
+  it("severed beats consequence/inconsistent/type (slate + dashed)", () => {
+    const out = deriveEdgeAppearance({
+      edge: mkEdge({
+        isInconsistent: true,
+        isSevered: true,
+        isConsequenceEdge: true,
+      }),
+      truthFilter: "verified",
+      isAblated: false,
+    });
+    expect(out.color).toBe("#78909c");
+    expect(out.isDashed).toBe(true);
+  });
+
+  it("consequence edge beats inconsistent + type (orange, solid unless type-confounded)", () => {
+    const out = deriveEdgeAppearance({
+      edge: mkEdge({ isConsequenceEdge: true, isInconsistent: true }),
+      truthFilter: "verified",
+      isAblated: false,
+    });
+    expect(out.color).toBe("#ff6d00");
+    // Inconsistent in verified mode still triggers dashed
+    expect(out.isDashed).toBe(true);
+  });
+
+  it("inconsistent only flags red in verified truthFilter mode", () => {
+    const raw = deriveEdgeAppearance({
+      edge: mkEdge({ isInconsistent: true }),
+      truthFilter: "raw",
+      isAblated: false,
+    });
+    expect(raw.color).toBe("#00e5ff"); // type-based fallback
+    expect(raw.isDashed).toBe(false);
+
+    const verified = deriveEdgeAppearance({
+      edge: mkEdge({ isInconsistent: true }),
+      truthFilter: "verified",
+      isAblated: false,
+    });
+    expect(verified.color).toBe("#ff1744");
+    expect(verified.isDashed).toBe(true);
+  });
+
+  it("type-based color fallback: directed → cyan, temporal → amber, confounded → orange", () => {
+    expect(
+      deriveEdgeAppearance({
+        edge: mkEdge({ type: "directed" }),
+        truthFilter: "raw",
+        isAblated: false,
+      }).color,
+    ).toBe("#00e5ff");
+    expect(
+      deriveEdgeAppearance({
+        edge: mkEdge({ type: "temporal" }),
+        truthFilter: "raw",
+        isAblated: false,
+      }).color,
+    ).toBe("#ffab00");
+    expect(
+      deriveEdgeAppearance({
+        edge: mkEdge({ type: "confounded" }),
+        truthFilter: "raw",
+        isAblated: false,
+      }).color,
+    ).toBe("#ff6d00");
+  });
+
+  it("confounded type is dashed even without ablation/inconsistency/sever", () => {
+    const out = deriveEdgeAppearance({
+      edge: mkEdge({ type: "confounded" }),
+      truthFilter: "raw",
+      isAblated: false,
+    });
+    expect(out.isDashed).toBe(true);
+  });
+
+  it("directed type is solid by default", () => {
+    const out = deriveEdgeAppearance({
+      edge: mkEdge({ type: "directed" }),
+      truthFilter: "raw",
+      isAblated: false,
+    });
+    expect(out.isDashed).toBe(false);
+  });
+});
+
+describe("edgeWidthFactor — power-scaled width", () => {
+  it("clamps weight to [0, 1]", () => {
+    expect(edgeWidthFactor(-1)).toBeCloseTo(0.7, 5);
+    expect(edgeWidthFactor(2)).toBeCloseTo(4.0, 5);
+  });
+
+  it("returns 0.7 at weight 0 and 4.0 at weight 1", () => {
+    expect(edgeWidthFactor(0)).toBeCloseTo(0.7, 5);
+    expect(edgeWidthFactor(1)).toBeCloseTo(4.0, 5);
+  });
+
+  it("widens the visible band over the typical 0.4–0.8 weight range", () => {
+    // Power-scaling — a 2× weight ratio should give meaningfully more
+    // than 2× width perception. Concretely: w=0.8 should be at least
+    // ~1.5× the width of w=0.4 once we subtract the constant base.
+    const w04 = edgeWidthFactor(0.4) - 0.7;
+    const w08 = edgeWidthFactor(0.8) - 0.7;
+    expect(w08 / Math.max(w04, 1e-6)).toBeGreaterThan(1.5);
+  });
+});

--- a/src/lib/edge-styling.ts
+++ b/src/lib/edge-styling.ts
@@ -1,0 +1,87 @@
+import type { CausalEdge } from "./types";
+
+/**
+ * Cross-view edge appearance — color, dash, width.
+ *
+ * The 3D view (`DAGEdge3D.tsx`) is the canonical source of truth for these
+ * conventions. This helper exists so the MAP view can mirror them without
+ * each surface drifting independently. 2D inlines the same color logic in
+ * `CausalDAG2D.tsx`'s edge memo; a future pass can route it through here too.
+ *
+ * Color tiers (highest precedence first):
+ *   1. ablated      → magenta (#e040fb)  — Pearl do(X) edge isolation
+ *   2. severed      → slate   (#78909c)  — Pearl link-break (distinct from Tarski red)
+ *   3. consequence  → orange  (#ff6d00)  — edge spawned downstream of an intervention
+ *   4. inconsistent → red     (#ff1744)  — Tarski-flagged, only in `verified` truthFilter
+ *   5. type-based   → cyan / amber / orange / cyan(fallback)
+ */
+
+export type TruthFilter = "raw" | "verified" | "incoherent";
+
+export interface EdgeStyleInput {
+  edge: CausalEdge;
+  truthFilter: TruthFilter;
+  isAblated: boolean;
+}
+
+export interface EdgeAppearance {
+  color: string;
+  isDashed: boolean;
+  /**
+   * Power-scaled stroke width factor in [0.7, 4.0] for an edge weight in
+   * [0, 1]. Mirrors the 3D mapping `0.7 + pow(w, 2.4) * 3.3` so a thick
+   * edge reads ~3× a thin one even at the typical 0.4–0.8 weight band.
+   * Callers convert this to whatever screen-space unit the renderer wants.
+   */
+  widthFactor: number;
+}
+
+const POWER_BASE = 0.7;
+const POWER_RANGE = 3.3;
+const POWER_EXPONENT = 2.4;
+
+export function edgeWidthFactor(weight: number): number {
+  const w = Math.max(0, Math.min(1, weight));
+  return POWER_BASE + Math.pow(w, POWER_EXPONENT) * POWER_RANGE;
+}
+
+export function deriveEdgeAppearance(input: EdgeStyleInput): EdgeAppearance {
+  const { edge, truthFilter, isAblated } = input;
+  const isSevered = edge.isSevered ?? false;
+  const isConsequence = edge.isConsequenceEdge ?? false;
+  const isInconsistent = truthFilter === "verified" && !!edge.isInconsistent;
+
+  let color: string;
+  if (isAblated) {
+    color = "#e040fb";
+  } else if (isSevered) {
+    color = "#78909c";
+  } else if (isConsequence) {
+    color = "#ff6d00";
+  } else if (isInconsistent) {
+    color = "#ff1744";
+  } else {
+    switch (edge.type) {
+      case "temporal":
+        color = "#ffab00";
+        break;
+      case "confounded":
+        color = "#ff6d00";
+        break;
+      case "directed":
+      default:
+        color = "#00e5ff";
+    }
+  }
+
+  // Dashed: confounded type, Tarski-verified inconsistent, ablation, or sever.
+  // Mirrors `DAGEdge3D.tsx`'s `isDashed = confounded || isVerifiedInconsistent || isAblated || isSevered`.
+  const isDashed =
+    edge.type === "confounded" || isInconsistent || isAblated || isSevered;
+
+  return {
+    color,
+    isDashed,
+    widthFactor: edgeWidthFactor(edge.weight),
+  };
+}


### PR DESCRIPTION
## Summary

The map's dotted-line edges had drifted from the 3D view on four axes:

1. **`edge.isInconsistent` painted red regardless of `truthFilter`** — 3D only flags red in `verified` mode. Map now matches.
2. **Pearl-ablated edges rendered as their base type color** instead of the magenta + dashed do(X) isolation marker. Now mirrors 3D's `#e040fb` + dash.
3. **`isConsequenceEdge` (edges spawned downstream of a Pearl link-break) rendered as their base type color** instead of orange. Now `#ff6d00`.
4. **Stroke width was linear** (`weight * 2 + 1.5`) while 3D and 2D use the power-scaled `0.7 + pow(w, 2.4) * 3.3` mapping that widens the visible band over the 0.4–0.8 weight cluster. Map now uses the same factor (scaled to the map's screen-space band).

Also adds single-`selectedNode` connected-edge dimming — clicking one node on the map now dims unrelated edges the same way it does in 3D. Previously dimming only kicked in for shift+drag multi-select.

## Refactor

Extracted `deriveEdgeAppearance` / `edgeWidthFactor` into `src/lib/edge-styling.ts`. The 3D file is documented as the canonical source this helper mirrors, so the rules are testable and there's a single place to change them next time the conventions evolve.

2D inlines the same color logic in `CausalDAG2D.tsx`'s edge memo and could be routed through this helper in a follow-up — left out of scope to keep the diff focused on the Asana ticket.

Closes Asana [1213910663170577](https://app.asana.com/1/1170302368162172/task/1213910663170577).

## Test plan

- [x] `vitest run` — 986 / 986 (87 files), including 10 new tests on `deriveEdgeAppearance` covering color-tier precedence, truthFilter gating, and the power-scaled width factor
- [x] `tsc --noEmit` — no new errors
- [x] `eslint` clean on changed files
- [ ] On a domain with geo-coordinates, switch to MAP view and confirm:
  - [ ] Confounded edges dotted-orange, directed edges solid-cyan, temporal edges solid-amber
  - [ ] Toggle `truthFilter` to `verified` → inconsistent edges go red+dashed; switch back to `raw` → return to type color
  - [ ] Engage Pearl ablation on an edge → magenta+dashed
  - [ ] Click a single node → unrelated edges dim
  - [ ] Shift+drag with isolation OFF → out-of-scope edges dim; ON → they cull
  - [ ] χ★ halo still renders behind in-scope edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)