### PR TITLE
fix(ui): remove stray &quot;CLIENT DEPLOYMENT → Athena Defense&quot; CTA on the canvas

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -883,6 +883,21 @@ The always-mount pattern was in place to keep the 3D WebGL context alive across 
 
 ---
 
+### 2026-05-22 — Shipped: remove stray "CLIENT DEPLOYMENT → Athena Defense" CTA from the canvas
+
+**PR:** TBD (about to open).
+
+**Trigger.** User: *"we randomly have on the bottom right of the product itself … CLIENT DEPLOYMENT … ATHENA DEFENSE SYSTEMS. It's just so random. I feel like this was intended to be a sandbox, but it seems like it's heavily out of date now … if we're gonna offer a sandbox, I feel like there's a different format that we should do it."*
+
+**What shipped.** Removed the `bottom-4 right-4` floating `<Link href="/client">` and dropped the now-unused `next/link` import in `src/app/page.tsx`. The `/client` route itself stays put — that's a separate decision; this PR only takes the CTA off the workspace canvas where it was reading as a promo on top of the user's live analysis.
+
+**Files.**
+- `src/app/page.tsx` — removed the floating CTA + `Link` import.
+
+**Verification.** `tsc --noEmit` clean (same inherited fci.test drift); lint clean on touched file; vitest 1319/1319 pass.
+
+---
+
 ## How a fresh session resumes
 
 1. Read this file bottom-up — the most recent entry is the live state.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
 import dynamic from "next/dynamic";
 import { useApexStore } from "@/stores/useApexStore";
 import { protectGraphData } from "@/lib/data-protection";
@@ -202,27 +201,12 @@ export default function Home() {
                 <CausalDAGRelief />
               </div>
             )}
-            {/* Client deployment CTA */}
-            <Link
-              href="/client"
-              className="absolute bottom-4 right-4 z-10 group flex items-center gap-2 px-3 py-2 rounded border border-border bg-surface-elevated/80 backdrop-blur-sm hover:border-accent-cyan/60 transition-all duration-200"
-            >
-              <span className="relative flex h-2 w-2">
-                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-accent-cyan opacity-75" />
-                <span className="relative inline-flex rounded-full h-2 w-2 bg-accent-cyan" />
-              </span>
-              <div className="flex flex-col">
-                <span className="text-[9px] font-[family-name:var(--font-michroma)] tracking-wider text-foreground group-hover:text-accent-cyan transition-colors">
-                  CLIENT DEPLOYMENT
-                </span>
-                <span className="text-[8px] font-mono text-text-muted">
-                  ATHENA DEFENSE SYSTEMS — Try it live
-                </span>
-              </div>
-              <span className="text-[10px] text-text-muted group-hover:text-accent-cyan transition-colors ml-1">
-                &rarr;
-              </span>
-            </Link>
+            {/* The bottom-right CLIENT DEPLOYMENT → /client CTA was removed.
+                It pointed at an Athena Defense sandbox that had drifted out
+                of date and read as a stray promo on a workspace canvas the
+                user is actively analysing. The /client route itself still
+                exists for direct access; surfacing a sandbox at all (and in
+                what shape) is a UX decision we'll revisit separately. */}
           </div>
 
           {/* Risk Propagation Flow */}


### PR DESCRIPTION
## Summary

User: *"we randomly have on the bottom right of the product itself … CLIENT DEPLOYMENT … ATHENA DEFENSE SYSTEMS. It's just so random. I feel like this was intended to be a sandbox, but it seems like it's heavily out of date now."*

Removed the floating `bottom-4 right-4` `<Link href="/client">` from `src/app/page.tsx` along with the now-unused `next/link` import.

The `/client` route itself stays in place — that's a separate decision; this PR only takes the CTA off the workspace canvas where it was overlapping the user's live analysis (and the "Try it live" framing is stale anyway).

If we later decide to surface a sandbox / demo deployment, it belongs somewhere intentional (e.g., a header tab or a marketing landing), not as a floating link layered over the active DAG canvas.

## Test plan

- [x] `tsc --noEmit` clean (same pre-existing inherited `fci.test` drift)
- [x] Lint clean on `src/app/page.tsx`
- [x] vitest 1319 / 1319 pass
- [ ] Open the workspace — confirm the bottom-right CTA is gone and the canvas's bottom edge is uncluttered
- [ ] Navigate directly to `/client` — confirm the route still serves (left intact for future decision)

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_