### PR TITLE
fix(feeds): OFAC parser + OpenFDA URL builder so two more feeds go live

### DIFF
--- a/src/lib/__tests__/feeds/ofac-sdn.test.ts
+++ b/src/lib/__tests__/feeds/ofac-sdn.test.ts
@@ -7,8 +7,11 @@ import {
 } from "@/lib/feeds/ofac-sdn";
 
 describe("OFAC_SDN_URL", () => {
-  it("points at Treasury's canonical pipe-delimited SDN download", () => {
-    expect(OFAC_SDN_URL).toContain("treasury.gov");
+  it("points at the OFAC sanctionslistservice canonical SDN export", () => {
+    // Treasury migrated the file from www.treasury.gov to
+    // sanctionslistservice.ofac.treas.gov; the legacy URL still 302s
+    // here, but pointing directly saves the redirect round-trip.
+    expect(OFAC_SDN_URL).toContain("sanctionslistservice.ofac.treas.gov");
     expect(OFAC_SDN_URL.endsWith("sdn.csv")).toBe(true);
   });
 });
@@ -76,6 +79,40 @@ describe("parseOfacSdnCsv", () => {
     const csv = ["", "1|", "|||", `2| "Org" |entity|"IRAN"|||||||||`].join("\n");
     const feed = parseOfacSdnCsv(csv);
     expect(feed.jurisdictions.IR.entryCount).toBe(1);
+  });
+
+  // Treasury migrated the file from pipe-delimited to comma-delimited
+  // with quoted strings (concurrent with the URL move). The parser
+  // auto-detects the delimiter so we keep working if they flip back;
+  // this test pins the new format.
+  it("parses comma-delimited rows (current Treasury format) and counts jurisdictions", () => {
+    const csv = [
+      `36,"AEROCARIBBEAN AIRLINES",-0- ,"CUBA",-0- ,-0- ,-0- ,-0- ,-0- ,-0- ,-0- ,-0-`,
+      `100,"BANCO IRANIAN",-0- ,"IRAN; IRAN-EO13599",-0- ,-0- ,-0- ,-0- ,-0- ,-0- ,-0- ,-0-`,
+      `200,"RUSSIAN BANK",-0- ,"RUSSIA-EO14024",-0- ,-0- ,-0- ,-0- ,-0- ,-0- ,-0- ,-0-`,
+      `300,"GENERIC TERROR ENTITY",-0- ,"SDGT",-0- ,-0- ,-0- ,-0- ,-0- ,-0- ,-0- ,-0-`,
+    ].join("\n");
+    const feed = parseOfacSdnCsv(csv);
+    expect(feed.jurisdictions.CU.entryCount).toBe(1);
+    expect(feed.jurisdictions.IR.entryCount).toBe(1);
+    expect(feed.jurisdictions.IR.programs).toContain("IRAN");
+    expect(feed.jurisdictions.IR.programs).toContain("IRAN-EO13599");
+    expect(feed.jurisdictions.RU.entryCount).toBe(1);
+    expect(feed.jurisdictions.SDGT).toBeUndefined();
+    expect(feed.totalEntries).toBe(4);
+  });
+
+  // SDN comma format uses `-0-` as the "empty field" sentinel rather
+  // than an empty string. Treat both as empty so we don't bump
+  // `totalEntries` for rows whose Program column has no real program.
+  it("treats `-0-` in the Program column as empty (SDN-empty sentinel)", () => {
+    const csv = [
+      `400,"NAME-ONLY ENTRY",-0- ,-0- ,-0- ,-0- ,-0- ,-0- ,-0- ,-0- ,-0- ,-0-`,
+      `401,"REAL ENTRY",-0- ,"CUBA",-0- ,-0- ,-0- ,-0- ,-0- ,-0- ,-0- ,-0-`,
+    ].join("\n");
+    const feed = parseOfacSdnCsv(csv);
+    expect(feed.totalEntries).toBe(1);
+    expect(feed.jurisdictions.CU.entryCount).toBe(1);
   });
 });
 

