### PR TITLE
feat(pareto): T1D relevance reference — F → hypo-event rate from real D1NAMO

### DIFF
--- a/public/relevance-references/d1namo-cgm-hypo.json
+++ b/public/relevance-references/d1namo-cgm-hypo.json
@@ -1,0 +1,89 @@
+{
+  "referenceId": "d1namo-cgm-hypo",
+  "substrateId": "cgm_glucose_mgdl",
+  "eventLabel": "Hypoglycemic episode (CGM < 70 mg/dL) within next 30 minutes",
+  "windowSize": 24,
+  "lookahead": 6,
+  "totalWindows": 8102,
+  "totalEvents": 960,
+  "baseRate": 0.11848926191063935,
+  "bins": [
+    {
+      "binLow": 0,
+      "binHigh": 0.1,
+      "count": 1999,
+      "eventCount": 260,
+      "eventRate": 0.13006503251625812
+    },
+    {
+      "binLow": 0.1,
+      "binHigh": 0.2,
+      "count": 1148,
+      "eventCount": 65,
+      "eventRate": 0.05662020905923345
+    },
+    {
+      "binLow": 0.2,
+      "binHigh": 0.3,
+      "count": 1312,
+      "eventCount": 103,
+      "eventRate": 0.07850609756097561
+    },
+    {
+      "binLow": 0.3,
+      "binHigh": 0.4,
+      "count": 1192,
+      "eventCount": 82,
+      "eventRate": 0.06879194630872483
+    },
+    {
+      "binLow": 0.4,
+      "binHigh": 0.5,
+      "count": 711,
+      "eventCount": 52,
+      "eventRate": 0.07313642756680731
+    },
+    {
+      "binLow": 0.5,
+      "binHigh": 0.6,
+      "count": 555,
+      "eventCount": 52,
+      "eventRate": 0.0936936936936937
+    },
+    {
+      "binLow": 0.6,
+      "binHigh": 0.7,
+      "count": 374,
+      "eventCount": 37,
+      "eventRate": 0.09893048128342247
+    },
+    {
+      "binLow": 0.7,
+      "binHigh": 0.8,
+      "count": 280,
+      "eventCount": 28,
+      "eventRate": 0.1
+    },
+    {
+      "binLow": 0.8,
+      "binHigh": 0.9,
+      "count": 145,
+      "eventCount": 18,
+      "eventRate": 0.12413793103448276
+    },
+    {
+      "binLow": 0.9,
+      "binHigh": 1,
+      "count": 386,
+      "eventCount": 263,
+      "eventRate": 0.6813471502590673
+    }
+  ],
+  "buildMeta": {
+    "builderVersion": "0.1.0",
+    "builtAt": "2026-05-21T01:46:29.301Z",
+    "source": "Derived from the live D1NAMO csd-fit-hypo-calibration run shipped in PR #200 (cohort: d1namo-2018, 9 T1D subjects, AUROC 0.589 on F → hypo). Real CGM substrate, real hypoglycemic event ground truth. Converter only: no re-computation, just a shape transformation from the discovery-run JSON to the relevance-reference JSON.",
+    "cohortFrom": "2026-05-03T17:21:56.475Z",
+    "cohortTo": "2026-05-03T17:21:56.592Z"
+  }
+}

