### PR TITLE
feat(chi-star): replace midpoint diamonds with edge-tracing outlines

### DIFF
--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -610,21 +610,32 @@ function EmphasizedEdge(props: EdgeProps<EmphasizedEdgeData>) {
   // `adjacency` import — only nodes need it; edges go via source/target.
   void adjacency;
 
-  // χ★ midpoint marker geometry. Diamond = 45°-rotated square; SVG
-  // <polygon> takes the four vertex coordinates.
-  const CHI_HALF = 5;
-  const chiStarPolygon =
-    midX !== null && midY !== null
-      ? `${midX},${midY - CHI_HALF} ${midX + CHI_HALF},${midY} ${midX},${midY + CHI_HALF} ${midX - CHI_HALF},${midY}`
-      : null;
-  const showChiStarMarker =
+  // χ★ edge outline — renders BEFORE the BaseEdge so the cyan/amber
+  // main line draws on top, leaving a thin violet ring around it.
+  // Solid for strict bridges, dashed for top-BES. Replaces the
+  // earlier midpoint-diamond approach (filled vs hollow polygon at
+  // the line midpoint) — on long edges the midpoint was visually
+  // disconnected from the edge itself, and filled/hollow was too
+  // subtle to distinguish at a glance. Tracing the full line makes
+  // the χ★ signal visible anywhere you look at the edge.
+  const showChiStarOutline =
     d.chiStarTier !== null &&
     !isThisSelected &&
-    d.propagationSignal === 0 &&
-    chiStarPolygon !== null;
+    d.propagationSignal === 0;
 
   return (
     <>
+      {showChiStarOutline && (
+        <path
+          d={edgePath}
+          stroke="#7B68EE"
+          strokeWidth={strokeWidth + 2.5}
+          strokeDasharray={d.chiStarTier === "top-bes" ? "4 3" : undefined}
+          fill="none"
+          opacity={opacity * 0.7}
+          style={{ transition: "opacity 180ms ease-out", pointerEvents: "none" }}
+        />
+      )}
       <BaseEdge
         id={id}
         path={edgePath}
@@ -637,24 +648,6 @@ function EmphasizedEdge(props: EdgeProps<EmphasizedEdgeData>) {
           transition: "opacity 180ms ease-out",
         }}
       />
-      {/* χ★ midpoint marker — discrete violet diamond at the edge
-          midpoint instead of a halo, so the load-bearing skeleton
-          reads as a constellation of pips rather than smudging the
-          cyan / amber edge color. Two tiers: filled diamond for
-          strict bridges (cutting disconnects the graph), hollow
-          outline for top-BES (high shortest-path load without
-          disconnecting). Skipped on the selected edge + during
-          propagation flash so those signals stay unambiguous. */}
-      {showChiStarMarker && (
-        <polygon
-          points={chiStarPolygon!}
-          fill={d.chiStarTier === "bridge" ? "#7B68EE" : "none"}
-          stroke="#7B68EE"
-          strokeWidth={1.5}
-          opacity={opacity * 0.95}
-          style={{ transition: "opacity 180ms ease-out", pointerEvents: "none" }}
-        />
-      )}
     </>
   );
 }

--- a/src/components/CausalDAGMap.tsx
+++ b/src/components/CausalDAGMap.tsx
@@ -253,7 +253,7 @@ function CausalDAGMapInner() {
     };
   }, [activeGraph]);
 
