### PR TITLE
feat(pearl): APPLY ALL & SIMULATE — auto-cascade after interdiction

### DIFF
--- a/src/components/ModulePanel.tsx
+++ b/src/components/ModulePanel.tsx
@@ -215,6 +215,14 @@ function CopilotInterdictionResults() {
   const setSelectedNodes = useApexStore((s) => s.setSelectedNodes);
   const isolateSelection = useApexStore((s) => s.isolateSelection);
   const setIsolateSelection = useApexStore((s) => s.setIsolateSelection);
+  // startAblationReplay reruns the cascade simulator against the
+  // current severed-edge + ablated-node set and flips replay into
+  // playing state. Wired into the new APPLY ALL & SIMULATE button so
+  // the scenario → cuts → impact loop runs as one motion instead of
+  // the analyst having to chase down a separate Start Replay control.
+  const startAblationReplay = useApexStore((s) => s.startAblationReplay);
+  const ablatedNodeIds = useApexStore((s) => s.ablatedNodeIds);
+  const severedEdges = useApexStore((s) => s.severedEdges);
   const [appliedIds, setAppliedIds] = useState<Set<string>>(new Set());
 
   // Affected node set. Memoised on the interdiction result + graph
@@ -238,6 +246,52 @@ function CopilotInterdictionResults() {
     return Array.from(ids);
   }, [lastResult, graphData.edges]);
 
+  // Apply every intervention in the result and immediately kick off
+  // cascade replay so the analyst sees propagation against the new
+  // cut set without a second click. Edge cuts flow through severEdge
+  // (idempotent — skipped if already severed); node cuts flow through
+  // toggleAblatedNode but we gate on the current ablated set so a
+  // double-tap of APPLY ALL & SIMULATE doesn't un-ablate something
+  // that was already cut. After the writes, startAblationReplay() runs
+  // simulateCascadeAsync against the merged state and flips replay on.
+  const applyAllAndSimulate = useCallback(() => {
+    if (!lastResult) return;
+    const ablatedSet = new Set(ablatedNodeIds);
+    const severedSet = new Set(severedEdges);
+    const newlyApplied: string[] = [];
+    for (const iv of lastResult.interventions) {
+      if (iv.target.type === "edge") {
+        if (!severedSet.has(iv.target.id)) {
+          severEdge(iv.target.id);
+          newlyApplied.push(iv.target.id);
+        }
+      } else if (iv.target.type === "node") {
+        if (!ablatedSet.has(iv.target.id)) {
+          toggleAblatedNode(iv.target.id);
+          newlyApplied.push(iv.target.id);
+        }
+      }
+    }
+    setAppliedIds((prev) => {
+      const next = new Set(prev);
+      for (const iv of lastResult.interventions) next.add(iv.target.id);
+      return next;
+    });
+    // Always kick off replay — even if every cut was already applied,
+    // re-running the cascade is what the analyst expects from a button
+    // labelled "& SIMULATE". The store wipes interventionEpochs first
+    // so the badges/pulses restart from epoch 0.
+    startAblationReplay();
+    return newlyApplied;
+  }, [
+    lastResult,
+    ablatedNodeIds,
+    severedEdges,
+    severEdge,
+    toggleAblatedNode,
+    startAblationReplay,
+  ]);
+
   if (!lastResult) return null;
 
   const hasInterventions = lastResult.interventions.length > 0;
