### PR TITLE
polish(domains): swap DATA LAYERS category emojis for monochrome SVG icons

### DIFF
--- a/src/components/DomainIcon.tsx
+++ b/src/components/DomainIcon.tsx
@@ -25,16 +25,20 @@ export type DomainIconName =
   | "bolt"        // energy
   | "factory"     // manufacturing / fertilizer
   | "chain"       // supply chain
-  | "bank"        // financial contagion
-  | "globe"       // sovereign risk
+  | "bank"        // financial contagion / finance category
+  | "globe"       // sovereign risk / geopolitical category
   | "cable"       // undersea infrastructure
   | "shield"      // defense / ISR
-  | "chart-bar"   // labor / growth / housing
+  | "chart-bar"   // labor / growth / housing / economic category
   | "trending"    // inflation / policy
   | "dna"         // β-cell biology
   | "syringe"     // VX-880 stem-cell transplant
   | "brain"       // AI safety
-  | "atom";       // frontier science
+  | "atom"        // frontier science
+  | "wheat"       // agriculture category
+  | "antenna"     // communications category
+  | "flask"       // science category (broader than `atom` which is frontier-physics-specific)
+  | "tower";      // infrastructure category (transmission-tower silhouette; distinct from `cable` which is undersea-specific)
 
 interface DomainIconProps {
   name: DomainIconName;
@@ -214,6 +218,58 @@ export default function DomainIcon({
           <ellipse cx="12" cy="12" rx="9" ry="3.5" />
           <ellipse cx="12" cy="12" rx="9" ry="3.5" transform="rotate(60 12 12)" />
           <ellipse cx="12" cy="12" rx="9" ry="3.5" transform="rotate(120 12 12)" />
+        </svg>
+      );
+
+    case "wheat":
+      // Central stalk + three pairs of angled grain heads. Agriculture.
+      return (
+        <svg {...commonProps}>
+          {title && <title>{title}</title>}
+          <path d="M12 22 V4" />
+          <path d="M12 18 L8 16 M12 18 L16 16" />
+          <path d="M12 13 L8 11 M12 13 L16 11" />
+          <path d="M12 8 L8 6 M12 8 L16 6" />
+          <path d="M12 4 L10 5.5 M12 4 L14 5.5" />
+        </svg>
+      );
+
+    case "antenna":
+      // Vertical mast with three concentric broadcast arcs. Communications.
+      return (
+        <svg {...commonProps}>
+          {title && <title>{title}</title>}
+          <path d="M12 21 V11" />
+          <path d="M9 22 H15" />
+          <circle cx="12" cy="9" r="1.2" fill={color ?? "currentColor"} stroke="none" />
+          <path d="M9.5 7 A 3 3 0 0 1 14.5 7" />
+          <path d="M7 5 A 6 6 0 0 1 17 5" />
+          <path d="M4.5 3 A 9 9 0 0 1 19.5 3" />
+        </svg>
+      );
+
+    case "flask":
+      // Erlenmeyer flask — narrow neck + flared body + fluid line. Science.
+      return (
+        <svg {...commonProps}>
+          {title && <title>{title}</title>}
+          <path d="M9 3 H15" />
+          <path d="M10 3 V10 L5 20 H19 L14 10 V3" />
+          <path d="M7.5 15 H16.5" />
+        </svg>
+      );
+
+    case "tower":
+      // Transmission-tower silhouette — flared base, narrow top, two cross-braces.
+      // Infrastructure category. Distinct from `cable` which is specifically the
+      // undersea-cable iconography used by the infrastructure-resilience domain.
+      return (
+        <svg {...commonProps}>
+          {title && <title>{title}</title>}
+          <path d="M5 22 L10 3 L14 3 L19 22" />
+          <path d="M7.2 14 H16.8" />
+          <path d="M8.7 8 H15.3" />
+          <path d="M5 22 H19" />
         </svg>
       );
   }

--- a/src/components/DomainSelector.tsx
+++ b/src/components/DomainSelector.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/lib/build-domain-graph";
 import type { NodeCategory } from "@/lib/types";
 import TTSControls from "@/components/TTSControls";
-import DomainIcon from "@/components/DomainIcon";
+import DomainIcon, { type DomainIconName } from "@/components/DomainIcon";
 import { WELCOME_DESCRIPTION } from "@/lib/tour-steps";
 import { DemoFlowPicker } from "@/components/DemoFlowPlayer";
 
@@ -28,16 +28,25 @@ import { DemoFlowPicker } from "@/components/DemoFlowPlayer";
 export { DOMAIN_CARDS } from "@/lib/domains";
 export { buildGraphFromDomains } from "@/lib/build-domain-graph";
 
-const NODE_CATEGORIES: { id: NodeCategory; label: string; icon: string }[] = [
-  { id: "economic", label: "ECONOMIC", icon: "📊" },
-  { id: "finance", label: "FINANCE", icon: "💰" },
-  { id: "energy", label: "ENERGY", icon: "⚡" },
-  { id: "infrastructure", label: "INFRASTRUCTURE", icon: "🏗" },
-  { id: "manufacturing", label: "MANUFACTURING", icon: "🏭" },
-  { id: "agriculture", label: "AGRICULTURE", icon: "🌾" },
-  { id: "geopolitical", label: "GEOPOLITICAL", icon: "🌐" },
-  { id: "communications", label: "COMMUNICATIONS", icon: "📡" },
-  { id: "science", label: "SCIENCE", icon: "🔬" },
+// Category icons swapped from OS-rendered emojis to the same hand-drawn
+// monochrome line-art SVG system as the domain cards (PR #344). The
+// DATA LAYERS accordion sits one click into the Domain Workspace modal;
+// before this, expanding it surfaced the same 📊 💰 ⚡ 🏗 🏭 🌾 🌐 📡 🔬
+// glyphs we just spent PR #344 retiring from the landing-page cards.
+// Most categories reuse icons already defined for domains (chart-bar /
+// bank / bolt / factory / globe) — `wheat` / `antenna` / `flask` /
+// `tower` are new, added to `DomainIcon` so the same component renders
+// both surfaces.
+const NODE_CATEGORIES: { id: NodeCategory; label: string; icon: DomainIconName }[] = [
+  { id: "economic", label: "ECONOMIC", icon: "chart-bar" },
+  { id: "finance", label: "FINANCE", icon: "bank" },
+  { id: "energy", label: "ENERGY", icon: "bolt" },
+  { id: "infrastructure", label: "INFRASTRUCTURE", icon: "tower" },
+  { id: "manufacturing", label: "MANUFACTURING", icon: "factory" },
+  { id: "agriculture", label: "AGRICULTURE", icon: "wheat" },
+  { id: "geopolitical", label: "GEOPOLITICAL", icon: "globe" },
+  { id: "communications", label: "COMMUNICATIONS", icon: "antenna" },
+  { id: "science", label: "SCIENCE", icon: "flask" },
 ];
 
 const DISCOVERY_SOURCES = [
@@ -418,7 +427,7 @@ export default function DomainSelector() {
                               <button
                                 key={cat.id}
                                 onClick={() => toggleCategory(cat.id)}
-                                className="px-2 py-1 rounded border text-[8px] font-mono transition-all"
+                                className="px-2 py-1 rounded border text-[8px] font-mono transition-all inline-flex items-center gap-1.5"
                                 style={{
                                   borderColor: localCategories.has(cat.id) ? "var(--accent-cyan)" : "var(--border)",
                                   backgroundColor: localCategories.has(cat.id) ? "rgba(0,229,255,0.08)" : "transparent",
@@ -426,7 +435,8 @@ export default function DomainSelector() {
                                   opacity: active ? 1 : 0.4,
                                 }}
                               >
-                                {cat.icon} {cat.label}
+                                <DomainIcon name={cat.icon} size={11} />
+                                {cat.label}
                               </button>
                             );
                           })}


### PR DESCRIPTION
## Summary
- Swaps the 9 emoji NodeCategory icons in the DATA LAYERS accordion for monochrome line-art SVGs, matching the treatment PR #344 just shipped on the landing Domain cards
- Reuses 5 existing icons (`chart-bar`, `bank`, `bolt`, `factory`, `globe`) — adds 4 new ones (`wheat`, `antenna`, `flask`, `tower`)
- Retypes `NODE_CATEGORIES.icon` from `string` → `DomainIconName` so the mapping is compiler-checked

## Before / After

Before (DATA LAYERS pill row, one click into the Domain Workspace modal):

```
📊 ECONOMIC   💰 FINANCE   ⚡ ENERGY      🏗 INFRASTRUCTURE
🏭 MANUFACTURING   🌾 AGRICULTURE   🌐 GEOPOLITICAL
📡 COMMUNICATIONS   🔬 SCIENCE
```

After: same chips, but each prefixed with a hand-drawn 11px line-art icon in the chip's text colour. Active chips use `var(--accent-cyan)`, inactive use `var(--text-muted)` at 0.4 opacity — same active/inactive style block, no extra logic.

## Why
PR #344 retired the OS-rendered emoji icons on the landing Domain cards in the same modal. The DATA LAYERS accordion sits one click deeper but kept the same emoji treatment for the NodeCategory chips, breaking the visual consistency we just established.

## Icon design notes
- **wheat** — central stalk + three pairs of angled grain heads (agriculture)
- **antenna** — vertical mast + three concentric broadcast arcs (communications, distinct from `cable`'s undersea-specific iconography)
- **flask** — Erlenmeyer profile + fluid line (broader-than-`atom` science; `atom` stays for the frontier-physics-specific domain card)
- **tower** — transmission-tower silhouette with two cross-braces (infrastructure category, distinct from `cable` which renders for the undersea-cable infrastructure-resilience domain card)

All four follow the same conventions as the existing 13 — `viewBox="0 0 24 24"`, 1.5px stroke, `currentColor` default.

## Out of scope
- `ShockPanel`'s `getCategoryIcon` (⬡ ⚡ ◈ ◆ ⚠ $ ⟁ § ❂ ✚ ●) is a different surface for `ShockCategory` — all monochrome glyphs already, no aesthetic mismatch.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on both touched files
- [ ] Vercel preview deploys
- [ ] Open the Domain Workspace modal in the preview, expand DATA LAYERS, confirm the 9 NodeCategory chips render with line-art icons matching the colour treatment of the surrounding chips (cyan when selected, muted when not)
- [ ] No layout regression — chips stay on the wrap grid with `flex-wrap gap-1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
