### PR TITLE
fix(feeds): swap upstream-discontinued PPIFGS + add STALE verdict to check:feeds

### DIFF
--- a/scripts/check-feed-health.ts
+++ b/scripts/check-feed-health.ts
@@ -28,7 +28,7 @@ import { WB_SERIES } from "../src/lib/feeds/world-bank";
 const BASE = process.env.BASE ?? "https://manifold.apexanalytica.co";
 const AUTH_COOKIE = process.env.AUTH_COOKIE;
 
-type Verdict = "LIVE" | "MOCK" | "MISS";
+type Verdict = "LIVE" | "MOCK" | "MISS" | "STALE";
 interface Row {
   feed: "FRED" | "WB";
   key: string;
@@ -36,13 +36,69 @@ interface Row {
   verdict: Verdict;
   source?: string;
   value?: number;
+  observedAt?: string;
+  ageDays?: number;
 }
 
+// Staleness thresholds — anything older than this with a non-mock source is
+// flagged as STALE. The class of bug this catches: a FRED (or WB) series
+// gets upstream-discontinued, but the API keeps returning the last-known
+// value indefinitely. The series passes the LIVE check (real source string,
+// non-mock value), so the canvas silently renders a years-old number as if
+// current.
+//
+// Concrete case it would have caught: PPIFGS ("PPI Final Demand Goods")
+// stopped publishing in 2015-12. As of 2026-05-22 it was 10 years stale
+// but check:feeds reported it as LIVE.
+//
+// Thresholds chosen by upstream cadence:
+//
+//   FRED: most series publish at least monthly. Quarterly series at worst
+//     run ~5 months behind. 1 year is the cap on "alive but slow"; older
+//     than 365 days = upstream-discontinued.
+//
+//   WB: publishes annually with a 1-2 year reporting lag — fertilizer
+//     consumption (kg/ha) is a classic example where the 2023 value is
+//     the latest available in 2026 (3.4 years from observation date, but
+//     the series is still alive). 5 years is the cap where we can say
+//     the series is genuinely dead vs. just slow.
+//
+// Dry-run against prod (2026-05-22) with WB at 3y caught WB fertilizer
+// as STALE, which was a false positive — these series are still alive,
+// just slow. Bumped to 5y to filter out normal WB lag while still
+// catching genuinely-dead series (PPIFGS at 10y, PPILFE at 10y).
+const STALENESS_THRESHOLD_DAYS = {
+  FRED: 365,
+  WB: 365 * 5,
+} as const;
+
 function paint(v: Verdict): string {
-  // ANSI: green/yellow/red. Harmless if stdout is plain.
+  // ANSI: green/amber/red/red. Harmless if stdout is plain.
   if (v === "LIVE") return `\x1b[32m${v}\x1b[0m`;
   if (v === "MOCK") return `\x1b[33m${v}\x1b[0m`;
+  if (v === "STALE") return `\x1b[35m${v}\x1b[0m`; // magenta — distinct from MOCK
   return `\x1b[31m${v}\x1b[0m`;
+}
+
+function daysSince(iso: string | undefined): number | undefined {
+  if (!iso) return undefined;
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return undefined;
+  return Math.floor((Date.now() - t) / 86_400_000);
+}
+
+function classifyWithFreshness(
+  source: string | undefined,
+  observedAt: string | undefined,
+  feed: "FRED" | "WB",
+): { verdict: Verdict; ageDays?: number } {
+  if (!source) return { verdict: "MISS" };
+  if (source.toLowerCase().includes("(mock")) return { verdict: "MOCK" };
+  const ageDays = daysSince(observedAt);
+  if (ageDays !== undefined && ageDays > STALENESS_THRESHOLD_DAYS[feed]) {
+    return { verdict: "STALE", ageDays };
+  }
+  return { verdict: "LIVE", ageDays };
 }
 
 async function fetchJson(path: string): Promise<unknown> {
@@ -63,31 +119,44 @@ async function fetchJson(path: string): Promise<unknown> {
   return r.json();
 }
 
-function classify(source: string | undefined): Verdict {
-  if (!source) return "MISS";
-  return source.toLowerCase().includes("(mock") ? "MOCK" : "LIVE";
-}
-
 async function checkFred(): Promise<Row[]> {
   const expected = new Map(
     FRED_SERIES.map((s) => [s.units ? `${s.id}_${s.units}` : s.id, s.label]),
   );
   const raw = (await fetchJson("/api/feeds/fred/series")) as {
-    observations?: Array<{ seriesId: string; source?: string; value?: number }>;
+    observations?: Array<{
+      seriesId: string;
+      source?: string;
+      value?: number;
+      observedAt?: string;
+    }>;
   };
   const obs = raw.observations ?? [];
-  const seen = new Map<string, { source?: string; value?: number }>();
-  for (const o of obs) seen.set(o.seriesId, { source: o.source, value: o.value });
+  const seen = new Map<
+    string,
+    { source?: string; value?: number; observedAt?: string }
+  >();
+  for (const o of obs)
+    seen.set(o.seriesId, {
+      source: o.source,
+      value: o.value,
+      observedAt: o.observedAt,
+    });
   const rows: Row[] = [];
   for (const [key, label] of expected) {
     const hit = seen.get(key);
+    const { verdict, ageDays } = hit
+      ? classifyWithFreshness(hit.source, hit.observedAt, "FRED")
+      : { verdict: "MISS" as Verdict, ageDays: undefined };
     rows.push({
       feed: "FRED",
       key,
       label,
-      verdict: hit ? classify(hit.source) : "MISS",
+      verdict,
       source: hit?.source,
       value: hit?.value,
+      observedAt: hit?.observedAt,
+      ageDays,
     });
   }
   return rows;
@@ -103,23 +172,36 @@ async function checkWb(): Promise<Row[]> {
       indicator: string;
       source?: string;
       value?: number;
+      observedAt?: string;
     }>;
   };
   const obs = raw.observations ?? [];
-  const seen = new Map<string, { source?: string; value?: number }>();
+  const seen = new Map<
+    string,
+    { source?: string; value?: number; observedAt?: string }
+  >();
   for (const o of obs) {
-    seen.set(`${o.country}/${o.indicator}`, { source: o.source, value: o.value });
+    seen.set(`${o.country}/${o.indicator}`, {
+      source: o.source,
+      value: o.value,
+      observedAt: o.observedAt,
+    });
   }
   const rows: Row[] = [];
   for (const [key, label] of expected) {
     const hit = seen.get(key);
+    const { verdict, ageDays } = hit
+      ? classifyWithFreshness(hit.source, hit.observedAt, "WB")
+      : { verdict: "MISS" as Verdict, ageDays: undefined };
     rows.push({
       feed: "WB",
       key,
       label,
-      verdict: hit ? classify(hit.source) : "MISS",
+      verdict,
       source: hit?.source,
       value: hit?.value,
+      observedAt: hit?.observedAt,
+      ageDays,
     });
   }
   return rows;
@@ -129,14 +211,31 @@ function summarize(rows: Row[], feed: string): void {
   const live = rows.filter((r) => r.verdict === "LIVE").length;
   const mock = rows.filter((r) => r.verdict === "MOCK").length;
   const miss = rows.filter((r) => r.verdict === "MISS").length;
+  const stale = rows.filter((r) => r.verdict === "STALE").length;
   console.log(
-    `\n=== ${feed} === ${rows.length} expected · ${paint("LIVE")} ${live} · ${paint("MOCK")} ${mock} · ${paint("MISS")} ${miss}\n`,
+    `\n=== ${feed} === ${rows.length} expected · ${paint("LIVE")} ${live} · ${paint("MOCK")} ${mock} · ${paint("STALE")} ${stale} · ${paint("MISS")} ${miss}\n`,
   );
   for (const r of rows) {
     const val = r.value !== undefined ? ` ${r.value}` : "";
-    const note = r.source ? ` ← ${r.source.slice(0, 65)}` : "";
-    console.log(`  [${paint(r.verdict)}] ${r.key.padEnd(28)} ${r.label.slice(0, 42).padEnd(42)}${val}${note}`);
+    // For LIVE rows, show a faint age annotation so the operator can eyeball
+    // freshness at a glance (e.g. "3d" / "47d" / "1.3y"). For STALE rows show
+    // the age in bold red so it's unmissable.
+    const ageNote = r.ageDays !== undefined
+      ? r.verdict === "STALE"
+        ? ` \x1b[31m\x1b[1m${formatAge(r.ageDays)}\x1b[0m`
+        : ` \x1b[2m${formatAge(r.ageDays)}\x1b[0m`
+      : "";
+    const note = r.source ? ` ← ${r.source.slice(0, 60)}` : "";
+    console.log(
+      `  [${paint(r.verdict)}] ${r.key.padEnd(28)} ${r.label.slice(0, 38).padEnd(38)}${val}${ageNote}${note}`,
+    );
   }
+}
+
+function formatAge(days: number): string {
+  if (days < 60) return `${days}d`;
+  if (days < 365) return `${Math.round(days / 30)}mo`;
+  return `${(days / 365).toFixed(1)}y`;
 }
 
 async function main() {
@@ -148,8 +247,9 @@ async function main() {
   const live = all.filter((r) => r.verdict === "LIVE").length;
   const mock = all.filter((r) => r.verdict === "MOCK").length;
   const miss = all.filter((r) => r.verdict === "MISS").length;
+  const stale = all.filter((r) => r.verdict === "STALE").length;
   console.log(
-    `\nOverall: ${all.length} expected · ${live} live · ${mock} mock · ${miss} missing`,
+    `\nOverall: ${all.length} expected · ${live} live · ${mock} mock · ${stale} stale · ${miss} missing`,
   );
   if (mock > 0) {
     console.log(
@@ -158,12 +258,32 @@ async function main() {
         `docs/api/api_key.html → Vercel project settings → Environment Variables → redeploy.`,
     );
   }
+  if (stale > 0) {
+    const staleRows = all.filter((r) => r.verdict === "STALE");
+    console.log(
+      `\nNote: ${stale} series have observations older than the staleness threshold ` +
+        `(FRED ${STALENESS_THRESHOLD_DAYS.FRED}d, WB ${STALENESS_THRESHOLD_DAYS.WB}d). ` +
+        `These are usually upstream-discontinued series — the API still returns the last-known\n` +
+        `value indefinitely, so the canvas silently shows years-old data as if current. Investigate\n` +
+        `each one: probe FRED/WB directly to confirm the series is dead, then either swap to a\n` +
+        `current equivalent or delete the catalog entry. See PR #350 (WB PAK swap) and PR #391\n` +
+        `(FRED PPIFGS swap) for the pattern.`,
+    );
+    for (const r of staleRows) {
+      console.log(`    ⚠ ${r.feed} ${r.key} — observed ${r.observedAt ?? "?"} (${formatAge(r.ageDays ?? 0)} old)`);
+    }
+  }
   if (miss > 0) {
     console.log(
       `\nNote: ${miss} series were registered in FRED_SERIES / WB_SERIES but not returned by the\n` +
         `proxy. This usually means a deploy lag — the route is on an older build that doesn't know\n` +
         `about the new entries. Wait for the next deploy or push a dummy commit.`,
     );
+    process.exit(1);
+  }
+  // STALE is a hard fail too — silently rendering 10-year-old data is the kind
+  // of bug that should block a deploy until investigated.
+  if (stale > 0) {
     process.exit(1);
   }
   if (live === 0) {

--- a/src/lib/feeds/fred.ts
+++ b/src/lib/feeds/fred.ts
@@ -68,7 +68,20 @@ export const FRED_SERIES: FredSeriesConfig[] = [
   { id: "EMRATIO", label: "Employment-Population Ratio", labelPatterns: ["employment-population ratio"], unit: "%", capacity: 65, mockValue: 60.1 },
   { id: "A191RL1Q225SBEA", label: "Real GDP — QoQ Annualized %", labelPatterns: ["gdp qoq annualized"], unit: "%", capacity: 4, mockValue: 2.5 },
   { id: "PPIACO", label: "PPI All Commodities", labelPatterns: ["ppi all commodities"], unit: "", capacity: 280, mockValue: 250 },
-  { id: "PPIFGS", label: "PPI Final Demand Goods", labelPatterns: ["ppi final demand energy"], unit: "", capacity: 145, mockValue: 138 },
+  // PPIFGS deleted 2026-05-22: upstream-discontinued since 2015-12. The
+  // FRED API still returns the last-known 2015 value (191.2) for any
+  // request, so check:feeds was reporting it as LIVE even though the
+  // data was 10 years stale. Compounding error: the original
+  // labelPattern was "ppi final demand energy" but PPIFGS is the
+  // *Goods* sub-index, not Energy — so it was also misrouted to the
+  // wrong graph node. Three replacement entries below wire each of the
+  // three PPI Final Demand sub-indices to its correct, current FRED
+  // series. See PR #391 (2026-05-22) for the full diagnostic — a
+  // similar discontinuation pattern was caught for PPILFE (Core PPI)
+  // which is documented as a follow-up.
+  { id: "PPIFIS", label: "PPI Final Demand", labelPatterns: ["ppi final demand"], unit: "", capacity: 165, mockValue: 156 },
+  { id: "PPIFDS", label: "PPI Final Demand Services", labelPatterns: ["ppi final demand services"], unit: "", capacity: 165, mockValue: 156 },
+  { id: "WPSFD4131", label: "PPI Final Demand Energy", labelPatterns: ["ppi final demand energy"], unit: "", capacity: 320, mockValue: 268 },
   { id: "T5YIFR", label: "5Y5Y Forward Inflation Expectation", labelPatterns: ["5y5y forward inflation expectation"], unit: "%", capacity: 4, mockValue: 2.3 },
   { id: "PWHEAMTUSDM", label: "Global Wheat Price (Soft Red Winter)", labelPatterns: ["global wheat price"], unit: "$/T", capacity: 400, mockValue: 230 },
   // EM FX stress series — daily FRED publication, scaled to local-per-USD.


### PR DESCRIPTION
## Two related changes — surgical swap + infrastructure that catches the next one

### Fix: PPIFGS replacement

FRED `PPIFGS` ("PPI Final Demand Goods") was upstream-discontinued in **2015-12**. The FRED API still returns the last-known 2015 value indefinitely (191.2), so `check:feeds` reported it as LIVE — but the value is **10 years stale**. Compounding error: the original `labelPatterns` was `["ppi final demand energy"]` but PPIFGS is the *Goods* sub-index, not Energy — so it was wired to the wrong graph node even when it had data. Three issues in one entry.

Probed FRED for current alternatives (via the FRED key we set up yesterday):

| Series | Latest value | Period | Verdict |
|---|---:|---:|---|
| `PPIFIS` | 156.50 | 2026-04 | ✓ current, headline |
| **`PPIFGS`** | 191.20 | **2015-12** | ✗ dead |
| `PPIFDS` | 156.11 | 2026-04 | ✓ current, Services |
| `WPSFD4131` | 267.86 | 2026-04 | ✓ current, Energy |
| `PPILFE` | 193.40 | **2015-12** | ✗ also dead (follow-up) |

Deleted PPIFGS entry, added three new entries covering each of the three PPI Final Demand sub-indices. The matcher's substring + first-match semantics handle the broad-to-specific pattern ordering correctly: `PPIFIS`'s `"ppi final demand"` pattern hits the first matching node (the headline at L2159); `PPIFDS`'s `"ppi final demand services"` only matches Services (L2187); `WPSFD4131`'s `"ppi final demand energy"` only matches Energy (L2201).

**Net coverage: 3 previously-unwired PPI graph nodes now wired to live upstream data; 1 stale-data time-bomb removed.**

`PPILFE` is another upstream-discontinued series caught in the same diagnostic — not fixed here to keep the PR focused. Documented as a known follow-up in the script's comment block.

### Feat: STALE verdict in check:feeds

The class of bug PPIFGS represented — series passes the LIVE check because the API returns a real (mock-free) source string, but the underlying observation is years out of date — would silently ride on prod indefinitely until someone happens to notice on the canvas.

`check:feeds` now classifies each observation against a per-feed staleness threshold and emits a 4th verdict tier alongside LIVE/MOCK/MISS:

> **STALE** = source is real (non-mock) but `observedAt` is older than the per-feed threshold. Strong signal of upstream discontinuation.

**Thresholds chosen by upstream cadence:**

| Feed | Threshold | Reasoning |
|---|---|---|
| FRED | **365 days** | Most series publish at least monthly. Quarterly at worst runs ~5 months behind. 1 year = "alive but slow" cap |
| WB | **5 years** | Annual cadence with 1-2 year reporting lag. Fertilizer is a classic case where 2023 data is the latest in 2026 (3.4y, still alive). 5y filters normal lag while catching genuinely dead series (PPIFGS-class) |

Calibration: dry-run with WB at 3y caught fertilizer as STALE (false positive); bumped to 5y to filter normal WB lag.

**Output enhancements:**
- Each row now shows a faint age annotation (e.g. `51d`, `3mo`, `2.4y`) so the operator can eyeball freshness at a glance
- STALE rows show the age in **bold red** so genuinely-dead series are unmissable
- The "What to do" note at the end points operators at the PR #350 (WB swap) and this PR (FRED swap) precedent for fixing each flagged series

**STALE > 0 is a hard CI failure** — silently rendering 10-year-old data should block a deploy until investigated.

## Test plan

- [x] `npx tsc --noEmit` — no new errors
- [x] 85 feed tests pass
- [x] Local dry-run against prod (still on old code): 0 STALE, 6 MISS (my 3 new FRED entries + 3 pre-existing deploy-lag from other PRs)
- [x] Calibration verified: WB fertilizer (3.4y) classified as LIVE under 5y threshold (correct — normal upstream lag)
- [ ] After deploy: re-run `check:feeds` → expect 3 new FRED entries flip from MISS to LIVE; PPIFGS no longer in catalog so doesn't appear
- [ ] After deploy: verify each new entry's graph node lights up on the canvas with a current value (`ip_ppi_final_demand` = 156.5, `ip_ppi_final_demand_services` = 156.1, `ip_ppi_final_demand_energy` = 267.9)

## Closes one of the three open threads from #389

This addresses thread #2 in `docs/sessions/geopolitical-macro.md`'s "Remaining open threads" section. Two left after this lands: EIA_API_KEY setup (Hormuz feed, needs user action) and the 2 WB null tuples to prune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
