### PR TITLE
fix(copilot): steer isolate_nodes to ids= for semantic intents

### DIFF
--- a/src/lib/copilot/eval/cases/seed.ts
+++ b/src/lib/copilot/eval/cases/seed.ts
@@ -287,14 +287,14 @@ export const SEED_CASES: TestCase[] = [
   {
     id: "isolate_by_explicit_ids",
     description:
-      "User names two nodes by id — should isolate to that pair.",
+      "User names two nodes by close-to-id phrasing — should isolate to that pair, mapping the user's text to the real graph ids (GRID_USA, FAB_TW).",
     user_message:
-      "show only USA_GRID and FAB_TW, hide everything else",
+      "show only USA Grid and TSMC Fab, hide everything else",
     graph_fixture: "geopolitical_main",
     accepted_tool_calls: [
       {
         name: "isolate_nodes",
-        params_match: { ids: { array_includes: "USA_GRID" } },
+        params_match: { ids: { array_includes: "GRID_USA" } },
       },
     ],
     tags: ["tool-selection", "filtering"],

--- a/src/lib/copilot/tools.ts
+++ b/src/lib/copilot/tools.ts
@@ -49,9 +49,13 @@ defineTool({
 defineTool({
   name: "isolate_nodes",
   description:
-    "Filter the visible graph to a subset of nodes — by free-text query or explicit ids. Non-matching nodes dim out across 2D / 3D / map views.",
+    "Filter the visible graph to a subset of nodes. Two modes: `query=<text>` does a literal substring match against id/shortLabel/label/category/domain (no semantic inference). `ids=A|B|C` isolates an explicit list. Non-matching nodes dim out across 2D / 3D / map views.",
   guidance:
-    "Use whenever the user names a topic, theme, sector, or set of entities ('focus on energy infrastructure', 'just show me the semiconductor stuff'). Match a query against label/category/domain; pass ids when the user names specific nodes. Emit reset_isolation when the conversation broadens again.",
+    "Pick the right mode:\n" +
+    "  - `ids=A|B|C` (PREFERRED for any semantic intent): when the user names a REGION, THEME, GEOGRAPHY, OR ANY CONCEPT that requires you to REASON about which nodes apply. You can see the full node list in === NODES === above — enumerate the relevant ids and emit them. Example: 'show me Europe-related' → enumerate the undersea cables that traverse Europe, the European banks, etc, then emit `ids=ic_flag_europe_asia|ic_seamewe5|fc_cross_border_banking|...`.\n" +
+    "  - `query=<text>` (ONLY for clear literal-substring intent): when you'd expect the literal text to appear in node names/labels. Example: 'show me energy nodes' where many node labels contain 'energy'. If you're not sure the literal text is in the searched fields (id/shortLabel/label/category/domain), use `ids=` instead — `query=` does NOT do semantic matching, only substring.\n" +
+    "Do NOT pre-narrate which specific nodes will be matched. The SYS line below your response shows the actual result. Describe the intent ('isolating Europe-related nodes') and let the result line confirm. If you list specific nodes in prose and the tool matches a different set, the user sees a mismatch.\n" +
+    "Emit reset_isolation when the conversation broadens again.",
   params: {
     query: {
       type: "string",


### PR DESCRIPTION
## What you saw

```
YOU: "show me just the [nodes] that are relevant to anything related to Europe"

APEX:
[ISOLATION ACTIVATED] The graph is now filtered to nodes relevant to "Europe":
*  FLAG EUROPE ASIA (ic_flag_europe_asia)
*  SEA-ME-WE 5 (ic_seamewe5)
*  SEA-ME-WE 6 (ic_seamewe6)
*  Orange Marine (ic_orange_marine)
*  Cross-Border Banking (fc_cross_border_banking)

SYS:
ACTIONS EXECUTED:
  • Isolated 2 nodes matching query="Europe": FEA, AA1
```

The AI's prose lists **5 nodes**. The actual tool result isolated **2**. User sees a mismatch.

## Why

LLM emitted `isolate_nodes:query=Europe`. The handler does a *literal substring* search across `id/shortLabel/label/category/domain`. Only 2 nodes have "europe" literally in those fields. The other 3 are **semantically** Europe-related (cable routes through Europe, European banking exposure) — the LLM correctly reasoned that, but the tool can't infer semantic relevance.

The `ids=A|B|C` mode would have worked — `isolate_nodes:ids=ic_flag_europe_asia|ic_seamewe5|ic_seamewe6|ic_orange_marine|fc_cross_border_banking`. The LLM can see those ids in the `=== NODES ===` block of the system prompt. It just defaulted to `query=` because the existing guidance only steered `ids=` for "when the user names specific nodes."

## Fix — prompt nudge

Rewrote `isolate_nodes` guidance with two clear paths and an anti-hallucination clause:

```
Pick the right mode:
  - ids=A|B|C (PREFERRED for any semantic intent): when the user names a
    REGION, THEME, GEOGRAPHY, OR ANY CONCEPT that requires you to REASON
    about which nodes apply. You can see the full node list in
    === NODES === above — enumerate the relevant ids and emit them.
    Example: 'show me Europe-related' → enumerate the undersea cables
    that traverse Europe, the European banks, etc, then emit
    ids=ic_flag_europe_asia|ic_seamewe5|fc_cross_border_banking|...
  - query=<text> (ONLY for clear literal-substring intent): when you'd
    expect the literal text to appear in node names/labels. Example:
    'show me energy nodes' where many node labels contain 'energy'.
    If you're not sure the literal text is in the searched fields,
    use ids= instead — query= does NOT do semantic matching, only substring.

Do NOT pre-narrate which specific nodes will be matched. The SYS line
below your response shows the actual result. Describe the intent
('isolating Europe-related nodes') and let the result line confirm.
If you list specific nodes in prose and the tool matches a different
set, the user sees a mismatch.
```

Tool description also tightened: `"query does a literal substring match … (no semantic inference)"`.

## Side fix — broken eval test case

While running the eval to verify the change, the `isolate_by_explicit_ids` case failed — turned out the case had a typo. User message said `USA_GRID and FAB_TW` but the actual graph id is `GRID_USA`. The case asserted `array_includes("USA_GRID")` — wrong literal.

With the new guidance, Gemini correctly looks up the real `GRID_USA` from the `=== NODES ===` list instead of echoing the user's typo. That's *exactly* the behavior we want. Updated the case:
- Friendlier user message (`USA Grid and TSMC Fab` — label-style, exercises the inference path)
- Correct expected assertion (`array_includes("GRID_USA")`)

## Test plan

- [x] 160/160 existing copilot tests pass
- [x] **Live eval against Gemini Flash: 20/20 PASS**, mean 1608ms
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `next build` passes
- [ ] Manual after merge: ask the chat "show me nodes related to Europe" — expect AI to emit `isolate_nodes:ids=` with multiple Europe-related ids enumerated, and the SYS line should match what the AI describes

## What this doesn't fix

If a future user query is genuinely ambiguous (e.g. "show me critical stuff" — what counts?), the LLM still has to make a judgment call about which nodes to enumerate. The new guidance reduces hallucination *risk* but doesn't eliminate it — the LLM might still confidently enumerate the "wrong" set per the user's intent. Workaround in those cases: be more specific, or ask the AI to list the candidates first ("which nodes do you consider Europe-related?") before isolating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