--- a/scripts/build-d1namo-relevance-reference.ts
+++ b/scripts/build-d1namo-relevance-reference.ts
@@ -1,0 +1,140 @@
+// ─── Convert the existing D1NAMO csd-fit calibration into a relevance-reference ──
+//
+// We already shipped a real calibration run against the D1NAMO cohort
+// (csd-fit-hypo-calibration, PR #200) that lives at
+// public/discovery-runs/d1namo-csd-fit-hypo-calibration-v0-1-0.json.
+// That JSON carries reliability bins (F → empirical hypo-event rate)
+// already — exactly the shape relevance-references consume.
+//
+// This builder is a thin converter, not a re-computation. It reads the
+// existing discovery-run JSON and emits the relevance-reference JSON
+// in the format the Pareto card lookup expects. No network, no model
+// re-fit, no synthetic data — the underlying calibration is the same
+// one already validated and shipped in #200 (AUROC 0.589 on the 9 T1D
+// subjects of D1NAMO, 8,102 (F, label) pairs).
+//
+// Output:
+//   public/relevance-references/d1namo-cgm-hypo.json
+//
+// What changes in the UI:
+//   T1D_PROFILE.relevanceReferenceId becomes "d1namo-cgm-hypo", so the
+//   T1D Pareto card now shows the same kind of lookup line the
+//   analyst card has had since #355/#359:
+//
+//     F=0.71 → 68% hypo-event rate (n=386, base 12%)
+
+import * as fs from "fs/promises";
+import * as path from "path";
+
+interface DiscoveryReliabilityBin {
+  binLow: number;
+  binHigh: number;
+  predictedMean: number;
+  observedRate: number;
+  count: number;
+}
+
+interface DiscoveryDiagnostics {
+  aurocFitHigh: number;
+  aurocFitLow: number;
+  baseRate: number;
+  brierScore: number;
+  ece: number;
+  meanCiHalfWidth: number;
+  nPairs: number;
+  nSubjects: number;
+  reliabilityBins: DiscoveryReliabilityBin[];
+}
+
+interface DiscoveryRun {
+  algorithm: { id: string; version: string };
+  cohortId: string;
+  startedAt: string;
+  completedAt: string;
+  params: {
+    cgmVariableId?: string;
+    hypoThresholdMgdl?: number;
+    predictionHorizonMin?: number;
+    gridSeconds?: number;
+    windowSize?: number;
+  };
+  result: {
+    diagnostics: DiscoveryDiagnostics;
+  };
+}
+
+async function main() {
+  const repoRoot = process.cwd();
+  const inputPath = path.join(
+    repoRoot,
+    "public",
+    "discovery-runs",
+    "d1namo-csd-fit-hypo-calibration-v0-1-0.json",
+  );
+  console.log(`[d1namo-ref] loading ${path.relative(repoRoot, inputPath)}...`);
+  const raw = await fs.readFile(inputPath, "utf8");
+  const run: DiscoveryRun = JSON.parse(raw);
+
+  const d = run.result.diagnostics;
+  const params = run.params;
+  console.log(
+    `[d1namo-ref] source run ${run.algorithm.id} v${run.algorithm.version}: ${d.nPairs} pairs across ${d.nSubjects} subjects, base rate ${(d.baseRate * 100).toFixed(2)}%`,
+  );
+
+  // Convert each discovery-bin to the relevance-reference bin shape.
+  // The discovery shape carries `observedRate` (= eventRate) and `count`
+  // per bin but not eventCount; derive it as count × observedRate
+  // (rounded to nearest integer for storage hygiene).
+  const bins = d.reliabilityBins.map((b) => ({
+    binLow: b.binLow,
+    binHigh: b.binHigh,
+    count: b.count,
+    eventCount: Math.round(b.count * b.observedRate),
+    eventRate: b.observedRate,
+  }));
+  const totalEvents = bins.reduce((s, b) => s + b.eventCount, 0);
+
+  const horizonMin = params.predictionHorizonMin ?? 30;
+
+  const reference = {
+    referenceId: "d1namo-cgm-hypo",
+    substrateId: params.cgmVariableId ?? "cgm_glucose_mgdl",
+    eventLabel: `Hypoglycemic episode (CGM < ${params.hypoThresholdMgdl ?? 70} mg/dL) within next ${horizonMin} minutes`,
+    windowSize: params.windowSize ?? 24,
+    // lookahead is in CGM steps (5-min grid)
+    lookahead: Math.round((horizonMin * 60) / (params.gridSeconds ?? 300)),
+    totalWindows: d.nPairs,
+    totalEvents,
+    baseRate: d.baseRate,
+    bins,
+    buildMeta: {
+      builderVersion: "0.1.0",
+      builtAt: new Date().toISOString(),
+      source: `Derived from the live D1NAMO csd-fit-hypo-calibration run shipped in PR #200 (cohort: ${run.cohortId}, ${d.nSubjects} T1D subjects, AUROC ${d.aurocFitHigh.toFixed(3)} on F → hypo). Real CGM substrate, real hypoglycemic event ground truth. Converter only: no re-computation, just a shape transformation from the discovery-run JSON to the relevance-reference JSON.`,
+      cohortFrom: run.startedAt,
+      cohortTo: run.completedAt,
+    },
+  };
+
+  const outDir = path.join(repoRoot, "public", "relevance-references");
+  await fs.mkdir(outDir, { recursive: true });
+  const outPath = path.join(outDir, `${reference.referenceId}.json`);
+  await fs.writeFile(outPath, JSON.stringify(reference, null, 2));
+  console.log("");
+  console.log(`[d1namo-ref] wrote ${path.relative(repoRoot, outPath)}`);
+  console.log("");
+  console.log("Histogram (F bin → empirical hypo-event rate):");
+  for (const b of bins) {
+    const rate = b.count > 0
+      ? `${(b.eventRate * 100).toFixed(1)}%`
+      : "(empty)";
+    console.log(
+      `  [${b.binLow.toFixed(1)}-${b.binHigh.toFixed(1)})  n=${String(b.count).padStart(5)}  events=${String(b.eventCount).padStart(4)}  rate=${rate}`,
+    );
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/lib/domain-profiles.ts
+++ b/src/lib/domain-profiles.ts
@@ -309,6 +309,13 @@ export const T1D_PROFILE: DomainProfile = {
     "nlme",
     "hlm-cross-species",
   ],
+  // F → "hypoglycemic episode (CGM < 70 mg/dL) within next 30 minutes"
+  // event rate, derived from the live D1NAMO csd-fit-hypo-calibration
+  // run (PR #200): 9 T1D subjects, 8,102 (F, label) pairs, AUROC 0.589
+  // on F → hypo. Real CGM substrate, real labelled hypos. The reference
+  // is a thin shape-conversion of the existing calibration JSON via
+  // scripts/build-d1namo-relevance-reference.ts.
+  relevanceReferenceId: "d1namo-cgm-hypo",
 };
 
 // ─── AI Safety / IDS — endogenous catastrophic failure in AI systems ─


### PR DESCRIPTION
## Summary

Mirror of the analyst-card calibration receipt (#355, #359), but for the T1D profile. The Pareto card on the scientist/T1D view now shows the same "F → historical event rate" line the geopolitical view has — calibrated against real D1NAMO CGM data and real labelled hypoglycemic events.

## Thin converter, not re-computation

The underlying calibration is the same one shipped in **PR #200** (`csd-fit-hypo-calibration v0.1.0`): 9 T1D subjects, 8,102 (F, label) pairs, AUROC 0.589 on F → hypo. That run's output already carries reliability bins (F → empirical event rate), which is exactly what relevance-references consume. The new builder is ~80 lines and just transforms the JSON shape — no model re-fit, no network.

## Real numbers (committed in `d1namo-cgm-hypo.json`)

```
F bin       n        rate
[0.0-0.1) 1,999     13.0%
[0.1-0.2) 1,148      5.7%
[0.2-0.3) 1,312      7.9%
[0.3-0.4) 1,192      6.9%
[0.4-0.5)   711      7.3%
[0.5-0.6)   555      9.4%
[0.6-0.7)   374      9.9%
[0.7-0.8)   280     10.0%
[0.8-0.9)   145     12.4%
[0.9-1.0)   386     68.1%   ← strong in-band signal
```

Base rate: **11.85%**. The top-bin spike at 68.1% is the same in-band signal #200 surfaced in the original calibration — F ≈ 1 (AR(1) fits the CGM trace almost exactly) correlates strongly with imminent hypo events on this cohort.

## What the scientist user now sees

T1D Pareto card, under the headline pill:

```
F=0.95 → 68% hypo-event rate (n=386, base 12%)
```

Tooltip carries the full disclosure: cohort id, n subjects, AUROC, substrate, source.

## Files

| File | Change |
|------|--------|
| `scripts/build-d1namo-relevance-reference.ts` | New ~80-line converter. Reads existing discovery-run JSON → emits relevance-reference JSON. |
| `public/relevance-references/d1namo-cgm-hypo.json` | 2.0 KB reference, generated by running the converter this commit. |
| `src/lib/domain-profiles.ts` | `T1D_PROFILE.relevanceReferenceId = "d1namo-cgm-hypo"`. |

## Backwards compat

`shortenEventLabel` in ModulePanel already maps `hypo` → `hypo-event rate`, so the UI line renders correctly with no further wiring. AI Safety and any custom profile continue to render no lookup line (no `relevanceReferenceId` set).

## Test plan

- [x] Converter runs end-to-end (~50ms) — output committed
- [x] No new tests; lookup math + loader edge cases covered by the 16 tests in #352
- [ ] PR-validate workflow green
- [ ] Vercel preview: T1D Pareto card shows "F=X → Y% hypo-event rate"; tooltip carries event label + reference id + base rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
