### PR TITLE
feat(discovery): FR (Forgetting Rate) estimator on TrainingTrace

### DIFF
--- a/src/lib/discovery/__tests__/fr-estimator.test.ts
+++ b/src/lib/discovery/__tests__/fr-estimator.test.ts
@@ -1,0 +1,486 @@
+// @vitest-environment node
+//
+// Tests for the FR (Forgetting Rate) estimator (Phase 3 PR 3). Verifies
+// per-task forgetting math on synthetic TrainingTraces with known
+// dynamics so the assertions are hand-computable.
+//
+// Test strategy:
+//   - Build synthetic traces with carefully chosen forgettingRate /
+//     learningRate so the expected FR values can be derived from the
+//     generator's closed-form recurrence
+//   - Exercise the Heartbleed archetype (high-forgettingRate task ranks
+//     first in normalizedFR ranking)
+//   - Verify the decay-rate fit recovers the generator's forgettingRate
+//     parameter within tolerance
+//   - Edge cases: never-trained task, single-epoch trace, no decay
+//   - Provenance forwarding (synthetic in → synthetic out)
+//
+// All traces use `noiseAmplitude: 0` unless the test specifically needs
+// noise — deterministic accuracy curves are what make the closed-form
+// assertions tight.
+
+import { describe, it, expect } from "vitest";
+import {
+  computeFR,
+  rankTasksByNormalizedFR,
+  meanNormalizedFR,
+} from "../fr-estimator";
+import {
+  buildSyntheticTrainingTrace,
+  sequentialCurriculum,
+} from "../training-trace-synthetic";
+import type { TaskRef, TrainingTrace } from "../training-trace-types";
+
+// ─── Fixture builders ─────────────────────────────────────────────────
+
+const ATTACK_TASKS: TaskRef[] = [
+  { id: "task_ddos", label: "DDoS", scope: "attack-class" },
+  { id: "task_mitm", label: "MITM", scope: "attack-class" },
+  { id: "task_heartbleed", label: "Heartbleed", scope: "attack-class" },
+];
+
+function defaultTrace(): TrainingTrace {
+  return buildSyntheticTrainingTrace({
+    id: "test-trace",
+    label: "Test",
+    tasks: ATTACK_TASKS,
+    curriculum: sequentialCurriculum(
+      ATTACK_TASKS.map((t) => t.id),
+      3, // 3 epochs each = 9 total
+    ),
+    seed: 42,
+    noiseAmplitude: 0,
+  });
+}
+
+// ─── Shape / contract tests ───────────────────────────────────────────
+
+describe("computeFR — shape contracts", () => {
+  it("returns one entry per task in the trace", () => {
+    const trace = defaultTrace();
+    const result = computeFR(trace);
+    expect(result.tasks).toHaveLength(trace.tasks.length);
+    const ids = new Set(result.tasks.map((t) => t.taskId));
+    expect(ids.size).toBe(trace.tasks.length);
+    for (const t of trace.tasks) {
+      expect(ids.has(t.id)).toBe(true);
+    }
+  });
+
+  it("time series length matches trace.epochs", () => {
+    const trace = defaultTrace();
+    const result = computeFR(trace);
+    for (const t of result.tasks) {
+      expect(t.frOverTime).toHaveLength(trace.epochs.length);
+      expect(t.normalizedFROverTime).toHaveLength(trace.epochs.length);
+    }
+  });
+
+  it("all FR-over-time values are non-negative", () => {
+    const result = computeFR(defaultTrace());
+    for (const t of result.tasks) {
+      for (const fr of t.frOverTime) {
+        expect(fr).toBeGreaterThanOrEqual(0);
+      }
+      for (const nfr of t.normalizedFROverTime) {
+        expect(nfr).toBeGreaterThanOrEqual(0);
+        expect(nfr).toBeLessThanOrEqual(1 + 1e-9);
+      }
+    }
+  });
+
+  it("absoluteForgetting equals peakAccuracy − finalAccuracy", () => {
+    const result = computeFR(defaultTrace());
+    for (const t of result.tasks) {
+      const expected = Math.max(0, t.peakAccuracy - t.finalAccuracy);
+      expect(t.absoluteForgetting).toBeCloseTo(expected, 12);
+    }
+  });
+
+  it("normalizedFR equals absoluteForgetting / peakAccuracy when peak > 0", () => {
+    const result = computeFR(defaultTrace());
+    for (const t of result.tasks) {
+      if (t.peakAccuracy > 0) {
+        expect(t.normalizedFR).toBeCloseTo(
+          t.absoluteForgetting / t.peakAccuracy,
+          12,
+        );
+      }
+    }
+  });
+});
+
+// ─── Provenance forwarding ────────────────────────────────────────────
+
+describe("computeFR — provenance", () => {
+  it("forwards source.kind from the trace verbatim", () => {
+    const trace = defaultTrace();
+    expect(trace.source.kind).toBe("synthetic");
+    const result = computeFR(trace);
+    expect(result.sourceKind).toBe("synthetic");
+  });
+
+  it("forwards the trace id", () => {
+    const result = computeFR(defaultTrace());
+    expect(result.traceId).toBe("test-trace");
+  });
+});
+
+// ─── Curriculum semantics ─────────────────────────────────────────────
+
+describe("computeFR — curriculum semantics", () => {
+  it("lastTrainedEpoch matches the last activeTaskIds appearance", () => {
+    // sequentialCurriculum with 3 epochs each: DDoS [0,3), MITM [3,6),
+    // Heartbleed [6,9). lastTrainedEpoch should be 2, 5, 8.
+    const result = computeFR(defaultTrace());
+    const ddos = result.tasks.find((t) => t.taskId === "task_ddos")!;
+    const mitm = result.tasks.find((t) => t.taskId === "task_mitm")!;
+    const heart = result.tasks.find((t) => t.taskId === "task_heartbleed")!;
+    expect(ddos.lastTrainedEpoch).toBe(2);
+    expect(mitm.lastTrainedEpoch).toBe(5);
+    expect(heart.lastTrainedEpoch).toBe(8);
+  });
+
+  it("never-trained task gets lastTrainedEpoch = -1", () => {
+    // Add a task to the trace but never include it in the curriculum.
+    const tasks: TaskRef[] = [
+      ...ATTACK_TASKS,
+      { id: "task_unused", label: "Unused", scope: "attack-class" },
+    ];
+    const trace = buildSyntheticTrainingTrace({
+      id: "unused-trace",
+      label: "Unused",
+      tasks,
+      curriculum: sequentialCurriculum(
+        ATTACK_TASKS.map((t) => t.id),
+        3,
+      ),
+      noiseAmplitude: 0,
+    });
+    const result = computeFR(trace);
+    const unused = result.tasks.find((t) => t.taskId === "task_unused")!;
+    expect(unused.lastTrainedEpoch).toBe(-1);
+  });
+
+  it("peakEpoch is within the trained window for a sequential curriculum", () => {
+    // Without noise, each task's accuracy is monotone-increasing while
+    // training and monotone-decreasing after. So peakEpoch must be at
+    // or after lastTrainedEpoch − k for some k — in practice equal to
+    // lastTrainedEpoch since the last training step closes the most
+    // gap.
+    const result = computeFR(defaultTrace());
+    for (const t of result.tasks) {
+      // For sequential, lastTrainedEpoch is the LAST epoch the task
+      // was active. Without noise the peak is at lastTrainedEpoch.
+      expect(t.peakEpoch).toBe(t.lastTrainedEpoch);
+    }
+  });
+});
+
+// ─── Hand-computed math on a tiny trace ──────────────────────────────
+
+describe("computeFR — closed-form math on noise-free trace", () => {
+  it("recovers exact peak / final / absoluteForgetting on a 2-task 4-epoch trace", () => {
+    // Two tasks, 2 epochs each. Defaults: baseline 0.05, plateau 0.95,
+    // learningRate 0.5, forgettingRate 0.05. Closed-form recurrence:
+    //   k = 1 − e^-0.5 ≈ 0.3934693
+    //   d = e^-0.05  ≈ 0.9512294
+    // Epoch 0: A trains. accA(0) = 0.05 + 0.9·k ≈ 0.4041224
+    // Epoch 1: A trains. accA(1) = 0.4041224 + (0.95 − 0.4041224)·k
+    //                            ≈ 0.6189085
+    // Epoch 2: B trains. accA(2) = 0.05 + (0.6189085 − 0.05)·d
+    //                            ≈ 0.5911531
+    // Epoch 3: B trains. accA(3) = 0.05 + (0.5911531 − 0.05)·d
+    //                            ≈ 0.5647674
+    // For task B, mirror: B peaks at epoch 3 ≈ 0.6189085.
+    const tasks: TaskRef[] = [
+      { id: "A", label: "A", scope: "attack-class" },
+      { id: "B", label: "B", scope: "attack-class" },
+    ];
+    const trace = buildSyntheticTrainingTrace({
+      id: "tiny",
+      label: "Tiny",
+      tasks,
+      curriculum: sequentialCurriculum(["A", "B"], 2),
+      noiseAmplitude: 0,
+    });
+    const result = computeFR(trace);
+    const a = result.tasks.find((t) => t.taskId === "A")!;
+    const b = result.tasks.find((t) => t.taskId === "B")!;
+
+    // Task A: trained epochs 0-1, then decays for epochs 2-3.
+    expect(a.peakAccuracy).toBeCloseTo(0.6189085, 3);
+    expect(a.peakEpoch).toBe(1);
+    expect(a.finalAccuracy).toBeCloseTo(0.5647674, 3);
+    const expectedAF = 0.6189085 - 0.5647674;
+    expect(a.absoluteForgetting).toBeCloseTo(expectedAF, 3);
+    expect(a.normalizedFR).toBeCloseTo(expectedAF / 0.6189085, 3);
+
+    // Task B: never trained for epochs 0-1, then trained 2-3 → peaks
+    // at final epoch → absoluteForgetting ≈ 0.
+    expect(b.peakAccuracy).toBeCloseTo(0.6189085, 3);
+    expect(b.peakEpoch).toBe(3);
+    expect(b.finalAccuracy).toBeCloseTo(0.6189085, 3);
+    expect(b.absoluteForgetting).toBeCloseTo(0, 6);
+    expect(b.normalizedFR).toBeCloseTo(0, 6);
+  });
+
+  it("frOverTime[i] = peakSoFar(i) − acc(i) exactly", () => {
+    const tasks: TaskRef[] = [
+      { id: "A", label: "A", scope: "attack-class" },
+      { id: "B", label: "B", scope: "attack-class" },
+    ];
+    const trace = buildSyntheticTrainingTrace({
+      id: "fr-time",
+      label: "FR over time",
+      tasks,
+      curriculum: sequentialCurriculum(["A", "B"], 2),
+      noiseAmplitude: 0,
+    });
+    const result = computeFR(trace);
+    const a = result.tasks.find((t) => t.taskId === "A")!;
+    // Hand-check epoch by epoch using the raw accuracy from the trace.
+    let peakSoFar = -Infinity;
+    for (let i = 0; i < trace.epochs.length; i++) {
+      const acc = trace.epochs[i].accuracy.find((x) => x.taskId === "A")!.value;
+      if (acc > peakSoFar) peakSoFar = acc;
+      const expectedFr = Math.max(0, peakSoFar - acc);
+      expect(a.frOverTime[i]).toBeCloseTo(expectedFr, 10);
+      const expectedNfr = peakSoFar > 0 ? expectedFr / peakSoFar : 0;
+      expect(a.normalizedFROverTime[i]).toBeCloseTo(expectedNfr, 10);
+    }
+  });
+});
+
+// ─── Heartbleed archetype ────────────────────────────────────────────
+
+describe("computeFR — Heartbleed archetype", () => {
+  it("a high-forgettingRate task ranks first in normalizedFR", () => {
+    // Train each task for 3 epochs, then 6 more epochs where it's not
+    // active. Heartbleed has forgettingRate 0.3, others 0.05. After
+    // 6 epochs of no training, Heartbleed retains exp(-0.3·6) ≈ 16.5%
+    // of its above-baseline accuracy; DDoS retains exp(-0.05·6) ≈ 74%.
+    // So normalizedFR(heartbleed) should be substantially larger than
+    // normalizedFR(ddos).
+    const trace = buildSyntheticTrainingTrace({
+      id: "heartbleed-archetype",
+      label: "Heartbleed archetype",
+      tasks: ATTACK_TASKS,
+      // Train Heartbleed FIRST so it has the longest off-task tail.
+      curriculum: [
+        { taskId: "task_heartbleed", startEpoch: 0, endEpoch: 3 },
+        { taskId: "task_ddos", startEpoch: 3, endEpoch: 6 },
+        { taskId: "task_mitm", startEpoch: 6, endEpoch: 9 },
+      ],
+      taskDynamics: {
+        task_heartbleed: { forgettingRate: 0.3 },
+        task_ddos: { forgettingRate: 0.05 },
+        task_mitm: { forgettingRate: 0.05 },
+      },
+      noiseAmplitude: 0,
+    });
+    const result = computeFR(trace);
+    const ranked = rankTasksByNormalizedFR(result);
+    expect(ranked[0].taskId).toBe("task_heartbleed");
+    const heart = result.tasks.find((t) => t.taskId === "task_heartbleed")!;
+    const ddos = result.tasks.find((t) => t.taskId === "task_ddos")!;
+    expect(heart.normalizedFR).toBeGreaterThan(ddos.normalizedFR);
+    // Heartbleed should have lost a substantial fraction of its peak.
+    expect(heart.normalizedFR).toBeGreaterThan(0.3);
+  });
+});
+
+// ─── Decay-rate fit ──────────────────────────────────────────────────
+
+describe("computeFR — decayRate fit", () => {
+  it("recovers a known forgettingRate within tolerance", () => {
+    // Set up a task that trains for 4 epochs (saturates near plateau),
+    // then has a long off-task tail of 16 epochs to fit the decay on.
+    // forgettingRate = 0.20, expecting decayRate ≈ 0.20.
+    const trace = buildSyntheticTrainingTrace({
+      id: "decay-recovery",
+      label: "Decay recovery",
+      tasks: [{ id: "T", label: "T", scope: "attack-class" }],
+      curriculum: [{ taskId: "T", startEpoch: 0, endEpoch: 4 }],
+      taskDynamics: { T: { forgettingRate: 0.2, plateau: 0.95, baseline: 0.05 } },
+      noiseAmplitude: 0,
+    });
+    // Add 16 more epochs by extending the trace via a second task
+    // never trained (so total epoch count = 20).
+    const traceLong = buildSyntheticTrainingTrace({
+      id: "decay-recovery-long",
+      label: "Decay recovery long",
+      tasks: [
+        { id: "T", label: "T", scope: "attack-class" },
+        { id: "U", label: "U", scope: "attack-class" },
+      ],
+      curriculum: [
+        { taskId: "T", startEpoch: 0, endEpoch: 4 },
+        { taskId: "U", startEpoch: 4, endEpoch: 20 },
+      ],
+      taskDynamics: { T: { forgettingRate: 0.2, plateau: 0.95, baseline: 0.05 } },
+      noiseAmplitude: 0,
+    });
+    // Override baseline so the regression uses the TRUE baseline (0.05)
+    // rather than the empirical min — the generator's exponential
+    // decay is exactly λ when baseline matches.
+    const result = computeFR(traceLong, { baselinePerTask: { T: 0.05 } });
+    const t = result.tasks.find((x) => x.taskId === "T")!;
+    expect(t.decayRate).toBeCloseTo(0.2, 2);
+    // Quick sanity that the shorter trace still produces a usable
+    // decayRate (the post-peak window is short but non-empty).
+    void trace;
+  });
+
+  it("returns NaN decayRate when task never decays below peak", () => {
+    // Task is trained on the LAST epoch → peak is final → no post-peak
+    // window. fitDecayRate returns NaN.
+    const trace = buildSyntheticTrainingTrace({
+      id: "no-decay",
+      label: "No decay",
+      tasks: [{ id: "T", label: "T", scope: "attack-class" }],
+      curriculum: [{ taskId: "T", startEpoch: 0, endEpoch: 3 }],
+      noiseAmplitude: 0,
+    });
+    const result = computeFR(trace);
+    const t = result.tasks.find((x) => x.taskId === "T")!;
+    // peakEpoch is the final epoch (2), so there are no post-peak
+    // points → decayRate is NaN.
+    expect(Number.isNaN(t.decayRate)).toBe(true);
+  });
+
+  it("returns NaN decayRate when post-peak window has only one point", () => {
+    // 2 training epochs + 1 off-task epoch → one post-peak point →
+    // regression undefined (< 2 points).
+    const trace = buildSyntheticTrainingTrace({
+      id: "one-point",
+      label: "One point",
+      tasks: [
+        { id: "T", label: "T", scope: "attack-class" },
+        { id: "U", label: "U", scope: "attack-class" },
+      ],
+      curriculum: [
+        { taskId: "T", startEpoch: 0, endEpoch: 2 },
+        { taskId: "U", startEpoch: 2, endEpoch: 3 },
+      ],
+      noiseAmplitude: 0,
+    });
+    const result = computeFR(trace);
+    const t = result.tasks.find((x) => x.taskId === "T")!;
+    expect(Number.isNaN(t.decayRate)).toBe(true);
+  });
+});
+
+// ─── Convenience helpers ─────────────────────────────────────────────
+
+describe("rankTasksByNormalizedFR", () => {
+  it("sorts descending by normalizedFR with NaN entries pushed to the end", () => {
+    // Build a trace where one task has NaN normalizedFR (never trained
+    // → peakAccuracy = baseline > 0 actually, so normalizedFR is
+    // defined… but absoluteForgetting = 0 → normalizedFR = 0, not NaN).
+    // To get NaN, peakAccuracy must be ≤ 0. We can't construct that
+    // with the synthetic generator (baseline defaults to 0.05).
+    // Instead, hand-build a trace with a task that has acc = 0 every
+    // epoch.
+    const trace: TrainingTrace = {
+      id: "nan-rank",
+      label: "NaN rank",
+      source: {
+        adapter: "test",
+        adapterVersion: "0.0.0",
+        kind: "synthetic",
+        builtAt: new Date().toISOString(),
+      },
+      tasks: [
+        { id: "A", label: "A", scope: "attack-class" },
+        { id: "B", label: "B", scope: "attack-class" },
+        { id: "C", label: "C", scope: "attack-class" },
+      ],
+      epochs: [
+        {
+          index: 0,
+          activeTaskIds: ["A"],
+          accuracy: [
+            { taskId: "A", value: 0.8 },
+            { taskId: "B", value: 0.6 },
+            { taskId: "C", value: 0 }, // never had any signal
+          ],
+        },
+        {
+          index: 1,
+          activeTaskIds: ["B"],
+          accuracy: [
+            { taskId: "A", value: 0.4 }, // decayed
+            { taskId: "B", value: 0.6 }, // same
+            { taskId: "C", value: 0 }, // still zero
+          ],
+        },
+      ],
+      metadata: { description: "test", accessTier: "internal-only" },
+    };
+    const result = computeFR(trace);
+    const ranked = rankTasksByNormalizedFR(result);
+    // A has FR 0.5, B has FR 0, C has peak=0 → normalizedFR is NaN.
+    expect(ranked[0].taskId).toBe("A");
+    expect(ranked[1].taskId).toBe("B");
+    expect(ranked[2].taskId).toBe("C");
+    expect(Number.isNaN(ranked[2].normalizedFR)).toBe(true);
+  });
+});
+
+describe("meanNormalizedFR", () => {
+  it("averages over tasks with defined normalizedFR", () => {
+    const result = computeFR(defaultTrace());
+    const defined = result.tasks.filter((t) => !Number.isNaN(t.normalizedFR));
+    const expected =
+      defined.reduce((s, t) => s + t.normalizedFR, 0) / defined.length;
+    expect(meanNormalizedFR(result)).toBeCloseTo(expected, 12);
+  });
+
+  it("returns NaN when no task has a defined normalizedFR", () => {
+    // Build a degenerate trace where every task has peakAccuracy = 0.
+    const trace: TrainingTrace = {
+      id: "degenerate",
+      label: "Degenerate",
+      source: {
+        adapter: "test",
+        adapterVersion: "0.0.0",
+        kind: "synthetic",
+        builtAt: new Date().toISOString(),
+      },
+      tasks: [
+        { id: "A", label: "A", scope: "attack-class" },
+        { id: "B", label: "B", scope: "attack-class" },
+      ],
+      epochs: [
+        {
+          index: 0,
+          activeTaskIds: [],
+          accuracy: [
+            { taskId: "A", value: 0 },
+            { taskId: "B", value: 0 },
+          ],
+        },
+      ],
+      metadata: { description: "test", accessTier: "internal-only" },
+    };
+    const result = computeFR(trace);
+    expect(Number.isNaN(meanNormalizedFR(result))).toBe(true);
+  });
+});
+
+// ─── Argument validation ─────────────────────────────────────────────
+
+describe("computeFR — argument validation", () => {
+  it("rejects empty epochs", () => {
+    const trace = defaultTrace();
+    const forged = { ...trace, epochs: [] };
+    expect(() => computeFR(forged)).toThrow(/zero epochs/);
+  });
+
+  it("rejects empty tasks", () => {
+    const trace = defaultTrace();
+    const forged = { ...trace, tasks: [] };
+    expect(() => computeFR(forged)).toThrow(/zero tasks/);
+  });
+});

