### PR TITLE
feat(discovery): health endpoint + deploy runbook for persistence layer

### DIFF
--- a/docs/DISCOVERY_DEPLOY.md
+++ b/docs/DISCOVERY_DEPLOY.md
@@ -1,0 +1,131 @@
+# Discovery Persistence — Deploy Runbook
+
+> **Scope:** Turning the `/api/discovery/*` endpoints from stateless ("compute and return") into durable ("compute, persist, return") on production. This is a **one-time DB migration** plus a verification check.
+> **Authoritative files:** `supabase-discovery-runs.sql`, `src/lib/discovery/persistence.ts`, `src/app/api/discovery/run/route.ts`, `src/app/api/discovery/runs/route.ts`, `src/app/api/discovery/runs/[id]/route.ts`, `src/app/api/discovery/health/route.ts`.
+
+---
+
+## 1. Why this exists
+
+The Discovery API ships every commit as part of the Next.js build. The TypeScript layer for persistence (`src/lib/discovery/persistence.ts`) has been in place since the feature went live — `persistRun`, `getRun`, `listRuns`, `isPersistenceAvailable` are all written and unit-tested.
+
+**What's missing on production**: the `discovery_runs` Postgres table itself. Until the schema is applied, the persistence layer detects the missing table at runtime and gracefully degrades:
+
+- `POST /api/discovery/run` — still works. Computes the run, returns it. The `persistRun(run)` call silently fails with `{persisted: false, reason: <table-missing-error>}`.
+- `GET /api/discovery/runs` — returns `503 persistence layer unavailable` (it pre-checks `isPersistenceAvailable()` and short-circuits).
+- `GET /api/discovery/runs/[id]` — same as above.
+
+So customers can compute Discovery runs from their pipelines today, but they can't list past runs, fetch one by id, or audit them. That's what this deploy fixes.
+
+---
+
+## 2. Pre-flight
+
+Confirm these are in place before running the migration:
+
+1. **Supabase project exists** and is the same one Manifold is already deployed against. Verify by reading `NEXT_PUBLIC_SUPABASE_URL` in the Vercel project's Environment Variables.
+2. **Service-role key is set** in Vercel as `SUPABASE_SERVICE_ROLE_KEY` (Production + Preview). The persistence layer uses this to bypass RLS.
+3. **`supabase-setup.sql` has already run.** The discovery migration is additive — it doesn't depend on existing tables, but it's expected to land in a Supabase instance that already has the rest of the schema.
+
+A quick way to confirm 1 and 2 are wired correctly **before** running the SQL: hit the health endpoint.
+
+```bash
+curl https://manifold.apexanalytica.co/api/discovery/health | jq
+```
+
+Expected response pre-deploy:
+
+```json
+{
+  "ok": false,
+  "persistenceAvailable": true,
+  "envWired": true,
+  "tableExists": false,
+  "rowCount": null,
+  "error": "relation \"public.discovery_runs\" does not exist",
+  "checkedAt": "2026-05-12T..."
+}
+```
+
+If `envWired` is **false**, fix the env vars in Vercel first — the migration would be useless until the application can authenticate against Supabase.
+
+If `envWired` is **true** but the `error` doesn't mention `discovery_runs`, something else is wrong (RLS misconfiguration, networking) — don't proceed.
+
+---
+
+## 3. Run the migration
+
+1. Open the Supabase dashboard → project → **SQL Editor** → **+ New query**.
+2. Copy the entire contents of `supabase-discovery-runs.sql` (repo root) and paste.
+3. Click **Run**. The script is idempotent (`create table if not exists`, `create index if not exists`, RLS policy via `do $$ begin ... exception when duplicate_object then null; end $$`) so re-running is safe.
+4. Expected result: `Success. No rows returned.` — the migration creates a table, three indexes, and an RLS policy.
+
+Sanity-check from the SQL Editor itself:
+
+```sql
+select count(*) from public.discovery_runs;
+```
+
+Should return `0`. Run it again after a Discovery API call to confirm runs are landing.
+
+---
+
+## 4. Verify from the deployed application
+
+```bash
+curl https://manifold.apexanalytica.co/api/discovery/health | jq
+```
+
+Expected response post-deploy:
+
+```json
+{
+  "ok": true,
+  "persistenceAvailable": true,
+  "envWired": true,
+  "tableExists": true,
+  "rowCount": 0,
+  "error": null,
+  "checkedAt": "2026-05-12T..."
+}
+```
+
+`ok: true` is the green light. From this point, every `POST /api/discovery/run` will persist its result and the list / get endpoints will return real data instead of 503.
+
+You can also confirm end-to-end by running an actual Discovery API call (any test cohort + the `lag-correlation` algorithm is the cheapest) and then refreshing the health endpoint — `rowCount` will tick up.
+
+---
+
+## 5. Rollback
+
+If something goes wrong (extremely unlikely — this is a CREATE-only migration), drop the table from the Supabase SQL Editor:
+
+```sql
+drop table if exists public.discovery_runs cascade;
+```
+
+The application will revert to graceful-degrade mode automatically; no application redeploy needed. The health endpoint will start reporting `tableExists: false` again on the next call.
+
+---
+
+## 6. What this does NOT do
+
+- **No authentication on the Discovery API.** Anyone with the URL can `POST /api/discovery/run` and trigger a computation. After this migration, those runs land in your `discovery_runs` table with no `customer_id` scoping — anyone can write anything. Add API-key auth before exposing the Discovery API externally (next PR after this one).
+- **No per-customer scoping on persisted runs.** The schema as deployed has no `customer_id` column. PR 3 in this sequence adds it once auth is in place.
+- **No retention policy.** The table will grow without bound. Set up a Supabase cron / scheduled function or add a TTL column if expected volume is high. v0 expectation: a few hundred runs per month; reassess if real customers push it past 10k rows.
+
+---
+
+## 7. Health endpoint reference
+
+| Field | Type | Meaning |
+|---|---|---|
+| `ok` | bool | `envWired && tableExists && !error` — the all-green deploy state |
+| `persistenceAvailable` | bool | `isPersistenceAvailable()` from the persistence layer — equivalent to `envWired` for the moment |
+| `envWired` | bool | `SUPABASE_SERVICE_ROLE_KEY` and `NEXT_PUBLIC_SUPABASE_URL` are real (not CI stubs) |
+| `tableExists` | bool \| null | Result of `select count(*)` probe; null when env is unwired |
+| `rowCount` | number \| null | Total rows in `discovery_runs`; null when no probe was made |
+| `error` | string \| null | Supabase error message if the probe failed |
+| `checkedAt` | ISO-8601 | When the probe ran (each call is fresh; no caching) |
+
+Always returns HTTP 200 — the response body carries the diagnostic, not the status code. Status codes are reserved for "the endpoint itself is broken" cases.

