### PR TITLE
feat(copilot): remove_restricted_nodes — bulk-ablate Tarski-flagged nodes

### DIFF
--- a/src/lib/__tests__/copilot-remove-restricted-tool.test.ts
+++ b/src/lib/__tests__/copilot-remove-restricted-tool.test.ts
@@ -1,0 +1,204 @@
+// ─── remove_restricted_nodes — focused tool tests ─────────────
+//
+// Direct unit tests for the bulk-ablate-restricted-nodes tool.
+// We import tools.ts (side-effect register) and then invoke the
+// tool via executeTagWithTrace against a mock store. Pure tests:
+// no live LLM, no DOM, no Supabase.
+
+import { describe, it, expect } from "vitest";
+import {
+  executeTagWithTrace,
+  type ToolContext,
+} from "@/lib/copilot/tool-registry";
+import type { ApexState } from "@/stores/useApexStore";
+import type { CausalGraph, TarskiAxiom, ProofTrace } from "@/lib/types";
+import { makeNode, makeEdge, makeGraph } from "./fixtures/graph-fixtures";
+// Side-effect: registers all built-in tools (including
+// remove_restricted_nodes) into the shared registry. The other
+// built-in-tool test suite uses the same pattern — don't reset
+// the registry between tests, just rely on this import.
+import "@/lib/copilot/tools";
+
+// ─── Mock store ─────────────────────────────────────────────────
+
+interface StoreSpy {
+  ablationModeCalls: boolean[];
+  toggledNodeIds: string[];
+  ablatedNodeIds: string[];
+}
+
+function makeCtx(
+  graph: CausalGraph,
+  tarskiReport: {
+    restrictedNodeIds: Set<string>;
+    proofTraces: ProofTrace[];
+  } | null,
+  initialAblated: string[] = [],
+): { ctx: ToolContext; spy: StoreSpy } {
+  const spy: StoreSpy = {
+    ablationModeCalls: [],
+    toggledNodeIds: [],
+    ablatedNodeIds: [...initialAblated],
+  };
+
+  const fakeStore = {
+    graphData: graph,
+    ablatedNodeIds: spy.ablatedNodeIds,
+    tarskiReport: tarskiReport
+      ? {
+          restrictedNodeIds: tarskiReport.restrictedNodeIds,
+          proofTraces: tarskiReport.proofTraces,
+          inconsistentEdgeIds: new Set<string>(),
+          totalViolations: tarskiReport.proofTraces.length,
+        }
+      : null,
+    setAblationMode: (on: boolean) => spy.ablationModeCalls.push(on),
+    toggleAblatedNode: (id: string) => {
+      spy.toggledNodeIds.push(id);
+      // Mirror real store: toggle membership in ablatedNodeIds.
+      const idx = spy.ablatedNodeIds.indexOf(id);
+      if (idx === -1) spy.ablatedNodeIds.push(id);
+      else spy.ablatedNodeIds.splice(idx, 1);
+    },
+  } as unknown as ApexState;
+
+  return { ctx: { getStore: () => fakeStore }, spy };
+}
+
+// ─── Fixtures ───────────────────────────────────────────────────
+
+function fixtureGraph(): CausalGraph {
+  // Five nodes, four edges. Restricted: GRID_USA, FAB_TW, ASML_NL.
+  // Proof traces flag GRID_USA → FAB_TW under A-01 (Temporal
+  // Priority), and ASML_NL → FAB_TW under A-04 (Hormuz Chokepoint).
+  const nodes = [
+    makeNode({ id: "GRID_USA", label: "USA Power Grid" }),
+    makeNode({ id: "OIL_TX", label: "TX Oil Pipeline" }),
+    makeNode({ id: "FAB_TW", label: "TSMC Fab" }),
+    makeNode({ id: "ASML_NL", label: "ASML EUV Tools" }),
+    makeNode({ id: "BANK_NY", label: "NY Clearing Bank" }),
+  ];
+  const edges = [
+    makeEdge({ id: "e1", source: "GRID_USA", target: "FAB_TW" }),
+    makeEdge({ id: "e2", source: "OIL_TX", target: "FAB_TW" }),
+    makeEdge({ id: "e3", source: "ASML_NL", target: "FAB_TW" }),
+    makeEdge({ id: "e4", source: "BANK_NY", target: "GRID_USA" }),
+  ];
+  return makeGraph(nodes, edges);
+}
+
+const restrictedReport = {
+  restrictedNodeIds: new Set(["GRID_USA", "FAB_TW", "ASML_NL"]),
+  proofTraces: [
+    {
+      edgeId: "e1",
+      violatedAxioms: ["A-01"],
+      verdict: "REJECTED" as const,
+      solverUsed: "Z3" as const,
+      checkTimeMs: 1,
+    },
+    {
+      edgeId: "e3",
+      violatedAxioms: ["A-04"],
+      verdict: "REJECTED" as const,
+      solverUsed: "Z3" as const,
+      checkTimeMs: 1,
+    },
+  ],
+};
+
+// ─── Tests ──────────────────────────────────────────────────────
+
+describe("remove_restricted_nodes", () => {
+  it("errors clearly when no Tarski report is present", async () => {
+    const { ctx } = makeCtx(fixtureGraph(), null);
+    const trace = await executeTagWithTrace(
+      { name: "remove_restricted_nodes", payload: "", raw: "" },
+      ctx,
+    );
+    expect(trace.result).toMatch(/no tarski report/i);
+    expect(trace.error).toBeNull();
+  });
+
+  it("returns a no-op message when the report has zero restricted nodes", async () => {
+    const { ctx, spy } = makeCtx(fixtureGraph(), {
+      restrictedNodeIds: new Set(),
+      proofTraces: [],
+    });
+    const trace = await executeTagWithTrace(
+      { name: "remove_restricted_nodes", payload: "", raw: "" },
+      ctx,
+    );
+    expect(trace.result).toMatch(/no restricted nodes/i);
+    expect(spy.toggledNodeIds).toEqual([]);
+    expect(spy.ablationModeCalls).toEqual([]);
+  });
+
+  it("ablates every restricted node when called with no filter", async () => {
+    const { ctx, spy } = makeCtx(fixtureGraph(), restrictedReport);
+    const trace = await executeTagWithTrace(
+      { name: "remove_restricted_nodes", payload: "", raw: "" },
+      ctx,
+    );
+    expect(trace.error).toBeNull();
+    // All three restricted nodes get ablated.
+    expect(spy.toggledNodeIds.sort()).toEqual(["ASML_NL", "FAB_TW", "GRID_USA"]);
+    // Ablation mode turned on so the renderer hides them.
+    expect(spy.ablationModeCalls).toContain(true);
+    // Result text counts + lists labels.
+    expect(trace.result).toMatch(/removed 3 restricted nodes/i);
+  });
+
+  it("skips already-ablated nodes so the toggle doesn't un-ablate them", async () => {
+    const { ctx, spy } = makeCtx(fixtureGraph(), restrictedReport, ["GRID_USA"]);
+    const trace = await executeTagWithTrace(
+      { name: "remove_restricted_nodes", payload: "", raw: "" },
+      ctx,
+    );
+    expect(trace.error).toBeNull();
+    // GRID_USA was already ablated — only the other two should toggle.
+    expect(spy.toggledNodeIds.sort()).toEqual(["ASML_NL", "FAB_TW"]);
+  });
+
+  it("filters by axiom id (exact)", async () => {
+    const { ctx, spy } = makeCtx(fixtureGraph(), restrictedReport);
+    const trace = await executeTagWithTrace(
+      { name: "remove_restricted_nodes", payload: "axiom=A-01", raw: "" },
+      ctx,
+    );
+    expect(trace.error).toBeNull();
+    // A-01 flags edge e1 (GRID_USA → FAB_TW). Both endpoints are
+    // in restrictedNodeIds, so both ablate.
+    expect(spy.toggledNodeIds.sort()).toEqual(["FAB_TW", "GRID_USA"]);
+    expect(spy.toggledNodeIds).not.toContain("ASML_NL");
+  });
+
+  it("filters by axiom name substring (case-insensitive)", async () => {
+    // Spot-check that the axiom library has a substring we expect.
+    const axiom = (await import("@/lib/tarski-data")).AXIOM_LIBRARY.find(
+      (a: TarskiAxiom) => a.id === "A-04",
+    );
+    expect(axiom).toBeDefined();
+    // Find some recognizable substring of A-04's name.
+    const namePart = axiom!.name.split(" ")[0].toLowerCase();
+
+    const { ctx, spy } = makeCtx(fixtureGraph(), restrictedReport);
+    const trace = await executeTagWithTrace(
+      { name: "remove_restricted_nodes", payload: `axiom=${namePart}`, raw: "" },
+      ctx,
+    );
+    expect(trace.error).toBeNull();
+    // A-04 flags e3 (ASML_NL → FAB_TW). Both endpoints restricted → both ablate.
+    expect(spy.toggledNodeIds.sort()).toEqual(["ASML_NL", "FAB_TW"]);
+  });
+
+  it("errors when the axiom string matches nothing", async () => {
+    const { ctx, spy } = makeCtx(fixtureGraph(), restrictedReport);
+    const trace = await executeTagWithTrace(
+      { name: "remove_restricted_nodes", payload: "axiom=unknown-axiom-xyz", raw: "" },
+      ctx,
+    );
+    expect(trace.result).toMatch(/no tarski axiom matched/i);
+    expect(spy.toggledNodeIds).toEqual([]);
+  });
+});

