### PR TITLE
feat(discovery): BES temporal monitoring on TrainingTrace + CausalGraph

### DIFF
--- a/src/lib/discovery/__tests__/bes-temporal.test.ts
+++ b/src/lib/discovery/__tests__/bes-temporal.test.ts
@@ -1,0 +1,362 @@
+// @vitest-environment node
+//
+// Tests for BES temporal monitoring (Phase 3 PR 2). Verifies the
+// epoch-by-epoch χ★ + BES computation against hand-computable
+// fixtures.
+//
+// Test strategy:
+//   - Build a small synthetic graph by hand (so we can reason about
+//     which edges should be in χ★ at each epoch)
+//   - Build a TrainingTrace with a known curriculum
+//   - Assert exact χ★ membership at specific epochs
+//   - Verify the source-kind forwarding (synthetic in → synthetic out)
+//
+// Uses minimal CausalNode / CausalEdge shapes via the same makeNode /
+// makeEdge fixtures the chi-star tests use, plus a tiny IDS-shaped
+// graph fixture defined inline.
+
+import { describe, it, expect } from "vitest";
+import {
+  computeBESTemporal,
+  summariseEdge,
+  rankEdgesByMaxBES,
+} from "../bes-temporal";
+import {
+  buildSyntheticTrainingTrace,
+  sequentialCurriculum,
+} from "../training-trace-synthetic";
+import type { CausalGraph } from "@/lib/types";
+import type { TaskRef, TrainingTrace } from "../training-trace-types";
+import { makeNode, makeEdge } from "../../__tests__/fixtures/graph-fixtures";
+
+// ─── Fixture builders ─────────────────────────────────────────────────
+
+const ATTACK_TASKS: TaskRef[] = [
+  { id: "task_ddos", label: "DDoS", scope: "attack-class" },
+  { id: "task_mitm", label: "MITM", scope: "attack-class" },
+  { id: "task_heartbleed", label: "Heartbleed", scope: "attack-class" },
+];
+
+/**
+ * Tiny IDS-shaped graph: one "GAT" substrate node + 3 attack-class
+ * task nodes + one "dataset" substrate node. Edges connect each
+ * attack class through the GAT to the dataset.
+ *
+ *           gat
+ *          /   \
+ *      task_ddos task_mitm task_heartbleed
+ *          \   |   /
+ *          dataset
+ *
+ * The substrate nodes (gat, dataset) are always active. The task
+ * nodes come and go as the curriculum advances, so the live
+ * sub-graph at each epoch differs.
+ */
+function buildIDSGraph(): CausalGraph {
+  const nodes = [
+    makeNode({ id: "gat" }),
+    makeNode({ id: "dataset" }),
+    makeNode({ id: "task_ddos" }),
+    makeNode({ id: "task_mitm" }),
+    makeNode({ id: "task_heartbleed" }),
+  ];
+  const edges = [
+    makeEdge({ id: "e_gat_ddos", source: "gat", target: "task_ddos" }),
+    makeEdge({ id: "e_gat_mitm", source: "gat", target: "task_mitm" }),
+    makeEdge({ id: "e_gat_heart", source: "gat", target: "task_heartbleed" }),
+    makeEdge({ id: "e_ddos_data", source: "task_ddos", target: "dataset" }),
+    makeEdge({ id: "e_mitm_data", source: "task_mitm", target: "dataset" }),
+    makeEdge({ id: "e_heart_data", source: "task_heartbleed", target: "dataset" }),
+    makeEdge({ id: "e_gat_data", source: "gat", target: "dataset" }),
+  ];
+  return {
+    nodes,
+    edges,
+    metadata: {
+      density: 0,
+      constraintType: "",
+      verificationStatus: "UNVERIFIED",
+      totalNodes: nodes.length,
+      totalEdges: edges.length,
+      inconsistentEdges: 0,
+      restrictedNodes: 0,
+    },
+  };
+}
+
+function defaultTrace(): TrainingTrace {
+  return buildSyntheticTrainingTrace({
+    id: "test-trace",
+    label: "Test",
+    tasks: ATTACK_TASKS,
+    curriculum: sequentialCurriculum(
+      ATTACK_TASKS.map((t) => t.id),
+      3, // 3 epochs each = 9 total
+    ),
+    seed: 42,
+    noiseAmplitude: 0,
+  });
+}
+
+// ─── Shape / contract tests ───────────────────────────────────────────
+
+describe("computeBESTemporal — shape contracts", () => {
+  it("returns one entry per edge in the source graph", () => {
+    const result = computeBESTemporal(defaultTrace(), buildIDSGraph());
+    expect(result.edges).toHaveLength(7);
+    const ids = new Set(result.edges.map((e) => e.edgeId));
+    expect(ids.size).toBe(7);
+  });
+
+  it("each edge series has length matching trace.epochs", () => {
+    const trace = defaultTrace();
+    const result = computeBESTemporal(trace, buildIDSGraph());
+    expect(result.epochIndices).toHaveLength(trace.epochs.length);
+    for (const e of result.edges) {
+      expect(e.bes).toHaveLength(trace.epochs.length);
+      expect(e.tier).toHaveLength(trace.epochs.length);
+    }
+  });
+
+  it("perEpoch arrays have matching length", () => {
+    const result = computeBESTemporal(defaultTrace(), buildIDSGraph());
+    const len = result.epochIndices.length;
+    expect(result.perEpoch.chiStarSize).toHaveLength(len);
+    expect(result.perEpoch.bridgeCount).toHaveLength(len);
+    expect(result.perEpoch.activeNodeCount).toHaveLength(len);
+    expect(result.perEpoch.activeEdgeCount).toHaveLength(len);
+  });
+
+  it("epochIndices is monotone strictly increasing", () => {
+    const result = computeBESTemporal(defaultTrace(), buildIDSGraph());
+    for (let i = 1; i < result.epochIndices.length; i++) {
+      expect(result.epochIndices[i]).toBeGreaterThan(result.epochIndices[i - 1]);
+    }
+  });
+});
+
+// ─── Provenance forwarding ────────────────────────────────────────────
+
+describe("computeBESTemporal — provenance", () => {
+  it("forwards source.kind from the trace verbatim", () => {
+    const trace = defaultTrace();
+    expect(trace.source.kind).toBe("synthetic");
+    const result = computeBESTemporal(trace, buildIDSGraph());
+    expect(result.sourceKind).toBe("synthetic");
+  });
+
+  it("forwards the trace id", () => {
+    const result = computeBESTemporal(defaultTrace(), buildIDSGraph());
+    expect(result.traceId).toBe("test-trace");
+  });
+});
+
+// ─── Per-epoch masking logic ──────────────────────────────────────────
+
+describe("computeBESTemporal — per-epoch masking", () => {
+  it("only the active task node is part of the live subgraph", () => {
+    const result = computeBESTemporal(defaultTrace(), buildIDSGraph());
+    // Epochs 0-2: only task_ddos active. Substrate (gat, dataset)
+    // always active. So 3 active nodes per epoch in [0, 3).
+    expect(result.perEpoch.activeNodeCount[0]).toBe(3); // gat + dataset + task_ddos
+    expect(result.perEpoch.activeNodeCount[1]).toBe(3);
+    expect(result.perEpoch.activeNodeCount[2]).toBe(3);
+    // Epochs 3-5: task_mitm active. Still 3.
+    expect(result.perEpoch.activeNodeCount[3]).toBe(3);
+    // Epochs 6-8: task_heartbleed active. Still 3.
+    expect(result.perEpoch.activeNodeCount[6]).toBe(3);
+  });
+
+  it("edges not touching the active task get NaN BES", () => {
+    const result = computeBESTemporal(defaultTrace(), buildIDSGraph());
+    // Epoch 0: DDoS active. Edges connecting MITM or Heartbleed should
+    // have NaN BES this epoch (they're masked out).
+    const mitm = result.edges.find((e) => e.edgeId === "e_gat_mitm")!;
+    expect(Number.isNaN(mitm.bes[0])).toBe(true);
+    expect(mitm.tier[0]).toBeNull();
+    // The DDoS edges should be present and have real BES values.
+    const ddos = result.edges.find((e) => e.edgeId === "e_gat_ddos")!;
+    expect(Number.isNaN(ddos.bes[0])).toBe(false);
+  });
+
+  it("active edges shift as the curriculum advances", () => {
+    const result = computeBESTemporal(defaultTrace(), buildIDSGraph());
+    // Epoch 0: DDoS active → e_gat_ddos has BES; e_gat_mitm NaN
+    // Epoch 4 (in MITM window): e_gat_mitm has BES; e_gat_ddos NaN
+    const ddos = result.edges.find((e) => e.edgeId === "e_gat_ddos")!;
+    const mitm = result.edges.find((e) => e.edgeId === "e_gat_mitm")!;
+    expect(Number.isNaN(ddos.bes[0])).toBe(false);
+    expect(Number.isNaN(mitm.bes[0])).toBe(true);
+    expect(Number.isNaN(ddos.bes[4])).toBe(true);
+    expect(Number.isNaN(mitm.bes[4])).toBe(false);
+  });
+
+  it("substrate-to-substrate edges stay active across all epochs", () => {
+    const result = computeBESTemporal(defaultTrace(), buildIDSGraph());
+    // e_gat_data connects gat ↔ dataset, both substrate nodes →
+    // active every epoch.
+    const gatData = result.edges.find((e) => e.edgeId === "e_gat_data")!;
+    for (let i = 0; i < gatData.bes.length; i++) {
+      expect(Number.isNaN(gatData.bes[i])).toBe(false);
+    }
+  });
+});
+
+// ─── χ★ tier evolution ────────────────────────────────────────────────
+
+describe("computeBESTemporal — χ★ membership", () => {
+  it("chi-star size > 0 when at least one task is active", () => {
+    const result = computeBESTemporal(defaultTrace(), buildIDSGraph());
+    for (let i = 0; i < result.epochIndices.length; i++) {
+      expect(result.perEpoch.chiStarSize[i]).toBeGreaterThan(0);
+    }
+  });
+
+  it("zero-edges epoch produces empty chi-star + NaN BES for all edges", () => {
+    // Construct a curriculum where epoch 5 has no active task. The
+    // sequentialCurriculum builds with no gaps; we override.
+    const trace = buildSyntheticTrainingTrace({
+      id: "gap-trace",
+      label: "Gap",
+      tasks: ATTACK_TASKS,
+      curriculum: [
+        { taskId: "task_ddos", startEpoch: 0, endEpoch: 3 },
+        // Gap epochs 3-5 — no task active
+        { taskId: "task_mitm", startEpoch: 5, endEpoch: 8 },
+      ],
+      noiseAmplitude: 0,
+    });
+    // Need to build a graph WITHOUT the gat-dataset substrate edge,
+    // so when all task nodes are inactive there are zero edges in
+    // the active subgraph and chi-star can't run.
+    const graph = buildIDSGraph();
+    graph.edges = graph.edges.filter((e) => e.id !== "e_gat_data");
+    graph.metadata = { ...graph.metadata, totalEdges: graph.edges.length };
+
+    const result = computeBESTemporal(trace, graph);
+    // Epoch 3 has no active task and no substrate-to-substrate edges
+    // (we just removed them) → active edges should be zero.
+    expect(result.perEpoch.activeEdgeCount[3]).toBe(0);
+    expect(result.perEpoch.chiStarSize[3]).toBe(0);
+    for (const e of result.edges) {
+      expect(Number.isNaN(e.bes[3])).toBe(true);
+      expect(e.tier[3]).toBeNull();
+    }
+  });
+});
+
+// ─── summariseEdge / rankEdgesByMaxBES ────────────────────────────────
+
+describe("summariseEdge", () => {
+  it("max BES ignores NaN epochs", () => {
+    const result = computeBESTemporal(defaultTrace(), buildIDSGraph());
+    const ddos = result.edges.find((e) => e.edgeId === "e_gat_ddos")!;
+    const stats = summariseEdge(ddos);
+    expect(stats.maxBes).toBeGreaterThan(0);
+    expect(stats.maxBes).toBeLessThanOrEqual(1);
+    expect(Number.isNaN(stats.maxBes)).toBe(false);
+  });
+
+  it("counts chiStar and bridge epochs separately", () => {
+    const result = computeBESTemporal(defaultTrace(), buildIDSGraph());
+    for (const series of result.edges) {
+      const stats = summariseEdge(series);
+      expect(stats.chiStarEpochs).toBeGreaterThanOrEqual(stats.bridgeEpochs);
+      expect(stats.chiStarEpochs).toBeLessThanOrEqual(stats.totalEpochs);
+    }
+  });
+
+  it("mean BES is NaN if the edge was never active", () => {
+    // Build a trace covering DDoS and MITM, then pass an explicit
+    // taskNodeIds set that includes task_heartbleed — so heartbleed
+    // is treated as a task node, but the curriculum never activates
+    // it. Result: heartbleed-touching edges are masked every epoch
+    // and their BES series is all-NaN.
+    const trace = buildSyntheticTrainingTrace({
+      id: "no-heart",
+      label: "No Heartbleed",
+      tasks: ATTACK_TASKS.filter((t) => t.id !== "task_heartbleed"),
+      curriculum: sequentialCurriculum(["task_ddos", "task_mitm"], 3),
+      noiseAmplitude: 0,
+    });
+    const result = computeBESTemporal(trace, buildIDSGraph(), {
+      taskNodeIds: new Set(["task_ddos", "task_mitm", "task_heartbleed"]),
+    });
+    const heart = result.edges.find((e) => e.edgeId === "e_gat_heart")!;
+    const stats = summariseEdge(heart);
+    expect(Number.isNaN(stats.meanBes)).toBe(true);
+  });
+});
+
+describe("rankEdgesByMaxBES", () => {
+  it("returns edges sorted descending by maxBes", () => {
+    const ranked = rankEdgesByMaxBES(
+      computeBESTemporal(defaultTrace(), buildIDSGraph()),
+    );
+    for (let i = 1; i < ranked.length; i++) {
+      expect(ranked[i].maxBes).toBeLessThanOrEqual(ranked[i - 1].maxBes);
+    }
+  });
+});
+
+// ─── Argument validation ──────────────────────────────────────────────
+
+describe("computeBESTemporal — argument validation", () => {
+  it("rejects empty trace", () => {
+    const trace = defaultTrace();
+    // forge a trace with empty epochs (validator would catch this in
+    // a real ingest; we test the computeBESTemporal guard directly)
+    const forged = { ...trace, epochs: [] };
+    expect(() => computeBESTemporal(forged, buildIDSGraph())).toThrow(/zero epochs/);
+  });
+
+  it("rejects empty graph", () => {
+    const empty: CausalGraph = {
+      nodes: [],
+      edges: [],
+      metadata: {
+        density: 0,
+        constraintType: "",
+        verificationStatus: "UNVERIFIED",
+        totalNodes: 0,
+        totalEdges: 0,
+        inconsistentEdges: 0,
+        restrictedNodes: 0,
+      },
+    };
+    expect(() => computeBESTemporal(defaultTrace(), empty)).toThrow(/zero nodes/);
+  });
+
+  it("throws when no task ids intersect the graph", () => {
+    // Trace tasks have ids "task_ddos", "task_mitm", "task_heartbleed"
+    // but the graph has nodes "x", "y" → no intersection.
+    const trace = defaultTrace();
+    const orphanGraph: CausalGraph = {
+      nodes: [makeNode({ id: "x" }), makeNode({ id: "y" })],
+      edges: [makeEdge({ id: "e_xy", source: "x", target: "y" })],
+      metadata: {
+        density: 0,
+        constraintType: "",
+        verificationStatus: "UNVERIFIED",
+        totalNodes: 2,
+        totalEdges: 1,
+        inconsistentEdges: 0,
+        restrictedNodes: 0,
+      },
+    };
+    expect(() => computeBESTemporal(trace, orphanGraph)).toThrow(
+      /no task ids from the trace appear/,
+    );
+  });
+
+  it("accepts an explicit taskNodeIds override", () => {
+    const trace = defaultTrace();
+    const graph = buildIDSGraph();
+    // Override to mark BOTH gat and task_ddos as task nodes (silly
+    // example but verifies the override path). Should not throw.
+    const result = computeBESTemporal(trace, graph, {
+      taskNodeIds: new Set(["task_ddos", "task_mitm", "task_heartbleed", "gat"]),
+    });
+    expect(result.edges).toHaveLength(7);
+  });
+});