--- a/src/lib/__tests__/feeds/openfda.test.ts
+++ b/src/lib/__tests__/feeds/openfda.test.ts
@@ -17,6 +17,41 @@ describe("buildOpenFdaUrl", () => {
     expect(url).toContain("receivedate");
     expect(url).toContain("limit=1");
   });
+
+  // Regression: a `+` in the Lucene search string form-encodes to `%2B`
+  // on the wire, which the upstream parser sees as a literal `+`
+  // character (not a space). Lucene then chokes on `+TO+` instead of
+  // ` TO ` and returns HTTP 500. We use spaces; `URLSearchParams` form-
+  // encodes them as `+` on the wire, which OpenFDA correctly decodes
+  // back to spaces. This test pins the contract so a well-meaning
+  // future edit ("let's use + to avoid spaces in URLs") doesn't break
+  // the upstream parse.
+  it("encodes Lucene operator separators as wire-`+` (form-space), not wire-`%2B`", () => {
+    const cfg = OPENFDA_QUERIES.find((q) => q.id === "tzield")!;
+    const url = buildOpenFdaUrl(cfg);
+    // The receivedate range MUST contain `+TO+` on the wire (URL-form
+    // for ` TO ` — server decodes back to spaces), NOT `%2BTO%2B`
+    // (which would decode to literal `+TO+`, breaking the Lucene parse).
+    // URLSearchParams also encodes `[` `]` and `:` so we match against
+    // the percent-encoded form of the surrounding bracket range.
+    expect(url).toMatch(/receivedate%3A%5B\d{8}\+TO\+\d{8}%5D/);
+    // And it MUST NOT contain `%2BTO%2B` anywhere — that would be the
+    // bug we're guarding against.
+    expect(url).not.toContain("%2BTO%2B");
+    // Same for AND between clauses.
+    expect(url).toContain("+AND+");
+    expect(url).not.toContain("%2BAND%2B");
+  });
+
+  it("TZIELD search uses OR not + between brand and generic name clauses", () => {
+    const cfg = OPENFDA_QUERIES.find((q) => q.id === "tzield")!;
+    // The Lucene operator MUST be `OR` (separated by spaces, encoded to
+    // wire-`+`). `+` between two clauses inside parens means BOTH must
+    // match in Lucene, which is the opposite of what we want for the
+    // brand-OR-generic-name fallback.
+    expect(cfg.search).toContain(" OR ");
+    expect(cfg.search).not.toMatch(/"[\w+]+\+patient/);
+  });
 });
 
 describe("parseOpenFdaResponse", () => {

--- a/src/lib/feeds/ofac-sdn.ts
+++ b/src/lib/feeds/ofac-sdn.ts
@@ -58,8 +58,17 @@ export interface OfacSdnFeed {
   source: string;
 }
 
-/** OFAC publishes the canonical SDN file at this Treasury URL (pipe-delimited CSV). */
-export const OFAC_SDN_URL = "https://www.treasury.gov/ofac/downloads/sdn.csv";
+/**
+ * OFAC publishes the canonical SDN file at this URL. Treasury migrated
+ * the export from `www.treasury.gov/ofac/downloads/sdn.csv` to the
+ * `sanctionslistservice.ofac.treas.gov` host; the legacy URL still 302s
+ * to here, but we point directly at the new host to save the redirect
+ * round-trip. Format also flipped from pipe-delimited to comma-delimited
+ * during the move — the parser auto-detects the delimiter on the first
+ * row so we keep working if Treasury flips back.
+ */
+export const OFAC_SDN_URL =
+  "https://sanctionslistservice.ofac.treas.gov/api/publicationpreview/exports/sdn.csv";
 
 /** Resolve an OFAC program token to a country code. Returns null when the
  *  program isn't bound to a single jurisdiction (cyber, SDGT, NPWMD, etc.). */
@@ -74,24 +83,45 @@ export function programToCountry(program: string): { code: string; country: stri
 /**
  * Parse OFAC SDN.csv text into a per-jurisdiction summary.
  *
- * The OFAC SDN file is pipe-delimited (despite the .csv extension). Columns:
- *   ent_num | SDN_Name | SDN_Type | Program | Title | Call_Sign |
- *   Vess_type | Tonnage | GRT | Vess_flag | Vess_owner | Remarks
+ * Columns (unchanged across format revisions):
+ *   ent_num , SDN_Name , SDN_Type , Program , Title , Call_Sign ,
+ *   Vess_type , Tonnage , GRT , Vess_flag , Vess_owner , Remarks
  *
  * The Program field is itself semicolon-separated (e.g. "IRAN; IRAN-EO13599").
- * Quoted fields containing pipes are unwrapped — defensive against future
- * rows but the official file historically does not embed pipes.
+ *
+ * Historically Treasury served this as a pipe-delimited file (despite the
+ * .csv extension) but they switched to comma-delimited with quoted strings
+ * at some point — likely when the file moved from `treasury.gov` to
+ * `sanctionslistservice.ofac.treas.gov`. The parser now auto-detects the
+ * delimiter on the first non-empty row: if it contains a `|`, the file is
+ * pipe-delimited; otherwise comma-delimited. This way we keep working if
+ * Treasury flips back without code changes.
+ *
+ * Empty fields in the comma-delimited file are encoded as `-0-` (a SDN
+ * convention) rather than an empty token. We treat both `-0-` and `""` as
+ * empty when extracting the Program column.
  */
 export function parseOfacSdnCsv(csv: string): OfacSdnFeed {
   const lines = csv.split(/\r?\n/).filter((l) => l.length > 0);
   const jurisdictions: Record<string, OfacJurisdictionEntry> = {};
   let totalEntries = 0;
 
+  // Auto-detect delimiter on the first non-empty line. Pipe wins if present
+  // (the historic format); fall back to comma (the new format).
+  const delimiter = lines.length > 0 && lines[0].includes("|") ? "|" : ",";
+
   for (const line of lines) {
-    const fields = splitPipeRow(line);
+    const fields = splitDelimitedRow(line, delimiter);
     if (fields.length < 4) continue;
-    const programField = fields[3] ?? "";
-    const programs = programField.split(/[;,]/).map((s) => s.trim()).filter(Boolean);
+    const rawProgramField = fields[3]?.trim() ?? "";
+    // `-0-` is the SDN convention for "empty" in the comma-delimited
+    // export; treat it the same as a literal empty string so we don't
+    // count empty-program rows.
+    if (rawProgramField === "" || rawProgramField === "-0-") continue;
+    const programs = rawProgramField
+      .split(/[;,]/)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0 && s !== "-0-");
     if (programs.length === 0) continue;
     totalEntries += 1;
 
@@ -124,8 +154,14 @@ export function parseOfacSdnCsv(csv: string): OfacSdnFeed {
   };
 }
 
-/** Split a pipe-delimited line, honouring `"..."` quoted fields. */
-function splitPipeRow(line: string): string[] {
+/**
+ * Split a delimited line honouring `"..."` quoted fields. Used for both
+ * the historic pipe-delimited and the current comma-delimited OFAC SDN
+ * exports — `parseOfacSdnCsv` picks the delimiter based on what the
+ * upstream file actually contains. Quote-handling logic is identical
+ * across delimiters; only the field separator changes.
+ */
+function splitDelimitedRow(line: string, delimiter: string): string[] {
   const out: string[] = [];
   let cur = "";
   let inQuotes = false;
@@ -135,7 +171,7 @@ function splitPipeRow(line: string): string[] {
       inQuotes = !inQuotes;
       continue;
     }
-    if (ch === "|" && !inQuotes) {
+    if (ch === delimiter && !inQuotes) {
       out.push(cur);
       cur = "";
       continue;

--- a/src/lib/feeds/openfda.ts
+++ b/src/lib/feeds/openfda.ts
@@ -32,12 +32,22 @@ export interface OpenFdaQueryConfig {
   mockValue: number;
 }
 
+// Lucene operator separators are literal SPACES in the search string;
+// `URLSearchParams` form-encodes spaces as `+` on the wire, and OpenFDA
+// decodes those back to spaces before handing them to Lucene. Using `+`
+// directly in the search string would form-encode to `%2B`, which
+// OpenFDA decodes to literal `+` — Lucene sees `+TO+` instead of ` TO `
+// and returns HTTP 500 "Encountered ] ... Was expecting TO". Same trap
+// applies to multi-word phrases inside `"..."` (e.g. "insulin glargine")
+// and to `AND` / `OR` between clauses.
 export const OPENFDA_QUERIES: OpenFdaQueryConfig[] = [
   {
     id: "tzield",
     label: "TZIELD (teplizumab) — anti-CD3 monoclonal",
-    // Match either brand or generic name — FDA labels are inconsistent
-    search: '(patient.drug.openfda.brand_name:"TZIELD"+patient.drug.openfda.generic_name:"teplizumab")',
+    // Brand OR generic — FDA labels are inconsistent, and AND would
+    // require both fields populated which excludes most reports.
+    search:
+      '(patient.drug.openfda.brand_name:"TZIELD" OR patient.drug.openfda.generic_name:"teplizumab")',
     labelPatterns: ["teplizumab"],
     unit: "rpts",
     capacity: 200,
@@ -46,7 +56,7 @@ export const OPENFDA_QUERIES: OpenFdaQueryConfig[] = [
   {
     id: "insulin-glargine",
     label: "Insulin glargine (basal long-acting)",
-    search: 'patient.drug.openfda.generic_name:"insulin+glargine"',
+    search: 'patient.drug.openfda.generic_name:"insulin glargine"',
     labelPatterns: ["insulin glargine"],
     unit: "rpts",
     capacity: 5000,
@@ -74,12 +84,14 @@ export function buildOpenFdaUrl(config: OpenFdaQueryConfig): string {
   const base = "https://api.fda.gov/drug/event.json";
   const params = new URLSearchParams();
   // Restrict to the last year so the count reflects recent scrutiny rather
-  // than cumulative-since-1990s reports.
+  // than cumulative-since-1990s reports. Lucene operator separators are
+  // literal SPACES — see the comment above OPENFDA_QUERIES for why `+`
+  // here would break the upstream parser.
   const year = new Date().getUTCFullYear();
-  const search = `${config.search}+AND+receivedate:[${year - 1}0101+TO+${year}1231]`;
+  const search = `${config.search} AND receivedate:[${year - 1}0101 TO ${year}1231]`;
   params.set("search", search);
   params.set("limit", "1");
-  return `${base}?${params.toString()}`.replace(/\+/g, "+"); // keep + literal in search
+  return `${base}?${params.toString()}`;
 }
 
 interface OpenFdaApiResponse {


### PR DESCRIPTION
## Summary
- Two prod feed routes were returning mock fallbacks not because of missing API keys but because of real code bugs masquerading as "upstream unreachable"
- **OFAC SDN parser** — file format flipped from pipe-delimited to comma-delimited-with-quoted-strings concurrent with a Treasury URL migration; parser auto-detects delimiter; URL points directly at the new sanctionslistservice host
- **OpenFDA URL builder** — used `+` in the Lucene search string, which `URLSearchParams` encodes as `%2B` on the wire → server sees literal `+` instead of space → Lucene HTTP 500. Fixed to use spaces; regression test pins the encoded shape
- 5 new tests across the two feed modules

## Audit context

User asked to provision API keys in Vercel so feeds flip from mock to live. Probing all 6 feed routes on prod:

| Feed | Status | Reason |
|---|---|---|
| FRED | ✅ LIVE | `FRED_API_KEY` already in Vercel |
| World Bank | ✅ LIVE | No key needed |
| ClinicalTrials.gov | ✅ LIVE | No key needed |
| EIA | ❌ MOCK | `EIA_API_KEY unset` — genuinely an ops task, not addressed here |
| **OFAC SDN** | ❌ MOCK | **Code bug — this PR** |
| **OpenFDA** | ❌ MOCK | **Code bug — this PR** |

So the original "10-minute env vars task" was actually 1 ops task + 2 code bugs.

## OFAC SDN — format + URL drift
Treasury migrated the SDN file from `www.treasury.gov/ofac/downloads/sdn.csv` to `sanctionslistservice.ofac.treas.gov/api/publicationpreview/exports/sdn.csv`. The legacy URL still 302s to the new one, but concurrent with the move they switched **pipe-delimited → comma-delimited-with-quoted-strings**.

Our parser used `splitPipeRow(line)` and skipped every row via the `fields.length < 4` guard, so we always fell back to mock with header `x-feed-error: parsed-zero-jurisdictions (csv-len=5562852)`.

**Fix:**
- `OFAC_SDN_URL` points directly at sanctionslistservice (saves a 302 round-trip)
- `splitPipeRow` generalised to `splitDelimitedRow(line, delimiter)`
- `parseOfacSdnCsv` auto-detects delimiter on the first non-empty line (pipe if `|` present, else comma). Keeps working if Treasury flips back without code changes
- Treat `-0-` in the Program column as empty (SDN convention for "no value")

**Verified locally** against the live 5.3 MB SDN file: parser now extracts **19,050 entries across 6 jurisdictions** (Cuba 88, Iran 2214, Belarus 252, Venezuela 406, North Korea 539, Russia 6724) vs the previous 0.

## OpenFDA — `+` vs space in Lucene operators
URL builder constructed the search query with `+` as operator separator:

```ts
const search = `${config.search}+AND+receivedate:[${y-1}0101+TO+${y}1231]`;
```

`URLSearchParams.toString()` encodes `+` as `%2B` on the wire — which OpenFDA URL-decodes back to literal `+`, NOT to a space. Lucene then parses `receivedate:[20250101+TO+20261231]` and chokes on `+TO+`, returning HTTP 500:

```
Encountered " "]" "] "" at line 1, column 127.
Was expecting: "TO" ...
```

Both queries failed identically; `0/2 queries fetched` → mock fallback.

Same trap inside `OPENFDA_QUERIES.search` strings — the TZIELD query used `+` between brand-name and generic-name clauses (which Lucene parses as "BOTH must match", excluding most reports) and embedded `+` inside the `"insulin+glargine"` quoted phrase.

**Fix:**
- Build URL with literal spaces around `AND` / `TO`. `URLSearchParams` form-encodes spaces as `+` on the wire; OpenFDA decodes back to spaces; Lucene parses correctly
- TZIELD query rewritten to use `OR` (proper Lucene operator) with spaces
- "insulin glargine" phrase uses a literal space inside the quote

**Verified locally** against the live OpenFDA API: TZIELD query returns 242 reports. Insulin glargine parses cleanly.

## Tests (5 new)
- `parseOfacSdnCsv` parses comma-delimited rows (current Treasury format) and counts jurisdictions correctly
- `parseOfacSdnCsv` treats `-0-` in Program column as empty (SDN-empty sentinel)
- `OFAC_SDN_URL` test updated to pin sanctionslistservice domain
- `buildOpenFdaUrl` encodes Lucene operator separators as wire-`+` (form-space), not wire-`%2B`. Asserts the encoded `receivedate%3A%5B...+TO+...%5D` shape so a future "let's avoid spaces in URLs" refactor can't silently break the upstream parse
- TZIELD search uses `OR` not `+` between brand/generic clauses

## Test plan
- [x] `npx vitest run` — 20/20 in the two suites; full test run clean
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on all 4 touched files
- [ ] Vercel preview deploys
- [ ] In preview, probe `/api/feeds/ofac/sdn` — should return `"source":"OFAC SDN"` (no "mock" suffix), `entryCount` populated for IR / RU / KP / CU / VE / BY
- [ ] In preview, probe `/api/feeds/openfda/events` — both queries should return non-zero counts, `source` field without "mock" suffix
- [ ] EIA stays mock until `EIA_API_KEY` is added to Vercel env (separate ops task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
