### PR TITLE
fix(copilot): tighten action-tag syntax + intent-not-result narration

### DIFF
--- a/src/lib/copilot/eval/cases/seed.ts
+++ b/src/lib/copilot/eval/cases/seed.ts
@@ -287,14 +287,14 @@ export const SEED_CASES: TestCase[] = [
   {
     id: "isolate_by_explicit_ids",
     description:
-      "User names two nodes by id — should isolate to that pair.",
+      "User names two nodes by close-to-id phrasing — should isolate to that pair, mapping the user's text to the real graph ids (GRID_USA, FAB_TW).",
     user_message:
-      "show only USA_GRID and FAB_TW, hide everything else",
+      "show only USA Grid and TSMC Fab, hide everything else",
     graph_fixture: "geopolitical_main",
     accepted_tool_calls: [
       {
         name: "isolate_nodes",
-        params_match: { ids: { array_includes: "USA_GRID" } },
+        params_match: { ids: { array_includes: "GRID_USA" } },
       },
     ],
     tags: ["tool-selection", "filtering"],

--- a/src/lib/copilot/system-prompt.ts
+++ b/src/lib/copilot/system-prompt.ts
@@ -24,6 +24,12 @@ Your capabilities:
 
 When the user asks a question, reference the live graph context provided below. Cite specific node names, Ω scores, domains, and edge mechanisms. Be precise, quantitative, and direct. Use the terminal's analytical voice — concise, structured, no fluff.
 
-Format responses with clear structure: use bracketed headers like [ANALYSIS], [RISK], [RECOMMENDATION] when appropriate. Reference specific Ω scores and node labels.
+Format response prose with clear structure: use bracketed headers like [ANALYSIS], [RISK], [RECOMMENDATION] when appropriate. These are PROSE HEADERS ONLY — they do not invoke tools, they only label sections of your written response.
 
-The available action commands and their parameters are documented in the LIVE GRAPH CONTEXT below (=== COPILOT ACTIONS ===). Emit them inline using <<<ACTION:name:param>>> tags as documented there.`;
+CRITICAL — invoking a tool requires the triple-angle-bracket syntax: <<<ACTION:name:param>>>. Square brackets like [ACTION:...] are NOT actions — they are just text in your prose and will be ignored. The available tools and their parameters are documented in the LIVE GRAPH CONTEXT below (=== COPILOT ACTIONS ===). Examples of correct syntax:
+  - Correct: <<<ACTION:set_module:pearl>>>
+  - Correct: <<<ACTION:isolate_nodes:ids=GRID_USA|FAB_TW>>>
+  - WRONG (will not fire): [ACTION:set_module:pearl]
+  - WRONG (will not fire): <ACTION:set_module:pearl>
+
+Rule about prose AROUND your action tags: describe the INTENT ("isolating Europe-related nodes", "running the interdiction solver"), not what the tool DID. The actual tool result appears in a SYS line below your response — let that line confirm what happened. If your prose claims one outcome and the tool produced a different one (different nodes matched, different module switched, different action entirely), the user sees a confusing mismatch. Be honest about what you're TRYING to do; trust the SYS line to report what was DONE.`;


### PR DESCRIPTION
## Two bugs found in your traces (Chrome MCP diagnostic)

I queried `/api/copilot/traces` to look at the actual prose + tool-call payload from your recent voice turns. Two distinct failures.

### Bug A — bracket confusion. Turn at `13:34:07Z`:

```
user_message: "business can you run an introduction for me please"
AI prose:     "[ACTION:add_shock:TAIWAN_BLOCKADE]..."
tool_calls:   []   ← nothing fired
```

The AI wrote the action with **square brackets**, mimicking the `[ANALYSIS]` / `[STATUS]` / `[RECOMMENDATION]` prose-header pattern the prompt already teaches. The actual action syntax is **triple angle brackets** `<<<ACTION:...>>>`. The prompt didn't make the distinction unmistakable, so the model conflated them and wrote a header-shaped string that the parser ignored. No tool fired.

### Bug B — prose vs tool mismatch. Turn at `13:34:38Z`:

```
user_message: "farmer in France curious about an intervention from Italy"
AI prose:     "[RESET ISOLATION] Resetting node isolation to show the full graph context..."
tool_calls:   [{ name: "solve_interdiction", params: { budget: 3, mode: "edge" } }]
              ← NOT reset_isolation
```

Same family as the Europe bug from #397 — AI narrates one action while emitting a different one. #397's fix was scoped to `isolate_nodes` guidance only; this PR generalizes the rule to ALL tools at the system-prompt level.

(Together with `set_domains` rebuilding the graph in between turns, this is what made you say *"it just unhighlighted everything"* — prose claimed reset, tool ran solver, and earlier turns' `set_domains` had already wiped the prior isolation as a side effect.)

## Fix — three system-prompt rewrites

**1. Bracket headers explicitly labeled prose-only:**
```
[ANALYSIS], [RISK], [RECOMMENDATION] when appropriate. These are
PROSE HEADERS ONLY — they do not invoke tools, they only label
sections of your written response.
```

**2. Action-tag syntax made unmistakable with positive AND negative examples:**
```
CRITICAL — invoking a tool requires the triple-angle-bracket syntax:
<<<ACTION:name:param>>>. Square brackets like [ACTION:...] are NOT
actions — they are just text in your prose and will be ignored.
  - Correct:           <<<ACTION:set_module:pearl>>>
  - Correct:           <<<ACTION:isolate_nodes:ids=GRID_USA|FAB_TW>>>
  - WRONG (will not fire): [ACTION:set_module:pearl]
  - WRONG (will not fire): <ACTION:set_module:pearl>
```

**3. New rule about prose AROUND action tags (generalizes #397's isolate-specific guidance):**
```
Rule about prose AROUND your action tags: describe the INTENT
("isolating Europe-related nodes", "running the interdiction
solver"), not what the tool DID. The actual tool result appears
in a SYS line below your response — let that line confirm what
happened. If your prose claims one outcome and the tool produced
a different one (different nodes matched, different module
switched, different action entirely), the user sees a confusing
mismatch. Be honest about what you're TRYING to do; trust the
SYS line to report what was DONE.
```

## Side-fix duplicated from #397

The `isolate_by_explicit_ids` eval case has the same `USA_GRID` vs `GRID_USA` typo bug. Included the fix here too so this PR works standalone (and is a no-op for that line if #397 lands first).

## Test plan

- [x] 160/160 copilot tests still pass
- [x] **Live eval against Gemini Flash: 20/20 PASS**, mean 1355ms
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `next build` passes
- [ ] Manual after merge: voice-mode chat, try "run an introduction" style requests + complex multi-action turns. Verify (a) AI uses `<<<ACTION:>>>` not `[ACTION:]`, and (b) prose intent matches the SYS line below it

## Why no test for the bracket-confusion case directly

The eval seed grades observed tool calls. By definition, the bracket-confusion bug shows up as **zero tool calls** when one was expected — which our existing tool-selection cases would catch if Gemini regressed (e.g. `switch_module_pearl` would fail). So it IS implicitly tested, just not with a focused case. If we want a focused regression, the right thing is a synthetic case that reproduces the exact prose-shaped-like-action-without-angle-brackets state — but that requires bypassing the LLM, which doesn't fit the eval harness's "grade real model output" design. Best to rely on the broader tool-selection cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
