### PR TITLE
fix(feeds): clear 2 WB MISS entries — PAK debt swap, drop dead WLD CPI

### DIFF
--- a/src/lib/feeds/world-bank.ts
+++ b/src/lib/feeds/world-bank.ts
@@ -79,17 +79,15 @@ export const WB_SERIES: WbSeriesConfig[] = [
     capacity: 80,
     mockValue: 60.5,
   },
-  // Global aggregate
-  {
-    country: "WLD",
-    indicator: "FP.CPI.TOTL.ZG",
-    label: "Global CPI Inflation YoY",
-    labelPatterns: ["global cpi"],
-    scale: 1,
-    unit: "%",
-    capacity: 6,
-    mockValue: 4.5,
-  },
+  // Global CPI YoY intentionally absent from WB. We probed every plausible
+  // regional aggregate (WLD, LMY, HIC, EMU, OED) and FP.CPI.TOTL.ZG is
+  // null at every aggregate level — WB only computes CPI inflation for
+  // individual countries. The "Macro Impact: Inflation & Policy" graph
+  // domain is FRED-owned (CPIAUCSL etc.); WB doesn't have a useful lane
+  // here. Previous entry (WLD/FP.CPI.TOTL.ZG) wired to label pattern
+  // "global cpi" which matched ZERO graph nodes, so removing it has no
+  // downstream effect — just eliminates a permanent MISS in the
+  // check-feeds verification.
   // Phase 8 — MENA Import Dependency real data. World Bank aggregates the
   // Middle East & North Africa region as country code "MEA". The indicator
   // NE.IMP.GNFS.ZS (Imports of goods and services, % of GDP) is the
@@ -132,15 +130,24 @@ export const WB_SERIES: WbSeriesConfig[] = [
     capacity: 700,
     mockValue: 605,
   },
+  // Originally wired to PAK/GC.DOD.TOTL.GD.ZS (central gov debt % GDP)
+  // but that WB series has been null for Pakistan since 2000 — likely a
+  // reporting gap. Swapped to DT.DOD.DECT.GN.ZS (external debt stocks %
+  // of GNI) which has 2024 data and is arguably the BETTER contagion
+  // signal for Pakistan anyway: FX-denominated external debt + IMF
+  // program dependence is what actually drives PAK distress episodes.
+  // Capacity recalibrated to 50 (IMF DSA "high external debt"
+  // threshold) since external-debt % GNI regimes run lower than
+  // central-gov-debt % GDP regimes.
   {
     country: "PAK",
-    indicator: "GC.DOD.TOTL.GD.ZS",
-    label: "Pakistan Central Government Debt (% of GDP)",
+    indicator: "DT.DOD.DECT.GN.ZS",
+    label: "Pakistan External Debt Stocks (% of GNI)",
     labelPatterns: ["debt-to-gdp ratio", "debt to gdp"],
     scale: 1,
     unit: "%",
-    capacity: 80,
-    mockValue: 76,
+    capacity: 50,
+    mockValue: 36,
   },
   {
     country: "TUR",


### PR DESCRIPTION
## Summary

Clears the two World Bank entries that came up as `MISS` in the May verification pass. Both root-caused; both fixed.

### PAK debt: indicator swap

Original `GC.DOD.TOTL.GD.ZS` (central gov debt % of GDP) has been **null for Pakistan since 2000** — a 25-year WB reporting gap, not a bug we can fix. Swapped to `DT.DOD.DECT.GN.ZS` (external debt stocks % of GNI), which has 2024 data (35.63%, 2023=39.45%).

Arguably the *better* contagion signal for Pakistan anyway — FX-denominated external debt + IMF-program dependence is what actually drives PAK distress episodes, not central-gov balance-sheet ratios. The `fc_debt_to_gdp` graph node's label patterns (`"debt-to-gdp ratio"`, `"debt to gdp"`) still match the same downstream node — no routing change.

Capacity recalibrated 80 → 50 (IMF DSA "high external debt" threshold; external-debt % GNI regimes run lower than central-gov-debt % GDP regimes). MockValue 76 → 36.

### WLD CPI: delete (orphaned both ways)

Probed every plausible regional aggregate:

| Aggregate | FP.CPI.TOTL.ZG status |
|---|---|
| WLD (World) | null at every year |
| LMY (Low/middle income) | null at every year |
| HIC (High income) | null at every year |
| EMU (Eurozone) | null in 2025 |
| OED (OECD) | null at every year |

WB only computes CPI inflation for individual countries — there's no working WLD lane.

Compounding: the label pattern `"global cpi"` matched **zero** graph nodes (verified via `grep -i "global cpi" src/lib/graph-data.ts`). So the entry was orphaned both upstream (no data) and downstream (no wiring). Removing it eliminates a permanent MISS and has no downstream effect.

The `"Macro Impact: Inflation & Policy"` graph domain (25 nodes from line 2027) is FRED-owned via `CPIAUCSL` and friends — that's the right lane for CPI signals.

### Coverage delta

| | Before | After |
|---|---|---|
| Live (WB) | 10 | 11 |
| MISS (WB) | 2 | 0 |
| WB_SERIES count | 12 (after #347) | 11 |

Total graph coverage: 66 → 67 live / 211.

Expected `check:feeds` verdict after merge:
```
=== World Bank === 11 expected · LIVE 11 · MOCK 0 · MISS 0
```

## Stacked on #347

This PR is stacked on top of #347 (matcher fan-out + fertilizer wiring), which is still open and edits the same file. When #347 merges to main, GitHub will auto-rebase this PR's base.

## Test plan

- [x] `npx vitest run src/lib/__tests__/feeds/world-bank.test.ts` — 12/12 pass (no test changes needed; mock-feed test iterates `WB_SERIES.length`, "tuples are unique" still holds)
- [x] Direct WB probe of new indicator: `curl .../PAK/indicator/DT.DOD.DECT.GN.ZS` returns 2024=35.63, 2023=39.45 — provider will pick 2024 as latest (per_page=20, parser drops null 2025)
- [ ] After merge + redeploy: re-run `AUTH_COOKIE='...' npm run check:feeds` and confirm `World Bank === 11 expected · LIVE 11 · MOCK 0 · MISS 0`
- [ ] After merge: confirm `fc_debt_to_gdp` tile in the canvas shows 35.6% (with the source string indicating `PAK/DT.DOD.DECT.GN.ZS (period 2024)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
