### PR TITLE
fix(feeds): remove deprecated WB WGI series + wire Core PPI YoY

### DIFF
--- a/src/lib/__tests__/feeds/world-bank.test.ts
+++ b/src/lib/__tests__/feeds/world-bank.test.ts
@@ -104,36 +104,21 @@ describe("mockWorldBankFeed", () => {
     expect(mena!.unit).toBe("%");
   });
 
-  it("includes the WGI Rule of Law series for China and Brazil (kind=governance)", () => {
+  // Regression: WGI Rule of Law entries (CHN/RL.EST + BRA/RL.EST) were
+  // removed 2026-05-22 after WB retired the entire WGI dataset from their
+  // v2 API ("The indicator was not found. It may have been deleted or
+  // archived." returned for all 6 WGI codes). The `kind` discriminator on
+  // WbSeriesConfig is retained for future re-wiring if a non-WB
+  // governance source ever lands.
+  it("does NOT include the deprecated WGI Rule of Law series", () => {
     const cnRol = WB_SERIES.find(
       (s) => s.country === "CHN" && s.indicator === "RL.EST",
     );
     const brRol = WB_SERIES.find(
       (s) => s.country === "BRA" && s.indicator === "RL.EST",
     );
-    expect(cnRol).toBeDefined();
-    expect(brRol).toBeDefined();
-    expect(cnRol!.kind).toBe("governance");
-    expect(brRol!.kind).toBe("governance");
-    expect(cnRol!.unit).toBe("WGI");
-  });
-});
-
-describe("parseWbSeriesResponse — WGI Rule of Law series", () => {
-  const config = WB_SERIES.find(
-    (s) => s.country === "CHN" && s.indicator === "RL.EST",
-  )!;
-
-  it("parses a WGI estimate (scale = 1, signed value preserved)", () => {
-    const raw = [
-      { page: 1, pages: 1 },
-      [{ date: "2023", value: -0.42 }],
-    ];
-    const obs = parseWbSeriesResponse(raw, config);
-    expect(obs).not.toBeNull();
-    expect(obs!.value).toBeCloseTo(-0.42, 2);
-    expect(obs!.unit).toBe("WGI");
-    expect(obs!.source).toContain("CHN/RL.EST");
+    expect(cnRol).toBeUndefined();
+    expect(brRol).toBeUndefined();
   });
 });
 