-  const { solidEdgeGeoJSON, dashedEdgeGeoJSON, chiStarMarkerGeoJSON } = useMemo(() => {
+  const { solidEdgeGeoJSON, dashedEdgeGeoJSON, chiStarOutlineGeoJSON } = useMemo(() => {
     const nodeMap = new Map<string, [number, number]>();
     activeGraph.nodes.forEach((node) => {
       nodeMap.set(
@@ -265,12 +265,16 @@ function CausalDAGMapInner() {
     const selectedSet = new Set(selectedNodes);
     const solidFeatures: Feature<LineString>[] = [];
     const dashedFeatures: Feature<LineString>[] = [];
-    // χ★ midpoint markers — discrete violet pips at each χ★ edge's
-    // visual midpoint (the t=0.5 point along the bezier polyline)
-    // rather than smudging the line color with a halo. Tier property
-    // ('bridge' / 'top-bes') drives the circle layer's fill via a
-    // paint expression below.
-    const markerFeatures: Feature<Point>[] = [];
+    // χ★ outline features — wider violet line traced along each χ★
+    // edge's full bezier polyline, rendered BEFORE the main edge
+    // layers so the narrower cyan/amber line draws on top and leaves
+    // a thin violet ring around the edge. Replaces the earlier
+    // midpoint-circle approach — on long ocean-spanning arcs the
+    // midpoint pip lived nowhere near the visible edge, which was
+    // confusing. Tier property ('bridge' / 'top-bes') drives the
+    // line-dasharray paint expression below: solid for bridges,
+    // dashed for top-BES.
+    const outlineFeatures: Feature<LineString>[] = [];
 
     activeGraph.edges.forEach((edge) => {
       const source = nodeMap.get(edge.source);
@@ -368,33 +372,33 @@ function CausalDAGMapInner() {
         solidFeatures.push(feature);
       }
 
-      // χ★ marker: discrete violet pip at the bezier midpoint
-      // (t=0.5 along the sampled polyline) rather than a halo around
-      // the line. Skipped on severed (their slate styling takes
-      // priority) and on dimmed multi-selection out-of-scope edges
-      // (would compete with the dim treatment). Tier property drives
-      // the circle layer paint expression — filled for strict
-      // bridges, hollow outline for top-BES.
+      // χ★ outline: wider violet line tracing the full bezier
+      // polyline. Same coordinates as the main edge, but rendered
+      // BEFORE so the narrower cyan/amber line on top leaves a thin
+      // violet ring around the edge. Skipped on severed (their slate
+      // styling takes priority) and on dimmed multi-selection
+      // out-of-scope edges (would compete with the dim treatment).
+      // Tier property drives the line-dasharray paint expression —
+      // solid for strict bridges, dashed for top-BES.
       if (chiStarInfo.chiStarSet.has(edge.id) && !isSevered && !edgeIsDimmed) {
-        const midIdx = Math.floor(coordinates.length / 2);
-        const mid = coordinates[midIdx];
-        if (mid) {
-          markerFeatures.push({
-            type: "Feature",
-            geometry: { type: "Point", coordinates: mid },
-            properties: {
-              id: `${edge.id}-chi`,
-              tier: chiStarInfo.bridgeSet.has(edge.id) ? "bridge" : "top-bes",
-            },
-          });
-        }
+        outlineFeatures.push({
+          type: "Feature",
+          geometry: { type: "LineString", coordinates },
+          properties: {
+            id: `${edge.id}-chi-outline`,
+            tier: chiStarInfo.bridgeSet.has(edge.id) ? "bridge" : "top-bes",
+            // Outline width derived from the main edge's width — keeps
+            // a consistent ring thickness across thin and thick edges.
+            width: edge.weight * 2 + 4.5,
+          },
+        });
       }
     });
 
     return {
       solidEdgeGeoJSON: { type: "FeatureCollection" as const, features: solidFeatures },
       dashedEdgeGeoJSON: { type: "FeatureCollection" as const, features: dashedFeatures },
-      chiStarMarkerGeoJSON: { type: "FeatureCollection" as const, features: markerFeatures },
+      chiStarOutlineGeoJSON: { type: "FeatureCollection" as const, features: outlineFeatures },
     };
   }, [activeGraph.nodes, activeGraph.edges, selectedNodes, isolateSelection, chiStarInfo]);
 
@@ -750,6 +754,36 @@ function CausalDAGMapInner() {
         boxZoom={false}
         attributionControl={false}
       >
+        {/* χ★ outline — wider violet line traced along each χ★ edge,
+            rendered FIRST so the narrower solid + dashed edge layers
+            below draw ON TOP and leave a thin violet ring around the
+            edge. Solid for strict bridges, dashed for top-BES (paint
+            expression on the `tier` property). Replaces the earlier
+            midpoint-circle approach so on long ocean-spanning arcs
+            the χ★ signal is visible along the whole edge instead of
+            stranded in the middle of the Pacific. */}
+        <Source id="edges-chi-star-outline" type="geojson" data={chiStarOutlineGeoJSON}>
+          <Layer
+            id="edge-chi-star-outline"
+            type="line"
+            paint={{
+              "line-color": "#7B68EE",
+              "line-opacity": 0.7,
+              "line-width": ["get", "width"],
+              "line-dasharray": [
+                "case",
+                ["==", ["get", "tier"], "top-bes"],
+                ["literal", [3, 2]],
+                ["literal", [1, 0]],
+              ],
+            }}
+            layout={{
+              "line-cap": "round",
+              "line-join": "round",
+            }}
+          />
+        </Source>
+
         {/* Solid edge lines: directed (cyan) + temporal (amber) */}
         <Source id="edges-solid" type="geojson" data={solidEdgeGeoJSON}>
           <Layer
@@ -781,32 +815,6 @@ function CausalDAGMapInner() {
             layout={{
               "line-cap": "round",
               "line-join": "round",
-            }}
-          />
-        </Source>
-
-        {/* χ★ midpoint markers — discrete violet pips at the bezier
-            midpoint of each χ★ edge. Rendered AFTER the edge lines so
-            the pip sits on top of the line, BEFORE the node circles so
-            nodes remain the dominant focal points. Two tiers via a
-            paint expression: filled circle for strict bridges, hollow
-            outline-only ring for top-BES. */}
-        <Source id="edges-chi-star-markers" type="geojson" data={chiStarMarkerGeoJSON}>
-          <Layer
-            id="edge-chi-star-markers"
-            type="circle"
-            paint={{
-              "circle-color": [
-                "case",
-                ["==", ["get", "tier"], "bridge"],
-                "#7B68EE",
-                "rgba(0,0,0,0)",
-              ],
-              "circle-radius": 4,
-              "circle-stroke-color": "#7B68EE",
-              "circle-stroke-width": 1.5,
-              "circle-opacity": 0.95,
-              "circle-stroke-opacity": 0.95,
             }}
           />
         </Source>

--- a/src/components/dag3d/DAGEdge3D.tsx
+++ b/src/components/dag3d/DAGEdge3D.tsx
@@ -204,6 +204,29 @@ function DAGEdge3DInner({
         <meshBasicMaterial transparent opacity={0} depthWrite={false} />
       </mesh>
 
+      {/* χ★ edge outline — drawn BEFORE the main edge line so the
+          narrower cyan/amber line below renders ON TOP, leaving a
+          thin violet ring along the edge instead of obscuring it.
+          Solid for strict bridges, dashed for top-BES. Skipped on
+          severed / ablated edges (their own markers take priority).
+          Note: this replaces the earlier midpoint-pip approach —
+          a traced outline rides the full edge so the χ★ signal
+          is visible anywhere you look at it, including the Map's
+          ocean-spanning arcs where the midpoint pip lived nowhere
+          near the visible edge. */}
+      {chiStarTier && !isSevered && !isAblated && (
+        <Line
+          points={curvePoints}
+          color="#7B68EE"
+          lineWidth={Math.max(1, lineWidth) + 1.5}
+          transparent
+          opacity={0.7}
+          dashed={chiStarTier === "top-bes"}
+          dashSize={chiStarTier === "top-bes" ? 0.4 : undefined}
+          gapSize={chiStarTier === "top-bes" ? 0.35 : undefined}
+        />
+      )}
+
       {/* Edge line — using drei Line for reliable rendering:
           directed = solid cyan
           temporal = solid amber (+ animated particle)
@@ -264,40 +287,6 @@ function DAGEdge3DInner({
         </group>
       )}
 
-      {/* χ★ midpoint marker. Discrete violet octahedron at the curve
-          midpoint, so the load-bearing skeleton reads as a constellation
-          of pips rather than smudging the cyan/amber edge color the
-          user is using to track causality. Skipped on severed / ablated
-          (their own marker takes priority) and during cascade replay
-          flash. Two tiers so the strict-bridge vs top-BES distinction
-          is at-a-glance — solid for bridge, wireframe for top-BES. */}
-      {chiStarTier && !isSevered && !isAblated && (
-        <group position={[midpoint.x, midpoint.y, midpoint.z]}>
-          {chiStarTier === "bridge" ? (
-            <>
-              <mesh>
-                <octahedronGeometry args={[1.0, 0]} />
-                <meshBasicMaterial color="#7B68EE" transparent opacity={0.95} />
-              </mesh>
-              {/* Soft outer glow so the pip carries on dense graphs */}
-              <mesh>
-                <octahedronGeometry args={[1.7, 0]} />
-                <meshBasicMaterial color="#7B68EE" transparent opacity={0.2} />
-              </mesh>
-            </>
-          ) : (
-            <mesh>
-              <octahedronGeometry args={[1.1, 0]} />
-              <meshBasicMaterial
-                color="#7B68EE"
-                transparent
-                opacity={0.8}
-                wireframe
-              />
-            </mesh>
-          )}
-        </group>
-      )}
     </group>
   );
 }

--- a/src/components/dag3d/DAGOverlay.tsx
+++ b/src/components/dag3d/DAGOverlay.tsx
@@ -217,37 +217,46 @@ function EncodingLegend({
           }
         />
         <LegendRow
-          label="χ★ STRICT BRIDGE (filled violet ◆)"
-          help="Filled violet diamond at the edge midpoint. Removing this edge disconnects the (undirected) graph — every cascade path between the two resulting components must traverse it. Click the edge for BES + rank. Source: Ghauri 2025 D.Eng."
+          label="χ★ STRICT BRIDGE (solid violet outline)"
+          help="A thin solid violet outline traces the edge along its full length. Removing this edge disconnects the (undirected) graph — every cascade path between the two resulting components must traverse it. Click the edge for BES + rank. Source: Ghauri 2025 D.Eng."
           swatch={
-            <div className="flex items-center justify-center">
-              <span
-                className="inline-block"
-                style={{
-                  width: 8,
-                  height: 8,
-                  backgroundColor: "#7B68EE",
-                  transform: "rotate(45deg)",
-                }}
-              />
+            <div className="flex items-center">
+              {/* Inner cyan line with violet outer ring — mirrors the
+                  canvas treatment so the swatch matches what the user
+                  sees on the graph. */}
+              <span className="relative h-1.5 w-7">
+                <span
+                  className="absolute inset-0 rounded-sm"
+                  style={{ backgroundColor: "#7B68EE", opacity: 0.75 }}
+                />
+                <span
+                  className="absolute left-0 right-0 top-1/2 -translate-y-1/2 h-px"
+                  style={{ backgroundColor: "#00e5ff" }}
+                />
+              </span>
             </div>
           }
         />
         <LegendRow
-          label="χ★ TOP-BES (hollow violet ◇)"
-          help="Hollow violet diamond outline at the edge midpoint. High Bridge-Edge Strength — participates in many shortest paths even though removing it doesn't formally disconnect the graph."
+          label="χ★ TOP-BES (dashed violet outline)"
+          help="A thin dashed violet outline traces the edge. High Bridge-Edge Strength — participates in many shortest paths even though removing it doesn't formally disconnect the graph."
           swatch={
-            <div className="flex items-center justify-center">
-              <span
-                className="inline-block"
-                style={{
-                  width: 8,
-                  height: 8,
-                  border: "1.5px solid #7B68EE",
-                  backgroundColor: "transparent",
-                  transform: "rotate(45deg)",
-                }}
-              />
+            <div className="flex items-center">
+              <span className="relative h-1.5 w-7">
+                <span
+                  className="absolute inset-0 rounded-sm"
+                  style={{
+                    backgroundImage:
+                      "linear-gradient(to right, #7B68EE 60%, transparent 60%)",
+                    backgroundSize: "5px 100%",
+                    opacity: 0.75,
+                  }}
+                />
+                <span
+                  className="absolute left-0 right-0 top-1/2 -translate-y-1/2 h-px"
+                  style={{ backgroundColor: "#00e5ff" }}
+                />
+              </span>
             </div>
           }
         />


### PR DESCRIPTION
## Summary

Your UX feedback: the midpoint diamond markers (#329) were visually disconnected from the edges they mark, especially on the Map view where a submarine cable can span an ocean and the midpoint pip lived nowhere near anything you were looking at. Filled vs hollow diamonds were also too subtle at zoom-out.

> "if you could just have a like, a border along the yellow and the blue lines rather than having it just kind of like a a shape in the middle of the line, that would be helpful"

This PR does exactly that.

## What changed

A thin violet **outline traces the full length** of each χ★ edge:

- **Strict bridge** → solid violet outline
- **Top-BES** → dashed violet outline

The χ★ signal rides the entire line, so anywhere you look at the edge you know its membership. The cyan/amber/orange causal-type color is preserved (the violet outline draws behind, the narrower main line draws on top, leaving a thin violet ring).

| Canvas | Mechanism |
|---|---|
| 3D | wider violet `<Line>` rendered before the main edge; `dashed` prop for top-BES |
| 2D | wider violet `<path>` before the BaseEdge; `strokeDasharray` for top-BES |
| Map | new `edges-chi-star-outline` GeoJSON line layer rendered before `edges-solid`; `line-dasharray` paint expression on the `tier` property |
| LEGEND | swatches now show cyan + violet outline, matching the canvas treatment exactly |
| Relief | unchanged — Relief has no edge lines to outline, so the opt-in midpoint pip stays |

## Data flow unchanged

- `chiStarInfo` memo per canvas still produces `chiStarSet + bridgeSet + bes + rank`
- `chiStarTier: 'bridge' | 'top-bes' | null` prop unchanged
- EdgeInspector + NodeInspector drill-downs unchanged

## Test plan

- [x] `vitest run`: **1168 passing**, no regressions
- [x] `tsc --noEmit` clean for touched files
- [x] Manual: select AI Safety / Endogenous Catastrophe → χ★ edges in 3D / 2D / Map show a thin violet outline tracing the edge instead of a midpoint diamond. Solid for strict bridges (e.g. dataset → GAT input edges), dashed for top-BES. LEGEND swatches mirror the canvas treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)