### PR TITLE
fix(tour): retarget time-dial step at the actual dial, not the cards strip

### DIFF
--- a/src/components/TimeDial.tsx
+++ b/src/components/TimeDial.tsx
@@ -474,7 +474,10 @@ export default function TimeDial() {
   if (!temporalData) return null;
 
   return (
-    <div className="relative flex items-center gap-3 px-4 py-2 border-t border-border bg-surface-elevated/90 backdrop-blur-sm select-none">
+    <div
+      data-tour="time-dial"
+      className="relative flex items-center gap-3 px-4 py-2 border-t border-border bg-surface-elevated/90 backdrop-blur-sm select-none"
+    >
       {/* Label — switches between Time Dial and CASCADE MODE */}
       <div className="flex flex-col items-center gap-0.5 min-w-[72px]">
         <AnimatePresence mode="wait">

--- a/src/lib/tour-steps.ts
+++ b/src/lib/tour-steps.ts
@@ -185,25 +185,35 @@ const FIRST_RUN_STEPS: TourStep[] = [
   },
   {
     id: "time-dial-and-cascade",
+    // Targets the TimeDial scrubber row at the bottom of the page, not
+    // the comparison/risk-flow strip above it. Earlier this targeted
+    // `[data-tour="risk-flow"]` (the ΩF comparison panel), which meant
+    // the spotlight + arrow + tooltip landed on the wrong band of the
+    // UI — the user was told "drag the time dial" while the highlight
+    // pulsed on the comparison cards above. With the ΩF comparison
+    // panel expanded to a tall curve view, the cards strip pushed the
+    // tooltip into mid-screen and the actual dial sat squeezed at the
+    // very bottom, often partially hidden. Pointing at the dial puts
+    // the spotlight + tooltip directly above it.
     phase: "first-run",
-    targetSelector: '[data-tour="risk-flow"]',
+    targetSelector: '[data-tour="time-dial"]',
     tooltipPosition: "top",
     copy: {
       analyst: {
         title: "TIME DIAL — CASCADE REPLAY",
         description:
-          "The timeline scrubber controls cascade replay. After a shock or intervention, drag the dial to scrub epochs and watch nodes activate, edges propagate, and the Ω-buffer deplete. The horizontal cards above show per-node vulnerability, color-coded by severity. Drag the dial back a few epochs now to feel the replay.",
+          "The timeline scrubber at the bottom controls cascade replay. After a shock or intervention, drag the dial to scrub epochs and watch nodes activate, edges propagate, and the Ω-buffer deplete on the canvas. The horizontal cards just above the dial show per-node vulnerability, color-coded by severity. Drag the dial back a few epochs now to feel the replay.",
       },
       scientist: {
         title: "TIME DIAL — TRAJECTORY REPLAY",
         description:
-          "The timeline scrubber controls mechanism-trajectory replay. After an intervention or natural-history step, drag the dial to scrub time and watch C-peptide, antigen exposure, and downstream phenotypes evolve epoch-by-epoch. The horizontal cards above show per-mechanism risk in real time. Drag the dial back a few epochs now to feel the replay.",
+          "The timeline scrubber at the bottom controls mechanism-trajectory replay. After an intervention or natural-history step, drag the dial to scrub time and watch C-peptide, antigen exposure, and downstream phenotypes evolve epoch-by-epoch. The horizontal cards just above the dial show per-mechanism risk in real time. Drag the dial back a few epochs now to feel the replay.",
       },
     },
     awaitInteraction: {
       hint: "Drag the time dial back a few epochs to continue.",
       predicate: (s) => s.currentEpoch > 0,
-      pulseSelector: '[data-tour="risk-flow"]',
+      pulseSelector: '[data-tour="time-dial"]',
     },
   },
   {


### PR DESCRIPTION
## Summary
- Adds `data-tour="time-dial"` to the TimeDial root row
- Retargets tour step `time-dial-and-cascade` from `[data-tour="risk-flow"]` (the ΩF comparison cards strip) to `[data-tour="time-dial"]` (the actual scrubber row)
- Pulse selector follows the target retarget so the cyan highlight ring lands on the dial
- Light copy edit so the description reads correctly with the new spotlight position

## Why
User flagged a real visibility issue with onboarding step 6 (TIME DIAL — CASCADE REPLAY). Screenshot showed:

- The tooltip parked dead-center on the page
- The cyan spotlight + arrow pulsing on the ΩF COMPARISON cards strip above the dial
- The actual scrubber squeezed into a thin strip at the very bottom of the viewport, barely visible behind the expanded comparison overlay
- Hint said "Drag the time dial back a few epochs to continue" — but the dial wasn't what the tour was pointing at

Root cause: step 6's `targetSelector` was `[data-tour="risk-flow"]`, which is the RiskPropagationFlow comparison panel (tall, sits ABOVE the dial). The TimeDial component itself had no `data-tour` attribute. The interaction predicate (`s.currentEpoch > 0`) gated correctly on dial interaction, but the spotlight + tooltip anchored to the wrong band of the UI.

## What changes per file

| File | Change |
| --- | --- |
| `src/components/TimeDial.tsx` | Add `data-tour="time-dial"` to the root row div |
| `src/lib/tour-steps.ts` | Retarget step `time-dial-and-cascade`: `targetSelector` + `pulseSelector` swap; inline comment explaining why; minor copy edit ("horizontal cards just above the dial" instead of "horizontal cards above") |

## Why `tooltipPosition: "top"` stays
TimeDial is short (~50px tall) and sits at the bottom of the viewport. With the new target, the tooltip lands just above the dial without obscuring the canvas. The comparison-cards strip stays visible above, the canvas stays visible behind, and the spotlight + arrow finally point at the element the hint is asking the user to drag.

## Test plan
- [x] `npx tsc --noEmit` clean on both touched files (one pre-existing unrelated warning)
- [x] `npx eslint` clean
- [x] `npx vitest run src/lib/__tests__/tour-steps-persona-coverage.test.ts` — 4/4 pass
- [ ] Vercel preview deploys
- [ ] In preview: enter the demo, advance to step 6 ("TIME DIAL — CASCADE REPLAY"), confirm:
  - Spotlight ring is on the dial scrubber row at the bottom (not the comparison cards above)
  - Tooltip sits just above the dial, not mid-screen
  - Arrow points from tooltip down to the dial
  - Dragging the dial advances the step

🤖 Generated with [Claude Code](https://claude.com/claude-code)
