### PR TITLE
feat(timedial): 1Y / 5Y / ALL preset buttons for annual-cadence signals

### DIFF
--- a/src/components/TimeDial.tsx
+++ b/src/components/TimeDial.tsx
@@ -6,11 +6,18 @@ import { useApexStore } from "@/stores/useApexStore";
 import type { TimeGranularity, TemporalEvent } from "@/lib/temporal-data";
 import { getEventsInRange } from "@/lib/temporal-data";
 
-const GRANULARITY_OPTIONS: { value: TimeGranularity; label: string }[] = [
-  { value: "hour", label: "1H" },
-  { value: "day", label: "1D" },
-  { value: "week", label: "1W" },
-  { value: "month", label: "1M" },
+// Two groups so we can render a subtle visual divider between fast presets
+// (sub-monthly, suitable for daily/weekly FRED + EIA Hormuz) and long presets
+// (year+, suitable for World Bank annual / WGI governance). The divider is
+// rendered inline in the JSX below.
+const GRANULARITY_OPTIONS: { value: TimeGranularity; label: string; group: "short" | "long" }[] = [
+  { value: "hour", label: "1H", group: "short" },
+  { value: "day", label: "1D", group: "short" },
+  { value: "week", label: "1W", group: "short" },
+  { value: "month", label: "1M", group: "short" },
+  { value: "year", label: "1Y", group: "long" },
+  { value: "5year", label: "5Y", group: "long" },
+  { value: "all", label: "ALL", group: "long" },
 ];
 
 const SPEED_OPTIONS = [0.5, 1, 2, 4];
@@ -37,6 +44,12 @@ function formatDate(ts: number, granularity: TimeGranularity): string {
         month: "short",
         year: "2-digit",
       });
+    case "year":
+    case "5year":
+    case "all":
+      // For long presets, year is the only meaningful x-axis label —
+      // showing month/day on a multi-year axis is noise.
+      return d.toLocaleDateString("en-US", { year: "numeric" });
   }
 }
 
@@ -87,6 +100,15 @@ function generateTicks(
       break;
     case "month":
       step = DAY * 30;
+      break;
+    case "year":
+      step = DAY * 90; // quarterly ticks across a 1y span
+      break;
+    case "5year":
+      step = DAY * 365; // annual ticks across 5y
+      break;
+    case "all":
+      step = DAY * 365 * 5; // 5-year ticks across the full span
       break;
   }
 
@@ -167,6 +189,9 @@ export default function TimeDial() {
       case "day": return DAY;
       case "week": return DAY * 7;
       case "month": return DAY * 30;
+      case "year": return DAY * 30; // step monthly through a 1y span
+      case "5year": return DAY * 90; // step quarterly through 5y
+      case "all": return DAY * 365; // step annually through ALL
     }
   }, [timelineGranularity]);
 