@@ -148,30 +133,11 @@ describe("worldBankProvider.matchPayload", () => {
     const batch = worldBankProvider.matchPayload(feed, nodes);
 
     expect(batch.providerId).toBe("world-bank");
-    // signalKinds now includes "governance" alongside "indicator" because
-    // the WGI series (Rule of Law) are emitted with kind="governance".
     expect(batch.signalKinds).toContain("indicator");
-    expect(batch.signalKinds).toContain("governance");
     const matchedIds = batch.updates.map((u) => u.nodeId).sort();
     expect(matchedIds).toContain("c_gdp");
     expect(matchedIds).toContain("b_gdp");
     expect(matchedIds).not.toContain("neutral");
-  });
-
-  it("emits a governance LiveDataPoint for the WGI Rule of Law series", () => {
-    const nodes = [
-      makeNode({ id: "c_gdp", label: "China Real GDP" }),
-      makeNode({ id: "b_gdp", label: "Brazil Real GDP" }),
-    ];
-    const feed = mockWorldBankFeed();
-    const batch = worldBankProvider.matchPayload(feed, nodes);
-    const govUpdates = batch.updates.filter((u) => u.point.kind === "governance");
-    expect(govUpdates.length).toBe(2);
-    const chinaGov = govUpdates.find((u) => u.nodeId === "c_gdp");
-    expect(chinaGov).toBeDefined();
-    expect(chinaGov!.point.unit).toBe("WGI");
-    // WGI Rule of Law is a -2.5..+2.5 scale; below 0 = below world average.
-    expect(typeof chinaGov!.point.value).toBe("number");
   });
 
   it("emits no event when no nodes match", () => {

--- a/src/lib/feeds/fred.ts
+++ b/src/lib/feeds/fred.ts
@@ -82,6 +82,12 @@ export const FRED_SERIES: FredSeriesConfig[] = [
   { id: "PPIFIS", label: "PPI Final Demand", labelPatterns: ["ppi final demand"], unit: "", capacity: 165, mockValue: 156 },
   { id: "PPIFDS", label: "PPI Final Demand Services", labelPatterns: ["ppi final demand services"], unit: "", capacity: 165, mockValue: 156 },
   { id: "WPSFD4131", label: "PPI Final Demand Energy", labelPatterns: ["ppi final demand energy"], unit: "", capacity: 320, mockValue: 268 },
+  // Core PPI YoY — wires the previously-unwired `ip_core_ppi_yoy` graph
+  // node to PPICOR (PPI by Commodity: Final Demand: Less Foods and Energy)
+  // with units=pc1 transform for year-over-year %. 5.23 % at 2026-04.
+  // Note: PPILFE was the canonical Core PPI series until 2015-12 when FRED
+  // discontinued it; PPICOR is the current successor.
+  { id: "PPICOR", label: "Core PPI Year-over-Year", labelPatterns: ["core ppi year-over-year"], unit: "%", capacity: 5, units: "pc1", mockValue: 3.2 },
   { id: "T5YIFR", label: "5Y5Y Forward Inflation Expectation", labelPatterns: ["5y5y forward inflation expectation"], unit: "%", capacity: 4, mockValue: 2.3 },
   { id: "PWHEAMTUSDM", label: "Global Wheat Price (Soft Red Winter)", labelPatterns: ["global wheat price"], unit: "$/T", capacity: 400, mockValue: 230 },
   // EM FX stress series — daily FRED publication, scaled to local-per-USD.

--- a/src/lib/feeds/world-bank.ts
+++ b/src/lib/feeds/world-bank.ts
@@ -179,37 +179,27 @@ export const WB_SERIES: WbSeriesConfig[] = [
     capacity: 1500,
     mockValue: 1100,
   },
-  // WGI — World Governance Indicators. Annual cadence. Scale runs from
-  // ~-2.5 (worst) to +2.5 (best) where 0 ≈ global average. We surface
-  // Rule of Law (RL.EST) — the dimension most directly relevant to R-04
-  // (Cross-Domain Dependency), which now applies a stricter confidence
-  // cutoff when an edge's endpoint sits in a weak-governance jurisdiction.
+  // WGI — World Governance Indicators — REMOVED 2026-05-22.
+  // Every WGI indicator (RL.EST = Rule of Law, GE.EST = Government
+  // Effectiveness, CC.EST = Control of Corruption, PV.EST = Political
+  // Stability, RQ.EST = Regulatory Quality, VA.EST = Voice & Accountability)
+  // now returns "The indicator was not found. It may have been deleted or
+  // archived." from the WB v2 API. The full WGI dataset has been retired
+  // from this endpoint — probed all 6 codes on 2026-05-22, all return the
+  // same archival message.
   //
-  // `capacity: 0` makes the qualifier display read as "ratio vs world
-  // average". `kind: "governance"` keeps the signal addressable separately
-  // from the generic WB macro indicators that share the same provider.
-  {
-    country: "CHN",
-    indicator: "RL.EST",
-    label: "China Rule of Law (WGI)",
-    labelPatterns: ["china real gdp"],
-    scale: 1,
-    unit: "WGI",
-    capacity: 0,
-    mockValue: -0.4,
-    kind: "governance",
-  },
-  {
-    country: "BRA",
-    indicator: "RL.EST",
-    label: "Brazil Rule of Law (WGI)",
-    labelPatterns: ["brazil real gdp"],
-    scale: 1,
-    unit: "WGI",
-    capacity: 0,
-    mockValue: -0.2,
-    kind: "governance",
-  },
+  // The CHN/RL.EST and BRA/RL.EST entries that previously sat here were
+  // showing as MISS in `check:feeds` and contributed no data to the
+  // R-04 Cross-Domain Dependency axiom. Removed cleanly with no graph-
+  // side change (label patterns "china real gdp" / "brazil real gdp"
+  // also matched the existing GDP entries above, so no node loses
+  // coverage from removing these — the GDP node was always the dominant
+  // signal anyway).
+  //
+  // The `kind: "governance"` discriminator on `WbSeriesConfig` is kept
+  // for future use if a non-WB governance source ever lands. If WB
+  // restores WGI to the v2 API or publishes it under a new code, the
+  // entries can be re-added in the same shape.
   // Phase 13 — promote the 4 fertilizer-market nodes (QAFCO + Ma'aden
   // export destinations for India and Brazil) to live via WB
   // AG.CON.FERT.ZS (Fertilizer consumption, kg per hectare of arable


### PR DESCRIPTION
## Two cleanups closing the remaining live-data follow-ups

### 1. Remove deprecated WB WGI Rule of Law entries

Probed **all 6 WGI indicator codes** (`RL.EST` / `GE.EST` / `CC.EST` / `PV.EST` / `RQ.EST` / `VA.EST`) against the WB v2 API on 2026-05-22. All 6 return:

> `"The indicator was not found. It may have been deleted or archived."`

**The WGI dataset has been retired from the WB v2 endpoint.** The `CHN/RL.EST` and `BRA/RL.EST` entries that previously sat in `WB_SERIES` were showing as MISS in `check:feeds` (which I'd initially assumed was deploy lag from a parallel PR), and were contributing zero data to the Tarski R-04 cross-domain dependency axiom that consumes them.

Removed both entries cleanly. R-04 gracefully degrades: `getLiveSignal(node, "governance")` now returns undefined for every node, threshold stays at `R04_STATIC_THRESHOLD` instead of tightening to `R04_LIVE_THRESHOLD`. Verified by reading `src/lib/tarski-data.ts:734-751` — the axiom is structured for the fallback case (both `sourceGov` and `targetGov` may be null).

The `kind: "governance"` discriminator on `WbSeriesConfig` and the formatter's `"governance"` branch in `feeds-display` are kept for future use if a non-WB governance source ever lands. No regressions, just removed entries that were dead-upstream.

### 2. Wire Core PPI Year-over-Year

Probed FRED for current Core PPI series during the WGI investigation:

| Series | Latest | Period | Verdict |
|---|---:|---|---|
| `PPILFE` | 193.40 | 2015-12 | ✗ also discontinued (same class as PPIFGS — pre-existing follow-up note) |
| `PPICOR` (level) | 154.30 | 2026-04 | ✓ current, headline Core PPI |
| **`PPICOR` (units=pc1)** | **5.23 %** | **2026-04** | ✓ matches `ip_core_ppi_yoy` graph node's expected shape |

Added `PPICOR` entry with `units=pc1` transform. Wires the previously-unwired `ip_core_ppi_yoy` graph node.

`PPILFE` was never in `FRED_SERIES` (probed but never added) — my earlier "follow-up" note about PPILFE as a time-bomb was speculative. Documented the upstream-discontinued history in the comment so a future session doesn't try to re-add it.

### Coverage state after deploy

```
FRED:       55 expected · LIVE 55 · MOCK 0 · STALE 0 · MISS 0
World Bank: 13 expected · LIVE 13 · MOCK 0 · STALE 0 · MISS 0
Overall:    68 expected · 68 live · clean
```

**Only remaining live-data thread**: `EIA_API_KEY` setup (needs your action — register at https://www.eia.gov/opendata/register.php, paste key, I add to Vercel, redeploy. Same flow as FRED earlier today).

## Test plan

- [x] 103 tests pass (added regression-shaped test confirming WGI RL.EST entries are *not* present)
- [x] `npx tsc --noEmit` clean for the touched files
- [x] Dry-run `check:feeds` shows projected post-deploy state: 0 mock / 0 stale / 0 miss across both feeds
- [ ] After deploy: re-run `check:feeds`, confirm 68/68 LIVE
- [ ] After deploy: confirm `ip_core_ppi_yoy` node shows 5.23 % on the canvas with source string `FRED · PPICOR (period 2026-04)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