--- a/src/lib/discovery/bes-temporal.ts
+++ b/src/lib/discovery/bes-temporal.ts
@@ -1,0 +1,328 @@
+// ─── Discovery — BES Temporal Monitoring ─────────────────────────────
+//
+// Phase 3 PR 2 of the Ghauri 2025 dissertation integration. Takes a
+// TrainingTrace (the per-epoch curriculum snapshot from PR #380) and a
+// CausalGraph (the IDS substrate from PR #275), then computes χ★ and
+// per-edge BES at each epoch of the trace.
+//
+// Why this is useful: in a continual-learning IDS, the GAT's
+// load-bearing skeleton SHIFTS as the model's attention shifts across
+// the curriculum. Edges that were critical at epoch 5 (when training
+// was on DDoS) may have collapsed in importance by epoch 20 (after
+// training moved to Heartbleed). Tracking χ★ membership and BES
+// values over epochs surfaces those shifts directly — the substrate
+// the FR estimator (PR 3) and Ω-Forgetting Pressure metric (PR 4)
+// read from.
+//
+// DOMAIN GATING
+// -------------
+// This module is AI-domain-only in SEMANTICS (FR / forgetting concepts
+// only apply when there's a model being trained over time). The
+// function signature is profile-agnostic — same pattern as `chiStar`
+// itself — and the AI-domain gating happens at the UI / registry
+// layer above (PR 4 will only surface this on AI_SAFETY_PROFILE).
+// Geopolitical / T1D / other domains will never call this.
+//
+// PROVENANCE
+// ----------
+// The result type forwards `source.kind` from the input TrainingTrace
+// verbatim. UI surfaces consuming a BESTemporalResult with
+// source.kind === "synthetic" MUST render a SYNTHETIC badge. This
+// preserves the badge contract from PR #380 — no customer business
+// decision runs off synthetic data.
+//
+// ALGORITHM
+// ---------
+// At each epoch e:
+//   1. Determine the set of "active" task nodes — those whose ids
+//      appear in epoch.activeTaskIds. Non-task nodes (substrate:
+//      datasets, GAT, replay buffer, eval harness) are always active.
+//   2. Mask out edges whose endpoints aren't both currently active
+//      AND aren't severed. This represents the GAT's attention
+//      having shifted away from inactive attack classes.
+//   3. Run chiStar() on the resulting subgraph. Capture per-edge BES
+//      and tier (bridge / top-BES / not in χ★).
+//   4. Aggregate into per-edge time series indexed by epoch.
+//
+// Cost: chiStar is O(V · E) per epoch. For a typical AI Safety
+// substrate (17 nodes, 18 edges, ~20 epochs) this is a small
+// computation; cached at the UI layer when the trace + graph are
+// stable.
+
+import type { CausalEdge, CausalGraph } from "@/lib/types";
+import type { TrainingTrace } from "./training-trace-types";
+import { chiStar } from "@/lib/estimators/chi-star";
+
+export type ChiStarTier = "bridge" | "top-bes" | null;
+
+export interface BESTemporalEdgeSeries {
+  /** Edge id. Matches the id field on the source CausalEdge. */
+  edgeId: string;
+  /**
+   * BES value at each epoch, in the same order as
+   * `BESTemporalResult.epochIndices`. NaN where the edge wasn't
+   * present in the χ★ computation that epoch (one or both
+   * endpoints inactive, or edge severed).
+   */
+  bes: number[];
+  /**
+   * χ★ tier at each epoch. `null` means the edge wasn't in the χ★
+   * set that epoch (either masked out, or in the live subgraph but
+   * not load-bearing enough to qualify).
+   */
+  tier: ChiStarTier[];
+}
+
+export interface BESTemporalResult {
+  /** Epoch indices in increasing order; identity-of-the-x-axis. */
+  epochIndices: number[];
+  /** Per-edge time series, one entry per edge in the source graph. */
+  edges: BESTemporalEdgeSeries[];
+  /**
+   * Inherited from the input trace's `source.kind`. UI surfaces
+   * displaying values derived from a synthetic result MUST render
+   * a SYNTHETIC badge.
+   */
+  sourceKind: "synthetic" | "live";
+  /** Echo of the input trace id for downstream cross-reference. */
+  traceId: string;
+  /**
+   * Per-epoch summary stats — useful for sparkline / aggregate UI.
+   * Same length / order as `epochIndices`.
+   */
+  perEpoch: {
+    chiStarSize: number[];
+    bridgeCount: number[];
+    activeNodeCount: number[];
+    activeEdgeCount: number[];
+  };
+}
+
+export interface ComputeBESTemporalOptions {
+  /**
+   * Override the set of node ids treated as "tasks" (i.e., subject
+   * to active/inactive masking). By default, derived from the
+   * trace's `tasks[].id`. Use this if your trace's task ids don't
+   * map 1:1 to graph node ids (e.g., dataset-scope curricula where
+   * one task spans multiple nodes).
+   */
+  taskNodeIds?: ReadonlySet<string>;
+  /**
+   * Optional χ★ top-k parameter forwarded into each per-epoch
+   * chiStar() call. Defaults to chiStar's own default
+   * (max(1, floor(0.1 * |E|))).
+   */
+  topK?: number;
+}
+
+/**
+ * Compute BES temporal monitoring over a TrainingTrace + CausalGraph.
+ *
+ * Throws if the trace and graph are obviously incompatible:
+ *   - empty trace
+ *   - empty graph
+ *   - task ids that don't appear as node ids in the graph (warning
+ *     case — surfaces via a thrown error so the caller knows the
+ *     intersection is empty rather than silently producing
+ *     all-empty epochs)
+ */
+export function computeBESTemporal(
+  trace: TrainingTrace,
+  graph: CausalGraph,
+  options: ComputeBESTemporalOptions = {},
+): BESTemporalResult {
+  if (trace.epochs.length === 0) {
+    throw new Error("computeBESTemporal: trace has zero epochs");
+  }
+  if (graph.nodes.length === 0) {
+    throw new Error("computeBESTemporal: graph has zero nodes");
+  }
+
+  // Resolve the task-node set. Default: every task id from the trace
+  // that also appears as a node in the graph. Caller override wins.
+  const graphNodeIds = new Set(graph.nodes.map((n) => n.id));
+  const taskNodeIds =
+    options.taskNodeIds ??
+    new Set(trace.tasks.map((t) => t.id).filter((id) => graphNodeIds.has(id)));
+
+  if (taskNodeIds.size === 0) {
+    throw new Error(
+      "computeBESTemporal: no task ids from the trace appear as nodes in the graph " +
+        "(traces task ids: " +
+        trace.tasks.map((t) => t.id).slice(0, 5).join(", ") +
+        (trace.tasks.length > 5 ? ", ..." : "") +
+        "). Pass options.taskNodeIds if your trace uses non-node ids.",
+    );
+  }
+
+  // Pre-build the node-id → graph node map for fast lookups inside
+  // the per-epoch loop.
+  const edges = graph.edges.filter((e) => !e.isSevered);
+  const allEdgeIds = graph.edges.map((e) => e.id);
+
+  const epochIndices: number[] = [];
+  const perEdgeBES: Map<string, number[]> = new Map();
+  const perEdgeTier: Map<string, ChiStarTier[]> = new Map();
+  for (const id of allEdgeIds) {
+    perEdgeBES.set(id, []);
+    perEdgeTier.set(id, []);
+  }
+  const chiStarSize: number[] = [];
+  const bridgeCount: number[] = [];
+  const activeNodeCount: number[] = [];
+  const activeEdgeCount: number[] = [];
+
+  for (const epoch of trace.epochs) {
+    epochIndices.push(epoch.index);
+
+    // Active node set: substrate (non-task) nodes are always active;
+    // task nodes are active only when in epoch.activeTaskIds.
+    const epochActiveTasks = new Set(epoch.activeTaskIds);
+    const activeNodes = new Set<string>();
+    for (const n of graph.nodes) {
+      if (taskNodeIds.has(n.id)) {
+        if (epochActiveTasks.has(n.id)) activeNodes.add(n.id);
+      } else {
+        activeNodes.add(n.id);
+      }
+    }
+
+    // Edges where both endpoints are in the active set.
+    const activeEdges = edges.filter(
+      (e) => activeNodes.has(e.source) && activeNodes.has(e.target),
+    );
+
+    activeNodeCount.push(activeNodes.size);
+    activeEdgeCount.push(activeEdges.length);
+
+    // Defensive: empty edge set means chi-star can't compute. Push
+    // NaN / null for every edge and zeros for the per-epoch stats.
+    if (activeEdges.length === 0) {
+      for (const id of allEdgeIds) {
+        perEdgeBES.get(id)!.push(NaN);
+        perEdgeTier.get(id)!.push(null);
+      }
+      chiStarSize.push(0);
+      bridgeCount.push(0);
+      continue;
+    }
+
+    // Build the per-epoch subgraph and run chi-star on it.
+    const subNodes = graph.nodes.filter((n) => activeNodes.has(n.id));
+    const subGraph: CausalGraph = {
+      nodes: subNodes,
+      edges: activeEdges,
+      metadata: graph.metadata,
+    };
+    const chi = chiStar(subGraph, {
+      topK: options.topK ?? null,
+    });
+    const chiSet = new Set(chi.chiStar);
+    const bridgeSet = new Set(chi.bridges);
+    chiStarSize.push(chiSet.size);
+    bridgeCount.push(bridgeSet.size);
+
+    // Record per-edge values. For edges not in the active subgraph
+    // this epoch, push NaN / null so the time series has consistent
+    // length.
+    const activeEdgeIdSet = new Set(activeEdges.map((e) => e.id));
+    for (const id of allEdgeIds) {
+      if (!activeEdgeIdSet.has(id)) {
+        perEdgeBES.get(id)!.push(NaN);
+        perEdgeTier.get(id)!.push(null);
+        continue;
+      }
+      perEdgeBES.get(id)!.push(chi.bes.get(id) ?? 0);
+      const tier: ChiStarTier = bridgeSet.has(id)
+        ? "bridge"
+        : chiSet.has(id)
+          ? "top-bes"
+          : null;
+      perEdgeTier.get(id)!.push(tier);
+    }
+  }
+
+  const edgesResult: BESTemporalEdgeSeries[] = allEdgeIds.map((id) => ({
+    edgeId: id,
+    bes: perEdgeBES.get(id)!,
+    tier: perEdgeTier.get(id)!,
+  }));
+
+  return {
+    epochIndices,
+    edges: edgesResult,
+    sourceKind: trace.source.kind,
+    traceId: trace.id,
+    perEpoch: {
+      chiStarSize,
+      bridgeCount,
+      activeNodeCount,
+      activeEdgeCount,
+    },
+  };
+}
+
+/**
+ * Compact summary statistics for one edge's BES time series. Useful
+ * for sorting / displaying edges by their forgetting-relevant signal
+ * (max BES seen, range, last value, fraction of epochs in χ★, etc.).
+ */
+export interface EdgeBESStatistics {
+  edgeId: string;
+  /** Max BES across the full trace (ignoring NaN epochs). */
+  maxBes: number;
+  /** Mean BES across epochs where the edge was active. NaN if never active. */
+  meanBes: number;
+  /** Number of epochs the edge appeared in χ★ (either tier). */
+  chiStarEpochs: number;
+  /** Number of epochs the edge appeared as a strict bridge. */
+  bridgeEpochs: number;
+  /** Total epochs in the trace (for normalisation). */
+  totalEpochs: number;
+}
+
+export function summariseEdge(series: BESTemporalEdgeSeries): EdgeBESStatistics {
+  let maxBes = 0;
+  let sum = 0;
+  let active = 0;
+  let chiStarEpochs = 0;
+  let bridgeEpochs = 0;
+  for (let i = 0; i < series.bes.length; i++) {
+    const v = series.bes[i];
+    if (!Number.isNaN(v)) {
+      if (v > maxBes) maxBes = v;
+      sum += v;
+      active++;
+    }
+    const t = series.tier[i];
+    if (t === "bridge") {
+      chiStarEpochs++;
+      bridgeEpochs++;
+    } else if (t === "top-bes") {
+      chiStarEpochs++;
+    }
+  }
+  return {
+    edgeId: series.edgeId,
+    maxBes,
+    meanBes: active === 0 ? NaN : sum / active,
+    chiStarEpochs,
+    bridgeEpochs,
+    totalEpochs: series.bes.length,
+  };
+}
+
+/**
+ * Convenience: rank edges by max BES, descending. Useful for the
+ * forgetting-pressure ranking surface (PR 4).
+ */
+export function rankEdgesByMaxBES(
+  result: BESTemporalResult,
+): EdgeBESStatistics[] {
+  return result.edges
+    .map(summariseEdge)
+    .sort((a, b) => b.maxBes - a.maxBes);
+}
+
+// Re-export for callers convenience.
+export type { CausalEdge };


