### PR TITLE
feat(discovery): TrainingTrace substrate for Phase 3 dissertation work

### DIFF
--- a/src/lib/discovery/__tests__/training-trace.test.ts
+++ b/src/lib/discovery/__tests__/training-trace.test.ts
@@ -1,0 +1,376 @@
+// @vitest-environment node
+//
+// Tests for the Phase 3 substrate: TrainingTrace types, validator,
+// and synthetic generator. Anchors the math contract that downstream
+// estimators (BES temporal monitoring, FR, Ω-Forgetting Pressure)
+// will read from.
+//
+// Hand-computable assertions where possible — the synthetic generator
+// is deterministic given a seed + curriculum, so we can pin exact
+// values and catch any future change to the dynamics math loudly.
+
+import { describe, it, expect } from "vitest";
+import {
+  buildSyntheticTrainingTrace,
+  DEFAULT_TASK_DYNAMICS,
+  sequentialCurriculum,
+  type BuildSyntheticTraceOptions,
+} from "../training-trace-synthetic";
+import {
+  validateTrainingTrace,
+  TrainingTraceValidationError,
+  DEFAULT_TRACE_LIMITS,
+} from "../training-trace-validator";
+import type { TaskRef, TrainingTrace } from "../training-trace-types";
+
+// ─── Fixtures ────────────────────────────────────────────────────────
+
+const ATTACK_TASKS: TaskRef[] = [
+  { id: "ais_attack_ddos", label: "DDoS", scope: "attack-class" },
+  { id: "ais_attack_mitm", label: "MITM", scope: "attack-class" },
+  { id: "ais_attack_heartbleed", label: "Heartbleed", scope: "attack-class" },
+];
+
+function defaultOpts(
+  overrides: Partial<BuildSyntheticTraceOptions> = {},
+): BuildSyntheticTraceOptions {
+  return {
+    id: "test-trace",
+    label: "Test Trace",
+    tasks: ATTACK_TASKS,
+    curriculum: sequentialCurriculum(
+      ATTACK_TASKS.map((t) => t.id),
+      5,
+    ),
+    seed: 42,
+    noiseAmplitude: 0, // disable noise for hand-computable assertions
+    ...overrides,
+  };
+}
+
+// ─── buildSyntheticTrainingTrace ─────────────────────────────────────
+
+describe("buildSyntheticTrainingTrace — shape", () => {
+  it("produces a trace marked source.kind = 'synthetic'", () => {
+    const trace = buildSyntheticTrainingTrace(defaultOpts());
+    expect(trace.source.kind).toBe("synthetic");
+    expect(trace.source.adapter).toBe("synthetic");
+  });
+
+  it("total epoch count = max(curriculum window endEpoch)", () => {
+    const trace = buildSyntheticTrainingTrace(defaultOpts());
+    expect(trace.epochs).toHaveLength(15); // 3 tasks × 5 epochs each
+    expect(trace.epochs[0].index).toBe(0);
+    expect(trace.epochs[14].index).toBe(14);
+  });
+
+  it("epoch indices are strictly increasing", () => {
+    const trace = buildSyntheticTrainingTrace(defaultOpts());
+    for (let i = 1; i < trace.epochs.length; i++) {
+      expect(trace.epochs[i].index).toBeGreaterThan(trace.epochs[i - 1].index);
+    }
+  });
+
+  it("every epoch carries an accuracy entry for every task", () => {
+    const trace = buildSyntheticTrainingTrace(defaultOpts());
+    for (const ep of trace.epochs) {
+      expect(ep.accuracy).toHaveLength(ATTACK_TASKS.length);
+      const ids = new Set(ep.accuracy.map((a) => a.taskId));
+      for (const t of ATTACK_TASKS) {
+        expect(ids.has(t.id)).toBe(true);
+      }
+    }
+  });
+
+  it("activeTaskIds match the curriculum at each epoch", () => {
+    const trace = buildSyntheticTrainingTrace(defaultOpts());
+    // Sequential curriculum: epoch e in window [i*5, (i+1)*5) for task i
+    expect(trace.epochs[0].activeTaskIds).toEqual(["ais_attack_ddos"]);
+    expect(trace.epochs[4].activeTaskIds).toEqual(["ais_attack_ddos"]);
+    expect(trace.epochs[5].activeTaskIds).toEqual(["ais_attack_mitm"]);
+    expect(trace.epochs[9].activeTaskIds).toEqual(["ais_attack_mitm"]);
+    expect(trace.epochs[10].activeTaskIds).toEqual(["ais_attack_heartbleed"]);
+    expect(trace.epochs[14].activeTaskIds).toEqual(["ais_attack_heartbleed"]);
+  });
+});
+
+describe("buildSyntheticTrainingTrace — dynamics", () => {
+  it("accuracy rises while task is active", () => {
+    const trace = buildSyntheticTrainingTrace(defaultOpts());
+    // DDoS is active epochs 0-4. Its accuracy should rise across that range.
+    const ddosAccs = trace.epochs
+      .slice(0, 5)
+      .map((ep) => ep.accuracy.find((a) => a.taskId === "ais_attack_ddos")!.value);
+    for (let i = 1; i < ddosAccs.length; i++) {
+      expect(ddosAccs[i]).toBeGreaterThan(ddosAccs[i - 1]);
+    }
+    // Last epoch under active training: closer to plateau (0.95) than baseline (0.05).
+    expect(ddosAccs[4]).toBeGreaterThan(0.5);
+  });
+
+  it("accuracy decays after training shifts away", () => {
+    const trace = buildSyntheticTrainingTrace(defaultOpts());
+    // After epoch 5, DDoS is no longer active. Accuracy should decay.
+    const ddosAccs = trace.epochs
+      .map((ep) => ep.accuracy.find((a) => a.taskId === "ais_attack_ddos")!.value);
+    expect(ddosAccs[5]).toBeLessThan(ddosAccs[4]);
+    expect(ddosAccs[14]).toBeLessThan(ddosAccs[5]);
+  });
+
+  it("higher forgettingRate → faster decay (Heartbleed archetype)", () => {
+    // Standard Heartbleed: high forgettingRate. Compare its decay to a
+    // calmer task by training both at epochs 0-4, then training a
+    // separate filler task at epochs 5-14 so the trace runs 15 epochs
+    // but stable/fragile decay freely the whole time.
+    const tasks: TaskRef[] = [
+      { id: "stable", label: "Stable", scope: "attack-class" },
+      { id: "fragile", label: "Fragile (Heartbleed-like)", scope: "attack-class" },
+      { id: "filler", label: "Filler", scope: "attack-class" },
+    ];
+    const trace = buildSyntheticTrainingTrace({
+      id: "decay-comparison",
+      label: "Decay comparison",
+      tasks,
+      curriculum: [
+        { taskId: "stable", startEpoch: 0, endEpoch: 5 },
+        { taskId: "fragile", startEpoch: 0, endEpoch: 5 },
+        // Filler keeps the trace running so stable/fragile decay freely
+        // across epochs 5-14 (10 idle epochs).
+        { taskId: "filler", startEpoch: 5, endEpoch: 15 },
+      ],
+      taskDynamics: {
+        stable: { forgettingRate: 0.02 },
+        fragile: { forgettingRate: 0.30 }, // Heartbleed archetype
+      },
+      seed: 7,
+      noiseAmplitude: 0,
+    });
+    expect(trace.epochs).toHaveLength(15);
+    const stableAt14 = trace.epochs[14].accuracy.find((a) => a.taskId === "stable")!.value;
+    const fragileAt14 = trace.epochs[14].accuracy.find((a) => a.taskId === "fragile")!.value;
+    // After 10 idle epochs, the high-forgettingRate task has dropped much more.
+    expect(fragileAt14).toBeLessThan(stableAt14);
+    // Sanity: stable should still be above baseline; fragile should be near baseline.
+    expect(stableAt14).toBeGreaterThan(DEFAULT_TASK_DYNAMICS.baseline + 0.4);
+    expect(fragileAt14).toBeLessThan(0.3);
+  });
+
+  it("accuracy never escapes [0, 1]", () => {
+    const trace = buildSyntheticTrainingTrace(
+      defaultOpts({ noiseAmplitude: 0.5 }), // heavy noise to stress clamping
+    );
+    for (const ep of trace.epochs) {
+      for (const a of ep.accuracy) {
+        expect(a.value).toBeGreaterThanOrEqual(0);
+        expect(a.value).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+});
+
+describe("buildSyntheticTrainingTrace — determinism", () => {
+  it("same seed + curriculum → bit-identical trace", () => {
+    const a = buildSyntheticTrainingTrace(defaultOpts({ seed: 123 }));
+    const b = buildSyntheticTrainingTrace(defaultOpts({ seed: 123 }));
+    // Strip builtAt (timestamp); everything else should match exactly.
+    expect(JSON.stringify({ ...a, source: { ...a.source, builtAt: "" } }))
+      .toBe(JSON.stringify({ ...b, source: { ...b.source, builtAt: "" } }));
+  });
+
+  it("different seeds → different traces but identical shape", () => {
+    // noiseAmplitude must be > 0 for the seed to actually affect
+    // accuracy values; defaultOpts disables noise for hand-computable
+    // tests, so override it here.
+    const a = buildSyntheticTrainingTrace(defaultOpts({ seed: 1, noiseAmplitude: 0.02 }));
+    const b = buildSyntheticTrainingTrace(defaultOpts({ seed: 2, noiseAmplitude: 0.02 }));
+    expect(a.epochs).toHaveLength(b.epochs.length);
+    // Accuracy values should differ (noise differs) — sample one epoch.
+    expect(a.epochs[3].accuracy[0].value).not.toBe(b.epochs[3].accuracy[0].value);
+  });
+
+  it("sourceHash stable across seed when curriculum + dynamics + noise + seed match", () => {
+    const a = buildSyntheticTrainingTrace(defaultOpts({ seed: 999 }));
+    const b = buildSyntheticTrainingTrace(defaultOpts({ seed: 999 }));
+    expect(a.source.sourceHash).toBe(b.source.sourceHash);
+  });
+
+  it("sourceHash differs when seed differs", () => {
+    const a = buildSyntheticTrainingTrace(defaultOpts({ seed: 1 }));
+    const b = buildSyntheticTrainingTrace(defaultOpts({ seed: 2 }));
+    expect(a.source.sourceHash).not.toBe(b.source.sourceHash);
+  });
+});
+
+describe("buildSyntheticTrainingTrace — validation", () => {
+  it("throws on empty tasks", () => {
+    expect(() =>
+      buildSyntheticTrainingTrace(
+        defaultOpts({ tasks: [], curriculum: [{ taskId: "x", startEpoch: 0, endEpoch: 1 }] }),
+      ),
+    ).toThrow(/tasks must not be empty/);
+  });
+
+  it("throws on empty curriculum", () => {
+    expect(() =>
+      buildSyntheticTrainingTrace(defaultOpts({ curriculum: [] })),
+    ).toThrow(/curriculum must not be empty/);
+  });
+
+  it("throws when curriculum references unknown task", () => {
+    expect(() =>
+      buildSyntheticTrainingTrace(
+        defaultOpts({
+          curriculum: [{ taskId: "unknown-task", startEpoch: 0, endEpoch: 5 }],
+        }),
+      ),
+    ).toThrow(/unknown task: unknown-task/);
+  });
+
+  it("throws on inverted curriculum window", () => {
+    expect(() =>
+      buildSyntheticTrainingTrace(
+        defaultOpts({
+          curriculum: [{ taskId: "ais_attack_ddos", startEpoch: 5, endEpoch: 3 }],
+        }),
+      ),
+    ).toThrow(/invalid curriculum window/);
+  });
+
+  it("throws on non-integer epoch boundaries", () => {
+    expect(() =>
+      buildSyntheticTrainingTrace(
+        defaultOpts({
+          curriculum: [{ taskId: "ais_attack_ddos", startEpoch: 0, endEpoch: 5.5 }],
+        }),
+      ),
+    ).toThrow(/integer epochs/);
+  });
+});
+
+// ─── validateTrainingTrace ───────────────────────────────────────────
+
+describe("validateTrainingTrace — accepts well-formed traces", () => {
+  it("accepts a synthetic trace round-trip", () => {
+    const trace = buildSyntheticTrainingTrace(defaultOpts());
+    const serialised = JSON.parse(JSON.stringify(trace));
+    expect(() => validateTrainingTrace(serialised)).not.toThrow();
+  });
+
+  it("returns the refined trace shape", () => {
+    const trace = buildSyntheticTrainingTrace(defaultOpts());
+    const validated = validateTrainingTrace(JSON.parse(JSON.stringify(trace)));
+    expect(validated.id).toBe(trace.id);
+    expect(validated.epochs).toHaveLength(trace.epochs.length);
+    expect(validated.source.kind).toBe("synthetic");
+  });
+});
+
+describe("validateTrainingTrace — rejects malformed traces", () => {
+  function baseTrace(): TrainingTrace {
+    return buildSyntheticTrainingTrace(defaultOpts());
+  }
+
+  it("rejects non-object body", () => {
+    expect(() => validateTrainingTrace(null)).toThrow(/body is not an object/);
+    expect(() => validateTrainingTrace("string")).toThrow(/body is not an object/);
+  });
+
+  it("rejects missing top-level field", () => {
+    const t = JSON.parse(JSON.stringify(baseTrace())) as Partial<TrainingTrace>;
+    delete (t as Record<string, unknown>).epochs;
+    expect(() => validateTrainingTrace(t)).toThrow(/missing required field "epochs"/);
+  });
+
+  it("rejects invalid source.kind", () => {
+    const t = JSON.parse(JSON.stringify(baseTrace()));
+    t.source.kind = "fake-kind";
+    expect(() => validateTrainingTrace(t)).toThrow(/source.kind must be one of/);
+  });
+
+  it("rejects accuracy value outside [0, 1]", () => {
+    const t = JSON.parse(JSON.stringify(baseTrace()));
+    t.epochs[0].accuracy[0].value = 1.5;
+    expect(() => validateTrainingTrace(t)).toThrow(/must be in \[0, 1\]/);
+  });
+
+  it("rejects accuracy entry referencing unknown task", () => {
+    const t = JSON.parse(JSON.stringify(baseTrace()));
+    t.epochs[0].accuracy[0].taskId = "unknown-task";
+    expect(() => validateTrainingTrace(t)).toThrow(/references unknown task/);
+  });
+
+  it("rejects activeTaskIds referencing unknown task", () => {
+    const t = JSON.parse(JSON.stringify(baseTrace()));
+    t.epochs[0].activeTaskIds = ["unknown-task"];
+    expect(() => validateTrainingTrace(t)).toThrow(/references unknown task/);
+  });
+
+  it("rejects epoch indices that aren't strictly increasing", () => {
+    const t = JSON.parse(JSON.stringify(baseTrace()));
+    t.epochs[1].index = t.epochs[0].index;
+    expect(() => validateTrainingTrace(t)).toThrow(/must be strictly increasing/);
+  });
+
+  it("rejects duplicate taskId in accuracy entries", () => {
+    const t = JSON.parse(JSON.stringify(baseTrace()));
+    t.epochs[0].accuracy[1].taskId = t.epochs[0].accuracy[0].taskId;
+    expect(() => validateTrainingTrace(t)).toThrow(/duplicate taskId/);
+  });
+
+  it("rejects duplicate task ids", () => {
+    const t = JSON.parse(JSON.stringify(baseTrace()));
+    t.tasks[1].id = t.tasks[0].id;
+    expect(() => validateTrainingTrace(t)).toThrow(/duplicate/);
+  });
+
+  it("rejects invalid accessTier", () => {
+    const t = JSON.parse(JSON.stringify(baseTrace()));
+    t.metadata.accessTier = "fake-tier";
+    expect(() => validateTrainingTrace(t)).toThrow(/accessTier must be one of/);
+  });
+
+  it("rejects trace exceeding maxTasks limit", () => {
+    const t = JSON.parse(JSON.stringify(baseTrace()));
+    expect(() =>
+      validateTrainingTrace(t, { ...DEFAULT_TRACE_LIMITS, maxTasks: 1 }),
+    ).toThrow(/maxTasks/);
+  });
+
+  it("rejects trace exceeding maxEpochs limit", () => {
+    const t = JSON.parse(JSON.stringify(baseTrace()));
+    expect(() =>
+      validateTrainingTrace(t, { ...DEFAULT_TRACE_LIMITS, maxEpochs: 5 }),
+    ).toThrow(/maxEpochs/);
+  });
+
+  it("custom limits accept synthetic traces", () => {
+    const t = JSON.parse(JSON.stringify(baseTrace()));
+    expect(() =>
+      validateTrainingTrace(t, { maxTasks: 64, maxEpochs: 100, maxAccuracyPoints: 10_000 }),
+    ).not.toThrow();
+  });
+});
+
+describe("validation — error class", () => {
+  it("throws TrainingTraceValidationError specifically", () => {
+    try {
+      validateTrainingTrace({});
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(TrainingTraceValidationError);
+    }
+  });
+});
+
+// ─── sequentialCurriculum helper ─────────────────────────────────────
+
+describe("sequentialCurriculum", () => {
+  it("produces non-overlapping windows of fixed length", () => {
+    const windows = sequentialCurriculum(["a", "b", "c"], 10);
+    expect(windows).toEqual([
+      { taskId: "a", startEpoch: 0, endEpoch: 10 },
+      { taskId: "b", startEpoch: 10, endEpoch: 20 },
+      { taskId: "c", startEpoch: 20, endEpoch: 30 },
+    ]);
+  });
+});

--- a/src/lib/discovery/training-trace-synthetic.ts
+++ b/src/lib/discovery/training-trace-synthetic.ts
@@ -1,0 +1,323 @@
+// ─── Discovery — Synthetic Training Trace Generator ──────────────────
+//
+// Substrate for Phase 3 dissertation work. Produces deterministic
+// TrainingTrace fixtures from a curriculum spec + per-task learning
+// dynamics. Used to test the math (FR, BES temporal monitoring,
+// Ω-Forgetting Pressure) and wire downstream UI without waiting for
+// a real continual-learning training pipeline.
+//
+// EXPLICIT NON-USE
+// ----------------
+// Synthetic traces are NEVER the basis for a customer business
+// decision. Every trace this generator produces is marked
+// `source.kind === "synthetic"`. UI surfaces that display values
+// derived from a synthetic trace MUST render a SYNTHETIC badge so
+// the discriminator is visible at the point of consumption (mirrors
+// the data-status pattern from the nPOD work — 2026-05-03 user
+// directive).
+//
+// MODEL OF FORGETTING
+// -------------------
+// Each task has two dynamics knobs:
+//
+//   learningRate     — how fast accuracy rises toward the plateau
+//                      while the task is in the active training batch.
+//                      Logistic approach: acc_{t+1} = acc_t + (plateau
+//                      - acc_t) · (1 - exp(-learningRate)).
+//
+//   forgettingRate   — how fast accuracy decays toward baseline after
+//                      training shifts away. Exponential decay:
+//                      acc_{t+1} = baseline + (acc_t - baseline) ·
+//                      exp(-forgettingRate).
+//
+// Per-task asymmetry is the whole point — the Ghauri 2025 Ch. 8
+// archetype is that Heartbleed has a high forgettingRate (drops fast
+// when training shifts to other classes), driving the high-FR /
+// high-mechanism-rarity reading. The synthetic generator lets us
+// reproduce that archetype on demand for testing.
+//
+// DETERMINISM
+// -----------
+// Same `seed` + `curriculum` + `taskDynamics` → bit-identical trace.
+// Uses mulberry32 (already used in the project for seeded tests —
+// see pareto-relevance test deflake PR #254). Noise is added to
+// accuracy values but stays deterministic so test assertions survive
+// across runs.
+
+import type {
+  TaskAccuracy,
+  TaskRef,
+  TrainingEpoch,
+  TrainingTrace,
+} from "./training-trace-types";
+
+/**
+ * One window in the training curriculum. Epoch range is
+ * [startEpoch, endEpoch) — start inclusive, end exclusive, matching
+ * standard half-open interval convention.
+ */
+export interface CurriculumWindow {
+  taskId: string;
+  startEpoch: number;
+  /** Exclusive. */
+  endEpoch: number;
+}
+
+/**
+ * Per-task learning dynamics. Defaults derived below; pass-in
+ * overrides let tests reproduce the Heartbleed-archetype (forgettingRate
+ * ≈ 0.15 → ~85% retention per epoch off-task, drops to 50% in ~5 epochs).
+ */
+export interface TaskDynamics {
+  /** Accuracy before the task is ever trained. Default 0.05. */
+  baseline: number;
+  /** Accuracy plateau under continuous training. Default 0.95. */
+  plateau: number;
+  /**
+   * Rate of approach to plateau per epoch while training. Higher =
+   * faster learning. Default 0.5 (≈40% of remaining gap closed per
+   * epoch).
+   */
+  learningRate: number;
+  /**
+   * Rate of decay toward baseline per epoch when not training.
+   * Higher = faster forgetting. Default 0.05 (≈5% relative drop
+   * per epoch — slow). Override per task to model archetypes
+   * (Heartbleed: ~0.15).
+   */
+  forgettingRate: number;
+}
+
+export const DEFAULT_TASK_DYNAMICS: TaskDynamics = {
+  baseline: 0.05,
+  plateau: 0.95,
+  learningRate: 0.5,
+  forgettingRate: 0.05,
+};
+
+export interface BuildSyntheticTraceOptions {
+  /** Stable trace id. */
+  id: string;
+  /** Human label. */
+  label: string;
+  /** All tasks the trace tracks. Order is preserved on the returned trace. */
+  tasks: TaskRef[];
+  /**
+   * Sequence of training windows. Windows may overlap (multi-task
+   * batches), be disjoint (canonical continual-learning curriculum),
+   * or have gaps (model is idle). The total epoch count is
+   * `max(window.endEpoch)` across all windows.
+   */
+  curriculum: CurriculumWindow[];
+  /**
+   * Per-task dynamics overrides. Any task not present here gets
+   * DEFAULT_TASK_DYNAMICS. Keyed by `TaskRef.id`.
+   */
+  taskDynamics?: Record<string, Partial<TaskDynamics>>;
+  /**
+   * PRNG seed for the noise term. Same seed → bit-identical trace.
+   * Default 42.
+   */
+  seed?: number;
+  /**
+   * Amplitude of the symmetric noise added to accuracy values, in
+   * raw accuracy units. Default 0.02 (≈±2 percentage points).
+   * Clamped so the final value stays in [0, 1].
+   */
+  noiseAmplitude?: number;
+  /** Free-form description; defaults to "synthetic training trace". */
+  description?: string;
+}
+
+// ─── Deterministic PRNG ──────────────────────────────────────────────
+//
+// mulberry32 — used elsewhere in the project for seeded tests. Tiny,
+// fast, statistically adequate for noise injection.
+function mulberry32(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function resolveDynamics(
+  taskId: string,
+  overrides: Record<string, Partial<TaskDynamics>> | undefined,
+): TaskDynamics {
+  const o = overrides?.[taskId] ?? {};
+  return {
+    baseline: o.baseline ?? DEFAULT_TASK_DYNAMICS.baseline,
+    plateau: o.plateau ?? DEFAULT_TASK_DYNAMICS.plateau,
+    learningRate: o.learningRate ?? DEFAULT_TASK_DYNAMICS.learningRate,
+    forgettingRate: o.forgettingRate ?? DEFAULT_TASK_DYNAMICS.forgettingRate,
+  };
+}
+
+/**
+ * Build a deterministic synthetic TrainingTrace from a curriculum.
+ *
+ * Pipeline:
+ *   1. Resolve total epoch count from the curriculum
+ *   2. For each epoch, determine which tasks are active
+ *   3. For each task, evolve its accuracy by one step:
+ *        - active     → logistic approach to plateau
+ *        - not active → exponential decay to baseline
+ *   4. Add deterministic noise, clamp to [0, 1]
+ *   5. Emit TrainingEpoch records, marking `source.kind: "synthetic"`
+ *
+ * Always returns a trace with `source.kind === "synthetic"`. This is
+ * load-bearing — callers (the UI badge wiring) rely on it.
+ */
+export function buildSyntheticTrainingTrace(
+  opts: BuildSyntheticTraceOptions,
+): TrainingTrace {
+  if (opts.tasks.length === 0) {
+    throw new Error("buildSyntheticTrainingTrace: tasks must not be empty");
+  }
+  if (opts.curriculum.length === 0) {
+    throw new Error("buildSyntheticTrainingTrace: curriculum must not be empty");
+  }
+  // Validate every curriculum entry references a known task.
+  const taskIds = new Set(opts.tasks.map((t) => t.id));
+  for (const w of opts.curriculum) {
+    if (!taskIds.has(w.taskId)) {
+      throw new Error(
+        `buildSyntheticTrainingTrace: curriculum references unknown task: ${w.taskId}`,
+      );
+    }
+    if (!Number.isInteger(w.startEpoch) || !Number.isInteger(w.endEpoch)) {
+      throw new Error(
+        `buildSyntheticTrainingTrace: curriculum windows must use integer epochs (got ${w.startEpoch}, ${w.endEpoch})`,
+      );
+    }
+    if (w.startEpoch < 0 || w.endEpoch <= w.startEpoch) {
+      throw new Error(
+        `buildSyntheticTrainingTrace: invalid curriculum window [${w.startEpoch}, ${w.endEpoch}) for task ${w.taskId}`,
+      );
+    }
+  }
+
+  const totalEpochs = Math.max(...opts.curriculum.map((w) => w.endEpoch));
+  const seed = opts.seed ?? 42;
+  const noiseAmplitude = opts.noiseAmplitude ?? 0.02;
+  const rng = mulberry32(seed);
+
+  // Pre-resolve per-task dynamics.
+  const dyn = new Map<string, TaskDynamics>();
+  for (const t of opts.tasks) {
+    dyn.set(t.id, resolveDynamics(t.id, opts.taskDynamics));
+  }
+
+  // Build an epoch → active-task-ids map up front so the main loop
+  // doesn't re-scan the curriculum each step.
+  const activeByEpoch: string[][] = Array.from({ length: totalEpochs }, () => []);
+  for (const w of opts.curriculum) {
+    for (let e = w.startEpoch; e < w.endEpoch; e++) {
+      if (e < totalEpochs) activeByEpoch[e].push(w.taskId);
+    }
+  }
+
+  // Per-task accuracy state, evolved epoch by epoch.
+  const acc = new Map<string, number>();
+  for (const t of opts.tasks) {
+    acc.set(t.id, dyn.get(t.id)!.baseline);
+  }
+
+  const epochs: TrainingEpoch[] = [];
+  for (let e = 0; e < totalEpochs; e++) {
+    const active = new Set(activeByEpoch[e]);
+    for (const t of opts.tasks) {
+      const d = dyn.get(t.id)!;
+      let next: number;
+      const prev = acc.get(t.id)!;
+      if (active.has(t.id)) {
+        // Logistic approach: close part of the remaining gap to plateau.
+        const gap = d.plateau - prev;
+        next = prev + gap * (1 - Math.exp(-d.learningRate));
+      } else {
+        // Exponential decay toward baseline.
+        const above = prev - d.baseline;
+        next = d.baseline + above * Math.exp(-d.forgettingRate);
+      }
+      // Symmetric noise in [-noiseAmplitude, +noiseAmplitude].
+      const noise = (rng() * 2 - 1) * noiseAmplitude;
+      next = Math.max(0, Math.min(1, next + noise));
+      acc.set(t.id, next);
+    }
+
+    const accuracy: TaskAccuracy[] = opts.tasks.map((t) => ({
+      taskId: t.id,
+      value: acc.get(t.id)!,
+    }));
+    epochs.push({
+      index: e,
+      activeTaskIds: activeByEpoch[e],
+      accuracy,
+    });
+  }
+
+  return {
+    id: opts.id,
+    label: opts.label,
+    source: {
+      adapter: "synthetic",
+      adapterVersion: "0.1.0",
+      kind: "synthetic",
+      builtAt: new Date().toISOString(),
+      // Hash the deterministic inputs so a trace with the same
+      // curriculum + seed has the same sourceHash regardless of
+      // when it was assembled.
+      sourceHash: synthHash({
+        curriculum: opts.curriculum,
+        taskDynamics: opts.taskDynamics ?? {},
+        seed,
+        noiseAmplitude,
+      }),
+    },
+    tasks: opts.tasks,
+    epochs,
+    metadata: {
+      description: opts.description ?? "synthetic training trace",
+      accessTier: "internal-only",
+    },
+  };
+}
+
+// Stable hash of synthetic inputs. djb2 over a canonical JSON
+// serialisation — not cryptographically strong, just deterministic
+// and tiny. Returned as a hex string so the schema's optional
+// `sourceHash` doesn't gain a numeric-only contract.
+function synthHash(input: unknown): string {
+  const s = JSON.stringify(input, Object.keys(input as object).sort());
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) {
+    h = ((h * 33) ^ s.charCodeAt(i)) >>> 0;
+  }
+  return h.toString(16).padStart(8, "0");
+}
+
+// ─── Canonical curricula ─────────────────────────────────────────────
+//
+// Reusable building blocks for tests / demos. Each is a curriculum
+// shape that maps onto a dissertation scenario; pass to
+// buildSyntheticTrainingTrace along with the matching TaskRef[].
+
+/**
+ * Sequential curriculum — train one task at a time for
+ * `epochsPerTask` epochs each, no overlap. The canonical continual-
+ * learning setup the Ghauri 2025 Ch. 8 forgetting analysis assumes.
+ */
+export function sequentialCurriculum(
+  taskIds: string[],
+  epochsPerTask: number,
+): CurriculumWindow[] {
+  return taskIds.map((taskId, i) => ({
+    taskId,
+    startEpoch: i * epochsPerTask,
+    endEpoch: (i + 1) * epochsPerTask,
+  }));
+}

--- a/src/lib/discovery/training-trace-types.ts
+++ b/src/lib/discovery/training-trace-types.ts
@@ -1,0 +1,169 @@
+// ─── Discovery — Training Trace Schema ───────────────────────────────
+//
+// A `TrainingTrace` is the per-epoch record of a continual-learning
+// training run. Every adapter (synthetic, PyTorch-checkpoint,
+// TensorFlow-event-file, customer-log) emits this shape; every
+// Phase 3 estimator (BES temporal monitoring, FR / Forgetting Rate,
+// Ω-Forgetting Pressure) reads from it.
+//
+// Why this is the canonical shape: the dissertation's catastrophic-
+// forgetting analysis (Ghauri 2025, Ch. 8) is fundamentally about
+// per-task accuracy degrading over training epochs as the curriculum
+// shifts. Everything downstream — FR, exposure-weighted forgetting
+// pressure, BES temporal monitoring — boils down to:
+//
+//   accuracy(task_k, epoch_t)   →   how well the model still knows
+//                                    task_k after training has moved on
+//
+//   χ★(graph_t)                 →   which edges are load-bearing right
+//                                    now, computed from the model state
+//
+// PROVENANCE CONTRACT
+// -------------------
+// Every trace MUST declare whether it was synthesized for substrate
+// testing or extracted from a real training run. The `source.kind`
+// discriminator is load-bearing — UI surfaces that display values
+// derived from this trace MUST render a SYNTHETIC badge whenever
+// `source.kind === "synthetic"`. No customer business decision is
+// ever made off synthetic data; the badge is the structural guarantee
+// of that contract.
+//
+// This mirrors the `CohortSource.containsPHI` contract from the
+// cohort schema — a hard-typed flag at the schema layer that
+// downstream code can rely on.
+
+/**
+ * Granularity of "task" the trace operates at. Two readings of the
+ * Ghauri 2025 dissertation:
+ *   - "attack-class" — each IDS attack class (DDoS, MITM, Heartbleed,
+ *     ...) is a task. 9 tasks for the canonical AI Safety substrate.
+ *     This is the finest granularity at which the Ch. 8 forgetting
+ *     analysis operates — Heartbleed's high mechanism-rarity / high-FR
+ *     archetype only shows up here.
+ *   - "dataset" — each source dataset (CICIDS-2017, UNSW-NB15,
+ *     AWID-H23Q) is a task. 3 tasks. Useful for cohort-level analysis;
+ *     loses the per-attack-class forgetting signal.
+ *
+ * Default for new traces: "attack-class".
+ */
+export type TaskScope = "attack-class" | "dataset";
+
+/**
+ * Stable reference to a task tracked by the trace. The id should be
+ * an existing graph node id when possible (e.g. `ais_attack_ddos`) so
+ * downstream code can join task-level metrics back to graph topology.
+ */
+export interface TaskRef {
+  id: string;
+  label: string;
+  scope: TaskScope;
+}
+
+/**
+ * Per-task accuracy reading at a single epoch. Value is in [0, 1] —
+ * "fraction of held-out samples for task_k that the current model
+ * classifies correctly." Adapters that emit other metrics (loss,
+ * F1, AUROC) should normalise to accuracy at ingest time or extend
+ * the schema in a follow-up PR.
+ */
+export interface TaskAccuracy {
+  taskId: string;
+  /** [0, 1]. */
+  value: number;
+}
+
+/**
+ * Optional auxiliary metrics recorded per epoch. None are required —
+ * the FR estimator runs purely on `accuracy[]`. Recorded when the
+ * adapter has cheap access (e.g., PyTorch lightning callbacks).
+ */
+export interface EpochModelState {
+  /** Mean loss on the training batch at this epoch. */
+  lossOnBatch?: number;
+  /** L2 norm of the gradient at the end of this epoch. */
+  gradientNorm?: number;
+}
+
+/**
+ * One snapshot in the training trace. The trace as a whole is an
+ * ordered sequence of these, indexed by `index` (0-indexed).
+ */
+export interface TrainingEpoch {
+  /** 0-indexed epoch number. Must be monotone strictly increasing across the trace. */
+  index: number;
+  /**
+   * Task id(s) the model was actively training on at this epoch.
+   * Multi-task batches are allowed (mixed curricula); single-task
+   * curricula have exactly one entry per epoch.
+   */
+  activeTaskIds: string[];
+  /**
+   * Accuracy across ALL tasks the trace tracks, not just the active
+   * one(s). This is what makes the FR computation possible — you
+   * need to read task_k's accuracy at every epoch, including the
+   * ones where it isn't being trained.
+   */
+  accuracy: TaskAccuracy[];
+  /** Optional auxiliary model-state metrics. */
+  modelState?: EpochModelState;
+}
+
+/**
+ * Provenance of the trace — synthetic substrate test or real training
+ * run. The `kind` field is the discriminator UI surfaces must render
+ * as a badge.
+ */
+export interface TrainingTraceSource {
+  /** Adapter id (e.g. `"synthetic"`, `"pytorch-lightning"`, `"tf-events"`). */
+  adapter: string;
+  /** Adapter version for reproducibility. */
+  adapterVersion: string;
+  /**
+   * Hard discriminator. UI surfaces displaying values derived from
+   * a `synthetic`-kind trace MUST render a SYNTHETIC badge. UI
+   * surfaces gated to live data only (e.g., the customer-facing
+   * Ω-Forgetting-Pressure metric) MUST skip rendering when this
+   * is `synthetic`.
+   */
+  kind: "synthetic" | "live";
+  /**
+   * ISO 8601 timestamp of when this trace object was assembled
+   * (NOT when the underlying training run happened).
+   */
+  builtAt: string;
+  /**
+   * SHA-256 of the underlying source artifacts — training log files,
+   * checkpoint serialisations, or for synthetic traces, the seed +
+   * curriculum hash. Optional but recommended for reproducibility.
+   */
+  sourceHash?: string;
+}
+
+/**
+ * Trace-level metadata. Free-form study description plus an access-
+ * tier flag matching the Cohort schema's `accessTier` convention.
+ */
+export interface TrainingTraceMetadata {
+  description: string;
+  citation?: string;
+  /** Licence / sharing tier. */
+  accessTier: "public" | "dua-restricted" | "internal-only";
+}
+
+/**
+ * The lingua-franca shape every training trace conforms to. Adapters
+ * read raw artifacts into this; estimators (FR, BES temporal,
+ * Ω-Forgetting Pressure) read this and never touch raw artifacts.
+ */
+export interface TrainingTrace {
+  /** Stable trace id, opaque. */
+  id: string;
+  /** Human label for UI display. */
+  label: string;
+  source: TrainingTraceSource;
+  /** All tasks the trace tracks. Order is the order they appear in the curriculum. */
+  tasks: TaskRef[];
+  /** Per-epoch snapshots, sorted by `epoch.index` ascending. */
+  epochs: TrainingEpoch[];
+  metadata: TrainingTraceMetadata;
+}

--- a/src/lib/discovery/training-trace-validator.ts
+++ b/src/lib/discovery/training-trace-validator.ts
@@ -1,0 +1,288 @@
+// ─── Discovery — Training Trace Validator ────────────────────────────
+//
+// Runtime validator for `TrainingTrace` blobs arriving from untrusted
+// sources (eventual customer adapters posting traces to an API
+// surface). The TS type system enforces the schema at compile time;
+// this file enforces it at runtime so a malformed or malicious
+// payload can't propagate downstream.
+//
+// Mirrors the `validateCohort` shape from cohort-validator.ts —
+// throws a precise pointer on any mismatch, returns the refined type
+// on success.
+
+import type {
+  TaskAccuracy,
+  TaskRef,
+  TaskScope,
+  TrainingEpoch,
+  TrainingTrace,
+  TrainingTraceMetadata,
+  TrainingTraceSource,
+} from "./training-trace-types";
+
+export interface TrainingTraceValidatorLimits {
+  /** Hard ceiling on task count. Synthetic traces typically have 9. */
+  maxTasks: number;
+  /** Hard ceiling on epoch count. Real continual-learning runs sometimes go to 10k+. */
+  maxEpochs: number;
+  /** Hard ceiling on total accuracy datapoints (tasks × epochs). */
+  maxAccuracyPoints: number;
+}
+
+export const DEFAULT_TRACE_LIMITS: TrainingTraceValidatorLimits = {
+  maxTasks: 64,
+  maxEpochs: 50_000,
+  maxAccuracyPoints: 500_000,
+};
+
+export class TrainingTraceValidationError extends Error {
+  constructor(message: string) {
+    super(`training trace validation failed: ${message}`);
+    this.name = "TrainingTraceValidationError";
+  }
+}
+
+const VALID_SCOPES: TaskScope[] = ["attack-class", "dataset"];
+const VALID_SOURCE_KINDS: TrainingTraceSource["kind"][] = ["synthetic", "live"];
+const VALID_ACCESS_TIERS: TrainingTraceMetadata["accessTier"][] = [
+  "public",
+  "dua-restricted",
+  "internal-only",
+];
+
+function requireField(obj: Record<string, unknown>, key: string, where: string) {
+  if (!(key in obj)) {
+    throw new TrainingTraceValidationError(`missing required field "${key}" on ${where}`);
+  }
+}
+
+function requireString(value: unknown, where: string) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new TrainingTraceValidationError(`${where} must be a non-empty string`);
+  }
+}
+
+function validateSource(blob: unknown): TrainingTraceSource {
+  if (!blob || typeof blob !== "object") {
+    throw new TrainingTraceValidationError("source must be an object");
+  }
+  const s = blob as Record<string, unknown>;
+  for (const k of ["adapter", "adapterVersion", "kind", "builtAt"]) {
+    requireField(s, k, "source");
+  }
+  requireString(s.adapter, "source.adapter");
+  requireString(s.adapterVersion, "source.adapterVersion");
+  if (typeof s.builtAt !== "string" || Number.isNaN(Date.parse(s.builtAt))) {
+    throw new TrainingTraceValidationError("source.builtAt must be an ISO 8601 string");
+  }
+  if (!VALID_SOURCE_KINDS.includes(s.kind as TrainingTraceSource["kind"])) {
+    throw new TrainingTraceValidationError(
+      `source.kind must be one of ${VALID_SOURCE_KINDS.join(", ")} (got ${String(s.kind)})`,
+    );
+  }
+  if (s.sourceHash !== undefined && typeof s.sourceHash !== "string") {
+    throw new TrainingTraceValidationError("source.sourceHash must be a string when present");
+  }
+  return s as unknown as TrainingTraceSource;
+}
+
+function validateTasks(blob: unknown, limits: TrainingTraceValidatorLimits): TaskRef[] {
+  if (!Array.isArray(blob)) {
+    throw new TrainingTraceValidationError("tasks must be an array");
+  }
+  if (blob.length === 0) {
+    throw new TrainingTraceValidationError("tasks must not be empty");
+  }
+  if (blob.length > limits.maxTasks) {
+    throw new TrainingTraceValidationError(
+      `tasks exceeds maxTasks (${blob.length} > ${limits.maxTasks})`,
+    );
+  }
+  const seen = new Set<string>();
+  blob.forEach((t, i) => {
+    if (!t || typeof t !== "object") {
+      throw new TrainingTraceValidationError(`tasks[${i}] must be an object`);
+    }
+    const r = t as Record<string, unknown>;
+    requireString(r.id, `tasks[${i}].id`);
+    requireString(r.label, `tasks[${i}].label`);
+    if (!VALID_SCOPES.includes(r.scope as TaskScope)) {
+      throw new TrainingTraceValidationError(
+        `tasks[${i}].scope must be one of ${VALID_SCOPES.join(", ")} (got ${String(r.scope)})`,
+      );
+    }
+    if (seen.has(r.id as string)) {
+      throw new TrainingTraceValidationError(`tasks[${i}].id duplicate: ${r.id}`);
+    }
+    seen.add(r.id as string);
+  });
+  return blob as TaskRef[];
+}
+
+function validateAccuracy(
+  blob: unknown,
+  taskIds: Set<string>,
+  where: string,
+): TaskAccuracy[] {
+  if (!Array.isArray(blob)) {
+    throw new TrainingTraceValidationError(`${where}.accuracy must be an array`);
+  }
+  const seen = new Set<string>();
+  blob.forEach((a, i) => {
+    if (!a || typeof a !== "object") {
+      throw new TrainingTraceValidationError(`${where}.accuracy[${i}] must be an object`);
+    }
+    const r = a as Record<string, unknown>;
+    requireString(r.taskId, `${where}.accuracy[${i}].taskId`);
+    if (!taskIds.has(r.taskId as string)) {
+      throw new TrainingTraceValidationError(
+        `${where}.accuracy[${i}].taskId references unknown task: ${r.taskId}`,
+      );
+    }
+    if (typeof r.value !== "number" || Number.isNaN(r.value)) {
+      throw new TrainingTraceValidationError(
+        `${where}.accuracy[${i}].value must be a finite number`,
+      );
+    }
+    if ((r.value as number) < 0 || (r.value as number) > 1) {
+      throw new TrainingTraceValidationError(
+        `${where}.accuracy[${i}].value must be in [0, 1] (got ${r.value})`,
+      );
+    }
+    if (seen.has(r.taskId as string)) {
+      throw new TrainingTraceValidationError(
+        `${where}.accuracy duplicate taskId: ${r.taskId}`,
+      );
+    }
+    seen.add(r.taskId as string);
+  });
+  return blob as TaskAccuracy[];
+}
+
+function validateEpochs(
+  blob: unknown,
+  taskIds: Set<string>,
+  limits: TrainingTraceValidatorLimits,
+): TrainingEpoch[] {
+  if (!Array.isArray(blob)) {
+    throw new TrainingTraceValidationError("epochs must be an array");
+  }
+  if (blob.length === 0) {
+    throw new TrainingTraceValidationError("epochs must not be empty");
+  }
+  if (blob.length > limits.maxEpochs) {
+    throw new TrainingTraceValidationError(
+      `epochs exceeds maxEpochs (${blob.length} > ${limits.maxEpochs})`,
+    );
+  }
+  let totalAccuracyPoints = 0;
+  let prevIndex = -1;
+  blob.forEach((e, i) => {
+    if (!e || typeof e !== "object") {
+      throw new TrainingTraceValidationError(`epochs[${i}] must be an object`);
+    }
+    const r = e as Record<string, unknown>;
+    if (typeof r.index !== "number" || !Number.isInteger(r.index) || r.index < 0) {
+      throw new TrainingTraceValidationError(
+        `epochs[${i}].index must be a non-negative integer`,
+      );
+    }
+    if (r.index <= prevIndex) {
+      throw new TrainingTraceValidationError(
+        `epochs[${i}].index must be strictly increasing (got ${r.index} after ${prevIndex})`,
+      );
+    }
+    prevIndex = r.index;
+    if (!Array.isArray(r.activeTaskIds)) {
+      throw new TrainingTraceValidationError(
+        `epochs[${i}].activeTaskIds must be an array`,
+      );
+    }
+    (r.activeTaskIds as unknown[]).forEach((id, j) => {
+      if (typeof id !== "string") {
+        throw new TrainingTraceValidationError(
+          `epochs[${i}].activeTaskIds[${j}] must be a string`,
+        );
+      }
+      if (!taskIds.has(id)) {
+        throw new TrainingTraceValidationError(
+          `epochs[${i}].activeTaskIds[${j}] references unknown task: ${id}`,
+        );
+      }
+    });
+    const accs = validateAccuracy(r.accuracy, taskIds, `epochs[${i}]`);
+    totalAccuracyPoints += accs.length;
+    if (totalAccuracyPoints > limits.maxAccuracyPoints) {
+      throw new TrainingTraceValidationError(
+        `total accuracy points exceeds maxAccuracyPoints (${totalAccuracyPoints} > ${limits.maxAccuracyPoints})`,
+      );
+    }
+    if (r.modelState !== undefined) {
+      const ms = r.modelState as Record<string, unknown>;
+      if (ms.lossOnBatch !== undefined && typeof ms.lossOnBatch !== "number") {
+        throw new TrainingTraceValidationError(
+          `epochs[${i}].modelState.lossOnBatch must be a number`,
+        );
+      }
+      if (ms.gradientNorm !== undefined && typeof ms.gradientNorm !== "number") {
+        throw new TrainingTraceValidationError(
+          `epochs[${i}].modelState.gradientNorm must be a number`,
+        );
+      }
+    }
+  });
+  return blob as TrainingEpoch[];
+}
+
+function validateMetadata(blob: unknown): TrainingTraceMetadata {
+  if (!blob || typeof blob !== "object") {
+    throw new TrainingTraceValidationError("metadata must be an object");
+  }
+  const r = blob as Record<string, unknown>;
+  requireString(r.description, "metadata.description");
+  if (!VALID_ACCESS_TIERS.includes(r.accessTier as TrainingTraceMetadata["accessTier"])) {
+    throw new TrainingTraceValidationError(
+      `metadata.accessTier must be one of ${VALID_ACCESS_TIERS.join(", ")}`,
+    );
+  }
+  if (r.citation !== undefined && typeof r.citation !== "string") {
+    throw new TrainingTraceValidationError(
+      "metadata.citation must be a string when present",
+    );
+  }
+  return r as unknown as TrainingTraceMetadata;
+}
+
+/**
+ * Validates an unknown blob as a TrainingTrace. Throws
+ * TrainingTraceValidationError with a precise pointer on any
+ * mismatch; returns a refined-type TrainingTrace on success.
+ */
+export function validateTrainingTrace(
+  blob: unknown,
+  limits: TrainingTraceValidatorLimits = DEFAULT_TRACE_LIMITS,
+): TrainingTrace {
+  if (!blob || typeof blob !== "object") {
+    throw new TrainingTraceValidationError("body is not an object");
+  }
+  const t = blob as Record<string, unknown>;
+  for (const k of ["id", "label", "source", "tasks", "epochs", "metadata"]) {
+    requireField(t, k, "root");
+  }
+  requireString(t.id, "id");
+  requireString(t.label, "label");
+  const source = validateSource(t.source);
+  const tasks = validateTasks(t.tasks, limits);
+  const taskIds = new Set(tasks.map((tt) => tt.id));
+  const epochs = validateEpochs(t.epochs, taskIds, limits);
+  const metadata = validateMetadata(t.metadata);
+
+  return {
+    id: t.id as string,
+    label: t.label as string,
+    source,
+    tasks,
+    epochs,
+    metadata,
+  };
+}


### PR DESCRIPTION
## Summary

First of 4 PRs porting the Ghauri 2025 Phase 3 continual-learning estimators (BES temporal monitoring, FR / Forgetting Rate, Ω-Forgetting Pressure). Lays the canonical data shape every trace — synthetic or live — conforms to, plus a synthetic generator for testing the math without waiting for real customer training runs.

## Scope discipline

**Substrate only.** No UI. No estimator math. No customer-facing flow. The next 3 PRs build on this.

## Three modules

### `training-trace-types.ts`
The lingua-franca `TrainingTrace` interface. Per-epoch snapshots of which task(s) were trained and per-task accuracy across **all** tasks (not just the active one — that's what makes FR computation possible).

**Crucial design choice:** `source.kind` is a `'synthetic' | 'live'` discriminator. UI surfaces displaying values derived from a synthetic trace MUST render a SYNTHETIC badge — mirrors the nPOD synthetic-cohort badging convention from the 2026-05-03 "nothing should be synthetic" directive. **No customer business decision ever runs off synthetic data.**

### `training-trace-validator.ts`
Runtime validator for untrusted blobs (eventual API surface). Catches malformed inputs with precise error pointers. Mirrors the `validateCohort` shape from `cohort-validator.ts`.

### `training-trace-synthetic.ts`
`buildSyntheticTrainingTrace(opts)` — deterministic curriculum-driven generator. Per-task dynamics knobs (`baseline`, `plateau`, `learningRate`, `forgettingRate`) let us reproduce the dissertation Heartbleed-archetype: `forgettingRate: 0.30` → fast decay when training shifts away. Seeded mulberry32 PRNG ensures bit-identical traces for the same (seed, curriculum, dynamics) triple.

`sequentialCurriculum()` helper builds the canonical no-overlap continual-learning curriculum (train each task for N epochs in order) — the setup the Ghauri 2025 Ch. 8 forgetting analysis assumes.

## Tests (35 new)

- **Shape contracts**: total epochs match curriculum, indices monotone, every epoch has accuracy for every task, activeTaskIds match the curriculum
- **Dynamics**: accuracy rises during training and decays after. Heartbleed archetype assertion: high-`forgettingRate` task drops faster than a low-`forgettingRate` task over the same idle window — anchors the asymmetry the dissertation analysis depends on
- **Determinism**: same seed → bit-identical trace; `sourceHash` stable across runs with matching inputs
- **Clamping**: accuracy never escapes [0, 1] even under heavy noise
- **Validation**: 13 negative-path tests (missing fields, bad enums, range violations, duplicates, limit overruns)

## Sequencing

| PR | Status | What |
|---|---|---|
| **PR 1** (this) | open | TrainingTrace substrate + synthetic generator |
| PR 2 | pending | BES temporal monitoring (compute χ★ per epoch) |
| PR 3 | pending | FR estimator math + tests |
| PR 4 | pending | Ω-Forgetting Pressure metric + UX with explicit SYNTHETIC badge wired in |
| PR 5 (future) | pending | Real ingester (PyTorch / TF training-log adapter); flips the badge to LIVE for customer use |

**No customer ever sees an unbadged Phase 3 surface.**

## Test plan

- [x] `vitest run`: **1212 passing** (was 1168 + 35 new + sibling-session work). No regressions.
- [x] `tsc --noEmit` clean for the new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)