### PR TITLE
feat(feeds): WB matcher fan-out + 4 fertilizer-market nodes live

### DIFF
--- a/scripts/check-feed-health.ts
+++ b/scripts/check-feed-health.ts
@@ -7,8 +7,16 @@
  *   npx tsx scripts/check-feed-health.ts                # against prod
  *   BASE=http://localhost:3000 npx tsx scripts/check-feed-health.ts
  *
- * Reads no secrets — the keys live in the server's env. Useful right
- * after rotating FRED_API_KEY on Vercel to confirm the next deploy
+ * Prod's /api/feeds/* routes are behind Supabase auth, so against prod
+ * you need to pass a session cookie:
+ *
+ *   AUTH_COOKIE='sb-...=...; sb-...-auth-token=...' npm run check:feeds
+ *
+ * Grab the cookie from a logged-in browser session (DevTools → Application →
+ * Cookies → manifold.apexanalytica.co → copy the sb-* entries).
+ *
+ * Reads no secrets — the FRED/WB keys live in the server's env. Useful
+ * right after rotating FRED_API_KEY on Vercel to confirm the next deploy
  * flipped every series from mock → live.
  *
  * Exits 0 if at least one series is live and none are unexpectedly
@@ -18,6 +26,7 @@ import { FRED_SERIES } from "../src/lib/feeds/fred";
 import { WB_SERIES } from "../src/lib/feeds/world-bank";
 
 const BASE = process.env.BASE ?? "https://manifold.apexanalytica.co";
