### PR TITLE
fix(copilot): remove redundant mic button at the chat input

### DIFF
--- a/src/components/SystemCopilot.tsx
+++ b/src/components/SystemCopilot.tsx
@@ -147,7 +147,7 @@ export default function SystemCopilot() {
   // most recent send. Drives a small hint in the chat input area
   // so the user knows we're not sending the full history.
   const [truncatedTurns, setTruncatedTurns] = useState<number>(0);
-  const [isListening, setIsListening] = useState(false);
+  // (Old isListening state removed — voiceStage covers it now.)
   const [ttsEnabled, setTtsEnabled] = useState(false);
   // ─── Voice conversation mode ──────────────────────────────
   // When `voiceMode` is true, the chat runs hands-free:
@@ -662,7 +662,7 @@ export default function SystemCopilot() {
     let submitted = false;
 
     recognition.onstart = () => {
-      setIsListening(true);
+      /* listening state now reflected via voiceStage */
       if (voiceModeRef.current) setVoiceStage("listening");
     };
 
@@ -706,7 +706,7 @@ export default function SystemCopilot() {
     };
 
     recognition.onerror = () => {
-      setIsListening(false);
+      /* listening state now reflected via voiceStage */
       // In voice mode, recover from transient errors by restarting
       // unless the user explicitly toggled voice mode off.
       if (voiceModeRef.current) {
@@ -718,7 +718,7 @@ export default function SystemCopilot() {
       }
     };
     recognition.onend = () => {
-      setIsListening(false);
+      /* listening state now reflected via voiceStage */
       // If we never got a final result AND voice mode is on, restart.
       // (Long silences trigger onend without onresult.)
       if (voiceModeRef.current && !submitted && voiceStageRef.current === "listening") {
@@ -738,11 +738,6 @@ export default function SystemCopilot() {
   // auto-restart logic can call startListening without circular deps.
   useEffect(() => { startListeningRef.current = startListening; }, [startListening]);
 
-  const stopListening = useCallback(() => {
-    recognitionRef.current?.stop();
-    setIsListening(false);
-  }, []);
-
   // ─── Voice-mode toggle ──────────────────────────────────
   // Single button. When entering, kick off listening; when
   // exiting, cancel any speech and stop the recognition loop.
@@ -759,7 +754,7 @@ export default function SystemCopilot() {
       // voiceModeRef is already false so the restart branch skips.
       recognitionRef.current?.stop();
       if (typeof window !== "undefined") window.speechSynthesis?.cancel();
-      setIsListening(false);
+      /* listening state now reflected via voiceStage */
       setVoiceStage("idle");
     }
   }, [voiceMode]);
@@ -1494,18 +1489,10 @@ export default function SystemCopilot() {
               autoComplete="off"
             />
           </div>
-          <button
-            onClick={isListening ? stopListening : startListening}
-            disabled={isLlmStreaming}
-            className={`text-[12px] px-1.5 py-1.5 rounded transition-colors disabled:opacity-40 ${
-              isListening
-                ? "text-accent-red bg-accent-red/10 animate-pulse"
-                : "text-text-muted hover:text-accent-cyan hover:bg-accent-cyan/10"
-            }`}
-            title={isListening ? "Stop listening" : "Voice input"}
-          >
-            {isListening ? "\u23F9" : "\uD83C\uDF99"}
-          </button>
+          {/* Voice input lives in the header now (\uD83C\uDFA4 voice mode toggle).
+              The old one-shot dictation button below the input was
+              redundant \u2014 two mic icons, one of which was a mode-toggle
+              and one a push-to-talk, with no visual distinction. */}
           <button
             onClick={handleSubmit}
             disabled={isLlmStreaming}


### PR DESCRIPTION
## Summary

Two mic icons on the chat surface with no visual distinction — flagged as confusing in review. Removed the bottom one. Voice mode (the header 🎤 toggle from #338) is a strict superset.

| | Bottom mic (removed) | Top mic (kept) |
|---|---|---|
| Behavior | One-shot dictation. Tap → talk one message → submit → no TTS | Persistent voice-conversation loop with TTS auto-restart |
| Location | Next to send button | Header, with the other mode toggles |
| Icon | 🎙 | 🎤 / 🎙️ |
| Shipped in | Pre-existing | #338 |

**Both used the same icon glyph family, no labels.** Two buttons with identical glyphs that behaved differently was the friction.

## Why kill the bottom one and not the top one

1. Voice mode is strictly more capable for the dictation use case — toggle on, say one thing, toggle off when the response lands. You get TTS as a bonus.
2. The other mode toggles (settings, datasets, history) all live in the header. Voice-mode toggle being in the header is consistent.
3. The "dictate without TTS speaking back" use case is rare. If production traces show users actually want it, the right answer is a sub-toggle inside voice mode (`silent: true`) — not a second mic button with no label.

## Side cleanup

- Removed `stopListening` callback (its only caller was the deleted button; voice mode uses `recognitionRef.current.stop()` directly).
- Removed unused `isListening` state. `voiceStage` covers the same ground for the only remaining UI path.

Diff: **+9 / −22 lines.** Pure removal.

## Test plan

- [x] `vitest run` — 1052/1052
- [x] `tsc --noEmit` clean
- [x] `eslint` clean (only pre-existing `currentSnapshot` warning)
- [x] `next build` passes
- [ ] Manual: chat input shows only the send arrow + autocomplete; mic moved entirely to the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)
