### PR TITLE
polish(domains): replace emoji domain icons with monochrome line-art SVGs

### DIFF
--- a/src/components/DomainIcon.tsx
+++ b/src/components/DomainIcon.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+/**
+ * Domain card icons — small monochrome line-art SVGs that replace the
+ * platform's previous emoji set on the Domain Workspace modal. Emojis
+ * (⚡ 🏭 🔗 🏦 🌍 …) rendered as full-colour OS glyphs that fought the
+ * dark-terminal aesthetic of the rest of the app; these icons render as
+ * 1.5px stroke line-art in the domain's accent colour, matching the
+ * minimal-monochrome treatment used throughout the canvas, the node
+ * inspector, and the tour.
+ *
+ * Each icon is hand-drawn against a 24×24 viewBox with stroke set via
+ * `currentColor`, so the caller controls colour via `style={{ color }}`
+ * — the same pattern used by other inline-SVG icons in the codebase
+ * (TTSControls, the speaker glyph). No new dep.
+ *
+ * To add a new icon, append a `case` to the switch and extend
+ * `DomainIconName` below. Keep stroke / viewBox conventions consistent
+ * so the grid stays visually uniform.
+ */
+
+import type { CSSProperties } from "react";
+
+export type DomainIconName =
+  | "bolt"        // energy
+  | "factory"     // manufacturing / fertilizer
+  | "chain"       // supply chain
+  | "bank"        // financial contagion
+  | "globe"       // sovereign risk
+  | "cable"       // undersea infrastructure
+  | "shield"      // defense / ISR
+  | "chart-bar"   // labor / growth / housing
+  | "trending"    // inflation / policy
+  | "dna"         // β-cell biology
+  | "syringe"     // VX-880 stem-cell transplant
+  | "brain"       // AI safety
+  | "atom";       // frontier science
+
+interface DomainIconProps {
+  name: DomainIconName;
+  size?: number;
+  /** Stroke colour. Defaults to currentColor so callers can drive it via
+   *  `style={{ color }}` or a Tailwind text-* class. */
+  color?: string;
+  className?: string;
+  style?: CSSProperties;
+  title?: string;
+}
+
+const STROKE_WIDTH = 1.5;
+
+export default function DomainIcon({
+  name,
+  size = 20,
+  color,
+  className,
+  style,
+  title,
+}: DomainIconProps) {
+  const commonProps = {
+    width: size,
+    height: size,
+    viewBox: "0 0 24 24",
+    fill: "none",
+    stroke: color ?? "currentColor",
+    strokeWidth: STROKE_WIDTH,
+    strokeLinecap: "round" as const,
+    strokeLinejoin: "round" as const,
+    className,
+    style,
+    role: "img" as const,
+    "aria-label": title ?? name,
+  };
+
+  switch (name) {
+    case "bolt":
+      // Classic lightning bolt — angular, asymmetric. Energy.
+      return (
+        <svg {...commonProps}>
+          {title && <title>{title}</title>}
+          <path d="M13 2 L4 14 L11 14 L10 22 L20 9 L13 9 Z" />
+        </svg>
+      );
+
+    case "factory":
+      // Building silhouette with two stepped smokestacks. Manufacturing.
+      return (
+        <svg {...commonProps}>
+          {title && <title>{title}</title>}
+          <path d="M3 21 V11 L9 14 V11 L15 14 V11 L21 14 V21 Z" />
+          <path d="M7 17 H8 M11 17 H12 M15 17 H16 M19 17 H20" />
+          <path d="M6 11 V5 H8 V11" />
+        </svg>
+      );
+
+    case "chain":
+      // Two interlocked link ovals — supply chain.
+      return (
+        <svg {...commonProps}>
+          {title && <title>{title}</title>}
+          <path d="M9.5 8 H8 a4 4 0 0 0 0 8 H10" />
+          <path d="M14.5 16 H16 a4 4 0 0 0 0 -8 H14" />
+          <path d="M8.5 12 H15.5" />
+        </svg>
+      );
+
+    case "bank":
+      // Classical bank facade — pediment, columns, base. Financial.
+      return (
+        <svg {...commonProps}>
+          {title && <title>{title}</title>}
+          <path d="M3 9 L12 4 L21 9 Z" />
+          <path d="M5 9 V18 M9 9 V18 M15 9 V18 M19 9 V18" />
+          <path d="M3 20 H21" />
+        </svg>
+      );
+
+    case "globe":
+      // Sphere with two longitude curves + equator. Sovereign / world.
+      return (
+        <svg {...commonProps}>
+          {title && <title>{title}</title>}
+          <circle cx="12" cy="12" r="9" />
+          <path d="M3 12 H21" />
+          <path d="M12 3 C8 7 8 17 12 21" />
+          <path d="M12 3 C16 7 16 17 12 21" />
+        </svg>
+      );
+
+    case "cable":
+      // Wavy undersea cable + two terminations. Infrastructure.
+      return (
+        <svg {...commonProps}>
+          {title && <title>{title}</title>}
+          <circle cx="4" cy="12" r="1.5" />
+          <circle cx="20" cy="12" r="1.5" />
+          <path d="M5.5 12 C7 8 9 16 11 12 C13 8 15 16 17 12 L18.5 12" />
+        </svg>
+      );
+
+    case "shield":
+      // Heater-shield silhouette with a central vertical mark. Defense.
+      return (
+        <svg {...commonProps}>
+          {title && <title>{title}</title>}
+          <path d="M12 2 L4 6 V12 C4 17 8 21 12 22 C16 21 20 17 20 12 V6 Z" />
+          <path d="M12 8 V14" />
+        </svg>
+      );
+
+    case "chart-bar":
+      // Three rising vertical bars + baseline. Labor / growth.
+      return (
+        <svg {...commonProps}>
+          {title && <title>{title}</title>}
+          <path d="M3 21 H21" />
+          <rect x="5" y="13" width="3" height="7" />
+          <rect x="10.5" y="9" width="3" height="11" />
+          <rect x="16" y="5" width="3" height="15" />
+        </svg>
+      );
+
+    case "trending":
+      // Rising line + small arrowhead. Inflation / policy.
+      return (
+        <svg {...commonProps}>
+          {title && <title>{title}</title>}
+          <path d="M3 17 L9 11 L13 15 L21 7" />
+          <path d="M15 7 H21 V13" />
+        </svg>
+      );
+
+    case "dna":
+      // Two intertwined helical strands + rungs. β-cell biology.
+      return (
+        <svg {...commonProps}>
+          {title && <title>{title}</title>}
+          <path d="M7 3 C7 9 17 9 17 15 C17 21 7 21 7 15" />
+          <path d="M17 3 C17 9 7 9 7 15" />
+          <path d="M9 6 H15 M9 10 H15 M9 14 H15 M9 18 H15" />
+        </svg>
+      );
+
+    case "syringe":
+      // Angled syringe — barrel, plunger, needle. VX-880 transplant.
+      return (
+        <svg {...commonProps}>
+          {title && <title>{title}</title>}
+          <path d="M14 4 L20 10" />
+          <path d="M9 9 L15 15" />
+          <path d="M5 13 L11 19" />
+          <path d="M3 21 L7 17 L10 14 L14 18 L11 21 Z" />
+          <path d="M16 6 L18 8" />
+        </svg>
+      );
+
+    case "brain":
+      // Two cerebral hemispheres meeting at a central sulcus. AI safety.
+      return (
+        <svg {...commonProps}>
+          {title && <title>{title}</title>}
+          <path d="M12 5 C10 3 6 4 6 8 C4 9 4 13 6 14 C6 18 10 19 12 17 Z" />
+          <path d="M12 5 C14 3 18 4 18 8 C20 9 20 13 18 14 C18 18 14 19 12 17 Z" />
+          <path d="M12 5 V17" />
+        </svg>
+      );
+
+    case "atom":
+      // Nucleus + three rotated orbital ellipses. Frontier physics.
+      return (
+        <svg {...commonProps}>
+          {title && <title>{title}</title>}
+          <circle cx="12" cy="12" r="1.2" fill={color ?? "currentColor"} stroke="none" />
+          <ellipse cx="12" cy="12" rx="9" ry="3.5" />
+          <ellipse cx="12" cy="12" rx="9" ry="3.5" transform="rotate(60 12 12)" />
+          <ellipse cx="12" cy="12" rx="9" ry="3.5" transform="rotate(120 12 12)" />
+        </svg>
+      );
+  }
+}