--- a/src/lib/discovery/fr-estimator.ts
+++ b/src/lib/discovery/fr-estimator.ts
@@ -1,0 +1,321 @@
+// ─── Discovery — FR (Forgetting Rate) Estimator ──────────────────────
+//
+// Phase 3 PR 3 of the Ghauri 2025 dissertation integration. Reads a
+// TrainingTrace (from PR #380) and computes per-task Forgetting Rate
+// values — how much accuracy on Task A was lost after training shifted
+// away from it.
+//
+// Why this matters for AI Safety: the dissertation's Ch. 8 catastrophic-
+// forgetting analysis argues that some attack classes (Heartbleed is
+// the archetype) get forgotten dramatically faster than others when
+// the curriculum shifts. FR is the per-task scalar that surfaces that
+// asymmetry — a high FR on Heartbleed = "the IDS just stopped catching
+// this attack class because training moved to DDoS."
+//
+// DOMAIN GATING
+// -------------
+// AI-domain only in SEMANTICS. The function signature is profile-
+// agnostic — same pattern as `computeBESTemporal` from PR #385 — and
+// gating happens upstream in the UI (PR 4 will only render FR on
+// AI_SAFETY_PROFILE). Geopolitical / T1D / other domains never invoke
+// this; their R-pillar still comes from Pearl-counterfactual recovery.
+//
+// PROVENANCE
+// ----------
+// The result forwards `source.kind` from the input trace verbatim.
+// UI surfaces displaying values derived from a synthetic result MUST
+// render a SYNTHETIC badge (preserving the contract from PR #380).
+//
+// FORMULAS
+// --------
+// For each task k tracked in the trace:
+//
+//   peakAccuracy_k       = max_t acc_{t, k}
+//   peakEpoch_k          = argmax_t acc_{t, k}
+//   finalAccuracy_k      = acc_{final, k}
+//   lastTrainedEpoch_k   = max_{t : k ∈ activeTaskIds_t} t  (or -1 if never)
+//   absoluteForgetting_k = peakAccuracy_k − finalAccuracy_k         (≥ 0)
+//   normalizedFR_k       = absoluteForgetting_k / peakAccuracy_k    (∈ [0, 1])
+//
+// And the time-varying signal that PR 4 reads to compute Ω-Forgetting
+// Pressure:
+//
+//   FR_k(t)            = max_{s ≤ t} acc_{s, k} − acc_{t, k}
+//   normalizedFR_k(t)  = FR_k(t) / max_{s ≤ t} acc_{s, k}    (or 0 when peak=0)
+//
+// Plus the empirical decay rate λ, fit on the post-peak window via
+// least-squares regression on log-residuals:
+//
+//   acc(t) − baseline = (peak − baseline) · exp(−λ · (t − peakEpoch))
+//   ⇒ log((acc(t) − baseline) / (peak − baseline)) = −λ · (t − peakEpoch)
+//
+// Linear regression on (t − peakEpoch, −log(...)) gives slope λ. Used
+// to verify the dissertation's synthetic-archetype tests (a trace
+// built with `forgettingRate: 0.30` should yield decayRate ≈ 0.30).
+// Returns NaN when there are fewer than 2 valid post-peak points
+// (insufficient data) or the task never decayed below peak (no
+// forgetting to fit).
+
+import type { TrainingTrace } from "./training-trace-types";
+
+export interface FRTaskResult {
+  taskId: string;
+  /** Highest accuracy observed for this task across the full trace. */
+  peakAccuracy: number;
+  /** Epoch index at which peakAccuracy was reached. */
+  peakEpoch: number;
+  /** Accuracy at the trace's final epoch. */
+  finalAccuracy: number;
+  /**
+   * Last epoch this task appeared in `activeTaskIds`. -1 if the task
+   * never trained — important guard: a task that never trained
+   * can't be "forgotten" in any meaningful sense.
+   */
+  lastTrainedEpoch: number;
+
+  /**
+   * Time-varying FR. `frOverTime[i]` = peak-so-far minus accuracy at
+   * epoch i. Length matches `trace.epochs.length`. Non-decreasing in
+   * the trivial sense (peak-so-far never decreases, and current
+   * accuracy can only re-establish a higher peak by replacing it,
+   * not by lowering FR).
+   */
+  frOverTime: number[];
+  /**
+   * Time-varying normalized FR ∈ [0, 1]. `normalizedFROverTime[i]`
+   * = `frOverTime[i] / peakSoFar(i)`. Zero when peakSoFar is 0
+   * (no training has happened yet for this task).
+   */
+  normalizedFROverTime: number[];
+
+  // ── Summary scalars ─────────────────────────────────────────────
+  /** peakAccuracy − finalAccuracy. ≥ 0. */
+  absoluteForgetting: number;
+  /** absoluteForgetting / peakAccuracy. ∈ [0, 1]. NaN when peakAccuracy ≤ 0. */
+  normalizedFR: number;
+  /**
+   * Empirical decay rate λ fit on the post-peak window.
+   * `acc(t) ≈ baseline + (peak − baseline) · exp(−λ · (t − peakEpoch))`.
+   * NaN when the fit is unreliable (< 2 valid post-peak points, or
+   * task never decayed below peak).
+   */
+  decayRate: number;
+}
+
+export interface FRResult {
+  tasks: FRTaskResult[];
+  /** Inherited verbatim from `trace.source.kind`. SYNTHETIC-badge gate. */
+  sourceKind: "synthetic" | "live";
+  /** Echo of the input trace id for downstream cross-reference. */
+  traceId: string;
+}
+
+export interface ComputeFROptions {
+  /**
+   * Baseline accuracy used in the decay-rate fit. The fit converges
+   * to exp(-λ·n) only when `(acc − baseline) / (peak − baseline)`
+   * stays in (0, 1]. If the caller knows the architecture's
+   * pre-training baseline, pass it here per task.
+   *
+   * Default: each task uses the minimum accuracy seen for it across
+   * the full trace as its baseline. Robust to traces where the
+   * "pre-training" epoch isn't 0.
+   */
+  baselinePerTask?: Record<string, number>;
+}
+
+// ─── Implementation helpers ─────────────────────────────────────────
+
+/**
+ * Least-squares linear regression of y on x. Returns the slope
+ * (β = Σ(x_i − x̄)(y_i − ȳ) / Σ(x_i − x̄)²). NaN when there are
+ * fewer than 2 points or all x values are identical (degenerate).
+ */
+function linRegressionSlope(xs: number[], ys: number[]): number {
+  const n = xs.length;
+  if (n < 2 || ys.length !== n) return NaN;
+  let sumX = 0;
+  let sumY = 0;
+  for (let i = 0; i < n; i++) {
+    sumX += xs[i];
+    sumY += ys[i];
+  }
+  const meanX = sumX / n;
+  const meanY = sumY / n;
+  let num = 0;
+  let den = 0;
+  for (let i = 0; i < n; i++) {
+    const dx = xs[i] - meanX;
+    num += dx * (ys[i] - meanY);
+    den += dx * dx;
+  }
+  if (den === 0) return NaN;
+  return num / den;
+}
+
+/**
+ * Fit decay rate λ on a post-peak accuracy window.
+ *
+ *   acc(t) = baseline + (peak − baseline) · exp(−λ · (t − peakEpoch))
+ *
+ * Returns NaN when the fit is unreliable (insufficient data, no
+ * decay, or numerical degenerate cases — accuracy below baseline at
+ * every post-peak point, etc.).
+ */
+function fitDecayRate(
+  epochs: number[],
+  accs: number[],
+  peakEpoch: number,
+  peakAcc: number,
+  baseline: number,
+): number {
+  if (peakAcc <= baseline) return NaN;
+  const range = peakAcc - baseline;
+  const xs: number[] = [];
+  const negLogYs: number[] = [];
+  for (let i = 0; i < epochs.length; i++) {
+    const t = epochs[i];
+    if (t <= peakEpoch) continue;
+    const dt = t - peakEpoch;
+    const y = (accs[i] - baseline) / range;
+    if (y <= 0 || y > 1) continue; // out of the model's valid range
+    xs.push(dt);
+    negLogYs.push(-Math.log(y));
+  }
+  return linRegressionSlope(xs, negLogYs);
+}
+
+// ─── Main entry point ───────────────────────────────────────────────
+
+/**
+ * Compute per-task FR values from a TrainingTrace. AI-domain semantics
+ * (gating happens upstream); profile-agnostic at the function level.
+ *
+ * Throws on empty trace — the caller should validate upstream via
+ * `validateTrainingTrace` before this point. Returns NaN entries
+ * gracefully for tasks that never trained or never decayed.
+ */
+export function computeFR(
+  trace: TrainingTrace,
+  options: ComputeFROptions = {},
+): FRResult {
+  if (trace.epochs.length === 0) {
+    throw new Error("computeFR: trace has zero epochs");
+  }
+  if (trace.tasks.length === 0) {
+    throw new Error("computeFR: trace has zero tasks");
+  }
+
+  const baselineOverride = options.baselinePerTask ?? {};
+  const taskResults: FRTaskResult[] = trace.tasks.map((task) => {
+    // ── Walk the trace once for this task. ──────────────────────
+    let peakAccuracy = -Infinity;
+    let peakEpoch = -1;
+    let lastTrainedEpoch = -1;
+    let minAccuracy = Infinity;
+    const accs: number[] = [];
+    const epochIndices: number[] = [];
+    const frOverTime: number[] = [];
+    const normalizedFROverTime: number[] = [];
+    let peakSoFar = -Infinity;
+
+    for (const epoch of trace.epochs) {
+      epochIndices.push(epoch.index);
+      const entry = epoch.accuracy.find((a) => a.taskId === task.id);
+      // Missing accuracy entries (shouldn't happen on validated traces
+      // but we defend) treat as 0 to keep the time series length
+      // consistent.
+      const acc = entry?.value ?? 0;
+      accs.push(acc);
+      if (acc > peakAccuracy) {
+        peakAccuracy = acc;
+        peakEpoch = epoch.index;
+      }
+      if (acc < minAccuracy) minAccuracy = acc;
+      if (acc > peakSoFar) peakSoFar = acc;
+      const fr = Math.max(0, peakSoFar - acc);
+      frOverTime.push(fr);
+      normalizedFROverTime.push(peakSoFar > 0 ? fr / peakSoFar : 0);
+      if (epoch.activeTaskIds.includes(task.id)) {
+        lastTrainedEpoch = epoch.index;
+      }
+    }
+
+    const finalAccuracy = accs[accs.length - 1];
+    const absoluteForgetting = Math.max(0, peakAccuracy - finalAccuracy);
+    const normalizedFR =
+      peakAccuracy > 0 ? absoluteForgetting / peakAccuracy : NaN;
+
+    // ── Decay-rate fit ─────────────────────────────────────────
+    // Default baseline: minimum accuracy observed across the trace.
+    // Override available per-task via options.
+    const baseline = baselineOverride[task.id] ?? minAccuracy;
+    const decayRate = fitDecayRate(
+      epochIndices,
+      accs,
+      peakEpoch,
+      peakAccuracy,
+      baseline,
+    );
+
+    return {
+      taskId: task.id,
+      peakAccuracy: peakAccuracy === -Infinity ? 0 : peakAccuracy,
+      peakEpoch: peakEpoch === -1 ? 0 : peakEpoch,
+      finalAccuracy,
+      lastTrainedEpoch,
+      frOverTime,
+      normalizedFROverTime,
+      absoluteForgetting,
+      normalizedFR,
+      decayRate,
+    };
+  });
+
+  return {
+    tasks: taskResults,
+    sourceKind: trace.source.kind,
+    traceId: trace.id,
+  };
+}
+
+// ─── Convenience helpers ────────────────────────────────────────────
+
+/**
+ * Rank tasks by `normalizedFR` descending. The dissertation's
+ * Heartbleed-archetype is exactly the task at the top of this list:
+ * highest fraction of peak accuracy lost. Useful for the
+ * forgetting-pressure surface (PR 4).
+ */
+export function rankTasksByNormalizedFR(result: FRResult): FRTaskResult[] {
+  // Sort with NaN at the end (NaN comparisons always return false).
+  return [...result.tasks].sort((a, b) => {
+    const an = Number.isNaN(a.normalizedFR);
+    const bn = Number.isNaN(b.normalizedFR);
+    if (an && bn) return 0;
+    if (an) return 1;
+    if (bn) return -1;
+    return b.normalizedFR - a.normalizedFR;
+  });
+}
+
+/**
+ * Aggregate per-task FR into a single trace-level scalar — the mean
+ * of `normalizedFR` across tasks that have a defined (non-NaN) value.
+ * Returns NaN when no task has a defined FR (degenerate trace).
+ *
+ * This is NOT yet the Ω-Forgetting Pressure metric — that one weights
+ * each task's FR by an exposure value (Σ exposure × FR), and exposure
+ * comes from outside the trace. PR 4 builds Ω-FP on top of this.
+ */
+export function meanNormalizedFR(result: FRResult): number {
+  let sum = 0;
+  let count = 0;
+  for (const t of result.tasks) {
+    if (!Number.isNaN(t.normalizedFR)) {
+      sum += t.normalizedFR;
+      count++;
+    }
+  }
+  return count === 0 ? NaN : sum / count;
+}