--- a/src/app/api/discovery/health/route.ts
+++ b/src/app/api/discovery/health/route.ts
@@ -1,0 +1,47 @@
+// ─── GET /api/discovery/health ────────────────────────────────────────
+//
+// Deploy-state diagnostic for the Discovery persistence layer. Used by
+// the operator to verify after running `supabase-discovery-runs.sql`
+// that the schema is live and the application can see it.
+//
+// Response shape:
+//   {
+//     ok: boolean,                  // envWired && tableExists && !error
+//     persistenceAvailable: boolean, // same as isPersistenceAvailable()
+//     envWired: boolean,            // service-role key + URL aren't stub
+//     tableExists: boolean | null,  // probe result; null when env unwired
+//     rowCount: number | null,      // discovery_runs row count
+//     error: string | null,         // Supabase error message if probe failed
+//     checkedAt: ISO-8601 string,   // when the probe ran
+//   }
+//
+// AUTH: intentionally unauthenticated in v0 — exposing booleans + a
+// row count to an unauth'd caller is mildly information-leaky but not
+// exploitable. Will be moved behind the API-key gate when that lands
+// (next PR), at which point this becomes an admin-only health check.
+//
+// Always returns HTTP 200 with the diagnostic body, even when probes
+// fail — that's the point of a health endpoint. Operators distinguish
+// healthy / unhealthy from the body, not the status code.
+
+import { NextResponse } from "next/server";
+import {
+  isPersistenceAvailable,
+  probeDiscoveryTable,
+} from "@/lib/discovery/persistence";
+
+export async function GET() {
+  const probe = await probeDiscoveryTable();
+  const persistenceAvailable = isPersistenceAvailable();
+  const ok =
+    probe.envWired && probe.tableExists === true && probe.error === null;
+  return NextResponse.json({
+    ok,
+    persistenceAvailable,
+    envWired: probe.envWired,
+    tableExists: probe.tableExists,
+    rowCount: probe.rowCount,
+    error: probe.error,
+    checkedAt: new Date().toISOString(),
+  });
+}

--- a/src/lib/discovery/__tests__/persistence.test.ts
+++ b/src/lib/discovery/__tests__/persistence.test.ts
@@ -16,6 +16,7 @@ import {
   listRuns,
   setServiceClientForTesting,
   isPersistenceAvailable,
+  probeDiscoveryTable,
 } from "../persistence";
 import type { DiscoveryRun } from "../run-types";
 
