### PR TITLE
perf(copilot): async tool handlers — solve_interdiction no longer freezes the chat

### DIFF
--- a/src/components/SystemCopilot.tsx
+++ b/src/components/SystemCopilot.tsx
@@ -673,8 +673,11 @@ export default function SystemCopilot() {
           setStreamingDisplayText(displayTextStreaming);
         }
 
-        // After streaming completes, execute any actions from the full response
-        const { displayText, actionResults, toolCalls } = processLlmActionsWithTrace(accumulated);
+        // After streaming completes, execute any actions from the full response.
+        // Awaited because the registry handlers may be async — `solve_interdiction`
+        // in particular runs the chunked minimax solver and yields between
+        // candidates so the chat UI stays responsive during the solve.
+        const { displayText, actionResults, toolCalls } = await processLlmActionsWithTrace(accumulated);
         // Flush final text to the store in one write
         useApexStore.setState((s) => ({
           copilotMessages: s.copilotMessages.map((m) =>

--- a/src/lib/__tests__/copilot-tool-registry.test.ts
+++ b/src/lib/__tests__/copilot-tool-registry.test.ts
@@ -167,15 +167,15 @@ describe("registry — defineTool / executeTag", () => {
     __resetRegistryForTests();
   });
 
-  it("returns 'Unknown action' for an unregistered name", () => {
-    const result = executeTag(
+  it("returns 'Unknown action' for an unregistered name", async () => {
+    const result = await executeTag(
       { name: "nope", payload: "", raw: "" },
       { getStore: () => ({}) as ApexState },
     );
     expect(result).toMatch(/Unknown action: nope/);
   });
 
-  it("rejects invalid params with a clear error before invoking the handler", () => {
+  it("rejects invalid params with a clear error before invoking the handler", async () => {
     let called = false;
     defineTool({
       name: "select_node",
@@ -187,7 +187,7 @@ describe("registry — defineTool / executeTag", () => {
         return "ok";
       },
     });
-    const result = executeTag(
+    const result = await executeTag(
       { name: "select_node", payload: "", raw: "" },
       { getStore: () => ({}) as ApexState },
     );
@@ -195,7 +195,7 @@ describe("registry — defineTool / executeTag", () => {
     expect(called).toBe(false);
   });
 
-  it("dispatches to the handler with typed params on a happy path", () => {
+  it("dispatches to the handler with typed params on a happy path", async () => {
     let received: { node?: string } | null = null;
     defineTool({
       name: "select_node",
@@ -207,7 +207,7 @@ describe("registry — defineTool / executeTag", () => {
         return "selected";
       },
     });
-    const result = executeTag(
+    const result = await executeTag(
       { name: "select_node", payload: "USA_GRID", raw: "" },
       { getStore: () => ({}) as ApexState },
     );
@@ -215,7 +215,7 @@ describe("registry — defineTool / executeTag", () => {
     expect(received).toEqual({ node: "USA_GRID" });
   });
 
-  it("catches handler exceptions and returns a readable error", () => {
+  it("catches handler exceptions and returns a readable error", async () => {
     defineTool({
       name: "boom",
       description: "test",
@@ -224,11 +224,51 @@ describe("registry — defineTool / executeTag", () => {
         throw new Error("kaboom");
       },
     });
-    const result = executeTag(
+    const result = await executeTag(
       { name: "boom", payload: "", raw: "" },
       { getStore: () => ({}) as ApexState },
     );
     expect(result).toMatch(/boom failed: kaboom/);
+  });
+
+  it("awaits an async handler and reports its resolved string", async () => {
+    // Tool handlers may now return `string | Promise<string>` so heavy
+    // tools (`solve_interdiction`) can call into the chunked async
+    // solver without blocking the chat thread. The executor must
+    // resolve the promise before building the trace; otherwise the
+    // result string would be `[object Promise]` and latency_ms would
+    // be measured before the work finishes.
+    defineTool({
+      name: "deferred_ok",
+      description: "test async happy-path",
+      params: {},
+      handler: async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        return "resolved";
+      },
+    });
+    const result = await executeTag(
+      { name: "deferred_ok", payload: "", raw: "" },
+      { getStore: () => ({}) as ApexState },
+    );
+    expect(result).toBe("resolved");
+  });
+
+  it("catches a rejected promise from an async handler with the same readable error", async () => {
+    defineTool({
+      name: "deferred_boom",
+      description: "test async failure",
+      params: {},
+      handler: async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        throw new Error("async kaboom");
+      },
+    });
+    const result = await executeTag(
+      { name: "deferred_boom", payload: "", raw: "" },
+      { getStore: () => ({}) as ApexState },
+    );
+    expect(result).toMatch(/deferred_boom failed: async kaboom/);
   });
 });
 
@@ -243,7 +283,7 @@ describe("built-in tools — wired via the registry", () => {
     const graph = buildSampleGraph();
     const { ctx, spy } = makeMockContext(graph);
 
-    const result = executeTag(
+    const result = await executeTag(
       { name: "isolate_nodes", payload: "query=energy", raw: "" },
       ctx,
     );
@@ -257,7 +297,7 @@ describe("built-in tools — wired via the registry", () => {
     const graph = buildSampleGraph();
     const { ctx, spy } = makeMockContext(graph);
 
-    const result = executeTag(
+    const result = await executeTag(
       { name: "isolate_nodes", payload: "ids=GRID_USA|FAB_TW", raw: "" },
       ctx,
     );
@@ -271,7 +311,7 @@ describe("built-in tools — wired via the registry", () => {
     const graph = buildSampleGraph();
     const { ctx, spy } = makeMockContext(graph);
 
-    const result = executeTag(
+    const result = await executeTag(
       { name: "isolate_nodes", payload: "query=nonexistent_topic", raw: "" },
       ctx,
     );
@@ -285,7 +325,7 @@ describe("built-in tools — wired via the registry", () => {
     const graph = buildSampleGraph();
     const { ctx, spy } = makeMockContext(graph);
 
-    const result = executeTag({ name: "isolate_nodes", payload: "", raw: "" }, ctx);
+    const result = await executeTag({ name: "isolate_nodes", payload: "", raw: "" }, ctx);
     expect(result).toMatch(/provide either query=/);
     expect(spy.setIsolateSelection.calls).toEqual([]);
   });
@@ -295,7 +335,7 @@ describe("built-in tools — wired via the registry", () => {
     const graph = buildSampleGraph();
     const { ctx, spy } = makeMockContext(graph);
 
-    executeTag({ name: "reset_isolation", payload: "", raw: "" }, ctx);
+    await executeTag({ name: "reset_isolation", payload: "", raw: "" }, ctx);
     expect(spy.setIsolateSelection.calls).toEqual([false]);
     expect(spy.setSelectedNodes.calls).toEqual([[]]);
   });
@@ -305,7 +345,7 @@ describe("built-in tools — wired via the registry", () => {
     const graph = buildSampleGraph();
     const { ctx, spy } = makeMockContext(graph);
 
-    const result = executeTag({ name: "select_node", payload: "GRID_USA", raw: "" }, ctx);
+    const result = await executeTag({ name: "select_node", payload: "GRID_USA", raw: "" }, ctx);
     expect(result).toMatch(/Selected node/);
     expect(spy.setSelectedNode.calls).toEqual(["GRID_USA"]);
   });
@@ -316,7 +356,7 @@ describe("built-in tools — wired via the registry", () => {
     const { ctx } = makeMockContext(graph);
 
     const text = "Focus on the energy stuff. <<<ACTION:isolate_nodes:query=energy>>>";
-    const { displayText, toolResults } = executeActions(text, ctx);
+    const { displayText, toolResults } = await executeActions(text, ctx);
     expect(displayText).toBe("Focus on the energy stuff.");
     expect(toolResults).toHaveLength(1);
     expect(toolResults[0]).toMatch(/Isolated 2 nodes/);

--- a/src/lib/__tests__/copilot-tools-extended.test.ts
+++ b/src/lib/__tests__/copilot-tools-extended.test.ts
@@ -88,9 +88,9 @@ function makeMockContext(graph: CausalGraph, tarskiReport: TarskiValidationRepor
 // ─── explain_node ───────────────────────────────────────────────
 
 describe("explain_node", () => {
-  it("returns a compact Ω-fragility breakdown for a known node", () => {
+  it("returns a compact Ω-fragility breakdown for a known node", async () => {
     const { ctx } = makeMockContext(buildGraph());
-    const result = executeTag({ name: "explain_node", payload: "GRID_USA", raw: "" }, ctx);
+    const result = await executeTag({ name: "explain_node", payload: "GRID_USA", raw: "" }, ctx);
     expect(result).toContain("USA Power Grid");
     expect(result).toContain("Energy");
     expect(result).toContain("Ω composite 8.5/10");
@@ -99,16 +99,16 @@ describe("explain_node", () => {
     expect(result).toContain("Downstream");
   });
 
-  it("resolves nodes by shortLabel as well as id", () => {
+  it("resolves nodes by shortLabel as well as id", async () => {
     const { ctx } = makeMockContext(buildGraph());
-    const result = executeTag({ name: "explain_node", payload: "TSMC", raw: "" }, ctx);
+    const result = await executeTag({ name: "explain_node", payload: "TSMC", raw: "" }, ctx);
     expect(result).toContain("TSMC Fab");
     expect(result).toContain("OMEGA-CRITICAL");
   });
 
-  it("returns 'Node not found' for unknown refs", () => {
+  it("returns 'Node not found' for unknown refs", async () => {
     const { ctx } = makeMockContext(buildGraph());
-    const result = executeTag({ name: "explain_node", payload: "NONEXISTENT", raw: "" }, ctx);
+    const result = await executeTag({ name: "explain_node", payload: "NONEXISTENT", raw: "" }, ctx);
     expect(result).toMatch(/Node not found/);
   });
 });
@@ -116,9 +116,9 @@ describe("explain_node", () => {
 // ─── compare_nodes ──────────────────────────────────────────────
 
 describe("compare_nodes", () => {
-  it("returns side-by-side analysis + delta on Ω composite", () => {
+  it("returns side-by-side analysis + delta on Ω composite", async () => {
     const { ctx } = makeMockContext(buildGraph());
-    const result = executeTag(
+    const result = await executeTag(
       { name: "compare_nodes", payload: "ids=GRID_USA|FAB_TW", raw: "" },
       ctx,
     );
@@ -129,18 +129,18 @@ describe("compare_nodes", () => {
     expect(result).toContain("TSMC is 1.0 Ω points more fragile than USA");
   });
 
-  it("rejects a single id with a clear error", () => {
+  it("rejects a single id with a clear error", async () => {
     const { ctx } = makeMockContext(buildGraph());
-    const result = executeTag(
+    const result = await executeTag(
       { name: "compare_nodes", payload: "ids=GRID_USA", raw: "" },
       ctx,
     );
     expect(result).toMatch(/needs at least two ids/);
   });
 
-  it("reports missing ids before doing any work", () => {
+  it("reports missing ids before doing any work", async () => {
     const { ctx } = makeMockContext(buildGraph());
-    const result = executeTag(
+    const result = await executeTag(
       { name: "compare_nodes", payload: "ids=GRID_USA|GHOST_NODE", raw: "" },
       ctx,
     );
@@ -151,7 +151,7 @@ describe("compare_nodes", () => {
 // ─── run_tarski ─────────────────────────────────────────────────
 
 describe("run_tarski", () => {
-  it("invokes the store's runTarskiWithAxioms and summarizes the report", () => {
+  it("invokes the store's runTarskiWithAxioms and summarizes the report", async () => {
     const fakeReport: TarskiValidationReport = {
       inconsistentEdgeIds: new Set(["e_1", "e_2"]),
       restrictedNodeIds: new Set(["n_1"]),
@@ -167,16 +167,16 @@ describe("run_tarski", () => {
       totalViolations: 3,
     };
     const { ctx, spy } = makeMockContext(buildGraph(), fakeReport);
-    const result = executeTag({ name: "run_tarski", payload: "", raw: "" }, ctx);
+    const result = await executeTag({ name: "run_tarski", payload: "", raw: "" }, ctx);
     expect(spy.runTarskiCalls).toBe(1);
     expect(result).toContain("2 inconsistent edge(s)");
     expect(result).toContain("1 restricted node(s)");
     expect(result).toContain("1 proof trace(s)");
   });
 
-  it("handles the no-report case without throwing", () => {
+  it("handles the no-report case without throwing", async () => {
     const { ctx, spy } = makeMockContext(buildGraph(), null);
-    const result = executeTag({ name: "run_tarski", payload: "", raw: "" }, ctx);
+    const result = await executeTag({ name: "run_tarski", payload: "", raw: "" }, ctx);
     expect(spy.runTarskiCalls).toBe(1);
     expect(result).toMatch(/produced no report/);
   });
@@ -185,9 +185,9 @@ describe("run_tarski", () => {
 // ─── set_node_size_metric ───────────────────────────────────────
 
 describe("set_node_size_metric", () => {
-  it("sets the metric on the store", () => {
+  it("sets the metric on the store", async () => {
     const { ctx, spy } = makeMockContext(buildGraph());
-    const result = executeTag(
+    const result = await executeTag(
       { name: "set_node_size_metric", payload: "betweenness", raw: "" },
       ctx,
     );
@@ -195,9 +195,9 @@ describe("set_node_size_metric", () => {
     expect(result).toMatch(/betweenness/);
   });
 
-  it("rejects values not in the enum", () => {
+  it("rejects values not in the enum", async () => {
     const { ctx, spy } = makeMockContext(buildGraph());
-    const result = executeTag(
+    const result = await executeTag(
       { name: "set_node_size_metric", payload: "purple", raw: "" },
       ctx,
     );
@@ -209,9 +209,9 @@ describe("set_node_size_metric", () => {
 // ─── reset_ablation ─────────────────────────────────────────────
 
 describe("reset_ablation", () => {
-  it("calls resetAblation on the store", () => {
+  it("calls resetAblation on the store", async () => {
     const { ctx, spy } = makeMockContext(buildGraph());
-    const result = executeTag({ name: "reset_ablation", payload: "", raw: "" }, ctx);
+    const result = await executeTag({ name: "reset_ablation", payload: "", raw: "" }, ctx);
     expect(spy.resetAblationCalls).toBe(1);
     expect(result).toMatch(/Reset all ablations/);
   });

--- a/src/lib/__tests__/copilot-trace-logger.test.ts
+++ b/src/lib/__tests__/copilot-trace-logger.test.ts
@@ -14,7 +14,7 @@ import type { ApexState } from "@/stores/useApexStore";
 describe("executeTagWithTrace — structured trace shape", () => {
   beforeEach(() => __resetRegistryForTests());
 
-  it("returns name + validated params + result + null error + latency on success", () => {
+  it("returns name + validated params + result + null error + latency on success", async () => {
     defineTool({
       name: "select_node",
       description: "test",
@@ -23,7 +23,7 @@ describe("executeTagWithTrace — structured trace shape", () => {
       handler: () => "Selected node: USA_GRID",
     });
 
-    const trace = executeTagWithTrace(
+    const trace = await executeTagWithTrace(
       { name: "select_node", payload: "USA_GRID", raw: "" },
       { getStore: () => ({}) as ApexState },
     );
@@ -36,7 +36,7 @@ describe("executeTagWithTrace — structured trace shape", () => {
     expect(trace.latency_ms).toBeGreaterThanOrEqual(0);
   });
 
-  it("populates error when validation fails", () => {
+  it("populates error when validation fails", async () => {
     defineTool({
       name: "needs_arg",
       description: "test",
@@ -44,7 +44,7 @@ describe("executeTagWithTrace — structured trace shape", () => {
       handler: () => "ok",
     });
 
-    const trace = executeTagWithTrace(
+    const trace = await executeTagWithTrace(
       { name: "needs_arg", payload: "", raw: "" },
       { getStore: () => ({}) as ApexState },
     );
@@ -53,7 +53,7 @@ describe("executeTagWithTrace — structured trace shape", () => {
     expect(trace.result).toMatch(/Missing required/);
   });
 
-  it("populates error when handler throws", () => {
+  it("populates error when handler throws", async () => {
     defineTool({
       name: "boom",
       description: "test",
@@ -63,7 +63,7 @@ describe("executeTagWithTrace — structured trace shape", () => {
       },
     });
 
-    const trace = executeTagWithTrace(
+    const trace = await executeTagWithTrace(
       { name: "boom", payload: "", raw: "" },
       { getStore: () => ({}) as ApexState },
     );
@@ -72,7 +72,7 @@ describe("executeTagWithTrace — structured trace shape", () => {
     expect(trace.result).toMatch(/boom failed: kaboom/);
   });
 
-  it("emits a trace per parsed tag from executeActionsWithTrace", () => {
+  it("emits a trace per parsed tag from executeActionsWithTrace", async () => {
     defineTool({
       name: "a",
       description: "",
@@ -88,7 +88,7 @@ describe("executeTagWithTrace — structured trace shape", () => {
     });
 
     const text = "Hello <<<ACTION:a>>> middle <<<ACTION:b:hi>>> end";
-    const result = executeActionsWithTrace(text, { getStore: () => ({}) as ApexState });
+    const result = await executeActionsWithTrace(text, { getStore: () => ({}) as ApexState });
 
     expect(result.toolCalls).toHaveLength(2);
     expect(result.toolCalls[0]).toMatchObject<Partial<ToolCallTrace>>({

--- a/src/lib/copilot-actions.ts
+++ b/src/lib/copilot-actions.ts
@@ -39,8 +39,11 @@ export const stripActions = stripActionTags;
  * Execute a single parsed action. Returns a human-readable result
  * string, or null if the action produced no output (kept for
  * backward compatibility — the registry always returns a string).
+ *
+ * Async because tool handlers may be async (`solve_interdiction` awaits
+ * `solveInterdictionAsync` to keep the copilot path non-blocking).
  */
-export function executeAction(action: ParsedAction): string | null {
+export async function executeAction(action: ParsedAction): Promise<string | null> {
   const tag: ParsedActionTag = { name: action.type, payload: action.param, raw: action.raw };
   return executeTag(tag);
 }
@@ -49,25 +52,27 @@ export function executeAction(action: ParsedAction): string | null {
  * Process all actions in an LLM response. Returns the cleaned
  * display text plus the list of action results.
  */
-export function processLlmActions(text: string): {
+export async function processLlmActions(text: string): Promise<{
   displayText: string;
   actionResults: string[];
-} {
-  const { displayText, toolResults } = executeActions(text);
+}> {
+  const { displayText, toolResults } = await executeActions(text);
   return { displayText, actionResults: toolResults };
 }
 
 /**
- * Same as processLlmActions, but also returns the structured
- * per-call trace data (for trace-logger / Supabase). Use this when
- * you want to capture timing + params + errors in addition to the
- * human-readable result strings.
+ * Same as `processLlmActions`, but also returns the structured per-call
+ * trace data (for trace-logger / Supabase). Use this when you want to
+ * capture timing + params + errors in addition to the human-readable
+ * result strings. `SystemCopilot` is the primary caller — it awaits
+ * this after the LLM stream completes, then flushes the trace to the
+ * trace API.
  */
-export function processLlmActionsWithTrace(text: string): {
+export async function processLlmActionsWithTrace(text: string): Promise<{
   displayText: string;
   actionResults: string[];
   toolCalls: ToolCallTrace[];
-} {
-  const { displayText, toolResults, toolCalls } = executeActionsWithTrace(text);
+}> {
+  const { displayText, toolResults, toolCalls } = await executeActionsWithTrace(text);
   return { displayText, actionResults: toolResults, toolCalls };
 }

--- a/src/lib/copilot/eval/runner.ts
+++ b/src/lib/copilot/eval/runner.ts
@@ -125,7 +125,7 @@ async function runCase(testCase: TestCase, opts: RunEvalOptions): Promise<EvalRe
     shocks: [] as ApexState["shocks"],
     severedEdges: [] as string[],
   } as unknown as ApexState;
-  const { displayText, toolCalls } = executeActionsWithTrace(rawAssistantMessage, {
+  const { displayText, toolCalls } = await executeActionsWithTrace(rawAssistantMessage, {
     getStore: () => stubStore,
   });
 

--- a/src/lib/copilot/tool-registry.ts
+++ b/src/lib/copilot/tool-registry.ts
@@ -83,8 +83,16 @@ export interface Tool<P extends ParamShape = ParamShape> {
    * no `=`, it is routed into this param.
    */
   legacyParam?: keyof P & string;
-  /** Handler — receives validated params and a context object. */
-  handler: (params: InferParams<P>, ctx: ToolContext) => string;
+  /**
+   * Handler — receives validated params and a context object. Returns
+   * either a result string directly (sync, the common case) or a
+   * Promise resolving to one (for handlers that need to run async
+   * work — e.g. `solve_interdiction` awaits `solveInterdictionAsync`
+   * so the copilot path doesn't block the UI for the full minimax
+   * solve). The executor handles both; sync handlers don't need any
+   * changes.
+   */
+  handler: (params: InferParams<P>, ctx: ToolContext) => string | Promise<string>;
 }
 
 // ─── Registry ───────────────────────────────────────────────────
@@ -284,34 +292,43 @@ export interface TracedExecutionResult extends ExecutionResult {
  * LLM response, validate each, run handlers, and return the cleaned
  * display text plus the list of human-readable tool results.
  *
+ * Async because `Tool.handler` may return a Promise — `solve_interdiction`
+ * is the current real case (awaits `solveInterdictionAsync` so the copilot
+ * path stays non-blocking even on a Hormuz-sized solve). Sync handlers
+ * resolve immediately and pay no extra cost.
+ *
  * Back-compat shape — discards the structured trace data. Use
- * executeActionsWithTrace when you want the trace for logging.
+ * `executeActionsWithTrace` when you want the trace for logging.
  */
-export function executeActions(
+export async function executeActions(
   text: string,
   ctx: ToolContext = defaultContext,
-): ExecutionResult {
-  const { displayText, toolResults } = executeActionsWithTrace(text, ctx);
+): Promise<ExecutionResult> {
+  const { displayText, toolResults } = await executeActionsWithTrace(text, ctx);
   return { displayText, toolResults };
 }
 
 /**
- * Same as executeActions, but also returns structured per-call
- * trace data (params, result, error, latency_ms) for each tag.
- * SystemCopilot uses this to build a TurnTrace and POST it to
- * /api/copilot/trace.
+ * Same as `executeActions`, but also returns structured per-call trace
+ * data (params, result, error, latency_ms) for each tag. SystemCopilot
+ * uses this to build a TurnTrace and POST it to `/api/copilot/trace`.
+ *
+ * Tags execute sequentially (`await` in a `for` loop, not `Promise.all`)
+ * because handlers are allowed to mutate the same store — running two
+ * in parallel would risk last-write-wins on dependent state mutations.
+ * If a future tool needs concurrency it can opt in by itself.
  */
-export function executeActionsWithTrace(
+export async function executeActionsWithTrace(
   text: string,
   ctx: ToolContext = defaultContext,
-): TracedExecutionResult {
+): Promise<TracedExecutionResult> {
   const tags = parseActionTags(text);
   const displayText = stripActionTags(text);
   const toolResults: string[] = [];
   const toolCalls: ToolCallTrace[] = [];
 
   for (const tag of tags) {
-    const traced = executeTagWithTrace(tag, ctx);
+    const traced = await executeTagWithTrace(tag, ctx);
     toolResults.push(traced.result);
     toolCalls.push(traced);
   }
@@ -320,19 +337,23 @@ export function executeActionsWithTrace(
 }
 
 /** Execute a single parsed action tag. Exported for tests. */
-export function executeTag(tag: ParsedActionTag, ctx: ToolContext = defaultContext): string {
-  return executeTagWithTrace(tag, ctx).result;
+export async function executeTag(tag: ParsedActionTag, ctx: ToolContext = defaultContext): Promise<string> {
+  return (await executeTagWithTrace(tag, ctx)).result;
 }
 
 /**
  * Execute a single tag and return both the result string and the
- * structured trace. Used by executeActionsWithTrace; exported for
+ * structured trace. Used by `executeActionsWithTrace`; exported for
  * targeted unit tests that want to inspect timing/error semantics.
+ *
+ * Awaits the handler so async tools (currently `solve_interdiction`)
+ * resolve before we measure latency and build the trace. Sync handlers
+ * still resolve in microtask time — no behavioural change for them.
  */
-export function executeTagWithTrace(
+export async function executeTagWithTrace(
   tag: ParsedActionTag,
   ctx: ToolContext = defaultContext,
-): ToolCallTrace {
+): Promise<ToolCallTrace> {
   const start = performanceNow();
   const tool = REGISTRY.get(tag.name);
   if (!tool) {
@@ -358,7 +379,7 @@ export function executeTagWithTrace(
   }
 
   try {
-    const result = tool.handler(validated.params, ctx);
+    const result = await tool.handler(validated.params, ctx);
     return {
       name: tag.name,
       params: validated.params as Record<string, unknown>,

--- a/src/lib/copilot/tools.ts
+++ b/src/lib/copilot/tools.ts
@@ -8,7 +8,10 @@ import { defineTool } from "./tool-registry";
 import { getPresetShocks } from "../omega-engine";
 import { DOMAIN_CARDS } from "@/lib/domains";
 import { buildGraphFromDomains } from "@/lib/build-domain-graph";
-import { solveInterdiction, type InterdictionCandidate } from "../interdiction-engine";
+import {
+  solveInterdictionAsync,
+  type InterdictionCandidate,
+} from "../interdiction-engine";
 import type { ApexState } from "@/stores/useApexStore";
 import type { CausalNode, CausalGraph } from "../types";
 
@@ -301,9 +304,14 @@ defineTool({
     budget: { type: "number", min: 1, max: 10, default: 3, description: "Max number of cuts" },
     mode: { type: "enum", values: ["edge", "node", "both"] as const, default: "edge" },
   },
-  handler: ({ budget, mode }, ctx) => {
+  // Async handler so the registry's `await tool.handler(...)` lets the
+  // chunked minimax solver yield to the event loop between candidates.
+  // Without this the copilot's "solve interdiction" tool would re-freeze
+  // the UI for the full 5–15s sync solve, even after PR #356 made the
+  // React-component CASCADE DEFENSE non-blocking.
+  handler: async ({ budget, mode }, ctx) => {
     const store = ctx.getStore();
-    const result = solveInterdiction(
+    const result = await solveInterdictionAsync(
       store.graphData,
       store.shocks,
       store.severedEdges,


### PR DESCRIPTION
## Summary
- Widens `Tool.handler` from `(...) => string` to `(...) => string | Promise<string>` so heavy tools can opt into async work
- Migrates `solve_interdiction` to await `solveInterdictionAsync` — the chat thread no longer freezes 5–15s on a Hormuz-sized minimax solve
- Sequential awaits in `executeActionsWithTrace` (not Promise.all) so handlers that mutate shared store state stay deterministic
- Sync handlers stay sync — no behavioural change for any other tool

## Why
PR #356 made the React-component CASCADE DEFENSE non-blocking by adding `solveInterdictionAsync` alongside the sync solver. But the copilot's `solve_interdiction` tool kept calling the sync solver because the registry handler signature didn't allow Promises. So when the LLM emitted `<<<ACTION:solve_interdiction:...>>>`, the chat thread still froze for the full sync solve — same UI freeze we just fixed elsewhere.

This widens the signature once so any tool can opt in. Today only `solve_interdiction` needs it; future heavy tools (search-over-shocks, multi-graph diff, future Web Worker dispatches) get the benefit for free.

## Design choices
- **Sequential awaits in `executeActionsWithTrace`** (`for ... await`, not `Promise.all`). Handlers are allowed to mutate the same store — running two in parallel risks last-write-wins on dependent state. Future concurrent tools can opt in by themselves if they're side-effect-free.
- **`latency_ms` measured after the promise resolves.** Was synchronous-only before, would have under-reported async work; now consistent across sync and async handlers.
- **Rejected promises caught with the same error shape as sync throws** — same `${name} failed: ${msg}` formatter, no separate code path.
- **Sync handlers untouched.** They return `string` directly; the `await` in the executor resolves it in microtask time. Zero behaviour change for the 20+ existing sync tools.

## What changes per file

| File | Change |
| --- | --- |
| `tool-registry.ts` | `Tool.handler` returns `string \| Promise<string>`; `executeTag`, `executeActions`, `executeTagWithTrace`, `executeActionsWithTrace` all async |
| `copilot-actions.ts` | `executeAction`, `processLlmActions`, `processLlmActionsWithTrace` all async |
| `SystemCopilot.tsx` | one new `await` on `processLlmActionsWithTrace` (already inside async fn) |
| `copilot/eval/runner.ts` | one new `await` on `executeActionsWithTrace` (already async) |
| `copilot/tools.ts` | `solve_interdiction` handler is `async`, awaits `solveInterdictionAsync`; sync `solveInterdiction` import dropped |
| 3 test files | every `executeTag`/`executeActions` call awaited, every `it(...)` made async |

## Tests added
- "awaits an async handler and reports its resolved string" — guards the happy path. Without `await`, result would be `[object Promise]` instead of the resolved string.
- "catches a rejected promise from an async handler with the same readable error" — guards the error path uses the same `${name} failed: ${msg}` shape as sync throws.

## Test plan
- [x] `npx vitest run` — 1134/1134 pass across 96 files (was 1131; +3 from this PR + PR #356)
- [x] `npx tsc --noEmit` — clean on touched files (pre-existing errors in onboarding-metrics / fci / notears test fixtures remain, unrelated)
- [x] `npx eslint` clean on all touched files
- [ ] Vercel preview deploys
- [ ] In preview: open copilot, inject a shock, ask "find optimal defensive cuts" — chat thread stays responsive during the solve, copilot reports cuts without UI freeze
- [ ] Other tools (select_node, isolate_nodes, run_tarski, etc.) still work — they're sync; the await just resolves in microtask time

🤖 Generated with [Claude Code](https://claude.com/claude-code)
