### PR TITLE
docs(sessions): log 2026-05 live-data coverage push + handoff prompt

### DIFF
--- a/docs/sessions/geopolitical-macro.md
+++ b/docs/sessions/geopolitical-macro.md
@@ -44,6 +44,74 @@ Owns the geopolitical, financial, macro, and defense graph data and the correspo
 
 - TODO: fill in as the session ships work / from `git log`.
 
+## 2026-05 Live-Data Coverage Push
+
+### What landed (5 PRs, all merged into main)
+
+| PR | Commit | What |
+|---|---|---|
+| #221 | `2035f04` | DXY → EM FX panel refit (β=0.520 [0.10, 0.94] on 15-EM annual PIMCO panel including Turkey/Argentina) · Frontier-science scaffold (6 placeholder fs_* nodes + 4 intra-domain edges) · Time-series overlay tooltip + legend chip now show raw underlying metric (e.g. "6.76 %" food inflation) instead of duplicating per-card omega sparkline · 5 new FRED series (HOUST, RSAFS, ULCNFB, CUSR0000SEHC, JTSHIR) · README empirical playbook (FRED → mirror → PIMCO → statsmodels → literature ladder) |
+| #255 | `8e67d00` | Tile sparkline (OmegaSparkline in RiskPropagationFlow) switched from index-based x to timestamp-based x mapped onto the global timelineRange. Every tile now shares the same x-axis as the TimeDial scrubber and the bottom overlay. Sparse-data: 1 point → horizontal hold-forward; 2+ → polyline + hold-forward to right edge. Date labels read the timeline window. |
+| #267 | `4696e77` | 3 more FRED series — PAYEMS(units=chg) for `mi_nonfarm_payrolls`, DTWEXBGS for `ip_dxy`, CES0500000003(units=pch) for `mi_ahe_mom`. Transform-aware routing key `{id}_{units?}` so duplicate FRED ids with different transforms don't collide in the provider matcher. |
+| #268 | `9ecf57e` | 9 historical-only nodes promoted to live: 6 FC nodes via World Bank (SAU FI.RES.TOTL.CD, MEX DT.DOD.DECT.CD, PAK GC.DOD.TOTL.GD.ZS, TUR BN.CAB.XOKA.CD, EGY PA.NUS.FCRF, ARG PA.NUS.FCRF) + 3 food nodes via FRED PFOODINDEXM (level for qf/mn global-food-price-stress; pc1 for sc_food_price_inflation). |
+| #333 | `0ef7599` | `.env.example` template at repo root · `scripts/check-feed-health.ts` + `npm run check:feeds` (hits FRED + WB endpoints, prints LIVE/MOCK/MISS verdict per series) · DEPLOYMENT.md §2.1a documenting the rotate-and-verify flow. |
+
+### Coverage state at end of session
+
+```
+Total nodes:          211
+Live (rolling tick):   62  (was 53 at session start)
+Historical only:      115  (was 124)
+Bare:                  14  (was 17)
+```
+
+The 14 remaining bare are all documented as either intentional placeholder (6 frontier-science with `dataStatus: "blank-needs-data"`) or no-public-source (5 Ma'aden private infra, 2 ISM PMI proprietary since ~2015, 1 NY Fed SCE non-FRED).
+
+### Open handoff for next session
+
+**Critical — confirm prod is actually getting real data, not mock:**
+
+The whole live-data wiring above only matters if `FRED_API_KEY` is set in Vercel's production environment. The audit suggested it might not be (every "live" FRED node would have been showing `mockValue` from `FRED_SERIES[].mockValue` this whole time). Four steps to confirm + fix:
+
+1. **Register a free FRED key** — https://fred.stlouisfed.org/docs/api/api_key.html → fill name + email → key shown on the page. ~30s.
+2. **Set it on Vercel** — vercel.com → manifold project → Settings → Environment Variables → `FRED_API_KEY = <paste>` → apply to Production + Preview + Development. ~30s.
+3. **Trigger a redeploy** — Deployments tab → top entry → ⋯ menu → Redeploy. (Vercel envs are immutable per build; new value needs a new build.) ~90s.
+4. **Verify** — locally: `git pull origin main && npm run check:feeds`. Expected:
+   ```
+   === FRED === 56 expected · LIVE 56 · MOCK 0 · MISS 0
+   === World Bank === 12 expected · LIVE 12 · MOCK 0 · MISS 0
+   ```
+   If `MOCK > 0` → `FRED_API_KEY` didn't take effect (wrong env selected in step 2, or redeploy didn't trigger). The script prints a fix-link in that case.
+
+While you're in Vercel, the same procedure for **`EIA_API_KEY`** (free at https://www.eia.gov/opendata/register.php) unlocks the live Strait of Hormuz throughput feed driving the Tarski A-04 chokepoint axiom.
+
+**Continuation prompt for the next Claude window (paste verbatim):**
+
+> I'm continuing the 2026-05 live-data coverage push for the geopolitical/macro vertical of apex-terminal. Read `docs/sessions/geopolitical-macro.md` for the full context. The last 5 PRs (#221, #255, #267, #268, #333) shipped; I just set `FRED_API_KEY` on Vercel and triggered a redeploy. Run `npm run check:feeds` and tell me what's flowing vs mock. If any series is `MISS`, diagnose. After that, the next batch is the 4 fertilizer-market nodes (qf_/mn_ India + Brazil) which need a routing change in the WB provider matcher so two graph nodes can share one (country, indicator) observation — currently `nodes.find(...)` returns only the first match. Open a PR for that.
+
+### Empirical playbook (the data ladder)
+
+When wiring a new edge or live feed, work the sources in this priority order — each tier is a strictly weaker fallback. Documented in full in `research/macro/README.md`.
+
+```
+1. FRED API     (FRED_API_KEY set)
+2. GitHub mirror of the FRED-equivalent series (datasets/* org)
+3. PIMCO annual EM panel (claire/timeseries.json → pimco_sovereign)
+4. statsmodels.macrodata bundled quarterly (1959-2009)
+5. Literature-cited weight, transparently disclosed
+```
+
+DXY → EM FX (PR #221) is the canonical worked example: tier-2 monthly fit for the high-confidence point estimate, tier-3 annual fit for panel breadth (Turkey + Argentina), final edge weight is a defensible blend (0.44, between the two point estimates).
+
+### Notable internals worth remembering
+
+- **FRED provider routing key is `{id}_{units?}` not just `{id}`** since PR #267 — multiple entries with the same series + different transforms (PAYEMS level + chg, CES0500000003 Y/Y + M/M) live in `FRED_SERIES[]`. Both `parseFredSeriesResponse` and `mockFredFeed` emit observations with the transform-aware key.
+- **WB provider routing key is `(country, indicator)` tuple** — `PA.NUS.FCRF` appears for both Egypt and Argentina, distinguished by country.
+- **WB provider matcher is single-match-per-observation**: `nodes.find(...)` returns the FIRST label-pattern match, dropping all subsequent. This is why the 4 fertilizer-market nodes (`qf_india_fertilizer_market`, `mn_india_fertilizer_market`, qf_brazil_, mn_brazil_) can't all be wired live with a single WB entry per (country, indicator) — needs a multi-match change.
+- **Tile sparkline x-axis now binds to `timelineRange`** — pan/zoom the TimeDial → every tile responds in lockstep. Sparse-data nodes render hold-forward lines edge-to-edge. The Hormuz "LIVE — building" empty tile from the screenshot user-report no longer happens.
+- **Time-series overlay tooltip + legend chip now show raw value with unit** (e.g. "6.76 %") not the omega-normalized 0-10 number. `NodeTemporalState.rawValue` carries the unnormalized number; `formatRawValue()` picks decimal precision by magnitude regime.
+- **`scripts/check-feed-health.ts`** is the verification entry point. `npm run check:feeds` runs against prod by default; `BASE=http://localhost:3000 npm run check:feeds` for local dev.
+
 ## Likely upcoming themes
 
 - New domain cards as customer pilots demand them.


### PR DESCRIPTION
## Summary

This session was running in a Dispatch-launched cloud sandbox (no browser control), so the user is switching to a window where the Chrome extension is available to handle the FRED + Vercel UI steps. Appending a session-log section so the next window can resume from full context.

What's captured in `docs/sessions/geopolitical-macro.md`:

- **5 PRs shipped this session** (#221, #255, #267, #268, #333) with one-liner descriptions
- **Coverage state delta** (53→62 live, 124→115 historical-only, 14 bare with categorization)
- **Open handoff** — the 4-step FRED_API_KEY setup, verification command, and what success looks like
- **Continuation prompt** to paste into the next Claude window (self-contained, references this doc)
- **Empirical playbook recap** (FRED → mirror → PIMCO → statsmodels → literature)
- **Internal-architecture gotchas** — transform-aware FRED routing key, (country, indicator) WB key, single-match-per-observation matcher behavior, timestamp-based tile sparkline

No code changes — pure documentation. Auto-merge candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014AELhRkzeHMphQeQLwTGZF)_