### PR TITLE
feat(canvas): cascade-sequence badges — see propagation order at a glance

### DIFF
--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -40,6 +40,7 @@ import {
   type Position2D,
 } from "@/lib/graph-layout-2d";
 import { computeNetworkMetrics, type NodeMetrics } from "@/lib/graph-layout";
+import { cascadeActivationOrder } from "@/lib/cascade-activation-order";
 import { AnimatePresence } from "framer-motion";
 
 type NodeEmphasis = "focus" | "neighbor" | "dim" | "none";
@@ -102,7 +103,7 @@ function computeNodeEmphasis(
 }
 
 function CausalNode2D({ data, selected, id }: NodeProps) {
-  const { label, category, domain, omegaComposite, isRestricted, datasetColor, shockIntensity, metrics } = data as {
+  const { label, category, domain, omegaComposite, isRestricted, datasetColor, shockIntensity, metrics, activationOrdinal } = data as {
     label: string;
     category: string;
     domain: string;
@@ -111,6 +112,7 @@ function CausalNode2D({ data, selected, id }: NodeProps) {
     datasetColor?: string;
     shockIntensity?: number;
     metrics?: NodeMetrics;
+    activationOrdinal?: number;
   };
   const { adjacency, hoveredNodeId } = useContext(Dag2DContext);
   const selectedNode = useApexStore((s) => s.selectedNode);
@@ -191,6 +193,44 @@ function CausalNode2D({ data, selected, id }: NodeProps) {
       <Handle type="source" position={Position.Bottom} style={{ background: "transparent", border: "none", width: 0, height: 0 }} />
       <Handle type="target" position={Position.Left} style={{ background: "transparent", border: "none", width: 0, height: 0 }} id="left-target" />
       <Handle type="source" position={Position.Right} style={{ background: "transparent", border: "none", width: 0, height: 0 }} id="right-source" />
+
+      {/* Cascade sequence badge. Mirrors the 3D affordance (yellow
+           pill anchored to the upper-right of the orb) so analysts get
+           the same propagation-order readout regardless of view mode.
+           Only renders during replay — when `activationOrdinal` is
+           undefined the badge is absent entirely. */}
+      {activationOrdinal !== undefined && (
+        <div
+          className="absolute pointer-events-none z-10"
+          style={{
+            top: -6,
+            right: -6,
+            minWidth: 16,
+            height: 16,
+            padding: "0 4px",
+            fontFamily: "monospace",
+            fontSize: 10,
+            fontWeight: 700,
+            color: "#0a0c14",
+            backgroundColor: "#ffd54f",
+            border: "1px solid rgba(10,12,20,0.7)",
+            borderRadius: 999,
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            lineHeight: 1,
+            boxShadow: "0 0 4px rgba(0,0,0,0.6)",
+            userSelect: "none",
+          }}
+          title={`Activation order: ${activationOrdinal} — fired ${
+            activationOrdinal === 1
+              ? "first"
+              : "after " + (activationOrdinal - 1) + " other node" + (activationOrdinal === 2 ? "" : "s")
+          } in the current cascade`}
+        >
+          {activationOrdinal}
+        </div>
+      )}
 
       <motion.div
         className="rounded-full absolute inset-0"
@@ -675,6 +715,14 @@ function CausalDAG2DInner() {
       ? replayEpochs[clampedEpoch] ?? null
       : null;
 
+  // 1-indexed activation order per node — mirrors the 3D canvas wiring
+  // so both views show the same propagation-sequence badges during
+  // replay. Outside replay this is an empty map and no badges render.
+  const activationOrder = useMemo(() => {
+    if (!replayActive || replayEpochs.length === 0) return new Map<string, number>();
+    return cascadeActivationOrder(replayEpochs, clampedEpoch);
+  }, [replayActive, replayEpochs, clampedEpoch]);
+
   const CONTRACTION = 0.18;
 
   // Force-directed layout. Cached positions come from a one-shot offline
@@ -866,10 +914,11 @@ function CausalDAG2DInner() {
           datasetColor: n.datasetColor,
           shockIntensity: epochShock,
           metrics: networkMetrics[n.id],
+          activationOrdinal: activationOrder.get(n.id),
         },
       };
     });
-  }, [graphData, nodePositions, truthFilter, currentSnapshot, adjacency, networkMetrics]);
+  }, [graphData, nodePositions, truthFilter, currentSnapshot, adjacency, networkMetrics, activationOrder]);
 
   // Filter nodes for isolation mode
   const visibleNodes = useMemo(() => {

--- a/src/components/CausalDAG3D.tsx
+++ b/src/components/CausalDAG3D.tsx
@@ -11,6 +11,7 @@ import { chiStar } from "@/lib/estimators/chi-star";
 import { severEdgeAndSpawnConsequences } from "@/lib/intervention-engine";
 import { getNodeDomainMap } from "@/lib/graph-data";
 import DAGNode3D, { orbitActiveRef } from "./dag3d/DAGNode3D";
+import { cascadeActivationOrder } from "@/lib/cascade-activation-order";
 import DAGEdge3D from "./dag3d/DAGEdge3D";
 import DAGOverlay from "./dag3d/DAGOverlay";
 import EdgeInspector from "./EdgeInspector";
@@ -541,6 +542,15 @@ export default function CausalDAG3D() {
     replayActive && replayEpochs.length > 0
       ? replayEpochs[clampedEpoch] ?? null
       : null;
+
+  // Map of nodeId → 1-indexed activation order. Drives the small
+  // numbered badges that float over the orbs during replay. Only
+  // populated when a cascade has actually run; outside replay the
+  // map is empty and no badges render.
+  const activationOrder = useMemo(() => {
+    if (!replayActive || replayEpochs.length === 0) return new Map<string, number>();
+    return cascadeActivationOrder(replayEpochs, clampedEpoch);
+  }, [replayActive, replayEpochs, clampedEpoch]);
 
   const canvasKey = useWebGLRecovery();
   const positionsRef = useRef<NodePosition[]>([]);
@@ -1126,6 +1136,7 @@ export default function CausalDAG3D() {
                     isActivated: node.omegaFragility.composite > 7,
                   } : undefined
                 )}
+                activationOrdinal={activationOrder.get(node.id)}
                 onDoubleClick={() => handleDoubleClick(node.id)}
                 onClick={() => {
                   if (ablationMode) {

--- a/src/components/dag3d/DAGNode3D.tsx
+++ b/src/components/dag3d/DAGNode3D.tsx
@@ -46,6 +46,14 @@ interface DAGNode3DProps {
   ablationMode?: boolean;
   metrics?: NodeMetrics;
   epochState?: NodeEpochState;
+  /**
+   * 1-indexed ordinal indicating when this node first activated in the
+   * current replay (1 = first to fire, 2 = second, …). When set, the
+   * node carries a small floating badge so analysts can see propagation
+   * order at a glance. `undefined` = no badge (replay isn't active OR
+   * this node hasn't joined the cascade yet at the current epoch).
+   */
+  activationOrdinal?: number;
   onClick?: () => void;
   onDoubleClick?: () => void;
 }
@@ -70,6 +78,7 @@ function DAGNode3DInner({
   ablationMode = false,
   metrics,
   epochState,
+  activationOrdinal,
   onClick,
   onDoubleClick,
 }: DAGNode3DProps) {
@@ -242,6 +251,50 @@ function DAGNode3DInner({
         </mesh>
       )}
 
+      {/* Cascade sequence badge — small numbered chip floating above
+           the orb during replay. The number is this node's 1-indexed
+           rank in the activation timeline (1 = first to fire). Only
+           renders when an ordinal is supplied AND the orb isn't
+           greyed-out / orbit-camera-active, so it stays out of the
+           way during normal exploration. Suppressed for ablated nodes
+           because they're not contributing to the cascade by
+           construction. */}
+      {activationOrdinal !== undefined && !isOrbiting && !isGreyedOut && !isAblated && (
+        <Html
+          position={[size * 0.9, size * 0.9, 0]}
+          center
+          style={{ pointerEvents: "none" }}
+          zIndexRange={[0, 0]}
+        >
+          <div
+            style={{
+              fontFamily: "monospace",
+              fontSize: "10px",
+              fontWeight: 700,
+              color: "#0a0c14",
+              backgroundColor: "#ffd54f",
+              border: "1px solid rgba(10,12,20,0.7)",
+              borderRadius: "999px",
+              minWidth: "16px",
+              height: "16px",
+              padding: "0 4px",
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              textAlign: "center",
+              userSelect: "none",
+              lineHeight: 1,
+              boxShadow: "0 0 4px rgba(0,0,0,0.6)",
+            }}
+            title={`Activation order: ${activationOrdinal} — fired ${
+              activationOrdinal === 1 ? "first" : "after " + (activationOrdinal - 1) + " other node" + (activationOrdinal === 2 ? "" : "s")
+            } in the current cascade`}
+          >
+            {activationOrdinal}
+          </div>
+        </Html>
+      )}
+
       {/* Label — only visible on hover, single-select, neighbour-of-
            select, or multi-select. v1 painted a label on every orb
            permanently and dense graphs read as a hodgepodge of overlapping
@@ -341,6 +394,10 @@ function arePropsEqual(prev: DAGNode3DProps, next: DAGNode3DProps) {
     if (pe.omegaComposite !== ne.omegaComposite) return false;
     if (pe.shockIntensity !== ne.shockIntensity) return false;
   }
+  // Cascade-sequence badge updates as the TimeDial scrubs through replay
+  // (ordinal flips between defined / undefined as nodes join the cascade).
+  // Plain value compare — both are number | undefined.
+  if (prev.activationOrdinal !== next.activationOrdinal) return false;
   // Intentionally not comparing onClick / onDoubleClick — closures rebuild
   // every parent render but their behavior is stable per node.id.
   return true;

--- a/src/lib/__tests__/cascade-activation-order.test.ts
+++ b/src/lib/__tests__/cascade-activation-order.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from "vitest";
+import { cascadeActivationOrder } from "../cascade-activation-order";
+import type { EpochSnapshot, NodeEpochState } from "../types";
+
+// ─── Test fixtures ──────────────────────────────────────────────
+
+/**
+ * Build a minimal snapshot per epoch. `activated` is the set of node
+ * ids that should have `isActivated: true` at that epoch. All other
+ * node-state fields are stubbed — the util only reads `isActivated`.
+ */
+function snapshot(epoch: number, activated: string[]): EpochSnapshot {
+  const nodeStates: Record<string, NodeEpochState> = {};
+  for (const id of activated) {
+    nodeStates[id] = {
+      omegaComposite: 5,
+      omegaProfile: {
+        composite: 5,
+        irreplaceability: 5,
+        restorationLatency: 5,
+        jurisdictionalHazard: 5,
+        cascadeLoad: 5,
+        tailDepth: 5,
+      },
+      shockIntensity: 0.5,
+      isActivated: true,
+    };
+  }
+  return {
+    epoch,
+    nodeStates,
+    edgeStates: {},
+    omegaBuffer: 80,
+    omegaStatus: "NOMINAL",
+    criticalityEstimate: null,
+    isStable: false,
+    isCritical: false,
+  };
+}
+
+describe("cascadeActivationOrder", () => {
+  it("returns an empty map for an empty snapshot array", () => {
+    const out = cascadeActivationOrder([], 100);
+    expect(out.size).toBe(0);
+  });
+
+  it("returns an empty map when upToEpoch is negative", () => {
+    const epochs = [snapshot(0, ["A", "B"])];
+    expect(cascadeActivationOrder(epochs, -1).size).toBe(0);
+  });
+
+  it("returns ordinals in activation order (single-epoch baseline)", () => {
+    // A and B both activate at epoch 0 — tied epoch, tiebreak by id.
+    // A < B lexicographically → A gets ordinal 1, B gets 2.
+    const epochs = [snapshot(0, ["B", "A"])];
+    const out = cascadeActivationOrder(epochs, 0);
+    expect(out.get("A")).toBe(1);
+    expect(out.get("B")).toBe(2);
+    expect(out.size).toBe(2);
+  });
+
+  it("orders across epochs by first-activation epoch", () => {
+    // A activates at epoch 0; B at epoch 1; C at epoch 2. Ordering
+    // follows the cascade timeline, not lexicographic order.
+    const epochs = [
+      snapshot(0, ["A"]),
+      snapshot(1, ["A", "B"]),
+      snapshot(2, ["A", "B", "C"]),
+    ];
+    const out = cascadeActivationOrder(epochs, 2);
+    expect(out.get("A")).toBe(1);
+    expect(out.get("B")).toBe(2);
+    expect(out.get("C")).toBe(3);
+  });
+
+  it("breaks within-epoch ties by node id (deterministic)", () => {
+    // Three nodes flip at epoch 1 simultaneously. Tie-break by id:
+    // ASCII order Z < a < b (capitals sort before lowercase). Map
+    // entries are in insertion order.
+    const epochs = [
+      snapshot(0, []),
+      snapshot(1, ["b", "Z", "a"]),
+    ];
+    const out = cascadeActivationOrder(epochs, 1);
+    expect(out.get("Z")).toBe(1);
+    expect(out.get("a")).toBe(2);
+    expect(out.get("b")).toBe(3);
+  });
+
+  it("honours the upToEpoch cutoff (hides later activations)", () => {
+    // C only activates at epoch 2 — hidden when we ask for up to epoch 1.
+    const epochs = [
+      snapshot(0, ["A"]),
+      snapshot(1, ["A", "B"]),
+      snapshot(2, ["A", "B", "C"]),
+    ];
+    const out = cascadeActivationOrder(epochs, 1);
+    expect(out.get("A")).toBe(1);
+    expect(out.get("B")).toBe(2);
+    expect(out.has("C")).toBe(false);
+    expect(out.size).toBe(2);
+  });
+
+  it("clamps upToEpoch beyond the end of the snapshot array", () => {
+    const epochs = [snapshot(0, ["A"]), snapshot(1, ["A", "B"])];
+    const out = cascadeActivationOrder(epochs, 99);
+    expect(out.get("A")).toBe(1);
+    expect(out.get("B")).toBe(2);
+  });
+
+  it("ignores nodes that appear in nodeStates but never set isActivated", () => {
+    // Build a snapshot where some node-states have isActivated=false.
+    const inactive: EpochSnapshot = {
+      epoch: 0,
+      nodeStates: {
+        A: {
+          omegaComposite: 5,
+          omegaProfile: {
+            composite: 5,
+            irreplaceability: 5,
+            restorationLatency: 5,
+            jurisdictionalHazard: 5,
+            cascadeLoad: 5,
+            tailDepth: 5,
+          },
+          shockIntensity: 0,
+          isActivated: false,
+        },
+      },
+      edgeStates: {},
+      omegaBuffer: 100,
+      omegaStatus: "NOMINAL",
+      criticalityEstimate: null,
+      isStable: true,
+      isCritical: false,
+    };
+    const out = cascadeActivationOrder([inactive], 0);
+    expect(out.size).toBe(0);
+  });
+
+  it("preserves first-activation epoch even if a node deactivates later", () => {
+    // A activates at 0, deactivates at 1, reactivates at 2.
+    // First-activation rule: still epoch 0 (we don't re-rank on re-activation).
+    const epochs = [
+      snapshot(0, ["A"]),
+      snapshot(1, []),
+      snapshot(2, ["A", "B"]),
+    ];
+    const out = cascadeActivationOrder(epochs, 2);
+    expect(out.get("A")).toBe(1);
+    expect(out.get("B")).toBe(2);
+  });
+});

--- a/src/lib/cascade-activation-order.ts
+++ b/src/lib/cascade-activation-order.ts
@@ -1,0 +1,72 @@
+// ─── Cascade activation order ────────────────────────────────────
+//
+// Given the snapshot array a cascade simulation produces, returns a
+// 1-indexed ordinal per node indicating *the order in which it first
+// activated*. This is the data driving the small "1, 2, 3, …" badges
+// that float over nodes on the canvas during replay — analysts watch
+// the sequence to see how a shock propagates through the graph.
+//
+// Honest framing
+// --------------
+// "Activation" is the simulator's binary `isActivated` flag, which is
+// set when a node's `shockIntensity` rises above ~0.001 (see
+// `cascade-simulator.ts:runEpoch`). It captures the moment a node
+// joined the cascade, not the moment of any particular Ω threshold.
+// Two cards may both be "activated" while having very different Ω
+// trajectories — the badge tells you about *propagation order*, not
+// *severity*. Severity reads from the orb size + colour as before.
+//
+// Determinism
+// -----------
+// Ties (multiple nodes flipping isActivated in the same epoch) are
+// broken by node id (ASCII lexicographic). This is the same rule the
+// graph data uses for stable iteration; downstream UI doesn't reorder
+// across renders.
+//
+// Cutoff
+// ------
+// `upToEpoch` clamps the search window — useful when the user is
+// scrubbing the TimeDial backwards. Only nodes that have activated by
+// `epochs[upToEpoch]` get an ordinal; later activations are hidden so
+// the badges always reflect the *currently-visible* state of the
+// cascade, not the full eventual one.
+
+import type { EpochSnapshot } from "./types";
+
+/**
+ * Map of nodeId → 1-indexed ordinal. Nodes that never activated
+ * (or that activate after `upToEpoch`) are absent from the map —
+ * callers should treat absence as "no badge."
+ */
+export function cascadeActivationOrder(
+  epochs: ReadonlyArray<EpochSnapshot>,
+  upToEpoch: number,
+): Map<string, number> {
+  if (epochs.length === 0 || upToEpoch < 0) return new Map();
+  const cutoff = Math.min(upToEpoch, epochs.length - 1);
+
+  // Pass 1 — first activation epoch per node.
+  const firstActivation = new Map<string, number>();
+  for (let e = 0; e <= cutoff; e++) {
+    const states = epochs[e].nodeStates;
+    for (const nodeId in states) {
+      if (!Object.prototype.hasOwnProperty.call(states, nodeId)) continue;
+      if (firstActivation.has(nodeId)) continue;
+      if (states[nodeId].isActivated) firstActivation.set(nodeId, e);
+    }
+  }
+
+  // Pass 2 — sort by (epoch ASC, nodeId ASC) and assign 1-indexed
+  // ordinals. The id tiebreaker keeps the output stable across renders
+  // even when the underlying snapshot iteration order varies.
+  const entries = [...firstActivation.entries()].sort((a, b) => {
+    if (a[1] !== b[1]) return a[1] - b[1];
+    return a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0;
+  });
+
+  const out = new Map<string, number>();
+  for (let i = 0; i < entries.length; i++) {
+    out.set(entries[i][0], i + 1);
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Per the session conversation: *"you should be able to kind of, like, see that in the main module. Like, you should see a number of things highlighted with numbers on top of them so you see what sequence is following the next."*

This PR ships exactly that — a small numbered chip floats above each node during replay showing its 1-indexed activation order (1 = first to fire, 2 = second, …). Updates live as the user scrubs the TimeDial.

## What you'll see

Inject a shock (any way — ScenarioInput, AblationPanel, copilot, or canvas click), hit Start Replay. As the cascade unfolds:

```
   ⓞ─→ ⓞ─→ ⓞ
   ①    ②    ③
```

The badges read left-to-right with the cascade's propagation order — first the seed node, then its downstream neighbours as they activate, then theirs. Same in 3D and 2D view modes. Disappears when replay isn't active.

## Honest framing

"Activation" is the simulator's binary `isActivated` flag — set when `shockIntensity` rises above ~0.001 in `cascade-simulator.runEpoch`. That captures the moment a node *joins* the cascade, not a particular Ω severity threshold. Two adjacent ordinals can be very different in damage — keep reading severity from orb size + colour, propagation order from the badge.

## Files

| File | Change |
|---|---|
| `src/lib/cascade-activation-order.ts` (new, ~70 LOC) | `cascadeActivationOrder(epochs, upToEpoch) → Map<nodeId, ordinal>`. Single pass to find first-activation epoch; sort by (epoch ASC, nodeId ASC) for deterministic tie-breaking; assign 1-indexed ordinals. |
| `src/lib/__tests__/cascade-activation-order.test.ts` (new) | 9 tests: happy path, empty input, negative cutoff, cross-epoch ordering, within-epoch id tie-break, upToEpoch cutoff, clamps past end, ignores isActivated=false, preserves first-activation through later deactivation. |
| `src/components/dag3d/DAGNode3D.tsx` | New optional `activationOrdinal?: number` prop. Yellow pill via drei `<Html>` anchored to the orb's upper-right corner. Suppressed when greyed out, ablated, or during orbit motion. Added to `arePropsEqual` so memo invalidates on scrub. |
| `src/components/CausalDAG3D.tsx` | Memoizes the order map on `(replayActive, replayEpochs, clampedEpoch)`; passes `activationOrdinal` to each node. |
| `src/components/CausalDAG2D.tsx` | Mirrors the 3D wiring — order map memoized at the same scope, threaded through React Flow node data, badge rendered in `CausalNode2D` so 2D and 3D carry the same affordance. |

## Test plan

- [x] 9 new util tests pass
- [x] `npx next build` clean with placeholder envs
- [x] Full vitest in isolation: 1156 / 1156 (1147 prior + 9 new). The NOTEARS / FCI concurrency flake under full-suite load is unrelated and known — passes clean in isolation; CI runner has less worker contention.
- [ ] PR-validate workflow green
- [ ] Vercel preview eyeball: inject a shock, start replay. Confirm yellow badges appear over activating nodes in both 2D and 3D, numbering follows the cascade order, scrubbing the TimeDial back hides later badges, leaving replay clears them entirely.

## Backwards compat

Purely additive. When no replay is active, the order map is empty and no node receives an `activationOrdinal`. Existing UX outside replay is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