--- a/src/lib/copilot/tools.ts
+++ b/src/lib/copilot/tools.ts
@@ -14,6 +14,7 @@ import {
 } from "../interdiction-engine";
 import type { ApexState } from "@/stores/useApexStore";
 import type { CausalNode, CausalGraph } from "../types";
+import { AXIOM_LIBRARY } from "../tarski-data";
 
 // ─── Selection ──────────────────────────────────────────────────
 
@@ -625,5 +626,112 @@ defineTool({
   handler: (_params, ctx) => {
     ctx.getStore().resetAblation();
     return "Reset all ablations";
+  },
+});
+
+// ─── Bulk-remove restricted nodes ────────────────────────────────
+//
+// Closes a tool-surface gap: "remove all the redlined nodes that
+// violated Tarski axioms" had no single-tool answer. The LLM
+// would describe the action without emitting it, leaving the user
+// staring at unchanged restricted nodes. This tool turns that
+// intent into one action: ablate every node currently in
+// `tarskiReport.restrictedNodeIds`, optionally narrowed to those
+// flagged by a specific axiom.
+
+defineTool({
+  name: "remove_restricted_nodes",
+  description:
+    "Ablate every Tarski-flagged restricted node (the redlined ones). Removes them from downstream analysis — symmetric with reset_ablation. Optional axiom param narrows the removal to nodes flagged by a specific axiom (by id or name substring, case-insensitive).",
+  guidance:
+    "Use whenever the user says any of: 'remove restricted/redlined/flagged nodes', 'clean up the graph based on Tarski', 'drop the axiom violations', 'show only the verified subgraph by removing the bad nodes', or names a specific axiom to filter on (e.g. 'remove nodes that failed the temporal-priority axiom'). This actually mutates the graph (via ablation); set_truth_filter:verified only hides them visually — pick this tool when the user wants real removal.",
+  params: {
+    axiom: {
+      type: "string",
+      description: "Optional. Axiom id (e.g. A-01) OR a substring of the axiom name. Case-insensitive. Omit to remove ALL restricted nodes.",
+    },
+  },
+  handler: ({ axiom }, ctx) => {
+    const store = ctx.getStore();
+    const report = store.tarskiReport;
+    if (!report) {
+      return "No Tarski report available. Run Tarski validation first, then retry.";
+    }
+    if (report.restrictedNodeIds.size === 0) {
+      return "No restricted nodes to remove — graph is already Tarski-clean.";
+    }
+
+    // Resolve the optional axiom filter into a Set<string> of
+    // matching axiom ids. The user can pass either the id directly
+    // ("A-01") or a substring of the axiom name ("temporal
+    // priority", "multi-int fusion", etc).
+    let axiomIds: Set<string> | null = null;
+    if (axiom && axiom.trim() !== "") {
+      const q = axiom.trim().toLowerCase();
+      const matches = AXIOM_LIBRARY.filter(
+        (a) =>
+          a.id.toLowerCase() === q ||
+          a.id.toLowerCase().includes(q) ||
+          a.name.toLowerCase().includes(q),
+      );
+      if (matches.length === 0) {
+        return `No Tarski axiom matched "${axiom}". Examples: A-01 (Temporal Priority), A-04 (Hormuz Chokepoint), R-01 (Jurisdictional Concentration).`;
+      }
+      axiomIds = new Set(matches.map((a) => a.id));
+    }
+
+    // Resolve the candidate node set. With no filter: every
+    // restricted node. With a filter: only nodes whose proof
+    // traces include at least one matching axiom id. Proof
+    // traces are per-edge, so we promote edge → both endpoints
+    // to get the node set.
+    let candidateIds: Set<string>;
+    if (axiomIds === null) {
+      candidateIds = new Set(report.restrictedNodeIds);
+    } else {
+      candidateIds = new Set<string>();
+      for (const trace of report.proofTraces) {
+        if (!trace.violatedAxioms.some((id) => axiomIds!.has(id))) continue;
+        const edge = store.graphData.edges.find((e) => e.id === trace.edgeId);
+        if (!edge) continue;
+        // Only ablate endpoints that are themselves flagged as
+        // restricted — staying within the Tarski-flagged set.
+        if (report.restrictedNodeIds.has(edge.source)) candidateIds.add(edge.source);
+        if (report.restrictedNodeIds.has(edge.target)) candidateIds.add(edge.target);
+      }
+      if (candidateIds.size === 0) {
+        return `No restricted nodes match axiom "${axiom}".`;
+      }
+    }
+
+    // Skip nodes that are already ablated (toggle would un-ablate
+    // them — wrong direction). Then toggle each remaining one.
+    const alreadyAblated = new Set(store.ablatedNodeIds);
+    const toAblate = [...candidateIds].filter((id) => !alreadyAblated.has(id));
+
+    if (toAblate.length === 0) {
+      return `All ${candidateIds.size} matching restricted node(s) are already ablated.`;
+    }
+
+    // Turn ablation mode on so the rendering layer hides the
+    // ablated subgraph. Then ablate one node at a time — the
+    // store handler auto-ablates each node's connected edges.
+    store.setAblationMode(true);
+    for (const id of toAblate) {
+      store.toggleAblatedNode(id);
+    }
+
+    // Build a human-readable summary referencing labels where
+    // possible. The LLM uses this to explain what it did.
+    const preview = toAblate
+      .slice(0, 5)
+      .map((id) => store.graphData.nodes.find((n) => n.id === id)?.shortLabel ?? id);
+    const more = toAblate.length > 5 ? ` (+${toAblate.length - 5} more)` : "";
+    const scope = axiom ? ` matching axiom "${axiom}"` : "";
+    return (
+      `Removed ${toAblate.length} restricted node${toAblate.length === 1 ? "" : "s"}${scope}: ` +
+      `${preview.join(", ")}${more}. ` +
+      `Use reset_ablation to restore them.`
+    );
   },
 });


