### PR TITLE
feat(pearl): ISOLATE AFFECTED button on interdiction results card

### DIFF
--- a/src/components/ModulePanel.tsx
+++ b/src/components/ModulePanel.tsx
@@ -202,7 +202,41 @@ function CopilotInterdictionResults() {
   const lastResult = useApexStore((s) => s.lastInterdictionResult);
   const severEdge = useApexStore((s) => s.severEdge);
   const toggleAblatedNode = useApexStore((s) => s.toggleAblatedNode);
+  // Graph + multi-selection store hooks for the "ISOLATE AFFECTED"
+  // affordance below: when the scenario interdiction returns cuts,
+  // the user wants to drill into just the affected nodes — same way
+  // the lasso ISOLATE button works on a marquee selection. We pull
+  // the affected node ids out of `lastResult.interventions` (target.id
+  // for node-type cuts; both edge endpoints for edge-type cuts), then
+  // write them into `selectedNodes` + flip `isolateSelection`. The
+  // existing canvas isolate machinery does the rest, identically
+  // across 3D / 2D / Map / Relief.
+  const graphData = useApexStore((s) => s.graphData);
+  const setSelectedNodes = useApexStore((s) => s.setSelectedNodes);
+  const isolateSelection = useApexStore((s) => s.isolateSelection);
+  const setIsolateSelection = useApexStore((s) => s.setIsolateSelection);
   const [appliedIds, setAppliedIds] = useState<Set<string>>(new Set());
+
+  // Affected node set. Memoised on the interdiction result + graph
+  // edge list so toggling isolate doesn't recompute it. Edge-cut
+  // interventions contribute BOTH endpoints — severing X → Y
+  // functionally affects both vertices' neighbourhoods.
+  const affectedNodeIds = useMemo(() => {
+    if (!lastResult) return [] as string[];
+    const ids = new Set<string>();
+    for (const iv of lastResult.interventions) {
+      if (iv.target.type === "node") {
+        ids.add(iv.target.id);
+      } else if (iv.target.type === "edge") {
+        const edge = graphData.edges.find((e) => e.id === iv.target.id);
+        if (edge) {
+          ids.add(edge.source);
+          ids.add(edge.target);
+        }
+      }
+    }
+    return Array.from(ids);
+  }, [lastResult, graphData.edges]);
 
   if (!lastResult) return null;
 
@@ -221,12 +255,46 @@ function CopilotInterdictionResults() {
         <span className="text-[9px] font-[family-name:var(--font-michroma)] tracking-wider text-accent-amber">
           {isFallback ? "STRUCTURAL VULNERABILITY CUTS" : "INTERDICTION RESULTS"}
         </span>
-        <button
-          onClick={() => useApexStore.getState().setLastInterdictionResult(null)}
-          className="text-[7px] font-mono text-text-muted hover:text-accent-red transition-colors"
-        >
-          DISMISS
-        </button>
+        <div className="flex items-center gap-2">
+          {/* ISOLATE AFFECTED — mirrors the lasso panel's ISOLATE
+              button, bootstrapped from the interdiction's affected node
+              set instead of a marquee drag. When toggled on, the
+              canvas across every view (3D / 2D / Map / Relief) filters
+              to just the affected nodes so the analyst can examine
+              "which ones are reflected" without losing them in the
+              field of 192 orbs. Toggling off keeps the selection
+              populated so the user can re-isolate without recomputing. */}
+          {affectedNodeIds.length > 0 && (
+            <button
+              onClick={() => {
+                if (isolateSelection) {
+                  setIsolateSelection(false);
+                } else {
+                  setSelectedNodes(affectedNodeIds);
+                  setIsolateSelection(true);
+                }
+              }}
+              className={`text-[7px] font-[family-name:var(--font-michroma)] tracking-wider px-1.5 py-0.5 rounded border transition-colors ${
+                isolateSelection
+                  ? "border-accent-amber/60 text-accent-amber bg-accent-amber/10"
+                  : "border-border text-text-muted hover:text-accent-amber hover:border-accent-amber/40"
+              }`}
+              title={
+                isolateSelection
+                  ? "Show all nodes again. The affected set stays selected so you can re-isolate later."
+                  : `Hide non-affected nodes across every view (${affectedNodeIds.length} node${affectedNodeIds.length === 1 ? "" : "s"} affected by the proposed cuts).`
+              }
+            >
+              {isolateSelection ? "SHOW ALL" : "ISOLATE AFFECTED"}
+            </button>
+          )}
+          <button
+            onClick={() => useApexStore.getState().setLastInterdictionResult(null)}
+            className="text-[7px] font-mono text-text-muted hover:text-accent-red transition-colors"
+          >
+            DISMISS
+          </button>
+        </div>
       </div>
 
       <div className="flex gap-3 text-[8px] font-mono">


### PR DESCRIPTION
## Summary

User feedback after testing the new ScenarioInput → interdiction flow from PR #369: the affected nodes get highlighted on canvas, but there's no way to drill into JUST them. The lasso panel surfaces an ISOLATE button for marquee selections — the same affordance was missing for interdiction results.

This PR adds **ISOLATE AFFECTED / SHOW ALL** next to the DISMISS button on the interdiction-results card. One click filters every canvas (3D / 2D / Map / Relief) to just the nodes the cuts touch.

## Behaviour

| Click | Effect |
|---|---|
| **ISOLATE AFFECTED** | Writes affected node IDs into `selectedNodes`, flips `isolateSelection: true`. Every view's existing isolate machinery filters the canvas. |
| **SHOW ALL** | Flips `isolateSelection: false`. `selectedNodes` stays populated so the user can re-isolate without recomputing. |
| Button hidden | When there are no interventions (no affected set to isolate). |

## Affected-set derivation

Memoised on `lastInterdictionResult` + `graphData.edges`:

- **Node-target intervention** → add `target.id`
- **Edge-target intervention** → add **both endpoints** of the edge (severing X → Y functionally affects both vertices' neighbourhoods, so both belong in the focus set)

## Why this design

The isolate plumbing is already universal across every view — PR #373 wired ablation through the same `selectedNodes` / `isolateSelection` pair, and the lasso uses it. This PR adds a NEW *source* of selection (the interdiction result) without inventing new state. Zero store changes; one derived `useMemo` for the affected-node array; one button.

The full one-click loop is now: **ScenarioInput → copilot → `solve_interdiction` → `lastInterdictionResult` → ISOLATE AFFECTED → see exactly what changed.**

## Files

| File | Change |
|---|---|
| `src/components/ModulePanel.tsx` | `CopilotInterdictionResults`: 4 new store hooks (`graphData`, `setSelectedNodes`, `isolateSelection`, `setIsolateSelection`); `affectedNodeIds` memoised; header row replaced with a `flex gap-2` wrapper hosting the new toggle next to the existing DISMISS. |

## Test plan

- [x] `npx next build` clean
- [ ] PR-validate workflow green
- [ ] Vercel preview eyeball: type a scenario in PEARL, hit RUN INTERDICTION, wait for cuts, click ISOLATE AFFECTED — canvas filters to just the affected nodes in whichever view you're in. Switch view modes, isolation persists. SHOW ALL toggles back. DISMISS clears the result but leaves the focus set alone.

## Backwards compat

Zero store changes. New button only renders when interventions exist. DISMISS behaviour is unchanged — it clears `lastInterdictionResult` but leaves `selectedNodes` alone so the user keeps their focus set even after the result card disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
