### PR TITLE
fix(map): shift+drag matches 3D — empty-clear, auto-frame, no double-fire

### DIFF
--- a/src/components/CausalDAGMap.tsx
+++ b/src/components/CausalDAGMap.tsx
@@ -11,6 +11,7 @@ import { getDomainColor } from "@/lib/graph-data";
 import { getDomainCardColor } from "@/lib/domains";
 import { getNodeCoordinates } from "@/lib/geo-coordinates";
 import { chiStar } from "@/lib/estimators/chi-star";
+import { isTinyDrag, nodesInsideRect, type ProjectedNode } from "@/lib/box-select";
 import { useFilteredGraph } from "@/hooks/useFilteredGraph";
 import DAGOverlay from "@/components/dag3d/DAGOverlay";
 import EdgeInspector from "@/components/EdgeInspector";
@@ -78,6 +79,11 @@ function CausalDAGMapInner() {
   const [selectionRect, setSelectionRect] = useState<{
     x1: number; y1: number; x2: number; y2: number;
   } | null>(null);
+  // Rect tracked in a ref so onPointerUp can hit-test the final box without
+  // depending on the asynchronously-batched selectionRect state.
+  const currentRectRef = useRef<{
+    x1: number; y1: number; x2: number; y2: number;
+  } | null>(null);
   const shiftDragRef = useRef(false);
   const dragStartRef = useRef({ x: 0, y: 0 });
 
@@ -100,7 +106,9 @@ function CausalDAGMapInner() {
       const y = e.clientY - rect.top;
       shiftDragRef.current = true;
       dragStartRef.current = { x, y };
-      setSelectionRect({ x1: x, y1: y, x2: x, y2: y });
+      const initial = { x1: x, y1: y, x2: x, y2: y };
+      currentRectRef.current = initial;
+      setSelectionRect(initial);
       // Disable map panning during box select
       mapRef.current?.getMap().dragPan.disable();
     };
@@ -110,9 +118,11 @@ function CausalDAGMapInner() {
       const rect = container.getBoundingClientRect();
       const x = e.clientX - rect.left;
       const y = e.clientY - rect.top;
-      setSelectionRect((prev) =>
-        prev ? { ...prev, x2: x, y2: y } : null,
-      );
+      const next = currentRectRef.current
+        ? { ...currentRectRef.current, x2: x, y2: y }
+        : null;
+      currentRectRef.current = next;
+      setSelectionRect(next);
     };
 
     const onPointerUp = () => {
@@ -120,34 +130,31 @@ function CausalDAGMapInner() {
       shiftDragRef.current = false;
       mapRef.current?.getMap().dragPan.enable();
 
-      setSelectionRect((rect) => {
-        if (!rect) return null;
-        const minX = Math.min(rect.x1, rect.x2);
-        const maxX = Math.max(rect.x1, rect.x2);
-        const minY = Math.min(rect.y1, rect.y2);
-        const maxY = Math.max(rect.y1, rect.y2);
+      // Snapshot the rect, clear it, and run hit-testing outside the
+      // setSelectionRect updater. Calling another state setter inside an
+      // updater callback can fire twice in StrictMode and led to spurious
+      // re-selections of stale ids.
+      const rect = currentRectRef.current;
+      currentRectRef.current = null;
+      setSelectionRect(null);
+      if (!rect) return;
 
-        // Ignore tiny drags (< 5px)
-        if (maxX - minX < 5 && maxY - minY < 5) return null;
+      // Tiny drags are click-equivalents — leave selection untouched.
+      // Mirrors the 3D shift-drag handler.
+      if (isTinyDrag(rect)) return;
 
-        const map = mapRef.current?.getMap();
-        if (!map) return null;
+      const map = mapRef.current?.getMap();
+      if (!map) return;
 
-        const ids: string[] = [];
-        for (const node of nodeCoords) {
-          const projected = map.project(node.lngLat as [number, number]);
-          if (
-            projected.x >= minX && projected.x <= maxX &&
-            projected.y >= minY && projected.y <= maxY
-          ) {
-            ids.push(node.id);
-          }
-        }
-        if (ids.length > 0) {
-          setSelectedNodes(ids);
-        }
-        return null;
+      const projected: ProjectedNode[] = nodeCoords.map((node) => {
+        const p = map.project(node.lngLat as [number, number]);
+        return { id: node.id, screenX: p.x, screenY: p.y };
       });
+      const ids = nodesInsideRect(rect, projected);
+      // Empty drag clears multi-select — matches 3D's `onSelect([])`
+      // contract. Previously the map silently dropped empty selections,
+      // so users had to click on blank canvas to wipe a stale selection.
+      setSelectedNodes(ids);
     };
 
     container.addEventListener("pointerdown", onPointerDown);
@@ -616,16 +623,25 @@ function CausalDAGMapInner() {
     ? activeGraph.nodes.find((n) => n.id === selectedEdge.target)?.label ?? selectedEdge.target
     : "";
 
-  // Nodes the map should currently frame. When isolating with a selection,
-  // frame only the selected subset (matches 3D isolate semantics); otherwise
-  // frame the full filtered graph.
+  // Nodes the map should currently frame. Mirrors 3D's CameraRig priority:
+  //   1. Multi-selection (shift-drag or shift-click) → frame the selection.
+  //   2. Single selection → frame just that node (small zoom-in).
+  //   3. Otherwise → frame the full filtered graph.
+  // Previously the map only auto-framed when ISOLATE was also engaged, so
+  // shift-drag landed a selection but the user still had to find ISOLATE
+  // to see it framed — divergent from 3D, which centers on the selection
+  // unconditionally.
   const nodesToFit = useMemo(() => {
-    if (isolateSelection && selectedNodes.length > 0) {
+    if (selectedNodes.length > 0) {
       const sel = new Set(selectedNodes);
       return activeGraph.nodes.filter((n) => sel.has(n.id));
     }
+    if (selectedNode) {
+      const single = activeGraph.nodes.find((n) => n.id === selectedNode);
+      if (single) return [single];
+    }
     return activeGraph.nodes;
-  }, [activeGraph.nodes, isolateSelection, selectedNodes]);
+  }, [activeGraph.nodes, selectedNode, selectedNodes]);
 
   // Stable key over the *set* of framed node ids. Re-fits when the set of
   // visible nodes changes, including count-preserving swaps (e.g. changing

--- a/src/lib/__tests__/box-select.test.ts
+++ b/src/lib/__tests__/box-select.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import {
+  isTinyDrag,
+  nodesInsideRect,
+  MIN_DRAG_PX,
+  type ProjectedNode,
+} from "@/lib/box-select";
+
+describe("isTinyDrag", () => {
+  it("treats a zero-size rect as tiny (click-equivalent)", () => {
+    expect(isTinyDrag({ x1: 100, y1: 100, x2: 100, y2: 100 })).toBe(true);
+  });
+
+  it("treats a 4×4 px rect as tiny", () => {
+    expect(isTinyDrag({ x1: 0, y1: 0, x2: 4, y2: 4 })).toBe(true);
+  });
+
+  it(`treats a ${MIN_DRAG_PX}×0 rect as not-tiny`, () => {
+    // Exactly MIN_DRAG_PX in width should clear the threshold even when
+    // the height collapses to zero — matches the 3D handler.
+    expect(isTinyDrag({ x1: 0, y1: 50, x2: MIN_DRAG_PX, y2: 50 })).toBe(false);
+  });
+
+  it("normalizes flipped corners (drag from bottom-right to top-left)", () => {
+    expect(isTinyDrag({ x1: 200, y1: 200, x2: 0, y2: 0 })).toBe(false);
+  });
+
+  it("respects an override threshold", () => {
+    expect(isTinyDrag({ x1: 0, y1: 0, x2: 10, y2: 10 }, 20)).toBe(true);
+    expect(isTinyDrag({ x1: 0, y1: 0, x2: 30, y2: 30 }, 20)).toBe(false);
+  });
+});
+
+describe("nodesInsideRect", () => {
+  const nodes: ProjectedNode[] = [
+    { id: "a", screenX: 50, screenY: 50 },
+    { id: "b", screenX: 150, screenY: 150 },
+    { id: "c", screenX: 250, screenY: 250 },
+    { id: "d", screenX: 100, screenY: 200 },
+  ];
+
+  it("returns ids of nodes inside the rect", () => {
+    const ids = nodesInsideRect(
+      { x1: 0, y1: 0, x2: 200, y2: 200 },
+      nodes,
+    );
+    expect(ids.sort()).toEqual(["a", "b", "d"].sort());
+  });
+
+  it("includes nodes on the edge of the rect (inclusive bounds)", () => {
+    // Catching boundary nodes matches user expectation: "everything I
+    // dragged the box around" — exclusive bounds drop nodes the user
+    // visibly framed.
+    const ids = nodesInsideRect(
+      { x1: 50, y1: 50, x2: 150, y2: 150 },
+      nodes,
+    );
+    expect(ids.sort()).toEqual(["a", "b"].sort());
+  });
+
+  it("returns empty for a rect that misses every node", () => {
+    // Empty array is the contract that lets `setSelectedNodes(ids)` clear
+    // a stale multi-selection — see the regression in the map handler.
+    const ids = nodesInsideRect({ x1: 500, y1: 500, x2: 600, y2: 600 }, nodes);
+    expect(ids).toEqual([]);
+  });
+
+  it("normalizes flipped corner drags", () => {
+    // Drag from bottom-right to top-left should hit the same nodes as
+    // the equivalent top-left to bottom-right drag.
+    const forward = nodesInsideRect(
+      { x1: 0, y1: 0, x2: 200, y2: 200 },
+      nodes,
+    );
+    const backward = nodesInsideRect(
+      { x1: 200, y1: 200, x2: 0, y2: 0 },
+      nodes,
+    );
+    expect(backward.sort()).toEqual(forward.sort());
+  });
+
+  it("returns empty for an empty node list", () => {
+    expect(
+      nodesInsideRect({ x1: 0, y1: 0, x2: 100, y2: 100 }, []),
+    ).toEqual([]);
+  });
+});

--- a/src/lib/box-select.ts
+++ b/src/lib/box-select.ts
@@ -1,0 +1,59 @@
+/**
+ * Screen-space box-select hit testing — shared by 3D and MAP shift+drag
+ * handlers. Pure function so each surface can compute its own projected
+ * coordinates (Three.js camera, MapLibre `project`) and forward the same
+ * intersection logic.
+ */
+
+export interface ScreenRect {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+export interface ProjectedNode {
+  id: string;
+  screenX: number;
+  screenY: number;
+}
+
+/**
+ * Minimum drag distance (px) before a shift+drag counts as a box-select.
+ * Anything smaller is treated as a click-equivalent and leaves the existing
+ * selection alone.
+ */
+export const MIN_DRAG_PX = 5;
+
+export function isTinyDrag(rect: ScreenRect, threshold = MIN_DRAG_PX): boolean {
+  const w = Math.abs(rect.x2 - rect.x1);
+  const h = Math.abs(rect.y2 - rect.y1);
+  return w < threshold && h < threshold;
+}
+
+/**
+ * Return the ids of all projected nodes whose screen position falls inside
+ * the rectangle. Rectangle corners may be supplied in any order — the
+ * helper normalizes to (min, max) before testing.
+ */
+export function nodesInsideRect(
+  rect: ScreenRect,
+  nodes: readonly ProjectedNode[],
+): string[] {
+  const minX = Math.min(rect.x1, rect.x2);
+  const maxX = Math.max(rect.x1, rect.x2);
+  const minY = Math.min(rect.y1, rect.y2);
+  const maxY = Math.max(rect.y1, rect.y2);
+  const ids: string[] = [];
+  for (const node of nodes) {
+    if (
+      node.screenX >= minX &&
+      node.screenX <= maxX &&
+      node.screenY >= minY &&
+      node.screenY <= maxY
+    ) {
+      ids.push(node.id);
+    }
+  }
+  return ids;
+}


### PR DESCRIPTION
## Summary

Three gaps with the 3D shift-drag contract:

1. **Empty-area shift+drag silently dropped the empty selection** so a stale multi-select survived on the map. 3D's handler always calls `onSelect(ids)` — including `onSelect([])` — so users could draw an empty box to clear. Map now matches.

2. **The map only auto-framed to the selection when ISOLATE was also engaged.** The Asana ticket calls out "Should support centering on the selected area" as parity with 3D, where `CameraRig` flies to the selection unconditionally. `nodesToFit` now uses the canvas selection (single + multi) regardless of `isolateSelection`.

3. **`setSelectedNodes` was called from inside a `setSelectionRect` updater callback.** That can fire twice in StrictMode and cause spurious re-selects. Snapshot the rect into a ref, clear it synchronously, then run hit-testing and selection update outside the updater.

## Refactor

Extracted the screen-rect / projected-node intersection into `src/lib/box-select.ts` (`isTinyDrag`, `nodesInsideRect`). Each surface projects its own coordinates (Three.js camera in 3D, MapLibre `project` in MAP) and forwards the same intersection logic — kills the silent drift between 3D's and MAP's hit-testing the next time either evolves.

3D's `CausalDAG3D.tsx` `SelectionBox` could be routed through this helper too — out of scope for this PR.

## Isolate semantics

The ISOLATE button (in `DAGOverlay`, shared with 3D) still toggles whether out-of-scope edges/nodes are culled vs. dimmed. Shift+drag now produces the selection; engaging ISOLATE on top of it still works exactly as before.

Closes Asana [1213910663246726](https://app.asana.com/1/1170302368162172/task/1213910663246726).

## Test plan

- [x] `vitest run` — 986 / 986, including 10 new tests on `isTinyDrag` and `nodesInsideRect` (boundary inclusion, flipped corners, empty-list, threshold override)
- [x] `tsc --noEmit` — no new errors
- [x] `eslint` clean on changed files
- [ ] On a domain with geo-coordinates, switch to MAP view and confirm:
  - [ ] Shift+drag a box around several nodes → selected, view auto-frames to them
  - [ ] Shift+drag on an empty area → previous multi-select clears
  - [ ] Tiny shift+click (< 5px) → existing selection untouched
  - [ ] Drag from bottom-right to top-left → same nodes selected as the equivalent forward drag
  - [ ] Click ISOLATE → out-of-scope nodes/edges hidden as before
  - [ ] Click a single node (no shift) → map zooms in on that node

🤖 Generated with [Claude Code](https://claude.com/claude-code)