### PR TITLE
fix(overlay): FIT-mode auto-reset on dial preset clicks + OUT-OF-WINDOW chip

### DIFF
--- a/src/components/TimeSeriesOverlay.tsx
+++ b/src/components/TimeSeriesOverlay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, useCallback, useRef, useLayoutEffect } from "react";
+import { useEffect, useMemo, useState, useCallback, useRef, useLayoutEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useApexStore } from "@/stores/useApexStore";
 import { getDomainColor } from "@/lib/graph-data";
@@ -130,6 +130,25 @@ export default function TimeSeriesOverlay() {
   //    This is the explicit trade-off — comparison mode for sparse
   //    series, alignment mode otherwise.
   const [xAxisMode, setXAxisMode] = useState<"dial" | "data">("dial");
+
+  // When the user clicks a dial preset (1H / 1D / 1W / 1M), `timelineRange.start`
+  // changes. That click is the strongest possible signal that they want the
+  // chart to track the dial again, so we auto-reset out of "data" mode.
+  //
+  // We watch `.start` specifically (not `.end`) because `.end` advances every
+  // live tick — watching `.end` would kick the user out of "data" mode every
+  // second, which would defeat the feature. `.start` only changes on dial-
+  // preset clicks and full timeline-range edits.
+  //
+  // Without this reset, the FIT toggle was a one-way trap: once a user clicked
+  // into "data" mode, the chart appeared to ignore subsequent dial clicks
+  // because the chart x-axis stayed pinned to the full data span while the
+  // dial scrubber moved beneath it. Reported as "1D shows curves, 1M flattens
+  // to a line, 1D doesn't restore detail" on 2026-05-21.
+  useEffect(() => {
+    setXAxisMode("dial");
+  }, [timelineRange.start]);
+
   const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   // The SVG uses preserveAspectRatio="none", so viewBox width is set to the
@@ -375,6 +394,24 @@ export default function TimeSeriesOverlay() {
     }
     return { xStart: timelineRange.start, xEnd: timelineRange.end };
   }, [xAxisMode, timelineRange, dataXBounds]);
+
+  // Per-curve count of history points that fall inside the visible x-range.
+  // Used by the legend's "OUT OF WINDOW" badge — when this is 0, the curve
+  // is rendering as a pure hold-forward line at the latest value with no
+  // intra-window detail, and the user should be told to widen the dial
+  // rather than think the data is broken. The hold-forward render itself
+  // stays correct; this is purely a UX signal.
+  const inWindowCounts = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const c of curves) {
+      let n = 0;
+      for (const h of c.history) {
+        if (h.timestamp >= xStart && h.timestamp <= xEnd) n++;
+      }
+      m.set(c.nodeId, n);
+    }
+    return m;
+  }, [curves, xStart, xEnd]);
 
   // Convert data coordinates to SVG coordinates. Per-curve normalization:
   // when curveId is provided, the value is mapped to its own 0..1 range