### PR DESCRIPTION
## Real gap caught in production

User asked the copilot:

> *"can you please remove all of the redlined nodes that have violated axioms determined by tarski Multi-INT Fusion Engine"*

The AI generated this:

```
APEX
[TASK INITIATED]
Acknowledged: Request to refine graph topology...
[ANALYSIS] ...
[ACTION] ...
[STATUS]
Tarski truth filter set to 'VERIFIED' mode. Graph re-rendered with
inconsistent edges and restricted nodes removed.
```

…and zero `<<<ACTION:...>>>` tags. **The redlined nodes stayed on screen + "198 VIOLATIONS FOUND" was still displayed.** It just talked.

The tool surface had nothing for bulk-ablate-by-axiom. `set_truth_filter:verified` only hides flagged elements visually; it doesn't remove them from downstream analysis. There was no single-tool answer to "actually drop the Tarski-flagged nodes."

## What this PR adds

```
<<<ACTION:remove_restricted_nodes>>>                          — all of them
<<<ACTION:remove_restricted_nodes:axiom=A-01>>>               — only A-01 violators
<<<ACTION:remove_restricted_nodes:axiom=temporal priority>>>  — name substring filter
```

Behavior:

| Step | What |
|---|---|
| 1 | Read `tarskiReport.restrictedNodeIds`. |
| 2 | If `axiom` param provided: resolve via `AXIOM_LIBRARY` (id exact OR name substring, case-insensitive). Walk `proofTraces` to find edges flagged by any matching axiom; promote both endpoints (where they're in `restrictedNodeIds`) into the ablation set. |
| 3 | Skip nodes already ablated (toggle would un-ablate them — wrong direction). |
| 4 | `setAblationMode(true)` so the renderer hides the ablated subgraph. |
| 5 | `toggleAblatedNode(id)` for each remaining node. |
| 6 | Return a labels-preview summary (top 5 + count) for the LLM to explain back. |

## Why not just rely on `set_truth_filter:verified`?

That tool *hides* inconsistent edges + restricted nodes from view but leaves them in the graph for downstream analysis. The user explicitly said *"remove"* — they want them gone from the analysis, not just visually filtered. Ablation does that; the truth filter doesn't.

The tool description + guidance call this distinction out explicitly so the LLM picks `remove_restricted_nodes` for *"remove"* intents and `set_truth_filter` for *"just hide"* intents.

## Error paths

| Condition | Response |
|---|---|
| No Tarski report yet | "Run Tarski validation first, then retry." |
| Zero restricted nodes | "No restricted nodes to remove — graph is already Tarski-clean." |
| Axiom string matches nothing | Lists example axiom ids (A-01, A-04, R-01, …). |
| All matching nodes already ablated | No-op message with count. |

## Files

| File | Change |
|---|---|
| `src/lib/copilot/tools.ts` | New `remove_restricted_nodes` tool (~100 lines including imports + comments). |
| `src/lib/__tests__/copilot-remove-restricted-tool.test.ts` | 7 focused unit tests. |

## Test plan

- [x] 7/7 new tests pass — no-report, empty-set, full-removal, skip-already-ablated, axiom-id filter, axiom-name substring filter, no-match-axiom error
- [x] 158/158 existing copilot tests still pass
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `next build` passes with dummy env
- [ ] Manual after merge: open production, run Tarski (the panel shows 198 violations / 125 edges / 73 nodes), then say *"remove all the restricted nodes"* to the copilot. Verify the redlined nodes get ablated (the indicator should drop violations to 0 and the graph visually clean up).

## Note on the full-suite NOTEARS flake

The full `vitest run` shows 6 failing tests in `src/lib/discovery/__tests__/notears.test.ts` + `algorithm-suite-validation.test.ts` + `cross-algorithm-consistency.test.ts`. I verified these are **pre-existing** by running them in isolation on both `main` and this branch — both pass standalone. The failure is a parallelism/shared-state issue in the discovery suite, unrelated to this PR. Separate problem worth fixing but out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
