### PR TITLE
perf(interdiction): async solver — CASCADE DEFENSE no longer freezes the UI

### DIFF
--- a/src/components/InterdictionPanel.tsx
+++ b/src/components/InterdictionPanel.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useApexStore } from "@/stores/useApexStore";
 import {
-  solveInterdiction,
+  solveInterdictionAsync,
   InterdictionResult,
 } from "@/lib/interdiction-engine";
 
@@ -19,17 +19,64 @@ export default function InterdictionPanel() {
   const [mode, setMode] = useState<InterdictionMode>("edge");
   const [result, setResult] = useState<InterdictionResult | null>(null);
   const [computing, setComputing] = useState(false);
+  // Progress in [0, 1] — drives the percentage shown on the SOLVE
+  // button while the async solver yields between candidate evaluations.
+  // Null when no run is in flight.
+  const [progress, setProgress] = useState<number | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
 
   const canRun = shocks.length > 0;
 
-  const runInterdiction = useCallback(() => {
+  // Cancel any in-flight solve on unmount so a long Hormuz run doesn't
+  // keep emitting progress callbacks after the user has navigated away.
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  const runInterdiction = useCallback(async () => {
+    // Cancel any previous run before starting a new one — clicking
+    // SOLVE twice in quick succession should switch to the new params,
+    // not stack two solvers fighting over `setResult`.
+    abortRef.current?.abort();
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
+
     setComputing(true);
-    // Defer to next frame so UI updates with "computing" state
-    requestAnimationFrame(() => {
-      const r = solveInterdiction(graphData, shocks, severedEdges, budget, mode);
-      setResult(r);
-      setComputing(false);
-    });
+    setProgress(0);
+    try {
+      const r = await solveInterdictionAsync(
+        graphData,
+        shocks,
+        severedEdges,
+        budget,
+        mode,
+        {
+          signal: ctrl.signal,
+          onProgress: (done, total) => {
+            if (ctrl.signal.aborted) return;
+            setProgress(total > 0 ? Math.min(1, done / total) : null);
+          },
+        },
+      );
+      if (!ctrl.signal.aborted) {
+        setResult(r);
+      }
+    } catch (e) {
+      // Abort is the expected "user clicked SOLVE again" path; any
+      // other error means the solver itself blew up — keep the prior
+      // result on screen and surface to the console rather than
+      // wedging the UI on a partial state.
+      if (!(e instanceof DOMException && e.name === "AbortError")) {
+        console.error("[InterdictionPanel] solver failed:", e);
+      }
+    } finally {
+      if (!ctrl.signal.aborted) {
+        setComputing(false);
+        setProgress(null);
+      }
+    }
   }, [graphData, shocks, severedEdges, budget, mode]);
 
   const applyIntervention = useCallback(
@@ -96,7 +143,11 @@ export default function InterdictionPanel() {
           background: computing ? "rgba(255, 171, 0, 0.15)" : "rgba(255, 171, 0, 0.05)",
         }}
       >
-        {computing ? "COMPUTING MINIMAX..." : "SOLVE CASCADE DEFENSE"}
+        {computing
+          ? progress !== null
+            ? `COMPUTING MINIMAX… ${Math.round(progress * 100)}%`
+            : "COMPUTING MINIMAX…"
+          : "SOLVE CASCADE DEFENSE"}
       </button>
 
       {!canRun && (

--- a/src/components/VX880TrialPanel.tsx
+++ b/src/components/VX880TrialPanel.tsx
@@ -13,7 +13,7 @@ import {
   VX880_COVARIATE_BASELINE,
   computeCovariateLogHR,
 } from "@/lib/vx880-trial-data";
-import { solveInterdiction } from "@/lib/interdiction-engine";
+import { solveInterdictionAsync } from "@/lib/interdiction-engine";
 import type { CausalShock } from "@/lib/types";
 
 // ─── C-peptide trajectory chart ─────────────────────────────────────
@@ -524,16 +524,27 @@ export default function VX880TrialPanel() {
   // broadcast across science-category nodes saturates the cascade and
   // collapses the solver's marginal-reduction step to "no candidate cuts".
   const runPreset = useCallback(
-    (preset: VX880Preset) => {
+    async (preset: VX880Preset) => {
       if (!hasVx880) return;
-      const result = solveInterdiction(
-        graphData,
-        preset.shocks,
-        severedEdges,
-        3,
-        "edge",
-      );
-      setLastInterdictionResult(result);
+      // VX-880 subgraph is small (~30 nodes) so the solver finishes in
+      // < 1s sync. Going async still wins because it stops blocking the
+      // C-peptide / Cox panel rerenders that fire off this click handler.
+      try {
+        const result = await solveInterdictionAsync(
+          graphData,
+          preset.shocks,
+          severedEdges,
+          3,
+          "edge",
+        );
+        setLastInterdictionResult(result);
+      } catch (e) {
+        // AbortError is benign (component unmounting mid-run); anything
+        // else is a real solver failure worth logging.
+        if (!(e instanceof DOMException && e.name === "AbortError")) {
+          console.error("[VX880TrialPanel] preset solver failed:", e);
+        }
+      }
     },
     [hasVx880, graphData, severedEdges, setLastInterdictionResult],
   );

--- a/src/lib/__tests__/t1d-vx880-graph-data.test.ts
+++ b/src/lib/__tests__/t1d-vx880-graph-data.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { VX880_GRAPH } from "../t1d-vx880-graph-data";
 import { simulateCascade } from "../cascade-simulator";
-import { solveInterdiction } from "../interdiction-engine";
+import { solveInterdiction, solveInterdictionAsync } from "../interdiction-engine";
 import { DOMAIN_MAP } from "@/hooks/useFilteredGraph";
 import type { CausalShock } from "../types";
 
@@ -103,5 +103,81 @@ describe("VX-880 flagship graph", () => {
     expect(result.baselineDamage).toBeGreaterThan(0);
     expect(result.interventions.length).toBeGreaterThan(0);
     expect(result.interventions[0].marginalReduction).toBeGreaterThan(0);
+  });
+
+  it("async solver returns the same interventions as the sync solver", async () => {
+    // The async variant has to be identical to the sync one — same
+    // greedy minimax algorithm, same `simulateCascade` call per
+    // candidate, same `computeDamage` scoring. The only differences are
+    // the periodic yield and the optional progress callback, neither of
+    // which should alter the picked interventions or their damages.
+    // This guard catches accidental divergence on future edits
+    // (re-ordering the inner loop, dropping a budget step, etc.).
+    const shock: CausalShock = {
+      id: "health_shock_async",
+      name: "Autoimmune recurrence flare",
+      severity: 0.6,
+      category: "health",
+      description: "Synthetic health shock",
+    };
+    const sync = solveInterdiction(VX880_GRAPH, [shock], [], 3, "edge");
+    const async = await solveInterdictionAsync(VX880_GRAPH, [shock], [], 3, "edge");
+
+    expect(async.baselineDamage).toBe(sync.baselineDamage);
+    expect(async.bestDamage).toBe(sync.bestDamage);
+    expect(async.reductionPct).toBe(sync.reductionPct);
+    expect(async.interventions.length).toBe(sync.interventions.length);
+    for (let i = 0; i < sync.interventions.length; i++) {
+      expect(async.interventions[i].target.id).toBe(sync.interventions[i].target.id);
+      expect(async.interventions[i].target.type).toBe(sync.interventions[i].target.type);
+      expect(async.interventions[i].damage).toBe(sync.interventions[i].damage);
+      expect(async.interventions[i].marginalReduction).toBe(
+        sync.interventions[i].marginalReduction,
+      );
+    }
+  });
+
+  it("async solver respects AbortSignal", async () => {
+    const shock: CausalShock = {
+      id: "health_shock_abort",
+      name: "Autoimmune recurrence flare",
+      severity: 0.6,
+      category: "health",
+      description: "Synthetic health shock",
+    };
+    const ctrl = new AbortController();
+    // Abort immediately so the solver bails before completing its
+    // first cascade run. This proves the signal is plumbed through;
+    // production callers (InterdictionPanel) rely on it to cancel a
+    // run when the user clicks SOLVE twice in quick succession.
+    ctrl.abort();
+    await expect(
+      solveInterdictionAsync(VX880_GRAPH, [shock], [], 3, "edge", {
+        signal: ctrl.signal,
+      }),
+    ).rejects.toThrow(/abort/i);
+  });
+
+  it("async solver emits progress callbacks", async () => {
+    const shock: CausalShock = {
+      id: "health_shock_progress",
+      name: "Autoimmune recurrence flare",
+      severity: 0.6,
+      category: "health",
+      description: "Synthetic health shock",
+    };
+    // Yield aggressively so we definitely get at least one mid-run
+    // progress callback even on a small graph. yieldEveryMs=0 means
+    // every candidate evaluation gets a yield.
+    const calls: Array<{ done: number; total: number }> = [];
+    await solveInterdictionAsync(VX880_GRAPH, [shock], [], 2, "edge", {
+      yieldEveryMs: 0,
+      onProgress: (done, total) => calls.push({ done, total }),
+    });
+    expect(calls.length).toBeGreaterThan(0);
+    // Monotonically non-decreasing `done` across the run.
+    for (let i = 1; i < calls.length; i++) {
+      expect(calls[i].done).toBeGreaterThanOrEqual(calls[i - 1].done);
+    }
   });
 });

--- a/src/lib/interdiction-engine.ts
+++ b/src/lib/interdiction-engine.ts
@@ -223,3 +223,221 @@ export function solveInterdiction(
     reductionPct,
   };
 }
+
+// ─── Async Variant ──────────────────────────────────────────────
+
+/**
+ * Options for `solveInterdictionAsync`.
+ */
+export interface SolveInterdictionAsyncOptions {
+  /** AbortSignal — when triggered, rejects with an AbortError. */
+  signal?: AbortSignal;
+  /**
+   * Progress callback fired periodically as candidate evaluations
+   * complete. `done` is candidates evaluated so far across all budget
+   * steps; `total` is the approximate maximum (budget × initial
+   * candidate count). The actual total can be lower if the budget loop
+   * exits early on a non-improving step.
+   */
+  onProgress?: (done: number, total: number) => void;
+  /**
+   * Time budget per uninterrupted sync slice, in ms. Once this elapses
+   * the solver yields to the event loop (so paint + input handlers can
+   * run) before resuming. Lower = smoother UI, slightly more overhead.
+   * Default 50ms — matches `requestIdleCallback`'s default deadline.
+   */
+  yieldEveryMs?: number;
+}
+
+/**
+ * Async variant of `solveInterdiction` — same greedy minimax algorithm
+ * and identical output, but yields to the event loop periodically so a
+ * Hormuz-sized graph (~350 edges × budget=3 ≈ 1,000+ cascade
+ * simulations) doesn't freeze the UI for the full ~5–15s solve. The
+ * cascade simulator itself is still called synchronously per candidate
+ * — each inner `simulateCascade` is fast enough (~10–50ms) that
+ * splitting it would add more yield-overhead than win-back. The yield
+ * happens between candidates.
+ *
+ * Tests and non-UI callers (copilot tool, local-provider) should keep
+ * using the sync `solveInterdiction` — deterministic single-tick
+ * execution and no Promise plumbing.
+ */
+export async function solveInterdictionAsync(
+  graph: CausalGraph,
+  shocks: CausalShock[],
+  severedEdges: string[],
+  budget: number = 3,
+  mode: "edge" | "node" | "both" = "edge",
+  options: SolveInterdictionAsyncOptions = {},
+): Promise<InterdictionResult> {
+  const { signal, onProgress, yieldEveryMs = 50 } = options;
+
+  const baseOmegaMap = new Map<string, number>();
+  for (const node of graph.nodes) {
+    baseOmegaMap.set(node.id, node.omegaFragility.composite);
+  }
+
+  // Baseline: no interventions. One cascade — fast enough to keep sync.
+  const baselineEpochs = simulateCascade(graph, shocks, severedEdges);
+  const baselineDamage = computeDamage(baselineEpochs, baseOmegaMap);
+
+  const interventions: InterdictionCandidate[] = [];
+  const removedEdgeIds = new Set(severedEdges);
+  const removedNodeIds = new Set<string>();
+  let currentDamage = baselineDamage;
+
+  // Estimate total candidate evaluations so `onProgress` can render a
+  // sensible bar. Uses the *initial* candidate count; the real total is
+  // a bit lower because each accepted intervention prunes the candidate
+  // set for the next round. Close enough for UI feedback.
+  const initialCandidateCount =
+    (mode === "edge" || mode === "both" ? graph.edges.length : 0) +
+    (mode === "node" || mode === "both" ? graph.nodes.length : 0);
+  const totalCandidatesEstimate = Math.max(1, budget * initialCandidateCount);
+  let evaluatedCount = 0;
+  let lastYieldAt = performance.now();
+
+  for (let step = 0; step < budget; step++) {
+    if (signal?.aborted) {
+      throw new DOMException("solveInterdictionAsync aborted", "AbortError");
+    }
+
+    let bestCandidate: InterdictionCandidate | null = null;
+    let bestDamage = currentDamage;
+
+    const candidates: InterdictionTarget[] = [];
+
+    if (mode === "edge" || mode === "both") {
+      for (const edge of graph.edges) {
+        if (removedEdgeIds.has(edge.id) || edge.isSevered) continue;
+        if (removedNodeIds.has(edge.source) || removedNodeIds.has(edge.target)) continue;
+        candidates.push({
+          type: "edge",
+          id: edge.id,
+          label: `${graph.nodes.find((n) => n.id === edge.source)?.shortLabel ?? edge.source} → ${graph.nodes.find((n) => n.id === edge.target)?.shortLabel ?? edge.target}`,
+        });
+      }
+    }
+
+    if (mode === "node" || mode === "both") {
+      for (const node of graph.nodes) {
+        if (removedNodeIds.has(node.id)) continue;
+        candidates.push({
+          type: "node",
+          id: node.id,
+          label: node.shortLabel || node.label,
+        });
+      }
+    }
+
+    for (const candidate of candidates) {
+      let testGraph = graph;
+      const testSevered = [...removedEdgeIds];
+
+      if (candidate.type === "edge") {
+        testSevered.push(candidate.id);
+      } else {
+        const nodeId = candidate.id;
+        testGraph = {
+          ...graph,
+          nodes: graph.nodes.filter(
+            (n) => n.id !== nodeId && !removedNodeIds.has(n.id),
+          ),
+          edges: graph.edges.filter(
+            (e) =>
+              e.source !== nodeId &&
+              e.target !== nodeId &&
+              !removedNodeIds.has(e.source) &&
+              !removedNodeIds.has(e.target),
+          ),
+          metadata: graph.metadata,
+        };
+      }
+
+      const epochs = simulateCascade(testGraph, shocks, testSevered);
+      const damage = computeDamage(epochs, baseOmegaMap);
+
+      if (damage < bestDamage) {
+        bestDamage = damage;
+        bestCandidate = {
+          target: candidate,
+          damage,
+          marginalReduction: currentDamage - damage,
+        };
+      }
+
+      evaluatedCount++;
+
+      // Time-sliced yield: check the wall clock, not a fixed candidate
+      // count. Tiny graphs (T1D ~20 nodes) finish without yielding;
+      // big graphs (Hormuz ~350 edges) yield ~every 50ms. Adapts to
+      // simulator cost per candidate (which varies with topology) so
+      // the UI stays smooth across very different graph scales without
+      // any per-call tuning.
+      if (performance.now() - lastYieldAt > yieldEveryMs) {
+        if (signal?.aborted) {
+          throw new DOMException(
+            "solveInterdictionAsync aborted",
+            "AbortError",
+          );
+        }
+        if (onProgress) onProgress(evaluatedCount, totalCandidatesEstimate);
+        await yieldToEventLoop();
+        lastYieldAt = performance.now();
+      }
+    }
+
+    if (!bestCandidate || bestCandidate.marginalReduction < 0.01) break;
+
+    interventions.push(bestCandidate);
+    if (bestCandidate.target.type === "edge") {
+      removedEdgeIds.add(bestCandidate.target.id);
+    } else {
+      removedNodeIds.add(bestCandidate.target.id);
+    }
+    currentDamage = bestDamage;
+  }
+
+  // Final progress flush so consumers see "done" even if the last batch
+  // didn't cross the yield threshold.
+  if (onProgress) onProgress(evaluatedCount, evaluatedCount);
+
+  const bestDamage = interventions.length > 0
+    ? interventions[interventions.length - 1].damage
+    : baselineDamage;
+
+  const reductionPct = baselineDamage > 0
+    ? Math.round(((baselineDamage - bestDamage) / baselineDamage) * 100)
+    : 0;
+
+  return {
+    interventions,
+    baselineDamage: Math.round(baselineDamage * 10) / 10,
+    bestDamage: Math.round(bestDamage * 10) / 10,
+    reductionPct,
+  };
+}
+
+/**
+ * Yield to the event loop so paint + input handlers can run before the
+ * next chunk of solver work. Prefers `requestIdleCallback` (browsers,
+ * gives the runtime control over scheduling) and falls back to
+ * `setTimeout(_, 0)` for node test runs. Duplicated from the same util
+ * in cascade-simulator.ts — kept inline here to avoid cross-module
+ * coupling for a 15-line helper.
+ */
+function yieldToEventLoop(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const w = typeof globalThis !== "undefined"
+      ? (globalThis as unknown as {
+          requestIdleCallback?: (cb: () => void, opts?: { timeout?: number }) => void;
+        })
+      : undefined;
+    if (w?.requestIdleCallback) {
+      w.requestIdleCallback(() => resolve(), { timeout: 50 });
+    } else {
+      setTimeout(resolve, 0);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `solveInterdictionAsync` alongside the existing sync `solveInterdiction` in `src/lib/interdiction-engine.ts` — same greedy minimax algorithm, periodic yield between candidate evaluations
- `InterdictionPanel` migrated: async click handler with AbortSignal-based cancel-on-rerun, unmount cleanup, percent-progress in the button label
- `VX880TrialPanel.runPreset` migrated to async too — small graph finishes fast either way, but it stops blocking the NLME / Cox panel rerenders that share the click handler
- 3 new tests guard the async path

## Why
`solveInterdiction` runs a greedy minimax over candidate edge / node removals. For each candidate it does a fresh full cascade simulation, picks the best, repeats up to `budget` times. On a Hormuz-sized graph (~350 edges × budget=3) that's 1,000+ synchronous cascade simulations stacked into one click handler — main thread freezes for 5–15 seconds with no feedback.

The cascade simulator itself was already async-chunked in PR #258 but its sync entry point was what interdiction called. So all the PR #258 work didn't help CASCADE DEFENSE.

## Design choices
- **Yield between candidates, not between epochs.** Each inner `simulateCascade` is fast enough (~10–50ms) that splitting it would add more yield overhead than it wins back. Yielding between candidates puts the yield point at exactly the right granularity.
- **Time-sliced yield (`yieldEveryMs`, default 50ms).** Adapts to graph size: VX-880 (~30 nodes) finishes without yielding; Hormuz (~350 edges) keeps the UI responsive throughout. No per-call tuning needed.
- **`AbortSignal` plumbed through.** Clicking SOLVE twice in quick succession cancels the in-flight run instead of stacking two solvers fighting over the same `setResult`.
- **`onProgress(done, total)` callback.** Button now shows `COMPUTING MINIMAX… 47%` while the solver chews through candidates instead of an indeterminate spinner.

## What stays on the sync solver
- The dataset-shape regression test (`t1d-vx880-graph-data.test.ts`) — deterministic single-tick execution, no Promise plumbing.
- `src/lib/copilot/tools.ts` — tool registry handler signature is sync today; making handlers async-capable is a wider refactor that touches every tool. Copilot already shows "Thinking…" during execution so the freeze is at least labelled there. Separate follow-up.

## Test plan
- [x] `npx vitest run src/lib/__tests__/t1d-vx880-graph-data.test.ts` — 14/14 pass (11 existing + 3 new)
- [x] `npx tsc --noEmit` clean on the four touched files
- [x] `npx eslint` clean on the four touched files
- [ ] Vercel preview deploys
- [ ] In preview: inject a shock, click CASCADE DEFENSE, confirm the SOLVE button shows percent progress and the canvas stays responsive (drag the 3D view, hover edges) during the solve
- [ ] Click CASCADE DEFENSE twice in quick succession — only the second run's result should land

## Tests added
- `async solver returns the same interventions as the sync solver` — asserts byte-identical output (interventions order, damages, marginal reductions) on a real T1D-VX-880 health-shock cascade. Guards against accidental algorithmic divergence on future edits.
- `async solver respects AbortSignal` — pre-aborted controller → rejects with AbortError.
- `async solver emits progress callbacks` — `yieldEveryMs=0` forces a callback per candidate; asserts monotonically non-decreasing `done` count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