+const AUTH_COOKIE = process.env.AUTH_COOKIE;
 
 type Verdict = "LIVE" | "MOCK" | "MISS";
 interface Row {
@@ -38,7 +47,18 @@ function paint(v: Verdict): string {
 
 async function fetchJson(path: string): Promise<unknown> {
   const url = `${BASE}${path}`;
-  const r = await fetch(url, { signal: AbortSignal.timeout(30_000) });
+  const r = await fetch(url, {
+    headers: AUTH_COOKIE ? { cookie: AUTH_COOKIE } : {},
+    redirect: "manual",
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (r.status === 307 || r.status === 302) {
+    throw new Error(
+      `${url} → HTTP ${r.status} → ${r.headers.get("location") ?? "?"}. ` +
+        `The feed route is auth-gated; pass AUTH_COOKIE='sb-...-auth-token=...' ` +
+        `(from a logged-in browser session) and retry.`,
+    );
+  }
   if (!r.ok) throw new Error(`${url} → HTTP ${r.status}`);
   return r.json();
 }

--- a/src/lib/__tests__/feeds/world-bank.test.ts
+++ b/src/lib/__tests__/feeds/world-bank.test.ts
@@ -180,4 +180,33 @@ describe("worldBankProvider.matchPayload", () => {
     expect(batch.updates).toHaveLength(0);
     expect(batch.event).toBeUndefined();
   });
+
+  it("fans one observation out to every label-pattern match", () => {
+    // Regression: before the matcher fix, `nodes.find(...)` returned the
+    // first label-pattern match and silently dropped subsequent ones.
+    // The 4 fertilizer-market nodes (qf_/mn_ India + Brazil) need
+    // one (country, indicator) observation to drive multiple downstream
+    // nodes — this asserts the fan-out works.
+    const nodes = [
+      makeNode({ id: "qf_india_fertilizer_market", label: "India fertilizer import market" }),
+      makeNode({ id: "mn_india_fertilizer_market", label: "India fertilizer market" }),
+      makeNode({ id: "qf_brazil_fertilizer_market", label: "Brazil fertilizer import market" }),
+      makeNode({ id: "mn_brazil_fertilizer_market", label: "Brazil fertilizer market" }),
+      makeNode({ id: "qf_australia_fertilizer_market", label: "Australia fertilizer customer market" }),
+      makeNode({ id: "qf_usa_fertilizer_market", label: "United States fertilizer customer market" }),
+    ];
+    const feed = mockWorldBankFeed();
+    const batch = worldBankProvider.matchPayload(feed, nodes);
+    const matchedIds = batch.updates.map((u) => u.nodeId).sort();
+
+    // The single IND/AG.CON.FERT.ZS observation should hit BOTH India nodes.
+    expect(matchedIds).toContain("qf_india_fertilizer_market");
+    expect(matchedIds).toContain("mn_india_fertilizer_market");
+    // Same for the single BRA/AG.CON.FERT.ZS observation.
+    expect(matchedIds).toContain("qf_brazil_fertilizer_market");
+    expect(matchedIds).toContain("mn_brazil_fertilizer_market");
+    // Australia / USA labels (with "customer market") must NOT collide.
+    expect(matchedIds).not.toContain("qf_australia_fertilizer_market");
+    expect(matchedIds).not.toContain("qf_usa_fertilizer_market");
+  });
 });

--- a/src/lib/feeds/providers/world-bank.ts
+++ b/src/lib/feeds/providers/world-bank.ts
@@ -16,18 +16,37 @@ function findSeriesConfig(obs: WbObservation) {
   );
 }
 
-function matchSeriesToNode(
+/**
+ * Resolve every node whose label matches the WB series' label patterns.
+ *
+ * Returns 0..N nodes — fan-out is required because a single (country,
+ * indicator) tuple can legitimately drive multiple graph nodes. Concrete
+ * case: WB `IND / AG.CON.FERT.ZS` (India fertilizer consumption) is the
+ * canonical free signal for *both* `qf_india_fertilizer_market` (QAFCO
+ * export market) and `mn_india_fertilizer_market` (Ma'aden export market)
+ * — same upstream signal, two downstream nodes. Same story for Brazil.
+ *
+ * Previously this returned a single node via `nodes.find(...)`, silently
+ * dropping every subsequent match. The bug was masked while every wired
+ * series only had one downstream node, and surfaced when the fertilizer
+ * batch came along.
+ */
+function matchSeriesToNodes(
   obs: WbObservation,
   nodes: ReadonlyArray<CausalNode>,
-): CausalNode | undefined {
+): CausalNode[] {
   const config = findSeriesConfig(obs);
-  if (!config) return undefined;
+  if (!config) return [];
+  const matched = new Set<CausalNode>();
   for (const pattern of config.labelPatterns) {
     const needle = pattern.toLowerCase();
-    const match = nodes.find((n) => n.label.toLowerCase().includes(needle));
-    if (match) return match;
+    for (const node of nodes) {
+      if (node.label.toLowerCase().includes(needle)) {
+        matched.add(node);
+      }
+    }
   }
-  return undefined;
+  return [...matched];
 }
 
 export const worldBankProvider: FeedProvider<WorldBankFeed> = {
@@ -42,8 +61,8 @@ export const worldBankProvider: FeedProvider<WorldBankFeed> = {
     let liveCount = 0;
 
     for (const obs of payload.observations) {
-      const node = matchSeriesToNode(obs, nodes);
-      if (!node) continue;
+      const matchedNodes = matchSeriesToNodes(obs, nodes);
+      if (matchedNodes.length === 0) continue;
       const config = findSeriesConfig(obs);
       const kind = config?.kind ?? "indicator";
       const point: LiveDataPoint = {
@@ -55,10 +74,13 @@ export const worldBankProvider: FeedProvider<WorldBankFeed> = {
         source: obs.source,
         history: obs.history,
       };
-      updates.push({ nodeId: node.id, point });
-      affectedNodeIds.push(node.id);
-      kindSet.add(kind);
-      if (!obs.source.toLowerCase().includes("(mock")) liveCount += 1;
+      const isLive = !obs.source.toLowerCase().includes("(mock");
+      for (const node of matchedNodes) {
+        updates.push({ nodeId: node.id, point });
+        affectedNodeIds.push(node.id);
+        kindSet.add(kind);
+        if (isLive) liveCount += 1;
+      }
     }
 
     return {

--- a/src/lib/feeds/world-bank.ts
+++ b/src/lib/feeds/world-bank.ts
@@ -203,6 +203,40 @@ export const WB_SERIES: WbSeriesConfig[] = [
     mockValue: -0.2,
     kind: "governance",
   },
+  // Phase 13 — promote the 4 fertilizer-market nodes (QAFCO + Ma'aden
+  // export destinations for India and Brazil) to live via WB
+  // AG.CON.FERT.ZS (Fertilizer consumption, kg per hectare of arable
+  // land). Annual cadence, free, no key. India ~165 kg/ha, Brazil ~390
+  // kg/ha in recent years — both far above the world average ~140,
+  // confirming high import-dependent demand.
+  //
+  // Each entry's label pattern intentionally fans out across TWO nodes:
+  // "india fertilizer" matches both `qf_india_fertilizer_market` ("India
+  // fertilizer import market") and `mn_india_fertilizer_market` ("India
+  // fertilizer market"), but NOT the QAFCO Australia/USA nodes (whose
+  // labels include "customer market" without the country-then-fertilizer
+  // ordering). The provider matcher now fan-outs one observation → all
+  // pattern matches; see `providers/world-bank.ts`.
+  {
+    country: "IND",
+    indicator: "AG.CON.FERT.ZS",
+    label: "India Fertilizer Consumption (kg/ha of arable land)",
+    labelPatterns: ["india fertilizer"],
+    scale: 1,
+    unit: "kg/ha",
+    capacity: 250, // elevated regime — India runs ~165, world avg ~140
+    mockValue: 175,
+  },
+  {
+    country: "BRA",
+    indicator: "AG.CON.FERT.ZS",
+    label: "Brazil Fertilizer Consumption (kg/ha of arable land)",
+    labelPatterns: ["brazil fertilizer"],
+    scale: 1,
+    unit: "kg/ha",
+    capacity: 500, // elevated regime — Brazil runs ~390 (one of the world's heaviest users)
+    mockValue: 388,
+  },
 ];
 
 export interface WbObservation {


### PR DESCRIPTION
## Summary

- **Fix WB provider matcher fan-out** — `matchSeriesToNode` returned a single node via `nodes.find(...)`, silently dropping every subsequent label-pattern match. Replaced with `matchSeriesToNodes` returning `CausalNode[]` (Set-based dedupe across patterns). `matchPayload` now fans one observation out to all matching nodes; `liveCount` increments per node so the event description balances.
- **Promote 4 fertilizer-market nodes to live** — 2 new `WB_SERIES` entries on `AG.CON.FERT.ZS` (India + Brazil, fertilizer consumption kg/ha). Each entry fans out to both the QAFCO (`qf_*`) and Maaden (`mn_*`) downstream node for that country. QAFCO Australia / USA siblings use "customer market" phrasing and intentionally do NOT collide.
- **Coverage**: 62 → 66 live / 211 total. Remaining bare unchanged.
- **Secondary** (separate commit): `scripts/check-feed-health.ts` now accepts an `AUTH_COOKIE` env var so it can probe prod's auth-gated `/api/feeds/*` routes. Detects the 307 → /login redirect explicitly with a clear remediation message.

### Files

| File | Change |
|---|---|
| `src/lib/feeds/providers/world-bank.ts` | Matcher fan-out (`nodes.find` → Set-based filter) |
| `src/lib/feeds/world-bank.ts` | +2 WB_SERIES entries (IND + BRA on AG.CON.FERT.ZS) |
| `src/lib/__tests__/feeds/world-bank.test.ts` | +1 fan-out regression test |
| `scripts/check-feed-health.ts` | Auth-cookie support + redirect diagnostic |

## Out of scope

- The 2 WB `MISS` entries surfaced in the May verification (PAK `GC.DOD.TOTL.GD.ZS`, WLD `FP.CPI.TOTL.ZG`) — both tuples exist upstream but recent years are `value: null`. Data-availability issue; needs a longer lookback or indicator swap. Deferred to a follow-up.
- `src/lib/node-timeseries-map.ts` entries for these 4 nodes still point to legacy proxies (gas exports, fertilizer_price_index). The WB provider hydrates the live tick on top; the historical layer keeps providing context. Refactor of the historical layer is a separate concern.

## Test plan

- [x] `npx vitest run src/lib/__tests__/feeds/world-bank.test.ts` — 12/12 pass (added 1 new test)
- [x] `npx vitest run src/lib/__tests__/feeds/` — 66/66 pass (no regressions in fred/eia/ofac/clinical/openfda/derivations)
- [x] tsc clean for all 4 changed files (pre-existing tsc errors elsewhere are unrelated)
- [ ] After merge: verify on prod via `AUTH_COOKIE='...' npm run check:feeds` that World Bank reports `12 expected · LIVE 12 · MOCK 0` (was `10 · LIVE 10` before, +2 with the new entries)
- [ ] After merge: confirm the 4 fertilizer-market tiles render a live value (not "LIVE — building") in the canvas

🤖 Generated with [Claude Code](https://claude.com/claude-code)
