### PR TITLE
feat(copilot): trace analytics — STATS tab on the trace browser

### DIFF
--- a/src/app/api/copilot/traces/analytics/__tests__/route.test.ts
+++ b/src/app/api/copilot/traces/analytics/__tests__/route.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment node
+//
+// Tests for GET /api/copilot/traces/analytics. Mocks the supabase
+// server client at the module level. Validates:
+//   - Anonymous → empty summary (200), never 401
+//   - Authenticated → rows pass through summarize() and the
+//     shape comes back as expected
+//   - Limit clamps to safe bounds (1 ≤ limit ≤ 5000)
+//   - Server-client init failures return 503
+//   - Postgres errors return 500
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+import type { AnalyticsSummary } from "@/lib/copilot/analytics";
+
+// ─── Mock the supabase server client ───────────────────────────
+
+let mockUser: { id: string } | null = null;
+let mockRows: unknown[] = [];
+let mockError: { message: string } | null = null;
+let mockClientThrows = false;
+let lastLimitCalledWith: number | undefined;
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => {
+    if (mockClientThrows) throw new Error("supabase client init failed");
+    return {
+      auth: { getUser: async () => ({ data: { user: mockUser } }) },
+      from: () => {
+        const chain = {
+          select: () => chain,
+          order: () => chain,
+          limit: (n: number) => {
+            lastLimitCalledWith = n;
+            return Promise.resolve({ data: mockRows, error: mockError });
+          },
+        };
+        return chain;
+      },
+    };
+  },
+}));
+
+// Import AFTER the mock.
+const { GET } = await import("@/app/api/copilot/traces/analytics/route");
+
+function req(url = "http://localhost/api/copilot/traces/analytics"): NextRequest {
+  return new NextRequest(url, { method: "GET" });
+}
+
+beforeEach(() => {
+  mockUser = null;
+  mockRows = [];
+  mockError = null;
+  mockClientThrows = false;
+  lastLimitCalledWith = undefined;
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+// ─── Tests ──────────────────────────────────────────────────────
+
+describe("GET /api/copilot/traces/analytics", () => {
+  it("returns an empty summary (200) for anonymous callers", async () => {
+    mockUser = null;
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { summary: AnalyticsSummary };
+    expect(body.summary.total_turns).toBe(0);
+    expect(body.summary.by_tool).toEqual([]);
+    expect(body.summary.by_model).toEqual([]);
+  });
+
+  it("aggregates rows through summarize() and returns the shape", async () => {
+    mockUser = { id: "u1" };
+    mockRows = [
+      {
+        created_at: "2026-05-09T10:00:00Z",
+        conversation_id: "c1",
+        tool_calls: [
+          { name: "isolate_nodes", latency_ms: 12, error: null },
+          { name: "explain_node", latency_ms: 30, error: null },
+        ],
+        model_provider: "gemini",
+        model_id: "gemini-2.5-flash",
+      },
+      {
+        created_at: "2026-05-09T10:01:00Z",
+        conversation_id: "c1",
+        tool_calls: [{ name: "isolate_nodes", latency_ms: 8, error: null }],
+        model_provider: "gemini",
+        model_id: "gemini-2.5-flash",
+      },
+    ];
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { summary: AnalyticsSummary };
+    expect(body.summary.total_turns).toBe(2);
+    expect(body.summary.total_tool_calls).toBe(3);
+    expect(body.summary.distinct_conversations).toBe(1);
+    expect(body.summary.by_tool[0].name).toBe("isolate_nodes");
+    expect(body.summary.by_tool[0].count).toBe(2);
+  });
+
+  it("clamps a too-large limit to MAX_LIMIT (5000)", async () => {
+    mockUser = { id: "u1" };
+    await GET(req("http://localhost/api/copilot/traces/analytics?limit=99999"));
+    expect(lastLimitCalledWith).toBe(5000);
+  });
+
+  it("clamps a non-positive limit to 1", async () => {
+    mockUser = { id: "u1" };
+    await GET(req("http://localhost/api/copilot/traces/analytics?limit=0"));
+    expect(lastLimitCalledWith).toBe(1);
+    await GET(req("http://localhost/api/copilot/traces/analytics?limit=-5"));
+    expect(lastLimitCalledWith).toBe(1);
+  });
+
+  it("falls back to the default limit (1000) when ?limit is absent or non-numeric", async () => {
+    mockUser = { id: "u1" };
+    await GET(req());
+    expect(lastLimitCalledWith).toBe(1000);
+    await GET(req("http://localhost/api/copilot/traces/analytics?limit=abc"));
+    expect(lastLimitCalledWith).toBe(1000);
+  });
+
+  it("returns 503 when the supabase server client fails to init", async () => {
+    mockClientThrows = true;
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await GET(req());
+    expect(res.status).toBe(503);
+    consoleSpy.mockRestore();
+  });
+
+  it("returns 500 when the select itself errors", async () => {
+    mockUser = { id: "u1" };
+    mockError = { message: "boom" };
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await GET(req());
+    expect(res.status).toBe(500);
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/app/api/copilot/traces/analytics/route.ts
+++ b/src/app/api/copilot/traces/analytics/route.ts
@@ -1,0 +1,77 @@
+// ─── GET /api/copilot/traces/analytics ──────────────────────────
+//
+// Returns aggregations over the authenticated user's recent
+// copilot turns. RLS on public.copilot_traces filters to
+// auth.uid() = user_id, same as the per-row endpoint at
+// /api/copilot/traces.
+//
+// Anonymous callers see an empty summary (not a 401), matching
+// the trace-list route's pattern. We do this so the trace
+// browser's STATS tab works on pre-auth surfaces without
+// spamming the logs.
+
+import { NextRequest, NextResponse } from "next/server";
+import { createClient as createServerClient } from "@/lib/supabase/server";
+import { summarize, type AnalyticsInputRow, type AnalyticsSummary } from "@/lib/copilot/analytics";
+
+// Wider than the per-row default (50) because aggregations get
+// more useful the more data they see, and we're not paying for
+// per-row rendering. Bounded so a malicious client can't ask
+// for an unbounded fetch.
+const DEFAULT_LIMIT = 1000;
+const MAX_LIMIT = 5000;
+
+export async function GET(request: NextRequest) {
+  const limitParam = request.nextUrl.searchParams.get("limit");
+  const requestedLimit = limitParam ? parseInt(limitParam, 10) : DEFAULT_LIMIT;
+  const limit = Math.min(
+    MAX_LIMIT,
+    Math.max(1, Number.isFinite(requestedLimit) ? requestedLimit : DEFAULT_LIMIT),
+  );
+
+  let supabase;
+  try {
+    supabase = await createServerClient();
+  } catch (err) {
+    console.error("[copilot-analytics] failed to create server client:", err);
+    return NextResponse.json(
+      { error: "Supabase server client unavailable" },
+      { status: 503 },
+    );
+  }
+
+  const { data: userData } = await supabase.auth.getUser();
+  if (!userData.user) {
+    return NextResponse.json({ summary: emptySummary() });
+  }
+
+  const { data, error } = await supabase
+    .from("copilot_traces")
+    .select("created_at, conversation_id, tool_calls, model_provider, model_id")
+    .order("created_at", { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    console.error("[copilot-analytics] select failed:", error);
+    return NextResponse.json(
+      { error: "Failed to load analytics" },
+      { status: 500 },
+    );
+  }
+
+  const rows = (data ?? []) as AnalyticsInputRow[];
+  const summary = summarize(rows);
+  return NextResponse.json({ summary });
+}
+
+function emptySummary(): AnalyticsSummary {
+  return {
+    total_turns: 0,
+    total_tool_calls: 0,
+    distinct_conversations: 0,
+    earliest_at: null,
+    latest_at: null,
+    by_tool: [],
+    by_model: [],
+  };
+}

--- a/src/components/CopilotTraceHistory.tsx
+++ b/src/components/CopilotTraceHistory.tsx
@@ -15,6 +15,9 @@ import { useEffect, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import type { TraceListRow } from "@/app/api/copilot/traces/route";
 import CopilotEvalCaseExporter from "@/components/CopilotEvalCaseExporter";
+import CopilotTraceStats from "@/components/CopilotTraceStats";
+
+type Tab = "list" | "stats";
 
 interface Props {
   /** When true, fetch fresh on mount and on every reopen. */
@@ -30,9 +33,12 @@ type LoadState =
 export default function CopilotTraceHistory({ open }: Props) {
   const [state, setState] = useState<LoadState>({ kind: "idle" });
   const [expanded, setExpanded] = useState<string | null>(null);
+  const [tab, setTab] = useState<Tab>("list");
 
   useEffect(() => {
-    if (!open) return;
+    // Only fetch the per-row list when its tab is showing — the
+    // stats tab fetches its own data through CopilotTraceStats.
+    if (!open || tab !== "list") return;
     let cancelled = false;
     // Wrap in an async IIFE so all setState calls happen inside
     // the awaited microtask, never synchronously in the effect
@@ -55,16 +61,23 @@ export default function CopilotTraceHistory({ open }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [open]);
+  }, [open, tab]);
 
   if (!open) return null;
 
   return (
     <div className="mt-2 pt-2 border-t border-border space-y-2">
-      <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted flex items-center justify-between">
-        <span>YOUR CONVERSATIONS</span>
-        {state.kind === "loaded" && (
-          <span className="text-text-muted/60">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-0.5 text-[8px] font-[family-name:var(--font-michroma)] tracking-wider">
+          <TabButton active={tab === "list"} onClick={() => setTab("list")}>
+            LIST
+          </TabButton>
+          <TabButton active={tab === "stats"} onClick={() => setTab("stats")}>
+            STATS
+          </TabButton>
+        </div>
+        {tab === "list" && state.kind === "loaded" && (
+          <span className="text-[8px] font-mono text-text-muted/60 tracking-wider">
             {state.traces.length === 0
               ? "no rows"
               : `${state.traces.length} turn${state.traces.length === 1 ? "" : "s"}`}
@@ -72,35 +85,61 @@ export default function CopilotTraceHistory({ open }: Props) {
         )}
       </div>
 
-      {state.kind === "loading" && (
-        <div className="text-[10px] font-mono text-text-muted">Loading…</div>
+      {tab === "list" && (
+        <>
+          {state.kind === "loading" && (
+            <div className="text-[10px] font-mono text-text-muted">Loading…</div>
+          )}
+          {state.kind === "error" && (
+            <div className="text-[10px] font-mono text-accent-amber">
+              Couldn&apos;t load history: {state.message}
+            </div>
+          )}
+          {state.kind === "loaded" && state.traces.length === 0 && (
+            <div className="text-[10px] font-mono text-text-muted leading-relaxed">
+              No turns yet. Send a message to the copilot — it&apos;ll appear here.
+            </div>
+          )}
+          {state.kind === "loaded" && state.traces.length > 0 && (
+            <div className="space-y-1 max-h-[60vh] overflow-y-auto">
+              {state.traces.map((trace) => (
+                <TraceRow
+                  key={trace.id}
+                  trace={trace}
+                  expanded={expanded === trace.id}
+                  onToggle={() => setExpanded(expanded === trace.id ? null : trace.id)}
+                />
+              ))}
+            </div>
+          )}
+        </>
       )}
 
-      {state.kind === "error" && (
-        <div className="text-[10px] font-mono text-accent-amber">
-          Couldn&apos;t load history: {state.message}
-        </div>
-      )}
-
-      {state.kind === "loaded" && state.traces.length === 0 && (
-        <div className="text-[10px] font-mono text-text-muted leading-relaxed">
-          No turns yet. Send a message to the copilot — it&apos;ll appear here.
-        </div>
-      )}
-
-      {state.kind === "loaded" && state.traces.length > 0 && (
-        <div className="space-y-1 max-h-[60vh] overflow-y-auto">
-          {state.traces.map((trace) => (
-            <TraceRow
-              key={trace.id}
-              trace={trace}
-              expanded={expanded === trace.id}
-              onToggle={() => setExpanded(expanded === trace.id ? null : trace.id)}
-            />
-          ))}
-        </div>
-      )}
+      {tab === "stats" && <CopilotTraceStats open />}
     </div>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="px-2 py-0.5 rounded transition-colors"
+      style={{
+        color: active ? "var(--accent-cyan)" : "var(--text-muted)",
+        backgroundColor: active ? "rgba(0,229,255,0.08)" : "transparent",
+      }}
+    >
+      {children}
+    </button>
   );
 }
 

--- a/src/components/CopilotTraceStats.tsx
+++ b/src/components/CopilotTraceStats.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+// ─── Copilot Trace Stats ────────────────────────────────────────
+//
+// Aggregate view of the authenticated user's recent trace data.
+// Sits alongside <CopilotTraceHistory />'s per-row list — toggled
+// via the STATS tab in the panel header.
+//
+// What you see:
+//   - Top-level: total turns, tool calls, distinct conversations,
+//     date range
+//   - Per-tool breakdown: count, error rate, mean & p95 latency
+//   - Per-model breakdown: turn count per (provider, model) pair
+//
+// The fetch loop matches CopilotTraceHistory's: fire on open,
+// cancel on close, show loading/error/empty/loaded states.
+
+import { useEffect, useState } from "react";
+import type { AnalyticsSummary } from "@/lib/copilot/analytics";
+
+interface Props {
+  open: boolean;
+}
+
+type LoadState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "loaded"; summary: AnalyticsSummary }
+  | { kind: "error"; message: string };
+
+export default function CopilotTraceStats({ open }: Props) {
+  const [state, setState] = useState<LoadState>({ kind: "idle" });
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    void (async () => {
+      setState({ kind: "loading" });
+      try {
+        const res = await fetch("/api/copilot/traces/analytics", {
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = (await res.json()) as { summary: AnalyticsSummary };
+        if (!cancelled) setState({ kind: "loaded", summary: data.summary });
+      } catch (err) {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : String(err);
+        setState({ kind: "error", message });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  if (state.kind === "loading") {
+    return <div className="text-[10px] font-mono text-text-muted">Loading…</div>;
+  }
+  if (state.kind === "error") {
+    return (
+      <div className="text-[10px] font-mono text-accent-amber">
+        Couldn&apos;t load stats: {state.message}
+      </div>
+    );
+  }
+  if (state.kind === "idle") return null;
+
+  const { summary } = state;
+  if (summary.total_turns === 0) {
+    return (
+      <div className="text-[10px] font-mono text-text-muted leading-relaxed">
+        No turns yet. Send a message to the copilot — stats will appear here.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <TopLevel summary={summary} />
+      <ToolBreakdown summary={summary} />
+      <ModelBreakdown summary={summary} />
+    </div>
+  );
+}
+
+// ─── Top-level totals ───────────────────────────────────────────
+
+function TopLevel({ summary }: { summary: AnalyticsSummary }) {
+  const span =
+    summary.earliest_at && summary.latest_at
+      ? formatDateRange(summary.earliest_at, summary.latest_at)
+      : null;
+  return (
+    <div className="space-y-0.5">
+      <SectionHeader>OVERVIEW</SectionHeader>
+      <div className="grid grid-cols-3 gap-1.5 text-[10px] font-mono">
+        <Cell label="turns" value={summary.total_turns} />
+        <Cell label="tool calls" value={summary.total_tool_calls} />
+        <Cell label="conversations" value={summary.distinct_conversations} />
+      </div>
+      {span && (
+        <div className="text-[9px] font-mono text-text-muted/60 pt-0.5">{span}</div>
+      )}
+    </div>
+  );
+}
+
+// ─── Per-tool breakdown ─────────────────────────────────────────
+
+function ToolBreakdown({ summary }: { summary: AnalyticsSummary }) {
+  if (summary.by_tool.length === 0) {
+    return (
+      <div>
+        <SectionHeader>BY TOOL</SectionHeader>
+        <div className="text-[10px] font-mono text-text-muted/70 leading-relaxed">
+          No tool calls yet.
+        </div>
+      </div>
+    );
+  }
+  const maxCount = summary.by_tool[0].count;
+  return (
+    <div className="space-y-0.5">
+      <SectionHeader>BY TOOL</SectionHeader>
+      <div className="space-y-1">
+        {summary.by_tool.map((t) => (
+          <div key={t.name} className="rounded border border-border bg-surface px-1.5 py-1 text-[10px] font-mono">
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-foreground truncate">{t.name}</span>
+              <span className="shrink-0 text-text-muted/80">
+                <span className="text-accent-cyan">{t.count}</span>
+                {t.error_rate > 0 && (
+                  <>
+                    {" · "}
+                    <span className={t.error_rate >= 0.1 ? "text-accent-amber" : "text-text-muted/70"}>
+                      {(t.error_rate * 100).toFixed(0)}% err
+                    </span>
+                  </>
+                )}
+                {" · "}
+                <span className="text-text-muted/70">
+                  {Math.round(t.mean_latency_ms)}ms avg · {Math.round(t.p95_latency_ms)}ms p95
+                </span>
+              </span>
+            </div>
+            {/* Tiny count bar so the visual relativity reads at a glance. */}
+            <div className="mt-1 h-0.5 bg-surface-elevated rounded overflow-hidden">
+              <div
+                className="h-full bg-accent-cyan/60"
+                style={{ width: `${(t.count / maxCount) * 100}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Per-model breakdown ────────────────────────────────────────
+
+function ModelBreakdown({ summary }: { summary: AnalyticsSummary }) {
+  return (
+    <div className="space-y-0.5">
+      <SectionHeader>BY MODEL</SectionHeader>
+      <div className="space-y-0.5">
+        {summary.by_model.map((m) => (
+          <div
+            key={`${m.provider}|${m.model_id}`}
+            className="flex items-center justify-between text-[10px] font-mono px-1.5 py-0.5"
+          >
+            <span className="text-foreground truncate">
+              <span className="text-accent-cyan">{m.provider}</span>
+              <span className="text-text-muted/60"> / </span>
+              <span className="text-text-muted">{m.model_id}</span>
+            </span>
+            <span className="text-text-muted">{m.count}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Tiny primitives ────────────────────────────────────────────
+
+function SectionHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted">
+      {children}
+    </div>
+  );
+}
+
+function Cell({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded border border-border bg-surface px-2 py-1">
+      <div className="text-[14px] text-foreground tabular-nums leading-none">{value}</div>
+      <div className="text-[8px] uppercase tracking-wider text-text-muted/70 mt-0.5">{label}</div>
+    </div>
+  );
+}
+
+function formatDateRange(earliest: string, latest: string): string {
+  const a = new Date(earliest);
+  const b = new Date(latest);
+  const fmt = (d: Date) =>
+    d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  if (a.toDateString() === b.toDateString()) return fmt(a);
+  return `${fmt(a)} → ${fmt(b)}`;
+}

--- a/src/lib/__tests__/copilot-analytics.test.ts
+++ b/src/lib/__tests__/copilot-analytics.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import { summarize, type AnalyticsInputRow } from "@/lib/copilot/analytics";
+
+function row(overrides: Partial<AnalyticsInputRow> = {}): AnalyticsInputRow {
+  return {
+    created_at: "2026-05-09T10:00:00Z",
+    conversation_id: "c1",
+    tool_calls: [],
+    model_provider: "gemini",
+    model_id: "gemini-2.5-flash",
+    ...overrides,
+  };
+}
+
+function tc(name: string, latency_ms: number, error: string | null = null) {
+  return { name, latency_ms, error };
+}
+
+describe("summarize", () => {
+  it("returns zeros + nulls on empty input", () => {
+    const s = summarize([]);
+    expect(s).toEqual({
+      total_turns: 0,
+      total_tool_calls: 0,
+      distinct_conversations: 0,
+      earliest_at: null,
+      latest_at: null,
+      by_tool: [],
+      by_model: [],
+    });
+  });
+
+  it("counts turns, tool calls, and distinct conversations", () => {
+    const s = summarize([
+      row({ conversation_id: "c1", tool_calls: [tc("a", 10), tc("b", 20)] }),
+      row({ conversation_id: "c1", tool_calls: [tc("a", 30)] }),
+      row({ conversation_id: "c2", tool_calls: [] }),
+    ]);
+    expect(s.total_turns).toBe(3);
+    expect(s.total_tool_calls).toBe(3);
+    expect(s.distinct_conversations).toBe(2);
+  });
+
+  it("picks the earliest + latest created_at correctly", () => {
+    const s = summarize([
+      row({ created_at: "2026-05-09T12:00:00Z" }),
+      row({ created_at: "2026-05-08T08:00:00Z" }),
+      row({ created_at: "2026-05-09T11:00:00Z" }),
+    ]);
+    expect(s.earliest_at).toBe("2026-05-08T08:00:00Z");
+    expect(s.latest_at).toBe("2026-05-09T12:00:00Z");
+  });
+
+  it("aggregates per-tool counts, sorted desc by count", () => {
+    const s = summarize([
+      row({ tool_calls: [tc("popular", 10), tc("popular", 20), tc("rare", 5)] }),
+      row({ tool_calls: [tc("popular", 30)] }),
+    ]);
+    expect(s.by_tool.map((t) => t.name)).toEqual(["popular", "rare"]);
+    expect(s.by_tool[0].count).toBe(3);
+    expect(s.by_tool[1].count).toBe(1);
+  });
+
+  it("computes mean / p50 / p95 latency correctly for a tool", () => {
+    const s = summarize([
+      row({
+        tool_calls: [
+          tc("solve", 100),
+          tc("solve", 200),
+          tc("solve", 300),
+          tc("solve", 400),
+          tc("solve", 500),
+        ],
+      }),
+    ]);
+    const stat = s.by_tool[0];
+    expect(stat.name).toBe("solve");
+    expect(stat.mean_latency_ms).toBe(300);
+    expect(stat.p50_latency_ms).toBe(300);
+    // p95 with 5 samples (indices 0..4): (5-1)*0.95 = 3.8 → between 400 and 500
+    // linear interp: 400 + 0.8 * (500 - 400) = 480. Float-tolerant.
+    expect(stat.p95_latency_ms).toBeCloseTo(480, 8);
+  });
+
+  it("computes error_count + error_rate per tool", () => {
+    const s = summarize([
+      row({
+        tool_calls: [
+          tc("flaky", 50, null),
+          tc("flaky", 50, "oops"),
+          tc("flaky", 50, "again"),
+          tc("flaky", 50, null),
+        ],
+      }),
+    ]);
+    const stat = s.by_tool[0];
+    expect(stat.count).toBe(4);
+    expect(stat.error_count).toBe(2);
+    expect(stat.error_rate).toBe(0.5);
+  });
+
+  it("groups by (provider, model_id) pair, sorted desc by count", () => {
+    const s = summarize([
+      row({ model_provider: "gemini", model_id: "gemini-2.5-flash" }),
+      row({ model_provider: "gemini", model_id: "gemini-2.5-flash" }),
+      row({ model_provider: "anthropic", model_id: "claude-sonnet-4-20250514" }),
+      row({ model_provider: "gemini", model_id: "gemini-2.5-pro" }),
+    ]);
+    expect(s.by_model).toEqual([
+      { provider: "gemini", model_id: "gemini-2.5-flash", count: 2 },
+      { provider: "anthropic", model_id: "claude-sonnet-4-20250514", count: 1 },
+      { provider: "gemini", model_id: "gemini-2.5-pro", count: 1 },
+    ]);
+  });
+
+  it("falls back to '?' for missing provider / model_id", () => {
+    const s = summarize([row({ model_provider: null, model_id: null })]);
+    expect(s.by_model[0]).toEqual({ provider: "?", model_id: "?", count: 1 });
+  });
+
+  it("treats a row with no tool_calls as a valid turn (just no tool stats)", () => {
+    const s = summarize([row({ tool_calls: [] })]);
+    expect(s.total_turns).toBe(1);
+    expect(s.total_tool_calls).toBe(0);
+    expect(s.by_tool).toEqual([]);
+  });
+});

--- a/src/lib/copilot/analytics.ts
+++ b/src/lib/copilot/analytics.ts
@@ -1,0 +1,170 @@
+// ─── Copilot trace analytics ───────────────────────────────────
+//
+// Aggregations over an array of copilot_traces rows. Pure
+// function — no I/O, no SQL knobs to twist. The API route fetches
+// the rows (RLS-filtered per-user), passes them to summarize(),
+// and returns the result.
+//
+// We do aggregation in TypeScript rather than SQL because:
+//   - The dataset is small (hundreds to low thousands of rows for
+//     the foreseeable future) and a Node aggregation is cheap.
+//   - Testing pure functions is meaningfully cheaper than testing
+//     against a real Postgres.
+//   - If we ever need real scale, we can move this to a SQL CTE
+//     or a materialized view without changing the response shape.
+
+// ─── Input shape ────────────────────────────────────────────────
+
+/** Subset of copilot_traces columns the aggregator needs.
+ *  Decoupled from the API route's TraceListRow so the analytics
+ *  module isn't pulled into the client bundle's API-route
+ *  dependency graph. */
+export interface AnalyticsInputRow {
+  created_at: string;
+  conversation_id: string;
+  tool_calls: Array<{
+    name: string;
+    error: string | null;
+    latency_ms: number;
+  }>;
+  model_provider: string | null;
+  model_id: string | null;
+}
+
+// ─── Output shape ───────────────────────────────────────────────
+
+export interface ToolStat {
+  name: string;
+  count: number;
+  error_count: number;
+  error_rate: number;
+  mean_latency_ms: number;
+  p50_latency_ms: number;
+  p95_latency_ms: number;
+}
+
+export interface ModelStat {
+  provider: string;
+  model_id: string;
+  /** Turn count (one per row, not one per tool call). */
+  count: number;
+}
+
+export interface AnalyticsSummary {
+  total_turns: number;
+  total_tool_calls: number;
+  distinct_conversations: number;
+  earliest_at: string | null;
+  latest_at: string | null;
+  /** Sorted by count desc. */
+  by_tool: ToolStat[];
+  /** Sorted by count desc. */
+  by_model: ModelStat[];
+}
+
+// ─── Aggregation ────────────────────────────────────────────────
+
+export function summarize(rows: AnalyticsInputRow[]): AnalyticsSummary {
+  if (rows.length === 0) {
+    return {
+      total_turns: 0,
+      total_tool_calls: 0,
+      distinct_conversations: 0,
+      earliest_at: null,
+      latest_at: null,
+      by_tool: [],
+      by_model: [],
+    };
+  }
+
+  // Per-tool latency buckets + error counts.
+  const toolLatencies = new Map<string, number[]>();
+  const toolErrors = new Map<string, number>();
+  let totalToolCalls = 0;
+
+  // Per-model turn counts.
+  const modelKey = (p: string | null, m: string | null) => `${p ?? "?"}|${m ?? "?"}`;
+  const modelCounts = new Map<string, ModelStat>();
+
+  // Per-conversation dedup.
+  const conversations = new Set<string>();
+
+  // Created-at extremes.
+  let earliest = rows[0].created_at;
+  let latest = rows[0].created_at;
+
+  for (const row of rows) {
+    conversations.add(row.conversation_id);
+    if (row.created_at < earliest) earliest = row.created_at;
+    if (row.created_at > latest) latest = row.created_at;
+
+    const mk = modelKey(row.model_provider, row.model_id);
+    const existing = modelCounts.get(mk);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      modelCounts.set(mk, {
+        provider: row.model_provider ?? "?",
+        model_id: row.model_id ?? "?",
+        count: 1,
+      });
+    }
+
+    for (const tc of row.tool_calls) {
+      totalToolCalls += 1;
+      const lat = toolLatencies.get(tc.name) ?? [];
+      lat.push(tc.latency_ms);
+      toolLatencies.set(tc.name, lat);
+      if (tc.error !== null) {
+        toolErrors.set(tc.name, (toolErrors.get(tc.name) ?? 0) + 1);
+      }
+    }
+  }
+
+  const by_tool: ToolStat[] = [];
+  for (const [name, latencies] of toolLatencies.entries()) {
+    const sorted = [...latencies].sort((a, b) => a - b);
+    const sum = sorted.reduce((s, n) => s + n, 0);
+    const errorCount = toolErrors.get(name) ?? 0;
+    by_tool.push({
+      name,
+      count: sorted.length,
+      error_count: errorCount,
+      error_rate: sorted.length === 0 ? 0 : errorCount / sorted.length,
+      mean_latency_ms: sum / sorted.length,
+      p50_latency_ms: percentile(sorted, 0.5),
+      p95_latency_ms: percentile(sorted, 0.95),
+    });
+  }
+  by_tool.sort((a, b) => b.count - a.count);
+
+  const by_model: ModelStat[] = [...modelCounts.values()].sort(
+    (a, b) => b.count - a.count,
+  );
+
+  return {
+    total_turns: rows.length,
+    total_tool_calls: totalToolCalls,
+    distinct_conversations: conversations.size,
+    earliest_at: earliest,
+    latest_at: latest,
+    by_tool,
+    by_model,
+  };
+}
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+/** Compute a percentile from a pre-sorted ascending array.
+ *  Returns 0 for empty arrays (defensive). Linear interpolation
+ *  between adjacent samples — same shape as numpy's default. */
+function percentile(sortedAsc: number[], p: number): number {
+  if (sortedAsc.length === 0) return 0;
+  if (sortedAsc.length === 1) return sortedAsc[0];
+  const idx = (sortedAsc.length - 1) * p;
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  if (lo === hi) return sortedAsc[lo];
+  const frac = idx - lo;
+  return sortedAsc[lo] * (1 - frac) + sortedAsc[hi] * frac;
+}


### PR DESCRIPTION
## Summary

Surfaces aggregate patterns over the user's own copilot traces. Adds a **STATS** tab alongside the existing LIST tab in the trace browser. Today the rows exist in `copilot_traces` but the only way to see them is per-row in LIST or via raw SQL — this is the second view: counts, error rates, latency distributions.

## Why now

Aggregations were the missing complement to the per-row trace browser (#315). Three reasons this earns its slot now:

1. **Trace data is invisible without an aggregate view.** Real usage patterns (which tools fire most, which fail) only become diagnostic at aggregate.
2. **Informs the distillation decision later.** When traces hit ~10K and we ask "should we fine-tune?", the first question is "fine-tune for *what*?" — answer comes from this view.
3. **Makes the eval-curation loop more useful.** Patterns surface "this tool fails 12% of the time" → exactly the kind of thing to lock as an eval case via the `+ EVAL CASE` button shipped in #324.

## What you'll see

Open the chat panel → click **⧉** (history icon) → tab to **STATS**:

```
[LIST | STATS]                        May 1 → May 9

OVERVIEW
┌──────────┐ ┌──────────┐ ┌───────────────┐
│   47     │ │   38     │ │       6       │
│  turns   │ │tool calls│ │ conversations │
└──────────┘ └──────────┘ └───────────────┘

BY TOOL
─────────────────────────────────────────────────
isolate_nodes              22 · 5% err · 11ms avg · 22ms p95
████████████████████░░░░
set_domains                 9 · 0% err · 18ms avg · 31ms p95
████████░░░░░░░░░░░░░░░░
solve_interdiction          4 · 0% err · 1840ms avg · 2900ms p95
███░░░░░░░░░░░░░░░░░░░░░
explain_node                3 · 0% err · 4ms avg · 7ms p95
██░░░░░░░░░░░░░░░░░░░░░░

BY MODEL
gemini / gemini-2.5-flash                    45
anthropic / claude-sonnet-4-20250514          2
```

Per-tool stats include count, error_count, error_rate (highlighted amber at ≥10%), mean & p95 latency. Per-model breakdown is straight turn counts.

## Files

| File | What |
|---|---|
| `src/lib/copilot/analytics.ts` (new) | Pure aggregator: `summarize(rows) → AnalyticsSummary`. Per-tool stats with mean / p50 / p95 latency (linear-interpolation percentiles, same shape as numpy). |
| `src/app/api/copilot/traces/analytics/route.ts` (new) | Auth-aware GET. RLS does the security work; route fetches up to `MAX_LIMIT=5000` rows and routes through `summarize()`. |
| `src/components/CopilotTraceStats.tsx` (new) | Renders the summary. Top-level cells, per-tool list with tiny count bars, per-model rollup. |
| `src/components/CopilotTraceHistory.tsx` | Gains a `[ LIST | STATS ]` tab toggle in the header. List behavior preserved; stats only fetches when its tab is active. |
| `src/lib/__tests__/copilot-analytics.test.ts` (new) | 9 pure-fn tests for `summarize()`. |
| `src/app/api/copilot/traces/analytics/__tests__/route.test.ts` (new) | 7 route tests (mock supabase). |

## Design notes

- **Aggregation in TypeScript, not SQL.** Dataset is small (hundreds → low thousands), Node aggregation is cheap, pure-fn tests are meaningfully easier to write, and we can move to a SQL CTE / materialized view later without changing the response shape.
- **No new icon in the chrome.** Stats lives as a sub-tab of the existing ⧉ history panel. Discoverable without crowding.
- **Stats tab fetches its own data.** Avoids double-fetching when toggling — list and stats each only load when their tab is active.
- **`?limit` capped at 5000.** Bounded so a malicious client can't ask for an unbounded fetch.

## Test plan

- [x] `vitest run` — **1040/1040 pass** (16 new — 9 aggregator + 7 route)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `next build` passes with dummy env
- [ ] Manual on Vercel preview: open chat → ⧉ → STATS, verify overview cells + per-tool breakdown + per-model rollup all render correctly
- [ ] Manual: tab back to LIST, confirm the per-row view still works (no regression on the existing behavior)

## Roadmap

```
[1]   Tool registry              ✅ #249
[2]   Trace store                 ✅ #251
[3.1] Provider abstraction        ✅ #296
[3.2] Model picker UI             ✅ #298
[4]   Eval harness                ✅ #302
[—]   Dataset routing TODO        ✅ #310
[—]   Trace browser UI            ✅ #315
[—]   Eval seed 7 → 20            ✅ #317
[—]   Eval CI gate                ✅ #319
[—]   "+ EVAL CASE" exporter      ✅ #324
[—]   Conversation window         🟡 #331 in review
[—]   Trace analytics view        ◀ this PR
[3.3] Native tool_use             queued (lower priority)
[5]   Distillation                unblocked when traces ≥ 10K
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
