### PR TITLE
feat(canvas): ablation mode persists across 2D / Map / Relief

### DIFF
--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -103,7 +103,7 @@ function computeNodeEmphasis(
 }
 
 function CausalNode2D({ data, selected, id }: NodeProps) {
-  const { label, category, domain, omegaComposite, isRestricted, datasetColor, shockIntensity, metrics, activationOrdinal } = data as {
+  const { label, category, domain, omegaComposite, isRestricted, datasetColor, shockIntensity, metrics, activationOrdinal, isAblated } = data as {
     label: string;
     category: string;
     domain: string;
@@ -113,6 +113,7 @@ function CausalNode2D({ data, selected, id }: NodeProps) {
     shockIntensity?: number;
     metrics?: NodeMetrics;
     activationOrdinal?: number;
+    isAblated?: boolean;
   };
   const { adjacency, hoveredNodeId } = useContext(Dag2DContext);
   const selectedNode = useApexStore((s) => s.selectedNode);
@@ -177,13 +178,19 @@ function CausalNode2D({ data, selected, id }: NodeProps) {
   const isHoverDriven = hoveredNodeId !== null;
   const dimOpacity = isHoverDriven ? 0.18 : 0.5;
 
+  // Ablated orbs are dimmed hard (mirrors the 3D `0.15` treatment in
+  // DAGNode3D). Ablation takes priority over the hover/select dim
+  // because an ablated node is functionally removed from the cascade
+  // and should read that way regardless of any other state.
+  const finalOpacity = isAblated ? 0.15 : isDim ? dimOpacity : 1;
+
   return (
     <motion.div
       className="relative"
       style={{
         width: diameter,
         height: diameter,
-        opacity: isDim ? dimOpacity : 1,
+        opacity: finalOpacity,
         transition: "opacity 180ms ease-out",
       }}
       animate={isRinged ? { scale: 1.1 } : { scale: 1 }}
@@ -723,6 +730,16 @@ function CausalDAG2DInner() {
     return cascadeActivationOrder(replayEpochs, clampedEpoch);
   }, [replayActive, replayEpochs, clampedEpoch]);
 
+  // Global ablation set — hoisted up so the node-builder useMemo
+  // below can dim ablated nodes. The store hooks themselves live a
+  // bit lower (next to the click handlers); we read the array here
+  // and read the actions there.
+  const ablatedNodeIdsForBuilder = useApexStore((s) => s.ablatedNodeIds);
+  const ablatedNodeSet = useMemo(
+    () => new Set(ablatedNodeIdsForBuilder),
+    [ablatedNodeIdsForBuilder],
+  );
+
   const CONTRACTION = 0.18;
 
   // Force-directed layout. Cached positions come from a one-shot offline
@@ -915,10 +932,11 @@ function CausalDAG2DInner() {
           shockIntensity: epochShock,
           metrics: networkMetrics[n.id],
           activationOrdinal: activationOrder.get(n.id),
+          isAblated: ablatedNodeSet.has(n.id),
         },
       };
     });
-  }, [graphData, nodePositions, truthFilter, currentSnapshot, adjacency, networkMetrics, activationOrder]);
+  }, [graphData, nodePositions, truthFilter, currentSnapshot, adjacency, networkMetrics, activationOrder, ablatedNodeSet]);
 
   // Filter nodes for isolation mode
   const visibleNodes = useMemo(() => {
@@ -1049,6 +1067,13 @@ function CausalDAG2DInner() {
   const setSelectedNode = useApexStore((s) => s.setSelectedNode);
   const selectedNodesCount = useApexStore((s) => s.selectedNodes.length);
   const setSelectedNodes = useApexStore((s) => s.setSelectedNodes);
+  // Ablation mode is global — when on, clicks across every visual
+  // toggle ablation instead of selection. Mirrors the 3D wiring; the
+  // canonical handler is `ablationMode ? toggleAblatedNode : setSelectedNode`.
+  // (The `ablatedNodeSet` Set used by the node-builder memo above is
+  // declared earlier — re-deriving here would shadow it.)
+  const ablationMode = useApexStore((s) => s.ablationMode);
+  const toggleAblatedNode = useApexStore((s) => s.toggleAblatedNode);
 
   // Hand-rolled shift+drag marquee. We bypass React Flow's built-in
   // selection (which is unreliable when combined with panOnDrag) and
@@ -1144,9 +1169,17 @@ function CausalDAG2DInner() {
   const onNodeClick: NodeMouseHandler = useCallback(
     (_event, rfNode) => {
       setSelectedEdge(null);
-      setSelectedNode(rfNode.id);
+      // In ablation mode, clicks toggle ablation instead of moving the
+      // selection. Matches the 3D / Map / Relief behaviour so the
+      // affordance is identical regardless of which view the user
+      // happens to be in.
+      if (ablationMode) {
+        toggleAblatedNode(rfNode.id);
+      } else {
+        setSelectedNode(rfNode.id);
+      }
     },
-    [setSelectedNode]
+    [setSelectedNode, ablationMode, toggleAblatedNode]
   );
 
   const onPaneClick = useCallback(() => {

--- a/src/components/CausalDAGMap.tsx
+++ b/src/components/CausalDAGMap.tsx
@@ -60,7 +60,14 @@ function CausalDAGMapInner() {
     selectedNodes,
     setSelectedNodes,
     isolateSelection,
+    // Global ablation state. Click in ablation mode toggles ablation
+    // instead of selection; ablated nodes paint with low opacity so
+    // they read as "removed from the cascade" the way they do in 3D.
+    ablationMode,
+    ablatedNodeIds,
+    toggleAblatedNode,
   } = useApexStore();
+  const ablatedNodeSet = useMemo(() => new Set(ablatedNodeIds), [ablatedNodeIds]);
   // Use the same filtered graph as 2D and 3D views for consistent data
   const activeGraph = useFilteredGraph();
 
@@ -176,14 +183,15 @@ function CausalDAGMapInner() {
         node.datasetColor ??
         getDomainColor(node.domain);
       const isSelected = selectedNode === node.id || selectedSet.has(node.id);
-      // Two dim modes:
-      //  - isolate ON  → opacity 0.15 (existing behaviour)
-      //  - isolate OFF → opacity 0.35 (multi-select spotlight, matches 2D
-      //    where multiSelected.length > 0 alone dims non-selected nodes)
+      // Three dim modes (in priority order):
+      //  - ablated     → opacity 0.15 (mirror 3D / 2D — wins regardless)
+      //  - isolate ON  → opacity 0.15
+      //  - multi-select with isolate OFF → opacity 0.35
       const isMultiSelectActive = selectedSet.size > 0;
       const isOutOfScope = isMultiSelectActive && !selectedSet.has(node.id);
-      const isDimmed = isOutOfScope;
-      const dimOpacity = isolateSelection ? 0.15 : 0.35;
+      const isAblated = ablatedNodeSet.has(node.id);
+      const isDimmed = isAblated || isOutOfScope;
+      const dimOpacity = isAblated ? 0.15 : isolateSelection ? 0.15 : 0.35;
       const omega = node.omegaFragility.composite;
 
       return {
@@ -199,6 +207,7 @@ function CausalDAGMapInner() {
           color: domainColor,
           isSelected,
           isDimmed,
+          isAblated,
           // Size based on omega score
           radius: Math.max(4, omega * 1.2),
           opacity: isDimmed ? dimOpacity : 1,
@@ -208,7 +217,7 @@ function CausalDAGMapInner() {
       };
     });
     return { type: "FeatureCollection", features };
-  }, [activeGraph.nodes, selectedNode, selectedNodes, isolateSelection]);
+  }, [activeGraph.nodes, selectedNode, selectedNodes, isolateSelection, ablatedNodeSet]);
 
   // Build GeoJSON for edges — split into solid and dashed to match 3D conventions:
   //   directed  → cyan (#00e5ff) — solid
@@ -542,7 +551,11 @@ function CausalDAGMapInner() {
         const nodeId = feature.properties?.id;
         if (nodeId) {
           setSelectedEdge(null);
-          if (e.originalEvent.shiftKey) {
+          // Ablation mode preempts both single and shift-select. Same
+          // semantics as 3D / 2D — click toggles ablation, full stop.
+          if (ablationMode) {
+            toggleAblatedNode(nodeId);
+          } else if (e.originalEvent.shiftKey) {
             setSelectedNodes(
               selectedNodes.includes(nodeId)
                 ? selectedNodes.filter((id: string) => id !== nodeId)
@@ -568,7 +581,7 @@ function CausalDAGMapInner() {
         return;
       }
     },
-    [selectedNode, selectedNodes, setSelectedNode, setSelectedNodes, activeGraph.edges, selectedEdge],
+    [selectedNode, selectedNodes, setSelectedNode, setSelectedNodes, activeGraph.edges, selectedEdge, ablationMode, toggleAblatedNode],
   );
 
   const [hoveredFeature, setHoveredFeature] = useState(false);

--- a/src/components/CausalDAGRelief.tsx
+++ b/src/components/CausalDAGRelief.tsx
@@ -861,6 +861,15 @@ function CausalDAGReliefInner() {
   const graphData = useFilteredGraph();
   const setSelectedNode = useApexStore((s) => s.setSelectedNode);
   const setSelectedNodes = useApexStore((s) => s.setSelectedNodes);
+  // Ablation mode is global — click on a mountain peak in ablation
+  // mode toggles the underlying node instead of selecting it, and
+  // ablated nodes get their composite zeroed so the mountain sinks
+  // into the terrain (visible "removed from cascade" treatment that
+  // works on a heightmap where opacity doesn't apply the same way).
+  const ablationMode = useApexStore((s) => s.ablationMode);
+  const ablatedNodeIds = useApexStore((s) => s.ablatedNodeIds);
+  const toggleAblatedNode = useApexStore((s) => s.toggleAblatedNode);
+  const ablatedNodeSet = useMemo(() => new Set(ablatedNodeIds), [ablatedNodeIds]);
   const [pickHint, setPickHint] = useState<string | null>(null);
   // χ★ overlay toggle. Default OFF: Relief is for the fragility heat
   // distribution; the chokepoint structure is a separate question
@@ -954,11 +963,24 @@ function CausalDAGReliefInner() {
         };
       });
     }
+    // Ablated nodes get their composite zeroed BEFORE the field-input
+    // builds the heightmap — the corresponding mountain sinks into the
+    // baseline terrain, which is the heightmap-native way to render
+    // "functionally removed from the cascade." Applied after the
+    // snapshot override so an ablated node stays sunk even if the
+    // simulator was about to put it under stress.
+    if (ablatedNodeSet.size > 0) {
+      nodes = nodes.map((n) =>
+        ablatedNodeSet.has(n.id)
+          ? { ...n, omegaFragility: { ...n.omegaFragility, composite: 0 } }
+          : n,
+      );
+    }
     if (isolateSelection && multiSelectedSet.size > 0) {
       nodes = nodes.filter((n) => multiSelectedSet.has(n.id));
     }
     return nodes;
-  }, [graphData.nodes, currentSnapshot, isolateSelection, multiSelectedSet]);
+  }, [graphData.nodes, currentSnapshot, isolateSelection, multiSelectedSet, ablatedNodeSet]);
 
   const surfaceTint =
     !isolateSelection && multiSelectedSet.size > 0 ? 0.4 : 1;