--- a/src/components/DomainSelector.tsx
+++ b/src/components/DomainSelector.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/lib/build-domain-graph";
 import type { NodeCategory } from "@/lib/types";
 import TTSControls from "@/components/TTSControls";
+import DomainIcon from "@/components/DomainIcon";
 import { WELCOME_DESCRIPTION } from "@/lib/tour-steps";
 import { DemoFlowPicker } from "@/components/DemoFlowPlayer";
 
@@ -337,7 +338,12 @@ export default function DomainSelector() {
                               : "none",
                           }}
                         >
-                          <span className="text-xl flex-shrink-0">{domain.icon}</span>
+                          <DomainIcon
+                            name={domain.icon}
+                            size={22}
+                            color={isSelected || domain.hasData ? domain.color : "var(--text-muted)"}
+                            className="flex-shrink-0"
+                          />
                           <div className="flex-1 min-w-0">
                             <div
                               className="text-[10px] font-[family-name:var(--font-michroma)] tracking-wider flex items-center gap-2"

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -10,6 +10,7 @@ import ImportButton from "./import/ImportButton";
 import TextSizeToggle from "./TextSizeToggle";
 import { ModuleId } from "@/lib/types";
 import { DOMAIN_CARDS } from "@/lib/domains";
+import DomainIcon from "./DomainIcon";
 import { GEOPOLITICAL_PROFILE } from "@/lib/domain-profiles";
 
 // Top-bar tabs are pinned to the four canonical labels regardless of active