### PR DESCRIPTION
## Summary

Phase 3 PR 2 of the Ghauri 2025 dissertation integration. Takes the TrainingTrace substrate from [#380](https://github.com/ApexAnalytica/apex-terminal/pull/380) plus a CausalGraph and computes χ★ + per-edge BES at each epoch of the trace. This is the substrate the FR estimator (PR 3) and Ω-Forgetting Pressure metric (PR 4) read from.

## What this does

In a continual-learning IDS, the GAT's load-bearing skeleton **shifts** as the model's attention shifts across the curriculum. Edges that were critical at epoch 5 (when training was on DDoS) may have collapsed in importance by epoch 20 (after training moved to Heartbleed). `computeBESTemporal` tracks that shift directly:

```ts
computeBESTemporal(trace, graph, options) -> BESTemporalResult
```

For each epoch:
1. **Determine active node set** — substrate (non-task) nodes always active; task nodes active only when their id is in `epoch.activeTaskIds`
2. **Mask edges** to the live subgraph (both endpoints active AND not severed)
3. **Run `chiStar()`** on the subgraph
4. **Record** per-edge BES and tier (`bridge` / `top-bes` / `null`)

Returns:
- `epochIndices` — the epoch axis
- `edges[]` — per-edge BES + tier time series (NaN / null where masked)
- `sourceKind` — forwarded from `trace.source.kind` (the SYNTHETIC badge contract)
- `perEpoch` — chi-star size, bridge count, active node/edge count summary

Plus two helper functions:
- `summariseEdge(series)` — per-edge max/mean BES + chi-star/bridge epoch counts
- `rankEdgesByMaxBES(result)` — descending sort for the forgetting-pressure surface

## Domain gating

**AI-domain only in semantics.** The function signature is profile-agnostic — same pattern as `chiStar` itself — but the gating happens upstream in the UI. PR 4 will only call this on `AI_SAFETY_PROFILE`. Geopolitical / T1D / other domains never invoke it.

## Provenance forwarding

`sourceKind` is forwarded verbatim from `trace.source.kind`. PR 4's UI surface will render a **SYNTHETIC** badge on any value derived from `sourceKind === "synthetic"`. No customer business decision runs off synthetic data; this PR doesn't ship any UI so the contract is intact.

## Tests (20 new)

- **Shape contracts**: one entry per graph edge, series length matches trace epochs, monotone increasing axis
- **Provenance**: source.kind forwarded correctly
- **Per-epoch masking**: only the active task plus substrate is in the live subgraph; edges shift between active/NaN as the curriculum advances; substrate-to-substrate edges stay active every epoch
- **χ★ evolution**: size > 0 when any task active; zero-edge epoch produces empty result + NaN BES across all edges
- **summariseEdge**: max BES ignores NaN; `meanBes` is NaN if the edge was never active
- **rankEdgesByMaxBES**: descending sort
- **Argument validation**: empty trace / graph / no task overlap throw with precise pointers

## Scope discipline

Math + tests **only**. No UI surface. No registry entry. No customer-facing flow.

## Sequencing

| PR | Status | What |
|---|---|---|
| [#380](https://github.com/ApexAnalytica/apex-terminal/pull/380) | ✅ merged | TrainingTrace substrate + synthetic generator |
| **this** | open | BES temporal monitoring math |
| PR 3 | next | FR (Forgetting Rate) estimator math |
| PR 4 | after | Ω-Forgetting Pressure metric + UX with SYNTHETIC badge wired in |
| PR 5 (future) | future | Real ingester (PyTorch / TF training-log adapter); flips badge to LIVE |

## Test plan

- [x] `vitest run`: **1252 passing**, no regressions
- [x] `tsc --noEmit` clean for the new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)