@@ -1080,6 +1102,18 @@ function CausalDAGReliefInner() {
       activeField,
     );
     if (id) {
+      if (ablationMode) {
+        // In ablation mode, picking a peak toggles ablation of that
+        // node — same semantics as 3D / 2D / Map. We still surface
+        // the pickHint so the user sees which node was hit.
+        toggleAblatedNode(id);
+        const node = graphData.nodes.find((n) => n.id === id);
+        setPickHint(
+          node ? `${node.label} — ${ablatedNodeSet.has(id) ? "restored" : "ablated"}` : id,
+        );
+        window.setTimeout(() => setPickHint(null), 1400);
+        return;
+      }
       setSelectedNode(id);
       const node = graphData.nodes.find((n) => n.id === id);
       setPickHint(node?.label ?? id);


### PR DESCRIPTION
## Summary

User-reported: ablation mode was 3D-only. A user who enabled ablation in 3D, switched to 2D / Map / Relief, lost the affordance entirely — click went back to selection and ablated nodes rendered identically to active ones.

This PR mirrors the 3D wiring across every view so the mode behaves identically regardless of where the user is.

## The identical contract, everywhere

| | Click in ablation mode | Ablated node visual |
|---|---|---|
| 3D | `toggleAblatedNode(id)` | opacity 0.15 |
| 2D | `toggleAblatedNode(id)` | opacity 0.15 (matches 3D) |
| Map | `toggleAblatedNode(id)` (preempts shift-select) | circle opacity 0.15 |
| Relief | `toggleAblatedNode(id)` + toast | mountain composite → 0 (sinks into terrain) |

Ablation takes priority over isolate / multi-select dim modes everywhere. Outside ablation mode, behaviour is unchanged.

## Per-view changes

**`CausalDAG2D.tsx`** — Reads `ablationMode` / `toggleAblatedNode` / `ablatedNodeIds`. `onNodeClick` routes through ablationMode. `ablatedNodeSet` is hoisted up so the node-builder memo can stamp `isAblated` onto each React Flow node; `CausalNode2D` dims at opacity 0.15.

**`CausalDAGMap.tsx`** — `onMapClick`'s `node-circles` branch routes through ablationMode ahead of shift/single-select. `nodeGeoJSON` carries `isAblated`; the per-feature `opacity` property now follows a priority chain (ablated → isolate → multi-select → 1).

**`CausalDAGRelief.tsx`** — Pick handler routes through ablationMode and feeds `pickHint` with "ablated" / "restored" since opacity isn't a heightmap affordance. The `fieldNodes` memo zeroes the `composite` for ablated nodes BEFORE the heightmap builds — the mountain sinks into the terrain, which is the heightmap-native way to render "functionally removed."

## Test plan

- [x] `npx next build` clean
- [x] Cascade activation-order tests still pass (9 / 9 — sequence-badge work from #371 untouched)
- [x] Full vitest pass in isolation
- [ ] PR-validate workflow green
- [ ] Vercel preview eyeball: enable ablation in 3D, click a few nodes, switch through 2D / Map / Relief — the same nodes read as ablated in each view (dim or sunk); click in each view toggles ablation rather than selection; disable ablation mode and the click affordance returns to normal selection everywhere

## Backwards compat

Zero store changes. The actions (`setAblationMode`, `toggleAblatedNode`, `resetAblation`, `startAblationReplay`) all pre-existed — this PR just makes them functional outside 3D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