@@ -79,13 +80,13 @@ export default function HeaderBar() {
                 const domain = DOMAIN_CARDS.find((d) => d.id === id);
                 if (!domain) return null;
                 return (
-                  <span
+                  <DomainIcon
                     key={id}
-                    className="text-sm"
+                    name={domain.icon}
+                    size={14}
+                    color={domain.color}
                     title={domain.label}
-                  >
-                    {domain.icon}
-                  </span>
+                  />
                 );
               })}
               <span className="text-[8px] font-mono text-text-muted group-hover:text-accent-cyan transition-colors ml-0.5 hidden md:inline">

--- a/src/lib/domains.ts
+++ b/src/lib/domains.ts
@@ -8,10 +8,15 @@
 // imports the heavy graph-data modules and is meant for code paths
 // that already need them (DomainSelector, copilot-actions, etc.).
 
+import type { DomainIconName } from "@/components/DomainIcon";
+
 export interface DomainCard {
   id: string;
   label: string;
-  icon: string;
+  /** Icon name resolved by `DomainIcon`. Previously an emoji string —
+   *  swapped for typed line-art icons so the modal matches the rest of
+   *  the platform's monochrome terminal aesthetic. */
+  icon: DomainIconName;
   color: string;
   colorVar: string;
   description: string;
@@ -72,7 +77,7 @@ export const DOMAIN_GROUPS: DomainGroup[] = [
       {
         id: "energy-systems",
         label: "Energy Systems",
-        icon: "\u{26A1}",
+        icon: "bolt",
         color: "#ff1744",
         colorVar: "var(--accent-red)",
         description: "Saudi Aramco crude/gas infrastructure, QatarEnergy LNG export chains",
@@ -82,7 +87,7 @@ export const DOMAIN_GROUPS: DomainGroup[] = [
       {
         id: "manufacturing",
         label: "Fertilizer & Agrochemical",
-        icon: "\u{1F3ED}",
+        icon: "factory",
         color: "#448aff",
         colorVar: "var(--accent-blue)",
         description: "QAFCO urea/ammonia complex, Ma'aden phosphate supply chains, food price transmission",
@@ -92,7 +97,7 @@ export const DOMAIN_GROUPS: DomainGroup[] = [
       {
         id: "supply-chain",
         label: "Supply Chain Shock Risk",
-        icon: "\u{1F517}",
+        icon: "chain",
         color: "#00e5ff",
         colorVar: "var(--accent-cyan)",
         description: "MENA food security, Bunge/Almarai supply chains, wheat price transmission",
@@ -108,7 +113,7 @@ export const DOMAIN_GROUPS: DomainGroup[] = [
       {
         id: "financial-contagion",
         label: "Financial Contagion Risk",
-        icon: "\u{1F3E6}",
+        icon: "bank",
         color: "#ff6d00",
         colorVar: "var(--accent-orange)",
         description: "Systemic banking failures, credit default cascades, liquidity traps",
@@ -118,7 +123,7 @@ export const DOMAIN_GROUPS: DomainGroup[] = [
       {
         id: "sovereign-risk",
         label: "Emerging Market Sovereign Risk",
-        icon: "\u{1F30D}",
+        icon: "globe",
         color: "#ffab00",
         colorVar: "var(--accent-amber)",
         description: "Currency crises, debt restructuring, capital flight contagion",
@@ -134,7 +139,7 @@ export const DOMAIN_GROUPS: DomainGroup[] = [
       {
         id: "infrastructure",
         label: "Infrastructure Resilience",
-        icon: "\u{1F3D7}",
+        icon: "cable",
         color: "#7c4dff",
         colorVar: "var(--accent-purple)",
         description: "Undersea cable systems, Red Sea exposure, Telecom Egypt/Orange Marine",
@@ -144,7 +149,7 @@ export const DOMAIN_GROUPS: DomainGroup[] = [
       {
         id: "defense-isr",
         label: "Defense & ISR",
-        icon: "\u{1F6E1}️",
+        icon: "shield",
         color: "#00e676",
         colorVar: "var(--accent-green)",
         description: "Drone swarms, SATCOM, ISR fusion, chip embargo, secure compute, kill chain",
@@ -160,7 +165,7 @@ export const DOMAIN_GROUPS: DomainGroup[] = [
       {
         id: "macro-labor",
         label: "Labor, Growth & Housing",
-        icon: "\u{1F4CA}",
+        icon: "chart-bar",
         color: "#40c4ff",
         colorVar: "var(--accent-cyan)",
         description: "Nonfarm payrolls, unemployment, wages, JOLTS, GDP, retail sales, industrial production, ISM PMI, housing",
@@ -170,7 +175,7 @@ export const DOMAIN_GROUPS: DomainGroup[] = [
       {
         id: "macro-inflation",
         label: "Inflation & Policy",
-        icon: "\u{1F4B9}",
+        icon: "trending",
         color: "#ff80ab",
         colorVar: "var(--accent-pink)",
         description: "CPI/PPI/PCE inflation, breakeven expectations, Fed funds rate, SOFR, Fed policy transmission",
@@ -186,7 +191,7 @@ export const DOMAIN_GROUPS: DomainGroup[] = [
       {
         id: "t1d-beta-cell",
         label: "T1D β-Cell Restoration",
-        icon: "\u{1F9EC}",
+        icon: "dna",
         color: "#40c4ff",
         colorVar: "var(--accent-blue)",
         description: "Autoimmune → β-cell loss → glycemic collapse → complications; teplizumab / stem-cell intervention paths",
@@ -196,7 +201,7 @@ export const DOMAIN_GROUPS: DomainGroup[] = [
       {
         id: "t1d-vx880",
         label: "T1D Stem-Cell Transplant (VX-880)",
-        icon: "\u{1F489}",
+        icon: "syringe",
         color: "#40c4ff",
         colorVar: "var(--accent-blue)",
         description: "Vertex VX-880 trial topology: HLA/autoantibody risk → dose + immunosuppression → engraftment → graft β-mass → MMTT / insulin-independence / severe-hypo endpoints",
@@ -212,7 +217,7 @@ export const DOMAIN_GROUPS: DomainGroup[] = [
       {
         id: "ai-safety-ids",
         label: "AI Safety / Endogenous Catastrophe",
-        icon: "\u{1F9E0}",
+        icon: "brain",
         color: "#7B68EE",
         colorVar: "var(--accent-violet)",
         description: "Catastrophic forgetting in continual-learning IDS, χ★-bridge cascade, adversarial drift — built from CICIDS-2017 / UNSW-NB15 / AWID-H23Q substrate (Ghauri 2025 D.Eng.)",
@@ -228,7 +233,7 @@ export const DOMAIN_GROUPS: DomainGroup[] = [
       {
         id: "frontier-science",
         label: "Frontier Science",
-        icon: "⚛️",
+        icon: "atom",
         color: "#e040fb",
         colorVar: "var(--accent-magenta)",
         description: "Post-Standard Model physics, neutrino frontier, quantum gravity, dark sector detection",


### PR DESCRIPTION
## Summary

Replaces the emoji icons on the Domain Workspace modal landing page with monochrome line-art SVGs that match the platform's terminal aesthetic.

The OS-rendered full-colour emojis (⚡ 🏭 🔗 🏦 🌍 🏗 🛡️ 📊 💹 🧬 💉 🧠 ⚛️) fought the dark monochrome treatment used throughout the canvas, node inspector, tour, and TTS controls. After this PR, each domain card mounts a 1.5px-stroke inline SVG drawn in the domain's accent colour.

## Changes

| File | Change |
|------|--------|
| **New** `src/components/DomainIcon.tsx` (~220 LOC) | 13 hand-drawn inline SVGs against 24×24 viewBox, stroke driven by `currentColor` so callers control colour via prop. Names: `bolt / factory / chain / bank / globe / cable / shield / chart-bar / trending / dna / syringe / brain / atom`. Matches the inline-SVG pattern already used by `TTSControls`. |
| **Modified** `src/lib/domains.ts` | `DomainCard.icon` retyped from `string` → typed `DomainIconName`. All 13 rows updated; swap anchored on `id:` so per-domain mapping is unambiguous. |
| **Modified** `src/components/DomainSelector.tsx` | Card render mounts `<DomainIcon name={domain.icon} size={22} color={...} />` instead of `<span>{domain.icon}</span>`. Colour resolves to the domain's accent when selected or has-data, text-muted otherwise. |
| **Modified** `src/components/HeaderBar.tsx` | The "selected domains" pill row in the workspace trigger also rendered `{domain.icon}` directly. Updated to render through `DomainIcon` too (size 14) — without this, those chips would have shown the literal strings "bolt" / "factory" / etc. after the type change. |

## What's not changed

The `NodeCategory` icons in `DomainSelector.tsx` (DATA LAYERS accordion, 📊 💰 ⚡ 🏗 🏭 🌾 🌐 📡 🔬) are still emojis — different surface, deeper in the modal, not on the landing page. Easy follow-up if you want them treated the same way.

No copy / API / persona / dataset changes.

## Test plan

- [ ] Clear `manifold:tour-seen` and reload — landing modal shows DomainIcon SVGs on every card, drawn in the domain's accent colour
- [ ] Pick a domain → its icon stays the colour (no re-tint), selection ring renders correctly
- [ ] Hover an inactive domain → no visible regression on layout (icon size is 22px, slightly tighter than the old `text-xl` emoji)
- [ ] Open the workspace trigger pill row in the platform header — selected domain icons render as small (14px) SVGs in the same colours, not as the literal strings "bolt" / "factory" / etc.
- [ ] Test all five persona pills (FINANCIAL / MACRO / GEOPOLITICAL / SCIENTIST / CROSS-DOMAIN) — every visible card has an icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)