### PR DESCRIPTION
## Summary

- Phase 3 PR 3 of the Ghauri 2025 dissertation integration. Reads a `TrainingTrace` (PR #380) and computes per-task Forgetting Rate values — how much accuracy on Task A was lost after training shifted away from it.
- `computeFR(trace, options)` returns an `FRResult` with per-task summary scalars (`peakAccuracy`, `peakEpoch`, `finalAccuracy`, `absoluteForgetting`, `normalizedFR`, `decayRate`) plus time-varying `frOverTime` / `normalizedFROverTime` series for the Ω-Forgetting-Pressure surface PR 4 will read.
- `decayRate` fit: least-squares regression on log-residuals of the exponential-decay model `acc(t) = baseline + (peak - baseline) * exp(-λ * (t - peakEpoch))`. Recovers the synthetic generator's `forgettingRate` parameter within tolerance.
- `rankTasksByNormalizedFR()` surfaces the Heartbleed archetype (the task that lost the largest fraction of its peak accuracy). `meanNormalizedFR()` is a trace-level scalar (NOT yet Ω-Forgetting Pressure — that weights by exposure in PR 4).

## Provenance contract preserved

`result.sourceKind` is forwarded verbatim from `trace.source.kind`. UI surfaces displaying synthetic-derived values MUST render a SYNTHETIC badge — PR 4 wires this end-to-end so no customer business decision is ever made off synthetic data without the discriminator visible.

## Domain gating

AI-domain semantics only. Function signature is profile-agnostic — same pattern as `computeBESTemporal` from PR #385 — and gating happens upstream in the UI (PR 4 only renders FR on `AI_SAFETY_PROFILE`). Geopolitical / T1D / other profiles never invoke this and continue using Pearl-counterfactual recovery for the R-pillar.

## Test plan

- [x] Shape contracts: one entry per task, time series length matches `trace.epochs`, FR values non-negative, identities (`absoluteForgetting = peakAccuracy − finalAccuracy`, `normalizedFR = absoluteForgetting / peakAccuracy`)
- [x] Provenance: `sourceKind` and `traceId` forwarded from trace
- [x] Curriculum semantics: `lastTrainedEpoch` matches last activeTaskIds appearance; never-trained task gets `-1`; `peakEpoch` lands inside the trained window
- [x] Closed-form math on a 2-task 4-epoch trace using the synthetic generator's logistic-learn + exponential-decay recurrence
- [x] Heartbleed archetype: high-`forgettingRate` task ranks first in `normalizedFR`
- [x] Decay-rate fit recovers a known `forgettingRate = 0.2` within tolerance; returns NaN on no-decay traces and on traces with < 2 post-peak points
- [x] Helper convenience: `rankTasksByNormalizedFR` pushes NaN entries to the end; `meanNormalizedFR` averages defined values and returns NaN on degenerate traces
- [x] Argument validation: empty epochs / empty tasks throw

21 new tests pass. All 76 Phase 3 substrate+BES+FR tests pass. No TypeScript errors in changed files.

## What's next

- **PR 4** — Ω-Forgetting Pressure metric (`Σ exposure × FR`) + UX surface with SYNTHETIC badges wired through the panel that consumes this result.
- **PR 5** — Real ingester (PyTorch / TF training-log adapter) that emits `source.kind = "live"` traces, flipping the badge to LIVE for customer-facing use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