@@ -445,6 +470,15 @@ export default function TimeDial() {
           case "month":
             step = DAY * 30;
             break;
+          case "year":
+            step = DAY * 30;
+            break;
+          case "5year":
+            step = DAY * 90;
+            break;
+          case "all":
+            step = DAY * 365;
+            break;
         }
 
         if (e.key === "ArrowLeft" && e.shiftKey) {
@@ -595,26 +629,45 @@ export default function TimeDial() {
             className="flex items-center gap-1 overflow-hidden"
           >
             <div className="flex gap-0.5 rounded border border-border overflow-hidden">
-              {GRANULARITY_OPTIONS.map((opt) => (
-                <button
-                  key={opt.value}
-                  onClick={() => setTimelineGranularity(opt.value)}
-                  className="px-1.5 py-0.5 text-[8px] font-[family-name:var(--font-michroma)] tracking-wider transition-colors"
-                  style={{
-                    backgroundColor:
-                      timelineGranularity === opt.value
-                        ? "rgba(0,229,255,0.15)"
-                        : "transparent",
-                    color:
-                      timelineGranularity === opt.value
-                        ? "var(--accent-cyan)"
-                        : "var(--text-muted)",
-                    borderRight: "1px solid var(--border)",
-                  }}
-                >
-                  {opt.label}
-                </button>
-              ))}
+              {GRANULARITY_OPTIONS.map((opt, i) => {
+                // Insert a slightly heavier separator between "month" (short
+                // group) and "year" (long group) so the eye picks up the
+                // cadence-tier boundary without needing a legend.
+                const prev = i > 0 ? GRANULARITY_OPTIONS[i - 1] : null;
+                const isGroupBoundary = prev && prev.group !== opt.group;
+                return (
+                  <button
+                    key={opt.value}
+                    onClick={() => setTimelineGranularity(opt.value)}
+                    className="px-1.5 py-0.5 text-[8px] font-[family-name:var(--font-michroma)] tracking-wider transition-colors"
+                    style={{
+                      backgroundColor:
+                        timelineGranularity === opt.value
+                          ? "rgba(0,229,255,0.15)"
+                          : "transparent",
+                      color:
+                        timelineGranularity === opt.value
+                          ? "var(--accent-cyan)"
+                          : "var(--text-muted)",
+                      borderRight: "1px solid var(--border)",
+                      borderLeft: isGroupBoundary
+                        ? "1px solid var(--border-bright)"
+                        : undefined,
+                    }}
+                    title={
+                      opt.value === "year"
+                        ? "1 year window — for annual signals (World Bank, WGI)"
+                        : opt.value === "5year"
+                          ? "5 year window — multi-year trend on annual signals"
+                          : opt.value === "all"
+                            ? "Full data span — shows every published observation"
+                            : undefined
+                    }
+                  >
+                    {opt.label}
+                  </button>
+                );
+              })}
             </div>
             {/* Historical play/pause button — only in non-live, non-replay mode */}
             {!isLive && (

--- a/src/lib/temporal-data.ts
+++ b/src/lib/temporal-data.ts
@@ -1,7 +1,13 @@
 import type { CausalNode, CausalEdge, OmegaFragilityProfile } from "./types";
 
 // ─── Temporal Types ──────────────────────────────────────────────
-export type TimeGranularity = "hour" | "day" | "week" | "month";
+// The short presets (hour/day/week/month) cover fast-moving signals (FRED
+// daily, EIA 5-min). The long presets (year/5year/all) cover annual-cadence
+// signals — World Bank annual series, WGI governance — whose published
+// history spans decades. Without these, the dial maxed out at 30 days and
+// annual data always rendered as a flat hold-forward line. See PR #381
+// (2026-05-21 user feedback after the live-data coverage finale).
+export type TimeGranularity = "hour" | "day" | "week" | "month" | "year" | "5year" | "all";
 
 export interface TemporalEvent {
   id: string;

--- a/src/stores/useApexStore.ts
+++ b/src/stores/useApexStore.ts
@@ -1081,19 +1081,42 @@ export const useApexStore = create<ApexState>((set, get) => ({
       // Result: subsequent clicks could shrink further but never expand back.
       // By saving timelineFullRange on first entry, we always have the
       // original extent to expand into.
+      const DAY_MS = 24 * 60 * 60 * 1000;
       const windowMs: Record<TimeGranularity, number> = {
         hour: 60 * 60 * 1000,
-        day: 24 * 60 * 60 * 1000,
-        week: 7 * 24 * 60 * 60 * 1000,
-        month: 30 * 24 * 60 * 60 * 1000,
+        day: DAY_MS,
+        week: 7 * DAY_MS,
+        month: 30 * DAY_MS,
+        year: 365 * DAY_MS,
+        "5year": 5 * 365 * DAY_MS,
+        // "all" maps to a very wide ceiling so it dominates the floor in
+        // the Math.max below. Effectively "show all available data".
+        // 50 years is wider than WB's earliest published series (1970-ish)
+        // so this captures the entire data extent in practice.
+        all: 50 * 365 * DAY_MS,
       };
       const end = s.timelineRange.end;
       const fullRange = s.timelineFullRange ?? { ...s.timelineRange };
-      const newStart = Math.max(fullRange.start, end - windowMs[g]);
+      // For short presets (hour/day/week/month) clamp to the captured
+      // `fullRange.start` (typically end - 60d, the synthetic-data default).
+      // For long presets (year/5year/all) bypass this clamp — the user is
+      // explicitly choosing a window wider than the synthetic baseline,
+      // because they want to see real published history for annual signals.
+      // Without this, 1Y would silently collapse back to 1M.
+      const isLongPreset = g === "year" || g === "5year" || g === "all";
+      const newStart = isLongPreset
+        ? end - windowMs[g]
+        : Math.max(fullRange.start, end - windowMs[g]);
+      // Also widen `timelineFullRange` when a long preset is picked so that
+      // a subsequent ZOOM OUT lands somewhere sensible instead of snapping
+      // back to the 60-day default mid-investigation.
+      const nextFullRange = isLongPreset
+        ? { start: Math.min(fullRange.start, newStart), end: Math.max(fullRange.end, end) }
+        : fullRange;
       return {
         timelineGranularity: g,
         timelineRange: { start: newStart, end },
-        timelineFullRange: fullRange,
+        timelineFullRange: nextFullRange,
       };
     }),
 


### PR DESCRIPTION
## The problem

After the live-data finale (PRs #347 / #350 / #353 / #375), annual signals — WB fertilizer / debt-to-GDP / GDP / employment, WGI governance — are flowing real history into the comparison overlay. But the dial preset buttons (`1H / 1D / 1W / 1M`) max out at a 30-day window, narrower than the gap between annual data points.

Result, reported by user after the previous fix landed: pin a fertilizer node → every dial preset shows a flat hold-forward line with the amber "OUT OF WINDOW" chip. To see the actual annual curve you have to know about the small "ZOOM OUT" button to the right of LIVE. Not discoverable.

## The fix — three new preset buttons

Adds **`1Y / 5Y / ALL`** next to the existing four, with a slightly heavier border between the short-cadence group (`1H / 1D / 1W / 1M`) and the long-cadence group (`1Y / 5Y / ALL`) so the tier boundary reads visually.

| Button | Window | Best for |
|---|---|---|
| 1H | 1 hour | EIA Hormuz (5-min ticks) |
| 1D | 1 day | FRED daily series (DGS10, SOFR) |
| 1W | 1 week | FRED weekly |
| 1M | 30 days | FRED monthly (CPI, PCE, food prices) |
| **1Y** | **365 days** | **WB annual — single point with current value** |
| **5Y** | **5 years** | **WB annual — 5-year trend** |
| **ALL** | **50 years** | **WB annual — full published-history span** |

Each new button gets a hover tooltip explaining the use case ("for annual signals — World Bank, WGI").

## Implementation

Three files:

1. **`src/lib/temporal-data.ts`** — extend the `TimeGranularity` type union with `"year" | "5year" | "all"`.

2. **`src/stores/useApexStore.ts`** — extend the `windowMs` map. For long presets, bypass the `fullRange.start` clamp (which capped at the 60-day synthetic-data baseline). Also widen `timelineFullRange` when a long preset is picked so a subsequent ZOOM OUT lands at the chosen extent, not back at 60 days.

3. **`src/components/TimeDial.tsx`** — add the three buttons with `group: "short" | "long"` tagging. Update `formatDate`, `generateTicks`, `historicalStepMs`, and the keyboard-step switch to handle the new types. For long presets, x-axis labels show year-only (month/day on a 5-year axis is noise); gridline steps scale appropriately (90d for 1Y, 365d for 5Y, 5y for ALL).

## Test plan

- [x] `npx tsc --noEmit` — no new errors
- [x] 85 feed tests pass
- [x] No consumers of `TimeGranularity` outside the three files touched (grep-verified)
- [ ] After deploy: pin `qf_india_fertilizer_market`, click **5Y** — confirm chart shows the multi-year trajectory (India fertilizer rose ~125 → ~175 kg/ha over the last 18 years)
- [ ] After deploy: pin `fc_debt_to_gdp`, click **ALL** — confirm chart shows the full annual history with the OUT OF WINDOW chip disappearing
- [ ] After deploy: previous repro (1D → 1M → 1D) on annual data — confirm the amber chip still appears in those tight windows (since the data is genuinely out of window for the tight presets)

## Combined with PR #375

PR #375 fixed the FIT-mode trap and added the OUT OF WINDOW chip so users **know** the curve is missing because of cadence mismatch. This PR adds the **next steps**: longer presets so users can do something about it without finding the ZOOM OUT button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