@@ -256,6 +310,22 @@ function CopilotInterdictionResults() {
           {isFallback ? "STRUCTURAL VULNERABILITY CUTS" : "INTERDICTION RESULTS"}
         </span>
         <div className="flex items-center gap-2">
+          {/* APPLY ALL & SIMULATE — one-click closure of the scenario
+              → cuts → impact loop. Applies every recommended cut
+              (idempotent, so re-clicks don't un-ablate) and then
+              kicks off cascade replay so the analyst sees propagation
+              + the MC fan reacts without chasing a separate Start
+              Replay button. Hidden when there are no interventions
+              (e.g. the solver's empty-cuts edge case). */}
+          {hasInterventions && (
+            <button
+              onClick={applyAllAndSimulate}
+              className="text-[7px] font-[family-name:var(--font-michroma)] tracking-wider px-1.5 py-0.5 rounded border transition-colors border-accent-amber/60 text-accent-amber bg-accent-amber/10 hover:bg-accent-amber/20"
+              title="Apply every recommended cut and immediately run cascade replay against the new cut set. Sees propagation in real time; the MC forecast updates automatically."
+            >
+              APPLY ALL &amp; SIMULATE
+            </button>
+          )}
           {/* ISOLATE AFFECTED — mirrors the lasso panel's ISOLATE
               button, bootstrapped from the interdiction's affected node
               set instead of a marquee drag. When toggled on, the

--- a/src/lib/copilot/tools.ts
+++ b/src/lib/copilot/tools.ts
@@ -421,18 +421,32 @@ defineTool({
       return "No interdiction results to apply. Run solve_interdiction first.";
     }
 
+    // Guard against re-applying a cut that's already in place (matters
+    // for node cuts: toggleAblatedNode is a toggle, so running it
+    // twice would un-ablate). Edge severing is already idempotent at
+    // the store level but we mirror the check here for symmetry.
+    const ablatedSet = new Set(store.ablatedNodeIds);
+    const severedSet = new Set(store.severedEdges);
+
     if (targets === "all") {
       const applied: string[] = [];
       for (const iv of last.interventions) {
         if (iv.target.type === "edge") {
-          store.severEdge(iv.target.id);
+          if (!severedSet.has(iv.target.id)) store.severEdge(iv.target.id);
           applied.push(iv.target.label);
         } else {
-          store.toggleAblatedNode(iv.target.id);
+          if (!ablatedSet.has(iv.target.id)) store.toggleAblatedNode(iv.target.id);
           applied.push(iv.target.label);
         }
       }
-      return `Applied all ${applied.length} interdictions: ${applied.join(", ")}`;
+      // Closing the scenario → cuts → impact loop: after the cuts
+      // land, kick off cascade replay so the analyst sees propagation
+      // and the MC fan updates against the new state without having
+      // to chase Start Replay manually. Matches the UI's APPLY ALL &
+      // SIMULATE affordance so chat-driven and click-driven paths
+      // behave identically.
+      store.startAblationReplay();
+      return `Applied all ${applied.length} interdictions: ${applied.join(", ")}. Cascade replay running against the new cut set.`;
     }
 
     // Accept either pipe-separated (new format) or comma-separated
@@ -444,16 +458,16 @@ defineTool({
       const iv = last.interventions[idx];
       if (!iv) continue;
       if (iv.target.type === "edge") {
-        store.severEdge(iv.target.id);
+        if (!severedSet.has(iv.target.id)) store.severEdge(iv.target.id);
         applied.push(iv.target.label);
       } else {
-        store.toggleAblatedNode(iv.target.id);
+        if (!ablatedSet.has(iv.target.id)) store.toggleAblatedNode(iv.target.id);
         applied.push(iv.target.label);
       }
     }
-    return applied.length > 0
-      ? `Applied interdictions: ${applied.join(", ")}`
-      : `No valid intervention indices: ${targets}`;
+    if (applied.length === 0) return `No valid intervention indices: ${targets}`;
+    store.startAblationReplay();
+    return `Applied interdictions: ${applied.join(", ")}. Cascade replay running against the new cut set.`;
   },
 });
 


### PR DESCRIPTION
## Summary

The scenario flow user testing exposed a missing closure: NL scenario in PEARL produces cuts, ISOLATE AFFECTED (PR #379) drills into them — but to actually *see propagation against the new cut set* the analyst had to chase a separate Start Replay button. The loop wasn't one motion.

This PR adds **APPLY ALL & SIMULATE** to the interdiction results card, next to ISOLATE AFFECTED and DISMISS. One click applies every recommended cut and immediately kicks off cascade replay so the activation-order badges restart from epoch 0, the 3D shock pulses fire on the new cuts, and the MC forecast updates against the new severed-edge set.

The full loop is now: **type scenario → solve_interdiction → APPLY ALL & SIMULATE → watch propagation.**

## Behaviour

| Click | Effect |
|---|---|
| **APPLY ALL & SIMULATE** | Applies every intervention (idempotent — gated on current ablated / severed sets) then calls `startAblationReplay()`. Cascade replay flips on against the new cut set. |
| Per-row **SEVER / ABLATE** | Unchanged. Granular control retained. |
| Button hidden | When `interventions.length === 0` (solver's empty-cuts edge case). |

## Idempotence guard

Both UI and copilot paths now gate each intervention on the current store state:
- Edges: skip `severEdge` if already in `severedEdges` (was already idempotent at the store level — mirrored here for symmetry).
- Nodes: skip `toggleAblatedNode` if already in `ablatedNodeIds` — critical because `toggleAblatedNode` is a **toggle**, so a second `apply_interdiction:targets=all` (or a double-click of APPLY ALL & SIMULATE) would previously have *un-ablated* every node cut. This was a latent bug; surfaced and fixed here.

## Chat parity

The copilot's `apply_interdiction` tool now also:
1. Applies the cuts with the same idempotence guard.
2. Calls `startAblationReplay()` after the writes.
3. Returns the trailing "Cascade replay running against the new cut set." so the chat transcript records what happened.

Click-driven and chat-driven paths now behave identically — both end with the cascade running.

## Files

| File | Change |
|---|---|
| `src/components/ModulePanel.tsx` | `CopilotInterdictionResults`: 3 new store hooks (`startAblationReplay`, `ablatedNodeIds`, `severedEdges`); `applyAllAndSimulate` callback memoised on the cut set; new button rendered in the header next to ISOLATE AFFECTED. |
| `src/lib/copilot/tools.ts` | `apply_interdiction` handler: idempotence guard for both targets=all and indexed paths; trailing `startAblationReplay()`; return strings include the cascade-replay confirmation. |

## Why this design

Zero store changes. `startAblationReplay()` already wipes `interventionEpochs`, flips `replayActive`, runs `simulateCascadeAsync` against the merged severed+ablated state, and flips `replayPlaying` once epochs land — same plumbing the AblationPanel's RUN CASCADE button uses. The MC forecast's existing `severedEdges` dependency takes care of the forecast side. We're stitching together existing primitives, not inventing new state.

## Test plan

- [x] `npx next build` clean
- [x] `npx vitest run copilot-tool-registry.test.ts copilot-tools-extended.test.ts copilot-eval.test.ts copilot-eval-case-snippet.test.ts` — 74/74 passing
- [ ] PR-validate workflow green
- [ ] Vercel preview eyeball:
  - Type a scenario in PEARL → RUN INTERDICTION → cuts return → click APPLY ALL & SIMULATE → cascade replay starts immediately, activation-order badges count up from 1, 3D shock pulses fire on the new cuts, MC forecast fan re-renders
  - Click APPLY ALL & SIMULATE again — no un-ablate; replay just restarts cleanly
  - Run `apply_interdiction:targets=all` from chat — same behaviour as the button
  - ISOLATE AFFECTED still works alongside; toggling it on after SIMULATE filters the canvas to the affected set during replay

## Backwards compat

Zero store changes. New button is additive. Per-row SEVER/ABLATE buttons retained for granular workflows. The `apply_interdiction` tool's response shape changed only by appending the cascade-replay sentence — existing eval cases that check for "Applied" / "interdictions" still match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
