### PR TITLE
feat(chi-star): parallel train-track outlines (no longer halo)

### DIFF
--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -526,8 +526,15 @@ function EmphasizedEdge(props: EdgeProps<EmphasizedEdgeData>) {
   const targetNode = useReactFlowStore((s) => s.nodeInternals.get(target));
 
   let edgePath: string | null = null;
-  let midX: number | null = null;
-  let midY: number | null = null;
+  // Perpendicular direction to the edge line, used to compute the
+  // two parallel χ★ "track" paths offset by ±CHI_TRACK_OFFSET pixels.
+  // null when the edge has zero length (no perpendicular defined).
+  let perpDx = 0;
+  let perpDy = 0;
+  let edgeX1 = 0;
+  let edgeY1 = 0;
+  let edgeX2 = 0;
+  let edgeY2 = 0;
   if (sourceNode && targetNode) {
     const sw = sourceNode.width ?? 30;
     const sh = sourceNode.height ?? 30;
@@ -548,13 +555,16 @@ function EmphasizedEdge(props: EdgeProps<EmphasizedEdgeData>) {
       // the orb and overruns the arrow head.
       const sr = sw / 2;
       const tr = tw / 2;
-      const x1 = sxC + ndx * sr;
-      const y1 = syC + ndy * sr;
-      const x2 = txC - ndx * tr;
-      const y2 = tyC - ndy * tr;
-      edgePath = `M ${x1} ${y1} L ${x2} ${y2}`;
-      midX = (x1 + x2) / 2;
-      midY = (y1 + y2) / 2;
+      edgeX1 = sxC + ndx * sr;
+      edgeY1 = syC + ndy * sr;
+      edgeX2 = txC - ndx * tr;
+      edgeY2 = tyC - ndy * tr;
+      edgePath = `M ${edgeX1} ${edgeY1} L ${edgeX2} ${edgeY2}`;
+      // Perpendicular in SVG screen space: rotate the unit direction
+      // 90° counter-clockwise. The +CHI side uses (perpDx, perpDy);
+      // the -CHI side uses (-perpDx, -perpDy).
+      perpDx = -ndy;
+      perpDy = ndx;
     }
   }
   if (!edgePath) return null;
@@ -610,29 +620,52 @@ function EmphasizedEdge(props: EdgeProps<EmphasizedEdgeData>) {
   // `adjacency` import — only nodes need it; edges go via source/target.
   void adjacency;
 
-  // χ★ edge outline — renders BEFORE the BaseEdge so the cyan/amber
-  // main line draws on top, leaving a thin violet ring around it.
-  // Solid for strict bridges, dashed for top-BES. Replaces the
-  // earlier midpoint-diamond approach (filled vs hollow polygon at
-  // the line midpoint) — on long edges the midpoint was visually
-  // disconnected from the edge itself, and filled/hollow was too
-  // subtle to distinguish at a glance. Tracing the full line makes
-  // the χ★ signal visible anywhere you look at the edge.
-  const showChiStarOutline =
+  // χ★ parallel tracks — two thin violet lines running alongside the
+  // main edge, offset perpendicular by CHI_TRACK_OFFSET pixels.
+  // Solid for strict bridges, dashed for top-BES. The cyan/amber
+  // main line stays untouched in the middle.
+  //
+  // Why parallel tracks instead of an outline-around (the previous
+  // approach): an outline visually tints the main line — even with
+  // narrow violet behind and cyan in front, the cyan reads as
+  // slightly desaturated because the violet leaks at the edges.
+  // Parallel tracks keep the main line at its true causal-type
+  // color and add the χ★ signal as a separate visual layer
+  // alongside it. Like train tracks.
+  const showChiStarTracks =
     d.chiStarTier !== null &&
     !isThisSelected &&
     d.propagationSignal === 0;
+  const CHI_TRACK_OFFSET = 3.5;
+  const trackTopPath = showChiStarTracks
+    ? `M ${edgeX1 + perpDx * CHI_TRACK_OFFSET} ${edgeY1 + perpDy * CHI_TRACK_OFFSET} L ${edgeX2 + perpDx * CHI_TRACK_OFFSET} ${edgeY2 + perpDy * CHI_TRACK_OFFSET}`
+    : null;
+  const trackBottomPath = showChiStarTracks
+    ? `M ${edgeX1 - perpDx * CHI_TRACK_OFFSET} ${edgeY1 - perpDy * CHI_TRACK_OFFSET} L ${edgeX2 - perpDx * CHI_TRACK_OFFSET} ${edgeY2 - perpDy * CHI_TRACK_OFFSET}`
+    : null;
+  const trackDasharray = d.chiStarTier === "top-bes" ? "4 3" : undefined;
 
   return (
     <>
-      {showChiStarOutline && (
+      {showChiStarTracks && trackTopPath && (
         <path
-          d={edgePath}
+          d={trackTopPath}
           stroke="#7B68EE"
-          strokeWidth={strokeWidth + 2.5}
-          strokeDasharray={d.chiStarTier === "top-bes" ? "4 3" : undefined}
+          strokeWidth={1.25}
+          strokeDasharray={trackDasharray}
           fill="none"
-          opacity={opacity * 0.7}
+          opacity={opacity * 0.85}
+          style={{ transition: "opacity 180ms ease-out", pointerEvents: "none" }}
+        />
+      )}
+      {showChiStarTracks && trackBottomPath && (
+        <path
+          d={trackBottomPath}
+          stroke="#7B68EE"
+          strokeWidth={1.25}
+          strokeDasharray={trackDasharray}
+          fill="none"
+          opacity={opacity * 0.85}
           style={{ transition: "opacity 180ms ease-out", pointerEvents: "none" }}
         />
       )}

--- a/src/components/CausalDAGMap.tsx
+++ b/src/components/CausalDAGMap.tsx
@@ -754,22 +754,45 @@ function CausalDAGMapInner() {
         boxZoom={false}
         attributionControl={false}
       >
-        {/* χ★ outline — wider violet line traced along each χ★ edge,
-            rendered FIRST so the narrower solid + dashed edge layers
-            below draw ON TOP and leave a thin violet ring around the
-            edge. Solid for strict bridges, dashed for top-BES (paint
-            expression on the `tier` property). Replaces the earlier
-            midpoint-circle approach so on long ocean-spanning arcs
-            the χ★ signal is visible along the whole edge instead of
-            stranded in the middle of the Pacific. */}
-        <Source id="edges-chi-star-outline" type="geojson" data={chiStarOutlineGeoJSON}>
+        {/* χ★ parallel tracks — TWO thin violet lines running alongside
+            each χ★ edge, offset perpendicular to the line direction
+            using MapLibre's `line-offset` paint property. Solid for
+            strict bridges, dashed for top-BES (driven by a paint
+            expression on the `tier` property). The cyan/amber main
+            line draws below at offset=0, untouched, so the parallel
+            tracks read as a clean "train tracks" outline alongside it
+            rather than smearing the main edge color. */}
+        <Source id="edges-chi-star-track-top" type="geojson" data={chiStarOutlineGeoJSON}>
           <Layer
-            id="edge-chi-star-outline"
+            id="edge-chi-star-track-top"
             type="line"
             paint={{
               "line-color": "#7B68EE",
-              "line-opacity": 0.7,
-              "line-width": ["get", "width"],
+              "line-opacity": 0.85,
+              "line-width": 1.5,
+              "line-offset": 3,
+              "line-dasharray": [
+                "case",
+                ["==", ["get", "tier"], "top-bes"],
+                ["literal", [3, 2]],
+                ["literal", [1, 0]],
+              ],
+            }}
+            layout={{
+              "line-cap": "round",
+              "line-join": "round",
+            }}
+          />
+        </Source>
+        <Source id="edges-chi-star-track-bottom" type="geojson" data={chiStarOutlineGeoJSON}>
+          <Layer
+            id="edge-chi-star-track-bottom"
+            type="line"
+            paint={{
+              "line-color": "#7B68EE",
+              "line-opacity": 0.85,
+              "line-width": 1.5,
+              "line-offset": -3,
               "line-dasharray": [
                 "case",
                 ["==", ["get", "tier"], "top-bes"],

--- a/src/components/dag3d/DAGEdge3D.tsx
+++ b/src/components/dag3d/DAGEdge3D.tsx
@@ -114,19 +114,51 @@ function DAGEdge3DInner({
 
   const posKey = `${sourcePos[0]},${sourcePos[1]},${sourcePos[2]}|${targetPos[0]},${targetPos[1]},${targetPos[2]}`;
 
-  const { curvePoints, midpoint, curve } = useMemo(() => {
+  const { curvePoints, midpoint, curve, chiTrackTop, chiTrackBottom } = useMemo(() => {
     const src = new THREE.Vector3(...sourcePos);
     const tgt = new THREE.Vector3(...targetPos);
     const mid = new THREE.Vector3().lerpVectors(src, tgt, 0.5);
     mid.add(curveOffset);
 
     const c = new THREE.QuadraticBezierCurve3(src, mid, tgt);
-    const pts = c.getPoints(32);
+    const N = 32;
+    const pts = c.getPoints(N);
     const midPt = c.getPoint(0.5);
+
+    // χ★ parallel-track offsets. For each point on the curve, compute
+    // the tangent there, cross with world-up to get a "side" vector
+    // perpendicular to the curve in the horizontal plane, then offset
+    // by ±CHI_TRACK_OFFSET along it. The result is two parallel
+    // 3D curves running alongside the main one — visible as
+    // train-tracks from the standard top-down camera angle. Fallback
+    // when the tangent is parallel to up (rare; vertical edges):
+    // use world-X as the reference perpendicular.
+    const CHI_TRACK_OFFSET = 0.85;
+    const worldUp = new THREE.Vector3(0, 1, 0);
+    const worldX = new THREE.Vector3(1, 0, 0);
+    const top: [number, number, number][] = [];
+    const bottom: [number, number, number][] = [];
+    for (let i = 0; i <= N; i++) {
+      const t = i / N;
+      const p = pts[i];
+      const tangent = c.getTangent(t);
+      // side = tangent × up, normalised. If tangent is parallel to up
+      // (cross is ~zero), use tangent × worldX as fallback.
+      const side = new THREE.Vector3().crossVectors(tangent, worldUp);
+      if (side.lengthSq() < 1e-6) {
+        side.crossVectors(tangent, worldX);
+      }
+      side.normalize().multiplyScalar(CHI_TRACK_OFFSET);
+      top.push([p.x + side.x, p.y + side.y, p.z + side.z]);
+      bottom.push([p.x - side.x, p.y - side.y, p.z - side.z]);
+    }
+
     return {
       curvePoints: pts.map(p => [p.x, p.y, p.z] as [number, number, number]),
       midpoint: midPt,
       curve: c,
+      chiTrackTop: top,
+      chiTrackBottom: bottom,
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [posKey, curveOffset]);
@@ -204,27 +236,37 @@ function DAGEdge3DInner({
         <meshBasicMaterial transparent opacity={0} depthWrite={false} />
       </mesh>
 
-      {/* χ★ edge outline — drawn BEFORE the main edge line so the
-          narrower cyan/amber line below renders ON TOP, leaving a
-          thin violet ring along the edge instead of obscuring it.
-          Solid for strict bridges, dashed for top-BES. Skipped on
-          severed / ablated edges (their own markers take priority).
-          Note: this replaces the earlier midpoint-pip approach —
-          a traced outline rides the full edge so the χ★ signal
-          is visible anywhere you look at it, including the Map's
-          ocean-spanning arcs where the midpoint pip lived nowhere
-          near the visible edge. */}
+      {/* χ★ parallel tracks — TWO thin violet lines running alongside
+          the main edge, offset perpendicular to the curve tangent by
+          CHI_TRACK_OFFSET world-units (see chiTrackTop / chiTrackBottom
+          in the curve memo above). The cyan/amber main line stays
+          untouched in the middle — this is "train-track" outlining,
+          not a halo. Solid for strict bridges, dashed for top-BES.
+          Skipped on severed / ablated edges (their own markers take
+          priority). */}
       {chiStarTier && !isSevered && !isAblated && (
-        <Line
-          points={curvePoints}
-          color="#7B68EE"
-          lineWidth={Math.max(1, lineWidth) + 1.5}
-          transparent
-          opacity={0.7}
-          dashed={chiStarTier === "top-bes"}
-          dashSize={chiStarTier === "top-bes" ? 0.4 : undefined}
-          gapSize={chiStarTier === "top-bes" ? 0.35 : undefined}
-        />
+        <>
+          <Line
+            points={chiTrackTop}
+            color="#7B68EE"
+            lineWidth={1.5}
+            transparent
+            opacity={0.85}
+            dashed={chiStarTier === "top-bes"}
+            dashSize={chiStarTier === "top-bes" ? 0.4 : undefined}
+            gapSize={chiStarTier === "top-bes" ? 0.35 : undefined}
+          />
+          <Line
+            points={chiTrackBottom}
+            color="#7B68EE"
+            lineWidth={1.5}
+            transparent
+            opacity={0.85}
+            dashed={chiStarTier === "top-bes"}
+            dashSize={chiStarTier === "top-bes" ? 0.4 : undefined}
+            gapSize={chiStarTier === "top-bes" ? 0.35 : undefined}
+          />
+        </>
       )}
 
       {/* Edge line — using drei Line for reliable rendering:

--- a/src/components/dag3d/DAGOverlay.tsx
+++ b/src/components/dag3d/DAGOverlay.tsx
@@ -217,44 +217,58 @@ function EncodingLegend({
           }
         />
         <LegendRow
-          label="χ★ STRICT BRIDGE (solid violet outline)"
-          help="A thin solid violet outline traces the edge along its full length. Removing this edge disconnects the (undirected) graph — every cascade path between the two resulting components must traverse it. Click the edge for BES + rank. Source: Ghauri 2025 D.Eng."
+          label="χ★ STRICT BRIDGE (solid violet tracks)"
+          help="Two thin solid violet lines run alongside the edge — like train tracks. Removing this edge disconnects the (undirected) graph; every cascade path between the resulting components must traverse it. Click the edge for BES + rank. Source: Ghauri 2025 D.Eng."
           swatch={
             <div className="flex items-center">
-              {/* Inner cyan line with violet outer ring — mirrors the
-                  canvas treatment so the swatch matches what the user
-                  sees on the graph. */}
-              <span className="relative h-1.5 w-7">
+              {/* Train-track swatch: cyan line in the middle, two thin
+                  violet rails above and below. Mirrors the canvas. */}
+              <span className="relative h-2.5 w-7">
                 <span
-                  className="absolute inset-0 rounded-sm"
-                  style={{ backgroundColor: "#7B68EE", opacity: 0.75 }}
+                  className="absolute left-0 right-0 h-px"
+                  style={{ top: "20%", backgroundColor: "#7B68EE", opacity: 0.85 }}
                 />
                 <span
                   className="absolute left-0 right-0 top-1/2 -translate-y-1/2 h-px"
                   style={{ backgroundColor: "#00e5ff" }}
+                />
+                <span
+                  className="absolute left-0 right-0 h-px"
+                  style={{ bottom: "20%", backgroundColor: "#7B68EE", opacity: 0.85 }}
                 />
               </span>
             </div>
           }
         />
         <LegendRow
-          label="χ★ TOP-BES (dashed violet outline)"
-          help="A thin dashed violet outline traces the edge. High Bridge-Edge Strength — participates in many shortest paths even though removing it doesn't formally disconnect the graph."
+          label="χ★ TOP-BES (dashed violet tracks)"
+          help="Two thin dashed violet lines run alongside the edge. High Bridge-Edge Strength — participates in many shortest paths even though removing it doesn't formally disconnect the graph."
           swatch={
             <div className="flex items-center">
-              <span className="relative h-1.5 w-7">
+              <span className="relative h-2.5 w-7">
                 <span
-                  className="absolute inset-0 rounded-sm"
+                  className="absolute left-0 right-0 h-px"
                   style={{
+                    top: "20%",
                     backgroundImage:
                       "linear-gradient(to right, #7B68EE 60%, transparent 60%)",
                     backgroundSize: "5px 100%",
-                    opacity: 0.75,
+                    opacity: 0.85,
                   }}
                 />
                 <span
                   className="absolute left-0 right-0 top-1/2 -translate-y-1/2 h-px"
                   style={{ backgroundColor: "#00e5ff" }}
+                />
+                <span
+                  className="absolute left-0 right-0 h-px"
+                  style={{
+                    bottom: "20%",
+                    backgroundImage:
+                      "linear-gradient(to right, #7B68EE 60%, transparent 60%)",
+                    backgroundSize: "5px 100%",
+                    opacity: 0.85,
+                  }}
                 />
               </span>
             </div>


### PR DESCRIPTION
## Summary

Your clarification on #377: the previous outline was a wider violet line behind the cyan/amber main line — which made the main line read as slightly tinted because the violet leaks at the edges. What you actually wanted: **TWO thin parallel violet lines running alongside** the main edge, like train tracks, leaving the main line completely untouched in the middle.

> "I wanted you to have true lines tracking any of the node connection lines, not a halo around it. The problem with the halo is that it fundamentally changes the color of it."

This PR ships exactly that.

## Per-canvas implementation

| Canvas | Mechanism |
|---|---|
| **3D** | Curve memo extended to produce two offset bezier point arrays — for each point on the curve, tangent × world-up gives a perpendicular side vector; offset by ±0.85 world-units. Two parallel `<Line>` elements, 1.5px wide |
| **2D (SVG)** | Hoisted edge endpoints + perpendicular direction out of the path-build block. Two new SVG `<path>` strings offset by ±3.5px perpendicular to the line direction. 1.25px stroke |
| **Map (MapLibre)** | Same source GeoJSON feeds two Source/Layer pairs using MapLibre's `line-offset` paint property: +3 / -3 pixels |
| **LEGEND** | Swatches now show a 3-line train-track — violet rail, cyan line, violet rail (or dashed violet rails for top-BES). Matches the canvas visual |

Solid for strict bridges, dashed for top-BES across all three line canvases.

## Why this fixes the prior critique

- **Main edge color preserved exactly.** The cyan/amber/orange line stays at its true color; no halo bleeds into it.
- **Solid vs dashed distinction is on its own dedicated line**, not competing with the main line's own dash treatment (confounded edges have their own dashes).
- **Train-track shape reads from any angle / zoom / projection**, including the Map's ocean-spanning arcs.

## Relief view — unchanged

Relief is a scalar heatmap; no edge lines are drawn there. The opt-in midpoint pip is the only sensible representation; not affected by this PR.

## Test plan

- [x] `vitest run`: **1197 passing**, no regressions
- [x] `tsc --noEmit` clean for the touched files
- [x] Manual: select AI Safety / Endogenous Catastrophe → χ★ edges in 3D / 2D / Map show two thin violet lines flanking the main cyan/amber line. Solid for strict bridges (e.g. dataset → GAT input edges), dashed for top-BES. The cyan line itself is visibly unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)