@@ -837,9 +874,14 @@ export default function TimeSeriesOverlay() {
             <div className="min-w-[72px] flex-shrink-0" />
             {curves.map((curve) => {
               const isSparse = curve.pointCount < SPARSE_POINT_THRESHOLD;
+              const inWindow = inWindowCounts.get(curve.nodeId) ?? 0;
+              const outOfWindow = inWindow === 0;
               const tooltipParts: string[] = [];
               if (curve.sourceLabel) tooltipParts.push(`${curve.sourceLabel}${curve.sourceUnit ? ` (${curve.sourceUnit})` : ""}`);
               tooltipParts.push(isSparse ? `${curve.pointCount} published timepoint${curve.pointCount !== 1 ? "s" : ""} — hold-forward rendering` : `${curve.pointCount} datapoints`);
+              if (outOfWindow) {
+                tooltipParts.push("⚠ no data inside the current dial window — widen the dial (1W / 1M / ZOOM OUT) to see this curve's shape");
+              }
               tooltipParts.push("Click to remove");
               return (
                 <button
@@ -889,6 +931,26 @@ export default function TimeSeriesOverlay() {
                       }}
                     >
                       {curve.pointCount === 1 ? "STATIC" : `${curve.pointCount}PT`}
+                    </span>
+                  )}
+                  {/* Out-of-window badge — zero history points fall inside
+                      the dial's visible range, so the curve is rendering as
+                      a flat hold-forward line at the latest value with no
+                      intra-window shape. Tells the user this is a cadence
+                      issue (window too tight for this signal's cadence),
+                      not broken data. Hidden in "data" x-axis mode since
+                      that mode by definition zooms to encompass all points. */}
+                  {outOfWindow && xAxisMode === "dial" && (
+                    <span
+                      className="text-[6px] font-[family-name:var(--font-michroma)] tracking-wide px-1 py-px rounded flex-shrink-0"
+                      style={{
+                        color: "var(--accent-amber, #ffb454)",
+                        backgroundColor: "rgba(255, 180, 84, 0.10)",
+                        border: "1px solid rgba(255, 180, 84, 0.40)",
+                      }}
+                      title="No data points inside the dial window — curve is hold-forward only. Widen the dial to see this signal's actual shape."
+                    >
+                      OUT OF WINDOW
                     </span>
                   )}
                   <span className="text-[7px] text-text-muted group-hover:text-accent-red transition-colors">


### PR DESCRIPTION
## The bug

PR #353 added the FIT: DIAL ⇄ DATA toggle so annual WB series could be rendered as real curves. That worked in isolation, but combined with the dial preset buttons it became a one-way trap.

User-reported repro (2026-05-21, screenshots in the parent thread):

> Start on **1D** — chart shows curves with detail.
> Click **1M** — curves "stretched out to a line".
> Click **1D** again — chart "remained as a line".

What was happening: somewhere in the transition the FIT button became visible (data extends past the dial), an extra click landed on it, and \`xAxisMode\` flipped to \`"data"\`. The chart x-axis pinned to the curves' full history span (~years), compressing the dial's visible window to ~0.001 % of chart width — looks like a flat stripe. Subsequent dial preset clicks moved the scrubber below but had no effect on the chart above, because the chart wasn't reading \`timelineRange\` anymore.

## The fix

**1. Auto-reset on dial preset clicks** — a \`useEffect\` that resets \`xAxisMode\` to \`"dial"\` whenever \`timelineRange.start\` changes. Dial preset buttons (1H / 1D / 1W / 1M) change \`.start\`; the live tick only advances \`.end\`, so users in \`"data"\` mode don't get kicked out every second by the live update. Clicking a preset is the strongest possible signal that the user wants chart-follows-dial behavior.

\`\`\`tsx
useEffect(() => {
  setXAxisMode("dial");
}, [timelineRange.start]);
\`\`\`

**2. Per-curve OUT OF WINDOW chip** — when zero history points fall inside \`[xStart, xEnd]\`, render a small amber badge in the legend next to that curve's label, with a tooltip hint to widen the dial. The render itself was already correct (sparse curves hold-forward, dense curves draw their actual polyline) — this is purely the missing UX signal so the user knows it's a cadence issue, not broken data. Hidden in DATA mode by definition.

\`inWindowCounts\` is a \`useMemo\` over \`[curves, xStart, xEnd]\`. Cheap: linear scan of \`curve.history\` per curve, typical N ≈ 5–18 points × 5 pinned curves.

## Test plan

- [x] \`npx tsc --noEmit\` — no new errors in TimeSeriesOverlay
- [x] 81 feed tests pass (\`vitest run src/lib/__tests__/feeds/\`)
- [ ] After deploy: reproduce the original sequence (pin a WB annual node, 1D → 1M → 1D) — confirm the chart restores to dial-following detail
- [ ] After deploy: pin a fertilizer node, look at 1D — confirm amber OUT OF WINDOW chip appears in the legend
- [ ] After deploy: click FIT: DATA explicitly, then click 1D — confirm chart auto-reverts to dial mode (DATA → DIAL on preset click)

## Behaviour summary

| User action | Before | After |
|---|---|---|
| Pin annual node, click 1D → 1M → 1D | Stuck "line" in 1D | Restores to dial-following detail |
| Click FIT: DATA, then dial preset | Stays in DATA mode silently | Auto-reverts to DIAL on preset click |
| Live tick advances \`.end\` while in DATA mode | (no effect) | (still no effect — \`.start\` unchanged) |
| Pin node with no data in window | Flat hold-forward line (looks broken) | Flat line + amber OUT OF WINDOW chip explaining why |

🤖 Generated with [Claude Code](https://claude.com/claude-code)