### PR TITLE
feat(copilot): sliding-window conversation memory (first cut)

### DIFF
--- a/src/components/SystemCopilot.tsx
+++ b/src/components/SystemCopilot.tsx
@@ -18,6 +18,7 @@ import {
   resolveActiveDataset,
   type TurnTrace,
 } from "@/lib/copilot/trace-logger";
+import { pruneConversation } from "@/lib/copilot/conversation-window";
 import { DOMAIN_CARDS } from "@/lib/domains";
 import { CopilotMessage } from "@/lib/types";
 import { getModelsForProvider, type LLMProvider } from "@/lib/llm-providers";
@@ -142,6 +143,10 @@ export default function SystemCopilot() {
   const [showDatasets, setShowDatasets] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
   const [contextBadge, setContextBadge] = useState<string | null>(null);
+  // Number of older turns dropped from the prompt window on the
+  // most recent send. Drives a small hint in the chat input area
+  // so the user knows we're not sending the full history.
+  const [truncatedTurns, setTruncatedTurns] = useState<number>(0);
   const [isListening, setIsListening] = useState(false);
   const [ttsEnabled, setTtsEnabled] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -393,11 +398,16 @@ export default function SystemCopilot() {
       });
 
       try {
-        // Build messages list including the new user message
-        const allMessages = [
+        // Build messages list including the new user message, then
+        // prune to a sliding window. Older turns drop out so prompts
+        // stay lean as conversations grow. droppedCount drives the
+        // small UI hint below the chat input.
+        const fullHistory = [
           ...copilotMessages.filter((m) => m.role !== "system"),
           { id: "temp", role: "user" as const, content: userContent, timestamp: Date.now() },
         ];
+        const { kept: allMessages, droppedCount } = pruneConversation(fullHistory);
+        setTruncatedTurns(droppedCount);
 
         // Enrich system context with snapshot data if available
         let snapshotContext = snapshotHistory.length > 0
@@ -1069,6 +1079,15 @@ export default function SystemCopilot() {
             </motion.div>
           )}
         </AnimatePresence>
+
+        {/* Truncation hint — shown when older turns dropped from the
+            prompt window. Surfaces so the user knows we're not
+            sending the entire history. */}
+        {truncatedTurns > 0 && (
+          <div className="mt-1.5 text-[8px] font-mono tracking-wider text-text-muted/70">
+            {truncatedTurns} earlier turn{truncatedTurns === 1 ? "" : "s"} omitted from context
+          </div>
+        )}
       </div>
 
       {/* Messages + Datasets overlay container */}

--- a/src/lib/__tests__/copilot-conversation-window.test.ts
+++ b/src/lib/__tests__/copilot-conversation-window.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import {
+  pruneConversation,
+  DEFAULT_CONVERSATION_WINDOW,
+} from "@/lib/copilot/conversation-window";
+import type { CopilotMessage } from "@/lib/types";
+
+function msg(role: "user" | "assistant", content: string): CopilotMessage {
+  return { id: `m-${content}`, role, content, timestamp: Date.now() };
+}
+
+describe("pruneConversation", () => {
+  it("returns history unchanged when under the limit", () => {
+    const history = [msg("user", "1"), msg("assistant", "2")];
+    const out = pruneConversation(history, 10);
+    expect(out.kept).toEqual(history);
+    expect(out.droppedCount).toBe(0);
+  });
+
+  it("returns history unchanged when exactly at the limit", () => {
+    const history = Array.from({ length: 12 }, (_, i) => msg("user", String(i)));
+    const out = pruneConversation(history, 12);
+    expect(out.kept).toHaveLength(12);
+    expect(out.droppedCount).toBe(0);
+  });
+
+  it("drops older messages from the front when over the limit", () => {
+    const history = Array.from({ length: 20 }, (_, i) => msg("user", String(i)));
+    const out = pruneConversation(history, 12);
+    expect(out.kept).toHaveLength(12);
+    expect(out.droppedCount).toBe(8);
+    // Kept the most recent.
+    expect(out.kept[0].content).toBe("8");
+    expect(out.kept[11].content).toBe("19");
+  });
+
+  it("defaults to DEFAULT_CONVERSATION_WINDOW when no limit is passed", () => {
+    const history = Array.from({ length: 20 }, (_, i) => msg("user", String(i)));
+    const out = pruneConversation(history);
+    expect(out.kept).toHaveLength(DEFAULT_CONVERSATION_WINDOW);
+    expect(out.droppedCount).toBe(20 - DEFAULT_CONVERSATION_WINDOW);
+  });
+
+  it("handles empty input", () => {
+    const out = pruneConversation([], 12);
+    expect(out.kept).toEqual([]);
+    expect(out.droppedCount).toBe(0);
+  });
+
+  it("treats limit=0 as 'keep nothing' (defensive)", () => {
+    const history = [msg("user", "1"), msg("assistant", "2")];
+    const out = pruneConversation(history, 0);
+    expect(out.kept).toEqual([]);
+    expect(out.droppedCount).toBe(2);
+  });
+
+  it("preserves message identity (kept array references the originals)", () => {
+    const original = [msg("user", "1"), msg("assistant", "2"), msg("user", "3")];
+    const out = pruneConversation(original, 2);
+    // Same object references, not a deep copy.
+    expect(out.kept[0]).toBe(original[1]);
+    expect(out.kept[1]).toBe(original[2]);
+  });
+});

--- a/src/lib/copilot/conversation-window.ts
+++ b/src/lib/copilot/conversation-window.ts
@@ -1,0 +1,70 @@
+// ─── Conversation window ────────────────────────────────────────
+//
+// First-cut conversation memory: a sliding window over the chat
+// history. Keep the last N user/assistant turns verbatim, drop
+// older ones, and report how many were dropped so the UI can
+// surface a hint to the user.
+//
+// Why a sliding window (and not summarization or retrieval yet):
+//   - We don't have evidence that long-context regressions are
+//     a real production pain point. Adding summarization now would
+//     be guessing at what to preserve.
+//   - Sliding window is reversible — easy to swap to summarization
+//     or retrieval later if `copilot_traces` data shows long,
+//     coherent conversations that suffer from dropped context.
+//   - It's a one-line plug into the existing
+//     copilotMessages.filter(...) chain in SystemCopilot.
+//
+// The "turn" unit here is *messages*, not user/assistant pairs.
+// That keeps the math simple — N=12 is roughly 6 turns of back-
+// and-forth. ACTIONS-EXECUTED system messages are filtered out
+// upstream (see SystemCopilot's `m.role !== "system"` filter), so
+// they don't enter this window.
+
+import type { CopilotMessage } from "@/lib/types";
+
+/**
+ * Hard cap on how many user/assistant messages get included in
+ * the prompt history. Picked at 12 = ~6 turns of back-and-forth,
+ * enough to preserve context for any normal chat session while
+ * keeping prompt cost bounded.
+ *
+ * Bumping this is cheap; lowering it gets aggressive about cost
+ * at the expense of conversational coherence. Move with intent.
+ */
+export const DEFAULT_CONVERSATION_WINDOW = 12;
+
+export interface PrunedWindow {
+  /** The messages that should be sent to the LLM (last N). */
+  kept: CopilotMessage[];
+  /** Count of messages dropped from the front. */
+  droppedCount: number;
+}
+
+/**
+ * Take a chat history (already filtered to user/assistant roles)
+ * and prune to the most recent `limit` entries.
+ *
+ * Edge cases:
+ *   - If history fits within the limit, returns it unchanged.
+ *   - If limit ≤ 0, returns an empty window (defensive — should
+ *     never happen in practice).
+ *   - Does NOT try to keep user/assistant pairs together. The
+ *     LLM tolerates a leading assistant turn fine; pair-aware
+ *     pruning is a future enhancement if it ever causes issues.
+ */
+export function pruneConversation(
+  messages: CopilotMessage[],
+  limit: number = DEFAULT_CONVERSATION_WINDOW,
+): PrunedWindow {
+  if (limit <= 0) {
+    return { kept: [], droppedCount: messages.length };
+  }
+  if (messages.length <= limit) {
+    return { kept: messages, droppedCount: 0 };
+  }
+  return {
+    kept: messages.slice(-limit),
+    droppedCount: messages.length - limit,
+  };
+}


### PR DESCRIPTION
## Summary

First-cut **conversation memory**: replace "send the full chat history every turn" with a sliding window of the most recent N messages. At N=12 (~6 turns of back-and-forth) the prompt stays lean while preserving conversational coherence for any normal session.

Live-validated against Gemini Flash: **20/20 eval PASS post-change, mean 1423ms** — no regression.

## Why a sliding window (and not summarization or retrieval)

There are three plausible options for conversation memory:

| Option | Cost | Risk | When to do it |
|---|---|---|---|
| **Sliding window** | trivial — one slice | drops old context cleanly | now |
| **LLM summarization** of older turns | adds an LLM call per N turns | guess at what to preserve | when traces show users hit deep coherent chats |
| **Retrieval over `copilot_traces`** | embeddings infra + Supabase pgvector or external | over-engineered for a problem we haven't seen | once we have multi-conversation history users want to recall |

Going with the window now because:
- **No evidence** long-context regressions are a real production pain point. Adding summarization without that evidence is guessing at what to preserve.
- **Reversible.** Easy to swap to summarization or retrieval later when trace data justifies it.
- **One-line plug** into the existing `copilotMessages.filter(...)` chain in `SystemCopilot`.

## What changed

| File | What |
|---|---|
| `src/lib/copilot/conversation-window.ts` (new) | Pure helper. `pruneConversation(messages, limit=12)` → `{ kept, droppedCount }`. Keeps last `limit` entries by slicing from the back; reports how many were dropped. |
| `src/components/SystemCopilot.tsx` | Calls the helper where `allMessages` is built. `droppedCount` flows into a `truncatedTurns` state; surfaces as a small `"N earlier turns omitted from context"` hint near the input when > 0. No prompt-construction logic touched. |
| `src/lib/__tests__/copilot-conversation-window.test.ts` (new) | 7 unit tests: under/at/over limit, default value, empty input, limit=0 (defensive), kept-array reference identity. |

## Design choices that may come up in review

- **Default 12, not 20 or 6.** 12 = ~6 turns back-and-forth. Conservative enough to keep prompts cheap, generous enough that normal chats never hit it. Easy to bump.
- **Window measured in messages, not user/assistant pairs.** The LLM tolerates a leading assistant turn fine; pair-aware pruning is a future enhancement if it ever causes issues in practice.
- **Truncation count surfaced as a tiny gray line, not a banner.** The user should know it's happening but not be alarmed.
- **`pruneConversation` is in `src/lib/copilot/` not in the component.** Easier to unit-test, and the future summarization version will live in the same module.

## Future-enhancement path (left in code comments)

```
Window → Summarization:
  When trace data justifies it, replace the dropped-count hint
  with an actual LLM-generated "earlier in this conversation,
  X happened" prefix message. Same module, swap the implementation.

Summarization → Retrieval:
  Per-user retrieval index built off copilot_traces for cross-
  conversation memory. Bigger move; gated on the user wanting it.
```

## Test plan

- [x] `vitest run` — **1020/1020 pass** (7 new in `copilot-conversation-window`)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `next build` passes with dummy env
- [x] **Live eval against Gemini Flash: 20/20 PASS, mean 1423ms** (single-turn cases, window has no effect; confirms no regression in the prompt path)
- [ ] Manual: send 14+ messages in production chat; verify the "N earlier turns omitted from context" hint appears after the 13th send

## Roadmap

```
[1]   Tool registry              ✅ #249
[2]   Trace store                 ✅ #251
[3.1] Provider abstraction        ✅ #296
[3.2] Model picker UI             ✅ #298
[4]   Eval harness                ✅ #302
[—]   Dataset routing TODO        ✅ #310
[—]   Trace browser UI            ✅ #315
[—]   Eval seed 7 → 20            ✅ #317
[—]   Eval CI gate                ✅ #319
[—]   "+ EVAL CASE" exporter      ✅ #324
[—]   Conversation window         ◀ this PR
[3.3] Native tool_use             queued (lower priority)
[5]   Distillation                unblocked when traces ≥ 10K
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
