### PR TITLE
fix(copilot): suppress mic during TTS — kill feedback loop

### DIFF
--- a/src/components/SystemCopilot.tsx
+++ b/src/components/SystemCopilot.tsx
@@ -390,6 +390,23 @@ export default function SystemCopilot() {
         closeVoiceLoop("empty-content");
         return;
       }
+      // ─── Suppress mic during TTS ──────────────────────────────
+      // Stop the active recognition before TTS starts. Otherwise
+      // the mic picks up the AI's own voice from the speakers,
+      // transcribes it, and submits it back — feedback loop. The
+      // generation bump invalidates any in-flight handlers from
+      // the old recognition so its onend can't restart while
+      // we're speaking. closeVoiceLoop will spin up a fresh
+      // recognition once TTS finishes.
+      recognitionGenerationRef.current += 1;
+      restartScheduledRef.current = false;
+      try {
+        recognitionRef.current?.stop();
+      } catch {
+        // ignore — recognition may already be finished
+      }
+      voiceLog("suppressed mic for TTS", { gen: recognitionGenerationRef.current });
+
       setVoiceStage("speaking");
       speakText(lastAssistant.content, () => closeVoiceLoop("onend"));
 


### PR DESCRIPTION
## Surfaced by Chrome MCP diagnostic on production

After PR #357 fixed the start-cascade, I drove the post-TTS path through the Chrome MCP with `APEX_VOICE_DEBUG=1` and captured this trace:

```
4:52:34 auto-speak effect (AI's first response)
4:52:43 recognition.onresult final  ← MIC PICKED UP AI'S VOICE
4:52:46 auto-speak effect (AI responding to its own voice)
4:52:48 recognition.onresult final  ← AGAIN
4:52:52 auto-speak effect (third loop)
```

**The AI's TTS audio is being captured by the open microphone, transcribed by the recognition engine, and submitted back as a "user message"** — triggering another response, which gets spoken, picked up again, etc. Classic hands-free voice feedback loop.

This very plausibly explains the original user report of *"audio stopped inputting"*: the loop monopolizes recognition with the AI's own voice, so the user's real speech never lands.

## Fix

Stop the active recognition before TTS starts. Bump the generation token so any in-flight handlers from the old recognition become no-ops. `closeVoiceLoop` spins up a fresh recognition after TTS finishes (existing behavior).

```ts
// ─── Suppress mic during TTS ─────────────────────────
recognitionGenerationRef.current += 1;
restartScheduledRef.current = false;
try { recognitionRef.current?.stop(); } catch {}
voiceLog("suppressed mic for TTS", { gen: recognitionGenerationRef.current });

setVoiceStage("speaking");
speakText(lastAssistant.content, () => closeVoiceLoop("onend"));
```

## Tradeoff

With the mic off during TTS, the user can't interrupt the AI by talking over it. That used to half-work (we cancelled TTS when `recognition.onstart` fired), but it also meant the feedback loop above.

If interruption matters in practice, the right pattern is explicit — click the mic button to interrupt. We can add that if users ask. For now: **no feedback > interruption**.

## Test plan

- [x] `vitest run` — 1132/1132
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] Reproduces cleanly in the Chrome MCP test path I ran during the singleton-fix verification
- [ ] Manual after merge: click 🎤, talk, get response — verify recognition stops during TTS and restarts cleanly after

## Roadmap

This is the seventh voice PR, and the **second** in this debug cycle that came from captured production behavior instead of speculation. The Chrome MCP diagnostic flow is paying off — it caught what 5 prior speculative PRs missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)