### PR TITLE
fix(copilot): voice mode stuck on 'processing' after turn-with-actions

### DIFF
--- a/src/components/SystemCopilot.tsx
+++ b/src/components/SystemCopilot.tsx
@@ -291,29 +291,51 @@ export default function SystemCopilot() {
   // chat loops listening → processing → speaking → listening.
   useEffect(() => {
     if (!ttsEnabled && !voiceMode) return;
-    const lastMsg = copilotMessages[copilotMessages.length - 1];
-    if (!lastMsg || lastMsg.role !== "assistant" || !lastMsg.content) return;
-    if (lastMsg.id === lastSpokenMsgRef.current) return;
+
+    // Find the MOST RECENT assistant message — not necessarily the
+    // last message overall. After a turn fires actions, the runtime
+    // appends a "SYS: ACTIONS EXECUTED: ..." message. If we keyed off
+    // the absolute last message, the role check would fail and the
+    // effect would bail, leaving voice mode stuck on "processing".
+    let lastAssistant: CopilotMessage | undefined;
+    for (let i = copilotMessages.length - 1; i >= 0; i--) {
+      if (copilotMessages[i].role === "assistant") {
+        lastAssistant = copilotMessages[i];
+        break;
+      }
+    }
+    if (!lastAssistant) return;
+    if (lastAssistant.id === lastSpokenMsgRef.current) return;
     if (isLlmStreaming) return;
 
-    lastSpokenMsgRef.current = lastMsg.id;
+    lastSpokenMsgRef.current = lastAssistant.id;
+
+    // Voice-mode loop closer: flips state back to listening and
+    // restarts speech recognition. Used both after TTS finishes
+    // AND when there's no text to speak (empty assistant message
+    // — possible if the LLM emitted only actions with no prose).
+    const closeVoiceLoop = () => {
+      if (voiceModeRef.current) {
+        setVoiceStage("listening");
+        setTimeout(() => {
+          if (voiceModeRef.current) startListeningRef.current?.();
+        }, 50);
+      } else {
+        setVoiceStage("idle");
+      }
+    };
+
     if (voiceMode) {
+      if (!lastAssistant.content) {
+        // Nothing to speak — bypass TTS and restart listening so
+        // the loop doesn't deadlock on actions-only turns.
+        closeVoiceLoop();
+        return;
+      }
       setVoiceStage("speaking");
-      speakText(lastMsg.content, () => {
-        // Only restart listening if voice mode is still on (user
-        // may have toggled it off mid-speech).
-        if (voiceModeRef.current) {
-          setVoiceStage("listening");
-          // Defer to next tick so any state mutations land first.
-          setTimeout(() => {
-            if (voiceModeRef.current) startListeningRef.current?.();
-          }, 50);
-        } else {
-          setVoiceStage("idle");
-        }
-      });
-    } else {
-      speakText(lastMsg.content);
+      speakText(lastAssistant.content, closeVoiceLoop);
+    } else if (lastAssistant.content) {
+      speakText(lastAssistant.content);
     }
   }, [copilotMessages, ttsEnabled, voiceMode, isLlmStreaming, speakText]);
 


### PR DESCRIPTION
Reported by Junaid via screenshot — voice mode advanced through LISTENING and PROCESSING fine on the first turn, then deadlocked on PROCESSING after the assistant response landed.

## Root cause

The auto-speak effect grabbed `copilotMessages[length-1]` and bailed if role !== 'assistant'. But after a turn that fires actions, the runtime appends a SYS 'ACTIONS EXECUTED' message AFTER the assistant message:

```
APEX  [assistant analysis]
SYS   ACTIONS EXECUTED: Node size metric set to: eigenvector
```

That made the LAST message a system message → role check failed → effect returned early → TTS never fired → voice mode deadlocked.

## Fix

Walk the array backwards to find the most recent **assistant** message regardless of what came after. The `lastSpokenMsgRef` dedup still prevents replay.

While in there, also handled assistant messages with **empty content** (the LLM sometimes emits only action tags with no prose) — previously also deadlocked voice mode; now skips TTS but still restarts listening via the extracted `closeVoiceLoop` helper.

## Test plan

- [x] 1052/1052 vitest pass
- [x] tsc clean, eslint clean
- [ ] Manual: try the exact prompt from the screenshot ("find the node with the highest eigenvector centrality") — that response fires `set_node_size_metric` which appends the SYS message, exposing the bug. With this fix, voice mode should transition cleanly through SPEAKING → LISTENING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)