@@ -258,5 +259,108 @@ describe("persistence — service connected", () => {
     expect(runs).toHaveLength(1);
     expect(runs[0].id).toBe("run-A");
     expect(runs[0].cohortSourceHash).toBe("hashA");
+  });
+});
+
+// ─── probeDiscoveryTable — deploy-state diagnostic ──────────────────
+
+/**
+ * Fake supabase client whose `select("*", { count, head })` resolves
+ * with the configured probe result. Used by the probe tests below.
+ * Kept separate from the main fake because the count+head variant
+ * resolves directly (the builder is await-able) rather than chaining
+ * through .order().limit().
+ */
+function makeProbeServiceClient(probeResult: {
+  count?: number | null;
+  error?: { message: string } | null;
+}) {
+  const selectSpy = vi.fn().mockResolvedValue({
+    count: probeResult.count ?? null,
+    error: probeResult.error ?? null,
+    data: null,
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fake: any = {
+    from: vi.fn().mockReturnValue({
+      select: selectSpy,
+    }),
+  };
+  return { fake, selectSpy };
+}
+
+describe("probeDiscoveryTable", () => {
+  beforeEach(() => {
+    setServiceClientForTesting(null);
+  });
+  afterEach(() => {
+    setServiceClientForTesting(null);
+  });
+
+  it("envWired=false / tableExists=null / rowCount=null when no service client", async () => {
+    const r = await probeDiscoveryTable();
+    expect(r.envWired).toBe(false);
+    expect(r.tableExists).toBeNull();
+    expect(r.rowCount).toBeNull();
+    expect(r.error).toBeNull();
+  });
+
+  it("envWired=true / tableExists=true / rowCount=N on successful probe", async () => {
+    const { fake, selectSpy } = makeProbeServiceClient({ count: 42 });
+    setServiceClientForTesting(fake);
+
+    const r = await probeDiscoveryTable();
+    expect(r.envWired).toBe(true);
+    expect(r.tableExists).toBe(true);
+    expect(r.rowCount).toBe(42);
+    expect(r.error).toBeNull();
+
+    // Verify the cheap-count shape: head:true + count:exact so no
+    // rows are serialised.
+    expect(selectSpy).toHaveBeenCalledWith("*", {
+      count: "exact",
+      head: true,
+    });
+  });
+
+  it("envWired=true / tableExists=false / error=<msg> when SELECT fails", async () => {
+    // What happens before the SQL migration has been run: the table
+    // doesn't exist, supabase-js returns a 42P01 / 'relation does not
+    // exist' error.
+    const { fake } = makeProbeServiceClient({
+      error: { message: 'relation "public.discovery_runs" does not exist' },
+    });
+    setServiceClientForTesting(fake);
+
+    const r = await probeDiscoveryTable();
+    expect(r.envWired).toBe(true);
+    expect(r.tableExists).toBe(false);
+    expect(r.rowCount).toBeNull();
+    expect(r.error).toContain("does not exist");
+  });
+
+  it("rowCount=0 reads cleanly on an empty table", async () => {
+    // The 'just deployed' state — table exists, no runs yet.
+    const { fake } = makeProbeServiceClient({ count: 0 });
+    setServiceClientForTesting(fake);
+
+    const r = await probeDiscoveryTable();
+    expect(r.envWired).toBe(true);
+    expect(r.tableExists).toBe(true);
+    expect(r.rowCount).toBe(0);
+  });
+
+  it("never throws on a client that explodes mid-call", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const exploding: any = {
+      from: () => {
+        throw new Error("network died");
+      },
+    };
+    setServiceClientForTesting(exploding);
+    const r = await probeDiscoveryTable();
+    expect(r.envWired).toBe(true);
+    expect(r.tableExists).toBe(false);
+    expect(r.error).toContain("network died");
   });
 });

--- a/src/lib/discovery/persistence.ts
+++ b/src/lib/discovery/persistence.ts
@@ -232,3 +232,84 @@ export async function listRuns(
 export function isPersistenceAvailable(): boolean {
   return getService() !== null;
 }
+
+export interface DiscoveryTableProbe {
+  /** Env is wired (URL + service-role key are real, not stub). */
+  envWired: boolean;
+  /**
+   * Result of a `select count(*)` against `discovery_runs`. null when
+   * env isn't wired (no probe attempted). Otherwise true if the
+   * SELECT succeeded; false if the table doesn't exist or any other
+   * Supabase error fired.
+   */
+  tableExists: boolean | null;
+  /** Row count returned by the SELECT. null when no probe was made. */
+  rowCount: number | null;
+  /**
+   * Supabase error message if the probe failed. Useful for diagnosing
+   * "SQL never ran" (table-missing error) vs. permission / RLS issues
+   * (different error string).
+   */
+  error: string | null;
+}
+
+/**
+ * Deploy-state diagnostic: probes the `discovery_runs` table with a
+ * cheap `select count(*)`. Distinguishes between three states the
+ * existing `isPersistenceAvailable()` can't:
+ *
+ *   1. envWired=false                          → env vars are stub or
+ *                                                 missing (CI / unset)
+ *   2. envWired=true,  tableExists=false       → real env but SQL
+ *                                                 schema has not been
+ *                                                 applied yet — run
+ *                                                 supabase-discovery-runs.sql
+ *   3. envWired=true,  tableExists=true        → fully deployed
+ *
+ * Used by `GET /api/discovery/health` so the operator can verify the
+ * deploy state without poking the Supabase dashboard. Cheap enough to
+ * call frequently — `count(*)` over an index is sub-millisecond on an
+ * empty table and bounded by row-count on a full one (we expect this
+ * table to stay small; if it grows past 1M rows we'll switch to a
+ * head-only query).
+ */
+export async function probeDiscoveryTable(): Promise<DiscoveryTableProbe> {
+  const service = getService();
+  if (!service) {
+    return {
+      envWired: false,
+      tableExists: null,
+      rowCount: null,
+      error: null,
+    };
+  }
+  try {
+    // Supabase's `count: 'exact', head: true` returns the count
+    // without serialising rows. `head: true` means no body — just
+    // the Content-Range header — so this is the cheapest probe shape.
+    const { count, error } = await service
+      .from("discovery_runs")
+      .select("*", { count: "exact", head: true });
+    if (error) {
+      return {
+        envWired: true,
+        tableExists: false,
+        rowCount: null,
+        error: error.message,
+      };
+    }
+    return {
+      envWired: true,
+      tableExists: true,
+      rowCount: count ?? 0,
+      error: null,
+    };
+  } catch (e) {
+    return {
+      envWired: true,
+      tableExists: false,
+      rowCount: null,
+      error: `unexpected: ${(e as Error).message}`,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

First of three PRs to make the Discovery API customer-ready (G + H in the backlog menu). The TypeScript persistence layer has been written since the feature went live, but the `discovery_runs` table has never been applied to prod Supabase — every run is computed and returned, **nothing is saved**, `GET /api/discovery/runs` returns 503.

## What this PR adds

### 1. `probeDiscoveryTable()` in `src/lib/discovery/persistence.ts`

Deploy-state diagnostic. Three states the existing `isPersistenceAvailable()` can't distinguish:

| State | Meaning |
|---|---|
| `envWired=false` | Env vars are stub / unset (CI / unset locally) |
| `envWired=true, tableExists=false` | Real env, SQL schema hasn't run yet |
| `envWired=true, tableExists=true` | Fully deployed |

Uses Supabase's `count: 'exact', head: true` so it's a sub-millisecond index-only probe. Gracefully degrades on any error (never throws).

### 2. `GET /api/discovery/health`

Returns the probe result as JSON. Always HTTP 200; diagnostic is in the body. `ok=true` is the all-green light.

```json
{
  "ok": true,
  "persistenceAvailable": true,
  "envWired": true,
  "tableExists": true,
  "rowCount": 0,
  "error": null,
  "checkedAt": "2026-05-12T..."
}
```

Unauthenticated for v0 — will be gated by the API-key middleware landing in the next PR. The fields reveal only booleans + a row count, no internal state.

### 3. `docs/DISCOVERY_DEPLOY.md` operator runbook

Covers:
- Pre-flight env checks (via the health endpoint)
- Running `supabase-discovery-runs.sql` in the SQL Editor
- Post-deploy verification (health endpoint flips to `ok: true`)
- Rollback procedure
- Explicit non-goals (no auth, no per-customer scoping yet)
- Health-response field reference table

## Sequencing

This PR (#current) — health endpoint + runbook + you run the SQL in prod
Next PR (#current+1) — API-key auth middleware + `api_keys` table
PR after — `customer_id` scoping on persisted runs + RLS policies

## Test plan

- [x] 5 new tests in `persistence.test.ts` covering all probe states (no service client, success, empty-table, table-missing error, exploding client). All assert the probe never throws and reports the right `envWired` / `tableExists` / `error` combination.
- [x] `vitest run`: **1052 passing**
- [x] tsc clean for touched files (pre-existing errors in `fci.test.ts` and `notears.test.ts` are unrelated sibling-session work)
- [x] By design — `persistRun`'s graceful-degrade behaviour means landing this code in prod without running the SQL is safe. The health endpoint will report `ok: false` until you run the SQL; nothing else changes for callers.

## Deploy step (you, after merge)

1. Merge this PR
2. Hit `GET https://manifold.apexanalytica.co/api/discovery/health` — should report `envWired: true, tableExists: false, error: 'relation "public.discovery_runs" does not exist'`
3. Open Supabase SQL Editor → paste `supabase-discovery-runs.sql` → Run
4. Hit the health endpoint again — should now report `ok: true, tableExists: true, rowCount: 0`

From that point, every `POST /api/discovery/run` persists; `GET /api/discovery/runs` returns real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)