### PR TITLE
fix(middleware): make /api/feeds public — kill ERR_CONNECTION_TIMED_OUT spam

### DIFF
--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -39,7 +39,18 @@ export async function updateSession(request: NextRequest) {
   // API-key validator from PR #337 actually gets to run — the
   // session middleware was 307-redirecting valid API-key requests to
   // /login before the validator could see them.
-  const publicRoutes = ["/login", "/trial-signup", "/trusted-signup", "/api/trusted-signup", "/api/webhooks", "/expired", "/forgot-password", "/reset-password", "/auth", "/pricing", "/request-access", "/api/request-access", "/api/discovery"];
+  //
+  // `/api/feeds` is here because every handler under it just proxies
+  // a public data source (FRED, EIA, World Bank, ClinicalTrials.gov,
+  // OFAC, OpenFDA, plus the derivation stub) — no user context, no
+  // per-tier quota, no PII. Routing them through the session check
+  // added a `supabase.auth.getUser()` round-trip on every poll, which
+  // cold-starts to ~18s on the derivations endpoint and starves
+  // Chrome's per-origin connection pool — surfacing as
+  // ERR_CONNECTION_TIMED_OUT spam in the browser console during the
+  // Hormuz demo. Making feeds public eliminates that hop while leaving
+  // session auth on every other API path untouched.
+  const publicRoutes = ["/login", "/trial-signup", "/trusted-signup", "/api/trusted-signup", "/api/webhooks", "/expired", "/forgot-password", "/reset-password", "/auth", "/pricing", "/request-access", "/api/request-access", "/api/discovery", "/api/feeds"];
   const isPublic =
     publicRoutes.some((r) => pathname.startsWith(r)) ||
     pathname.startsWith("/_next") ||


### PR DESCRIPTION
## Summary
- Adds `/api/feeds` to the middleware's `publicRoutes` allowlist so feed-proxy handlers skip the `supabase.auth.getUser()` round-trip
- Same pattern PR #346 used for `/api/discovery` — session auth on every other API path (copilot, structure, compute, admin, news, etc.) is unchanged

## Why
Hormuz demo console showed repeating `ERR_CONNECTION_TIMED_OUT` errors against `/api/feeds/eia/hormuz` and `/api/feeds/derivations/trigger`. Direct probe against prod confirmed the cause:

| Endpoint | Response time | Status |
| --- | --- | --- |
| `/api/feeds/eia/hormuz` | 6.99s | 307 → /login |
| `/api/feeds/derivations/trigger` | 18.88s | 307 → /login |
| `/api/feeds/fred/series` | 4.77s | 307 → /login |

That's the unauthenticated path, but the in-browser warm path still pays the `supabase.auth.getUser()` round-trip. `useFeedRegistry` fires `tick()` immediately on graph load, then every 5 minutes — those slow auth-gated polls saturate Chrome's per-origin connection pool (default 6) when stacked with copilot streams + Supabase auth checks, and the kernel reports `ERR_CONNECTION_TIMED_OUT`.

## Verified there's no user context in feed handlers

```
grep -rln "supabase\|getUser\|session\|cookies" src/app/api/feeds/ src/lib/feeds/
# (no matches)
```

Every handler proxies a public data source (FRED, EIA, World Bank, ClinicalTrials.gov, OFAC, OpenFDA, plus the `derivations/trigger` stub). No PII, no per-tier quota, no user-scoped output.

## Test plan
- [ ] Vercel preview deploys
- [ ] Open the preview, sign in, launch the Hormuz demo
- [ ] DevTools Console — no `ERR_CONNECTION_TIMED_OUT` against `/api/feeds/*`
- [ ] DevTools Network — `/api/feeds/derivations/trigger` returns 200 in < 1s (was 307 in 18s)
- [ ] Other API paths still require auth (visit `/api/copilot/...` while logged out → 307)

🤖 Generated with [Claude Code](https://claude.com/claude-code)