### PR TITLE
feat(discovery): Ω-Forgetting Pressure metric + AI Safety UX surface

### DIFF
--- a/src/components/SnapshotDiagnostics.tsx
+++ b/src/components/SnapshotDiagnostics.tsx
@@ -22,8 +22,21 @@
 
 import { useMemo, useState } from "react";
 import { useFilteredGraph } from "@/hooks/useFilteredGraph";
+import { useApexStore } from "@/stores/useApexStore";
 import { cvarW1, tailDepthScore } from "@/lib/estimators/cvar-w1";
 import { omegaBridgeDensity } from "@/lib/estimators/omega-bridge-density";
+import { resolveDomainProfile } from "@/lib/domain-profiles";
+import { computeFR } from "@/lib/discovery/fr-estimator";
+import {
+  computeOmegaForgettingPressure,
+  peakPressure,
+} from "@/lib/discovery/omega-forgetting-pressure";
+import { forgettingPressureBand } from "@/lib/omega-forgetting-pressure-display";
+import {
+  AI_SAFETY_DEMO_EXPOSURE,
+  buildAISafetyDemoTrace,
+} from "@/lib/discovery/ai-safety-demo-trace";
+import CapabilityBadge from "./CapabilityBadge";
 
 type Band = {
   label: string;
@@ -86,7 +99,35 @@ function topologyBand(density: number): Band {
 
 export default function SnapshotDiagnostics() {
   const graph = useFilteredGraph();
-  const [expanded, setExpanded] = useState<"tail" | "topology" | null>(null);
+  const selectedDomains = useApexStore((s) => s.selectedDomains);
+  const isAISafety = useMemo(
+    () => resolveDomainProfile(selectedDomains).id === "ai-safety",
+    [selectedDomains],
+  );
+  const [expanded, setExpanded] = useState<
+    "tail" | "topology" | "forgetting" | null
+  >(null);
+
+  // Ω-Forgetting Pressure — AI-domain-only diagnostic. Runs on the
+  // built-in synthetic demo trace until PR 5 lands a real ingester;
+  // sourceKind stays "synthetic" so the SYNTHETIC badge is rendered
+  // alongside the reading and no customer business decision runs off it.
+  const forgetting = useMemo(() => {
+    if (!isAISafety) return null;
+    const trace = buildAISafetyDemoTrace();
+    const fr = computeFR(trace);
+    const result = computeOmegaForgettingPressure(fr, {
+      exposure: AI_SAFETY_DEMO_EXPOSURE,
+    });
+    const peak = peakPressure(result);
+    return {
+      result,
+      band: forgettingPressureBand(result.pressure),
+      peak,
+      taskCount: fr.tasks.length,
+      epochCount: trace.epochs.length,
+    };
+  }, [isAISafety]);
 
   // Tail Depth — empirical α-CVaR over the per-node ΩF composite
   // distribution of the live filtered graph. α = 0.9 standard.
@@ -240,6 +281,62 @@ export default function SnapshotDiagnostics() {
         </button>
       </div>
 
+      {/* ── Ω-Forgetting Pressure (AI Safety only) ───────────────── */}
+      {forgetting && (
+        <button
+          onClick={() =>
+            setExpanded(expanded === "forgetting" ? null : "forgetting")
+          }
+          className="w-full text-left p-2 rounded border transition-all"
+          style={{
+            borderColor:
+              expanded === "forgetting"
+                ? forgetting.band.color
+                : "var(--border)",
+            backgroundColor: "var(--surface)",
+          }}
+        >
+          <div className="flex items-center justify-between gap-1">
+            <span className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted">
+              FORGETTING · Ω-FP
+            </span>
+            <div className="flex items-center gap-1.5">
+              {forgetting.result.sourceKind === "synthetic" && (
+                <CapabilityBadge capability="live-synthetic" />
+              )}
+              {Number.isFinite(forgetting.result.pressure) && (
+                <span
+                  className="text-[8px] font-[family-name:var(--font-michroma)] tabular-nums font-bold"
+                  style={{ color: forgetting.band.color }}
+                >
+                  {forgetting.band.label}
+                </span>
+              )}
+            </div>
+          </div>
+          <div className="mt-1.5 flex items-baseline gap-2">
+            {Number.isFinite(forgetting.result.pressure) ? (
+              <>
+                <span
+                  className="text-[20px] font-[family-name:var(--font-michroma)] tabular-nums leading-none"
+                  style={{ color: forgetting.band.color }}
+                >
+                  {forgetting.result.pressure.toFixed(3)}
+                </span>
+                <span className="text-[9px] font-mono text-text-muted/70">
+                  Σ exposure · FR · {forgetting.taskCount} tasks ·{" "}
+                  {forgetting.epochCount} epochs
+                </span>
+              </>
+            ) : (
+              <span className="text-[10px] font-mono text-text-muted">
+                NO TRAINING TRACE
+              </span>
+            )}
+          </div>
+        </button>
+      )}
+
       {/* Expanded detail ─────────────────────────────────────── */}
       {expanded === "tail" && tail.ok && (
         <div className="p-3 rounded border border-border bg-surface space-y-2">
@@ -292,6 +389,58 @@ export default function SnapshotDiagnostics() {
           </div>
         </div>
       )}
+
+      {expanded === "forgetting" &&
+        forgetting &&
+        Number.isFinite(forgetting.result.pressure) && (
+          <div className="p-3 rounded border border-border bg-surface space-y-2">
+            <div className="text-[9px] font-mono text-text-muted leading-relaxed">
+              <span className="text-foreground">
+                {forgetting.band.tooltip}
+              </span>
+            </div>
+            <div className="text-[9px] font-mono text-text-muted leading-relaxed">
+              Ω-FP = Σ<sub>k</sub> exposure<sub>k</sub> · normalizedFR
+              <sub>k</sub> on the canonical AI Safety IDS demo trace
+              (DDoS / MITM / Heartbleed curriculum,{" "}
+              {forgetting.epochCount} epochs). Peak Ω-FP ={" "}
+              {Number.isFinite(forgetting.peak.value)
+                ? forgetting.peak.value.toFixed(3)
+                : "—"}
+              {forgetting.peak.epochIndex >= 0 && (
+                <> at epoch {forgetting.peak.epochIndex}</>
+              )}
+              .
+            </div>
+            <div className="space-y-0.5">
+              <div className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted">
+                TOP CONTRIBUTORS
+              </div>
+              {forgetting.result.contributions.slice(0, 3).map((c) => (
+                <div
+                  key={c.taskId}
+                  className="font-mono text-[9px] text-foreground tabular-nums flex items-center gap-2"
+                >
+                  <span className="text-text-muted">{c.taskId}</span>
+                  <span className="text-text-muted/70">
+                    exp {c.exposure.toFixed(2)} · FR{" "}
+                    {c.normalizedFR.toFixed(3)} →{" "}
+                  </span>
+                  <span className="text-foreground">
+                    {c.contribution.toFixed(3)}
+                  </span>
+                </div>
+              ))}
+            </div>
+            <div className="text-[8px] font-mono text-text-muted/70 leading-relaxed">
+              SYNTHETIC trace — no customer business decision runs off
+              this reading. A real PyTorch / TF training-log ingester
+              ships in PR 5; once a live trace is loaded the badge
+              flips to LIVE. Source: Ghauri 2025 (D.Eng., Ch. 8 —
+              catastrophic forgetting in continual-learning IDS).
+            </div>
+          </div>
+        )}
     </div>
   );
 }

--- a/src/lib/__tests__/omega-forgetting-pressure-display.test.ts
+++ b/src/lib/__tests__/omega-forgetting-pressure-display.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+//
+// Tests for the Ω-Forgetting Pressure display-band helper. Pure
+// function — no React or DOM access — so the test pins the band
+// thresholds + tooltip strings the UI relies on.
+
+import { describe, it, expect } from "vitest";
+import { forgettingPressureBand } from "../omega-forgetting-pressure-display";
+
+describe("forgettingPressureBand — thresholds", () => {
+  it("NaN / negative inputs return the '—' placeholder band", () => {
+    for (const v of [NaN, -0.1, -1, Number.POSITIVE_INFINITY * -1]) {
+      const b = forgettingPressureBand(v);
+      expect(b.label).toBe("—");
+      expect(b.band).toBe("nominal");
+      expect(b.color).toBe("var(--text-muted)");
+    }
+  });
+
+  it("pressure < 0.15 → NOMINAL (green)", () => {
+    for (const v of [0, 0.05, 0.149]) {
+      const b = forgettingPressureBand(v);
+      expect(b.band).toBe("nominal");
+      expect(b.label).toBe("NOMINAL");
+      expect(b.color).toBe("var(--accent-green)");
+    }
+  });
+
+  it("0.15 < pressure ≤ 0.30 → ELEVATED (amber)", () => {
+    for (const v of [0.16, 0.2, 0.3]) {
+      const b = forgettingPressureBand(v);
+      expect(b.band).toBe("elevated");
+      expect(b.label).toBe("ELEVATED");
+      expect(b.color).toBe("var(--accent-amber)");
+    }
+  });
+
+  it("0.30 < pressure ≤ 0.60 → CRITICAL", () => {
+    for (const v of [0.31, 0.45, 0.6]) {
+      const b = forgettingPressureBand(v);
+      expect(b.band).toBe("critical");
+      expect(b.label).toBe("CRITICAL");
+      expect(b.color).toBe("#ff7043");
+    }
+  });
+
+  it("pressure > 0.60 → CATASTROPHIC (red)", () => {
+    for (const v of [0.61, 0.8, 1.0]) {
+      const b = forgettingPressureBand(v);
+      expect(b.band).toBe("catastrophic");
+      expect(b.label).toBe("CATASTROPHIC");
+      expect(b.color).toBe("#ff1744");
+    }
+  });
+});
+
+describe("forgettingPressureBand — tooltip content", () => {
+  it("tooltips contain the threshold ranges", () => {
+    expect(forgettingPressureBand(0.05).tooltip).toMatch(/< 0\.15/);
+    expect(forgettingPressureBand(0.2).tooltip).toMatch(/0\.15.{0,4}0\.30/);
+    expect(forgettingPressureBand(0.45).tooltip).toMatch(/0\.30.{0,4}0\.60/);
+    expect(forgettingPressureBand(0.8).tooltip).toMatch(/> 0\.60/);
+  });
+
+  it("placeholder tooltip explains the no-data condition", () => {
+    expect(forgettingPressureBand(NaN).tooltip).toMatch(/unavailable|degenerate/i);
+  });
+});

--- a/src/lib/discovery/__tests__/fr-estimator.test.ts
+++ b/src/lib/discovery/__tests__/fr-estimator.test.ts
@@ -1,0 +1,486 @@
+// @vitest-environment node
+//
+// Tests for the FR (Forgetting Rate) estimator (Phase 3 PR 3). Verifies
+// per-task forgetting math on synthetic TrainingTraces with known
+// dynamics so the assertions are hand-computable.
+//
+// Test strategy:
+//   - Build synthetic traces with carefully chosen forgettingRate /
+//     learningRate so the expected FR values can be derived from the
+//     generator's closed-form recurrence
+//   - Exercise the Heartbleed archetype (high-forgettingRate task ranks
+//     first in normalizedFR ranking)
+//   - Verify the decay-rate fit recovers the generator's forgettingRate
+//     parameter within tolerance
+//   - Edge cases: never-trained task, single-epoch trace, no decay
+//   - Provenance forwarding (synthetic in → synthetic out)
+//
+// All traces use `noiseAmplitude: 0` unless the test specifically needs
+// noise — deterministic accuracy curves are what make the closed-form
+// assertions tight.
+
+import { describe, it, expect } from "vitest";
+import {
+  computeFR,
+  rankTasksByNormalizedFR,
+  meanNormalizedFR,
+} from "../fr-estimator";
+import {
+  buildSyntheticTrainingTrace,
+  sequentialCurriculum,
+} from "../training-trace-synthetic";
+import type { TaskRef, TrainingTrace } from "../training-trace-types";
+
+// ─── Fixture builders ─────────────────────────────────────────────────
+
+const ATTACK_TASKS: TaskRef[] = [
+  { id: "task_ddos", label: "DDoS", scope: "attack-class" },
+  { id: "task_mitm", label: "MITM", scope: "attack-class" },
+  { id: "task_heartbleed", label: "Heartbleed", scope: "attack-class" },
+];
+
+function defaultTrace(): TrainingTrace {
+  return buildSyntheticTrainingTrace({
+    id: "test-trace",
+    label: "Test",
+    tasks: ATTACK_TASKS,
+    curriculum: sequentialCurriculum(
+      ATTACK_TASKS.map((t) => t.id),
+      3, // 3 epochs each = 9 total
+    ),
+    seed: 42,
+    noiseAmplitude: 0,
+  });
+}
+
+// ─── Shape / contract tests ───────────────────────────────────────────
+
+describe("computeFR — shape contracts", () => {
+  it("returns one entry per task in the trace", () => {
+    const trace = defaultTrace();
+    const result = computeFR(trace);
+    expect(result.tasks).toHaveLength(trace.tasks.length);
+    const ids = new Set(result.tasks.map((t) => t.taskId));
+    expect(ids.size).toBe(trace.tasks.length);
+    for (const t of trace.tasks) {
+      expect(ids.has(t.id)).toBe(true);
+    }
+  });
+
+  it("time series length matches trace.epochs", () => {
+    const trace = defaultTrace();
+    const result = computeFR(trace);
+    for (const t of result.tasks) {
+      expect(t.frOverTime).toHaveLength(trace.epochs.length);
+      expect(t.normalizedFROverTime).toHaveLength(trace.epochs.length);
+    }
+  });
+
+  it("all FR-over-time values are non-negative", () => {
+    const result = computeFR(defaultTrace());
+    for (const t of result.tasks) {
+      for (const fr of t.frOverTime) {
+        expect(fr).toBeGreaterThanOrEqual(0);
+      }
+      for (const nfr of t.normalizedFROverTime) {
+        expect(nfr).toBeGreaterThanOrEqual(0);
+        expect(nfr).toBeLessThanOrEqual(1 + 1e-9);
+      }
+    }
+  });
+
+  it("absoluteForgetting equals peakAccuracy − finalAccuracy", () => {
+    const result = computeFR(defaultTrace());
+    for (const t of result.tasks) {
+      const expected = Math.max(0, t.peakAccuracy - t.finalAccuracy);
+      expect(t.absoluteForgetting).toBeCloseTo(expected, 12);
+    }
+  });
+
+  it("normalizedFR equals absoluteForgetting / peakAccuracy when peak > 0", () => {
+    const result = computeFR(defaultTrace());
+    for (const t of result.tasks) {
+      if (t.peakAccuracy > 0) {
+        expect(t.normalizedFR).toBeCloseTo(
+          t.absoluteForgetting / t.peakAccuracy,
+          12,
+        );
+      }
+    }
+  });
+});
+
+// ─── Provenance forwarding ────────────────────────────────────────────
+
+describe("computeFR — provenance", () => {
+  it("forwards source.kind from the trace verbatim", () => {
+    const trace = defaultTrace();
+    expect(trace.source.kind).toBe("synthetic");
+    const result = computeFR(trace);
+    expect(result.sourceKind).toBe("synthetic");
+  });
+
+  it("forwards the trace id", () => {
+    const result = computeFR(defaultTrace());
+    expect(result.traceId).toBe("test-trace");
+  });
+});
+
+// ─── Curriculum semantics ─────────────────────────────────────────────
+
+describe("computeFR — curriculum semantics", () => {
+  it("lastTrainedEpoch matches the last activeTaskIds appearance", () => {
+    // sequentialCurriculum with 3 epochs each: DDoS [0,3), MITM [3,6),
+    // Heartbleed [6,9). lastTrainedEpoch should be 2, 5, 8.
+    const result = computeFR(defaultTrace());
+    const ddos = result.tasks.find((t) => t.taskId === "task_ddos")!;
+    const mitm = result.tasks.find((t) => t.taskId === "task_mitm")!;
+    const heart = result.tasks.find((t) => t.taskId === "task_heartbleed")!;
+    expect(ddos.lastTrainedEpoch).toBe(2);
+    expect(mitm.lastTrainedEpoch).toBe(5);
+    expect(heart.lastTrainedEpoch).toBe(8);
+  });
+
+  it("never-trained task gets lastTrainedEpoch = -1", () => {
+    // Add a task to the trace but never include it in the curriculum.
+    const tasks: TaskRef[] = [
+      ...ATTACK_TASKS,
+      { id: "task_unused", label: "Unused", scope: "attack-class" },
+    ];
+    const trace = buildSyntheticTrainingTrace({
+      id: "unused-trace",
+      label: "Unused",
+      tasks,
+      curriculum: sequentialCurriculum(
+        ATTACK_TASKS.map((t) => t.id),
+        3,
+      ),
+      noiseAmplitude: 0,
+    });
+    const result = computeFR(trace);
+    const unused = result.tasks.find((t) => t.taskId === "task_unused")!;
+    expect(unused.lastTrainedEpoch).toBe(-1);
+  });
+
+  it("peakEpoch is within the trained window for a sequential curriculum", () => {
+    // Without noise, each task's accuracy is monotone-increasing while
+    // training and monotone-decreasing after. So peakEpoch must be at
+    // or after lastTrainedEpoch − k for some k — in practice equal to
+    // lastTrainedEpoch since the last training step closes the most
+    // gap.
+    const result = computeFR(defaultTrace());
+    for (const t of result.tasks) {
+      // For sequential, lastTrainedEpoch is the LAST epoch the task
+      // was active. Without noise the peak is at lastTrainedEpoch.
+      expect(t.peakEpoch).toBe(t.lastTrainedEpoch);
+    }
+  });
+});
+
+// ─── Hand-computed math on a tiny trace ──────────────────────────────
+
+describe("computeFR — closed-form math on noise-free trace", () => {
+  it("recovers exact peak / final / absoluteForgetting on a 2-task 4-epoch trace", () => {
+    // Two tasks, 2 epochs each. Defaults: baseline 0.05, plateau 0.95,
+    // learningRate 0.5, forgettingRate 0.05. Closed-form recurrence:
+    //   k = 1 − e^-0.5 ≈ 0.3934693
+    //   d = e^-0.05  ≈ 0.9512294
+    // Epoch 0: A trains. accA(0) = 0.05 + 0.9·k ≈ 0.4041224
+    // Epoch 1: A trains. accA(1) = 0.4041224 + (0.95 − 0.4041224)·k
+    //                            ≈ 0.6189085
+    // Epoch 2: B trains. accA(2) = 0.05 + (0.6189085 − 0.05)·d
+    //                            ≈ 0.5911531
+    // Epoch 3: B trains. accA(3) = 0.05 + (0.5911531 − 0.05)·d
+    //                            ≈ 0.5647674
+    // For task B, mirror: B peaks at epoch 3 ≈ 0.6189085.
+    const tasks: TaskRef[] = [
+      { id: "A", label: "A", scope: "attack-class" },
+      { id: "B", label: "B", scope: "attack-class" },
+    ];
+    const trace = buildSyntheticTrainingTrace({
+      id: "tiny",
+      label: "Tiny",
+      tasks,
+      curriculum: sequentialCurriculum(["A", "B"], 2),
+      noiseAmplitude: 0,
+    });
+    const result = computeFR(trace);
+    const a = result.tasks.find((t) => t.taskId === "A")!;
+    const b = result.tasks.find((t) => t.taskId === "B")!;
+
+    // Task A: trained epochs 0-1, then decays for epochs 2-3.
+    expect(a.peakAccuracy).toBeCloseTo(0.6189085, 3);
+    expect(a.peakEpoch).toBe(1);
+    expect(a.finalAccuracy).toBeCloseTo(0.5647674, 3);
+    const expectedAF = 0.6189085 - 0.5647674;
+    expect(a.absoluteForgetting).toBeCloseTo(expectedAF, 3);
+    expect(a.normalizedFR).toBeCloseTo(expectedAF / 0.6189085, 3);
+
+    // Task B: never trained for epochs 0-1, then trained 2-3 → peaks
+    // at final epoch → absoluteForgetting ≈ 0.
+    expect(b.peakAccuracy).toBeCloseTo(0.6189085, 3);
+    expect(b.peakEpoch).toBe(3);
+    expect(b.finalAccuracy).toBeCloseTo(0.6189085, 3);
+    expect(b.absoluteForgetting).toBeCloseTo(0, 6);
+    expect(b.normalizedFR).toBeCloseTo(0, 6);
+  });
+
+  it("frOverTime[i] = peakSoFar(i) − acc(i) exactly", () => {
+    const tasks: TaskRef[] = [
+      { id: "A", label: "A", scope: "attack-class" },
+      { id: "B", label: "B", scope: "attack-class" },
+    ];
+    const trace = buildSyntheticTrainingTrace({
+      id: "fr-time",
+      label: "FR over time",
+      tasks,
+      curriculum: sequentialCurriculum(["A", "B"], 2),
+      noiseAmplitude: 0,
+    });
+    const result = computeFR(trace);
+    const a = result.tasks.find((t) => t.taskId === "A")!;
+    // Hand-check epoch by epoch using the raw accuracy from the trace.
+    let peakSoFar = -Infinity;
+    for (let i = 0; i < trace.epochs.length; i++) {
+      const acc = trace.epochs[i].accuracy.find((x) => x.taskId === "A")!.value;
+      if (acc > peakSoFar) peakSoFar = acc;
+      const expectedFr = Math.max(0, peakSoFar - acc);
+      expect(a.frOverTime[i]).toBeCloseTo(expectedFr, 10);
+      const expectedNfr = peakSoFar > 0 ? expectedFr / peakSoFar : 0;
+      expect(a.normalizedFROverTime[i]).toBeCloseTo(expectedNfr, 10);
+    }
+  });
+});
+
+// ─── Heartbleed archetype ────────────────────────────────────────────
+
+describe("computeFR — Heartbleed archetype", () => {
+  it("a high-forgettingRate task ranks first in normalizedFR", () => {
+    // Train each task for 3 epochs, then 6 more epochs where it's not
+    // active. Heartbleed has forgettingRate 0.3, others 0.05. After
+    // 6 epochs of no training, Heartbleed retains exp(-0.3·6) ≈ 16.5%
+    // of its above-baseline accuracy; DDoS retains exp(-0.05·6) ≈ 74%.
+    // So normalizedFR(heartbleed) should be substantially larger than
+    // normalizedFR(ddos).
+    const trace = buildSyntheticTrainingTrace({
+      id: "heartbleed-archetype",
+      label: "Heartbleed archetype",
+      tasks: ATTACK_TASKS,
+      // Train Heartbleed FIRST so it has the longest off-task tail.
+      curriculum: [
+        { taskId: "task_heartbleed", startEpoch: 0, endEpoch: 3 },
+        { taskId: "task_ddos", startEpoch: 3, endEpoch: 6 },
+        { taskId: "task_mitm", startEpoch: 6, endEpoch: 9 },
+      ],
+      taskDynamics: {
+        task_heartbleed: { forgettingRate: 0.3 },
+        task_ddos: { forgettingRate: 0.05 },
+        task_mitm: { forgettingRate: 0.05 },
+      },
+      noiseAmplitude: 0,
+    });
+    const result = computeFR(trace);
+    const ranked = rankTasksByNormalizedFR(result);
+    expect(ranked[0].taskId).toBe("task_heartbleed");
+    const heart = result.tasks.find((t) => t.taskId === "task_heartbleed")!;
+    const ddos = result.tasks.find((t) => t.taskId === "task_ddos")!;
+    expect(heart.normalizedFR).toBeGreaterThan(ddos.normalizedFR);
+    // Heartbleed should have lost a substantial fraction of its peak.
+    expect(heart.normalizedFR).toBeGreaterThan(0.3);
+  });
+});
+
+// ─── Decay-rate fit ──────────────────────────────────────────────────
+
+describe("computeFR — decayRate fit", () => {
+  it("recovers a known forgettingRate within tolerance", () => {
+    // Set up a task that trains for 4 epochs (saturates near plateau),
+    // then has a long off-task tail of 16 epochs to fit the decay on.
+    // forgettingRate = 0.20, expecting decayRate ≈ 0.20.
+    const trace = buildSyntheticTrainingTrace({
+      id: "decay-recovery",
+      label: "Decay recovery",
+      tasks: [{ id: "T", label: "T", scope: "attack-class" }],
+      curriculum: [{ taskId: "T", startEpoch: 0, endEpoch: 4 }],
+      taskDynamics: { T: { forgettingRate: 0.2, plateau: 0.95, baseline: 0.05 } },
+      noiseAmplitude: 0,
+    });
+    // Add 16 more epochs by extending the trace via a second task
+    // never trained (so total epoch count = 20).
+    const traceLong = buildSyntheticTrainingTrace({
+      id: "decay-recovery-long",
+      label: "Decay recovery long",
+      tasks: [
+        { id: "T", label: "T", scope: "attack-class" },
+        { id: "U", label: "U", scope: "attack-class" },
+      ],
+      curriculum: [
+        { taskId: "T", startEpoch: 0, endEpoch: 4 },
+        { taskId: "U", startEpoch: 4, endEpoch: 20 },
+      ],
+      taskDynamics: { T: { forgettingRate: 0.2, plateau: 0.95, baseline: 0.05 } },
+      noiseAmplitude: 0,
+    });
+    // Override baseline so the regression uses the TRUE baseline (0.05)
+    // rather than the empirical min — the generator's exponential
+    // decay is exactly λ when baseline matches.
+    const result = computeFR(traceLong, { baselinePerTask: { T: 0.05 } });
+    const t = result.tasks.find((x) => x.taskId === "T")!;
+    expect(t.decayRate).toBeCloseTo(0.2, 2);
+    // Quick sanity that the shorter trace still produces a usable
+    // decayRate (the post-peak window is short but non-empty).
+    void trace;
+  });
+
+  it("returns NaN decayRate when task never decays below peak", () => {
+    // Task is trained on the LAST epoch → peak is final → no post-peak
+    // window. fitDecayRate returns NaN.
+    const trace = buildSyntheticTrainingTrace({
+      id: "no-decay",
+      label: "No decay",
+      tasks: [{ id: "T", label: "T", scope: "attack-class" }],
+      curriculum: [{ taskId: "T", startEpoch: 0, endEpoch: 3 }],
+      noiseAmplitude: 0,
+    });
+    const result = computeFR(trace);
+    const t = result.tasks.find((x) => x.taskId === "T")!;
+    // peakEpoch is the final epoch (2), so there are no post-peak
+    // points → decayRate is NaN.
+    expect(Number.isNaN(t.decayRate)).toBe(true);
+  });
+
+  it("returns NaN decayRate when post-peak window has only one point", () => {
+    // 2 training epochs + 1 off-task epoch → one post-peak point →
+    // regression undefined (< 2 points).
+    const trace = buildSyntheticTrainingTrace({
+      id: "one-point",
+      label: "One point",
+      tasks: [
+        { id: "T", label: "T", scope: "attack-class" },
+        { id: "U", label: "U", scope: "attack-class" },
+      ],
+      curriculum: [
+        { taskId: "T", startEpoch: 0, endEpoch: 2 },
+        { taskId: "U", startEpoch: 2, endEpoch: 3 },
+      ],
+      noiseAmplitude: 0,
+    });
+    const result = computeFR(trace);
+    const t = result.tasks.find((x) => x.taskId === "T")!;
+    expect(Number.isNaN(t.decayRate)).toBe(true);
+  });
+});
+
+// ─── Convenience helpers ─────────────────────────────────────────────
+
+describe("rankTasksByNormalizedFR", () => {
+  it("sorts descending by normalizedFR with NaN entries pushed to the end", () => {
+    // Build a trace where one task has NaN normalizedFR (never trained
+    // → peakAccuracy = baseline > 0 actually, so normalizedFR is
+    // defined… but absoluteForgetting = 0 → normalizedFR = 0, not NaN).
+    // To get NaN, peakAccuracy must be ≤ 0. We can't construct that
+    // with the synthetic generator (baseline defaults to 0.05).
+    // Instead, hand-build a trace with a task that has acc = 0 every
+    // epoch.
+    const trace: TrainingTrace = {
+      id: "nan-rank",
+      label: "NaN rank",
+      source: {
+        adapter: "test",
+        adapterVersion: "0.0.0",
+        kind: "synthetic",
+        builtAt: new Date().toISOString(),
+      },
+      tasks: [
+        { id: "A", label: "A", scope: "attack-class" },
+        { id: "B", label: "B", scope: "attack-class" },
+        { id: "C", label: "C", scope: "attack-class" },
+      ],
+      epochs: [
+        {
+          index: 0,
+          activeTaskIds: ["A"],
+          accuracy: [
+            { taskId: "A", value: 0.8 },
+            { taskId: "B", value: 0.6 },
+            { taskId: "C", value: 0 }, // never had any signal
+          ],
+        },
+        {
+          index: 1,
+          activeTaskIds: ["B"],
+          accuracy: [
+            { taskId: "A", value: 0.4 }, // decayed
+            { taskId: "B", value: 0.6 }, // same
+            { taskId: "C", value: 0 }, // still zero
+          ],
+        },
+      ],
+      metadata: { description: "test", accessTier: "internal-only" },
+    };
+    const result = computeFR(trace);
+    const ranked = rankTasksByNormalizedFR(result);
+    // A has FR 0.5, B has FR 0, C has peak=0 → normalizedFR is NaN.
+    expect(ranked[0].taskId).toBe("A");
+    expect(ranked[1].taskId).toBe("B");
+    expect(ranked[2].taskId).toBe("C");
+    expect(Number.isNaN(ranked[2].normalizedFR)).toBe(true);
+  });
+});
+
+describe("meanNormalizedFR", () => {
+  it("averages over tasks with defined normalizedFR", () => {
+    const result = computeFR(defaultTrace());
+    const defined = result.tasks.filter((t) => !Number.isNaN(t.normalizedFR));
+    const expected =
+      defined.reduce((s, t) => s + t.normalizedFR, 0) / defined.length;
+    expect(meanNormalizedFR(result)).toBeCloseTo(expected, 12);
+  });
+
+  it("returns NaN when no task has a defined normalizedFR", () => {
+    // Build a degenerate trace where every task has peakAccuracy = 0.
+    const trace: TrainingTrace = {
+      id: "degenerate",
+      label: "Degenerate",
+      source: {
+        adapter: "test",
+        adapterVersion: "0.0.0",
+        kind: "synthetic",
+        builtAt: new Date().toISOString(),
+      },
+      tasks: [
+        { id: "A", label: "A", scope: "attack-class" },
+        { id: "B", label: "B", scope: "attack-class" },
+      ],
+      epochs: [
+        {
+          index: 0,
+          activeTaskIds: [],
+          accuracy: [
+            { taskId: "A", value: 0 },
+            { taskId: "B", value: 0 },
+          ],
+        },
+      ],
+      metadata: { description: "test", accessTier: "internal-only" },
+    };
+    const result = computeFR(trace);
+    expect(Number.isNaN(meanNormalizedFR(result))).toBe(true);
+  });
+});
+
+// ─── Argument validation ─────────────────────────────────────────────
+
+describe("computeFR — argument validation", () => {
+  it("rejects empty epochs", () => {
+    const trace = defaultTrace();
+    const forged = { ...trace, epochs: [] };
+    expect(() => computeFR(forged)).toThrow(/zero epochs/);
+  });
+
+  it("rejects empty tasks", () => {
+    const trace = defaultTrace();
+    const forged = { ...trace, tasks: [] };
+    expect(() => computeFR(forged)).toThrow(/zero tasks/);
+  });
+});

--- a/src/lib/discovery/__tests__/omega-forgetting-pressure.test.ts
+++ b/src/lib/discovery/__tests__/omega-forgetting-pressure.test.ts
@@ -1,0 +1,379 @@
+// @vitest-environment node
+//
+// Tests for Ω-Forgetting Pressure (Phase 3 PR 4). Verifies the
+// exposure-weighted reduction over FR values, NaN handling for
+// degenerate tasks, normalization semantics, and the time-varying
+// series shape.
+//
+// Test strategy:
+//   - Hand-build minimal FRResult objects so the expected pressure
+//     values are computable from a one-line formula.
+//   - Use the AI Safety demo trace as an end-to-end fixture to verify
+//     the Heartbleed archetype dominates the contributions list under
+//     the canonical exposure.
+
+import { describe, it, expect } from "vitest";
+import {
+  computeOmegaForgettingPressure,
+  peakPressure,
+  topContributors,
+} from "../omega-forgetting-pressure";
+import type { FRResult, FRTaskResult } from "../fr-estimator";
+import { computeFR } from "../fr-estimator";
+import {
+  buildAISafetyDemoTrace,
+  AI_SAFETY_DEMO_EXPOSURE,
+} from "../ai-safety-demo-trace";
+
+// ─── Fixture builders ─────────────────────────────────────────────────
+
+function makeFRTask(
+  overrides: Partial<FRTaskResult> & { taskId: string },
+): FRTaskResult {
+  return {
+    taskId: overrides.taskId,
+    peakAccuracy: overrides.peakAccuracy ?? 0.9,
+    peakEpoch: overrides.peakEpoch ?? 1,
+    finalAccuracy: overrides.finalAccuracy ?? 0.45,
+    lastTrainedEpoch: overrides.lastTrainedEpoch ?? 1,
+    frOverTime: overrides.frOverTime ?? [0, 0, 0.2, 0.45],
+    normalizedFROverTime: overrides.normalizedFROverTime ?? [0, 0, 0.2222, 0.5],
+    absoluteForgetting: overrides.absoluteForgetting ?? 0.45,
+    normalizedFR: overrides.normalizedFR ?? 0.5,
+    decayRate: overrides.decayRate ?? NaN,
+  };
+}
+
+function makeFRResult(tasks: FRTaskResult[]): FRResult {
+  return {
+    tasks,
+    sourceKind: "synthetic",
+    traceId: "test-trace",
+  };
+}
+
+// ─── Shape / contract tests ───────────────────────────────────────────
+
+describe("computeOmegaForgettingPressure — shape contracts", () => {
+  it("returns one contribution per non-degenerate task", () => {
+    const fr = makeFRResult([
+      makeFRTask({ taskId: "A", normalizedFR: 0.5 }),
+      makeFRTask({ taskId: "B", normalizedFR: 0.2 }),
+      makeFRTask({ taskId: "C", normalizedFR: 0.0 }),
+    ]);
+    const result = computeOmegaForgettingPressure(fr);
+    expect(result.contributions).toHaveLength(3);
+    const ids = new Set(result.contributions.map((c) => c.taskId));
+    expect(ids).toEqual(new Set(["A", "B", "C"]));
+  });
+
+  it("contributions are sorted descending by contribution", () => {
+    const fr = makeFRResult([
+      makeFRTask({ taskId: "A", normalizedFR: 0.1 }),
+      makeFRTask({ taskId: "B", normalizedFR: 0.8 }),
+      makeFRTask({ taskId: "C", normalizedFR: 0.4 }),
+    ]);
+    const result = computeOmegaForgettingPressure(fr);
+    for (let i = 1; i < result.contributions.length; i++) {
+      expect(result.contributions[i].contribution).toBeLessThanOrEqual(
+        result.contributions[i - 1].contribution,
+      );
+    }
+    expect(result.contributions[0].taskId).toBe("B");
+  });
+
+  it("pressureOverTime length matches the FR series length", () => {
+    const fr = makeFRResult([
+      makeFRTask({
+        taskId: "A",
+        normalizedFROverTime: [0, 0.1, 0.2, 0.3, 0.4],
+      }),
+      makeFRTask({
+        taskId: "B",
+        normalizedFROverTime: [0, 0, 0.1, 0.2, 0.5],
+      }),
+    ]);
+    const result = computeOmegaForgettingPressure(fr);
+    expect(result.pressureOverTime).toHaveLength(5);
+  });
+
+  it("forwards sourceKind and traceId verbatim", () => {
+    const fr: FRResult = {
+      tasks: [makeFRTask({ taskId: "A" })],
+      sourceKind: "synthetic",
+      traceId: "abc-123",
+    };
+    const result = computeOmegaForgettingPressure(fr);
+    expect(result.sourceKind).toBe("synthetic");
+    expect(result.traceId).toBe("abc-123");
+  });
+});
+
+// ─── Default-exposure math ────────────────────────────────────────────
+
+describe("computeOmegaForgettingPressure — default uniform exposure", () => {
+  it("uniform default → arithmetic mean of normalizedFR values", () => {
+    // 3 tasks, all defined → uniform weights 1/3 each → pressure =
+    // average of normalizedFR.
+    const fr = makeFRResult([
+      makeFRTask({ taskId: "A", normalizedFR: 0.6 }),
+      makeFRTask({ taskId: "B", normalizedFR: 0.3 }),
+      makeFRTask({ taskId: "C", normalizedFR: 0.0 }),
+    ]);
+    const result = computeOmegaForgettingPressure(fr);
+    expect(result.pressure).toBeCloseTo((0.6 + 0.3 + 0.0) / 3, 12);
+    expect(result.totalExposure).toBeCloseTo(1, 12);
+    for (const c of result.contributions) {
+      expect(c.exposure).toBeCloseTo(1 / 3, 12);
+    }
+  });
+});
+
+// ─── Custom exposure ─────────────────────────────────────────────────
+
+describe("computeOmegaForgettingPressure — custom exposure", () => {
+  it("weighted sum honors the override", () => {
+    const fr = makeFRResult([
+      makeFRTask({ taskId: "A", normalizedFR: 0.8 }),
+      makeFRTask({ taskId: "B", normalizedFR: 0.2 }),
+    ]);
+    // Raw weights 3:1 → normalized 0.75:0.25
+    const result = computeOmegaForgettingPressure(fr, {
+      exposure: { A: 3, B: 1 },
+    });
+    expect(result.pressure).toBeCloseTo(0.75 * 0.8 + 0.25 * 0.2, 10);
+    const a = result.contributions.find((c) => c.taskId === "A")!;
+    const b = result.contributions.find((c) => c.taskId === "B")!;
+    expect(a.exposure).toBeCloseTo(0.75, 10);
+    expect(b.exposure).toBeCloseTo(0.25, 10);
+  });
+
+  it("missing exposure entries default to weight 1", () => {
+    const fr = makeFRResult([
+      makeFRTask({ taskId: "A", normalizedFR: 0.5 }),
+      makeFRTask({ taskId: "B", normalizedFR: 0.5 }),
+    ]);
+    // No exposure passed → both default to 1 → normalized 0.5:0.5
+    const result = computeOmegaForgettingPressure(fr, { exposure: {} });
+    expect(result.pressure).toBeCloseTo(0.5, 10);
+  });
+
+  it("zero exposure on a task drops its contribution", () => {
+    const fr = makeFRResult([
+      makeFRTask({ taskId: "A", normalizedFR: 0.8 }),
+      makeFRTask({ taskId: "B", normalizedFR: 0.2 }),
+    ]);
+    // B's exposure is 0 → all weight goes to A → pressure = 0.8
+    const result = computeOmegaForgettingPressure(fr, {
+      exposure: { A: 1, B: 0 },
+    });
+    expect(result.pressure).toBeCloseTo(0.8, 10);
+  });
+
+  it("negative / NaN exposures are clamped to 0", () => {
+    const fr = makeFRResult([
+      makeFRTask({ taskId: "A", normalizedFR: 0.5 }),
+      makeFRTask({ taskId: "B", normalizedFR: 0.5 }),
+      makeFRTask({ taskId: "C", normalizedFR: 0.5 }),
+    ]);
+    const result = computeOmegaForgettingPressure(fr, {
+      exposure: { A: 1, B: -5, C: NaN },
+    });
+    // B / C zeroed → only A contributes → pressure = 0.5
+    expect(result.pressure).toBeCloseTo(0.5, 10);
+  });
+
+  it("normalizeWeights: false preserves the raw scale", () => {
+    const fr = makeFRResult([
+      makeFRTask({ taskId: "A", normalizedFR: 0.5 }),
+      makeFRTask({ taskId: "B", normalizedFR: 0.5 }),
+    ]);
+    const result = computeOmegaForgettingPressure(fr, {
+      exposure: { A: 2, B: 2 },
+      normalizeWeights: false,
+    });
+    // Σ 2·0.5 + 2·0.5 = 2
+    expect(result.pressure).toBeCloseTo(2, 10);
+    expect(result.totalExposure).toBeCloseTo(4, 10);
+  });
+});
+
+// ─── NaN / degenerate handling ───────────────────────────────────────
+
+describe("computeOmegaForgettingPressure — degenerate tasks", () => {
+  it("drops tasks with NaN normalizedFR from the sum", () => {
+    const fr = makeFRResult([
+      makeFRTask({ taskId: "A", normalizedFR: 0.5 }),
+      makeFRTask({ taskId: "B", normalizedFR: NaN }),
+    ]);
+    const result = computeOmegaForgettingPressure(fr);
+    // B drops; A gets all the weight after normalization → pressure = 0.5
+    expect(result.pressure).toBeCloseTo(0.5, 10);
+    expect(result.contributions).toHaveLength(1);
+    expect(result.contributions[0].taskId).toBe("A");
+    expect(result.degenerateTaskCount).toBe(1);
+  });
+
+  it("returns NaN pressure when every task is degenerate", () => {
+    const fr = makeFRResult([
+      makeFRTask({ taskId: "A", normalizedFR: NaN }),
+      makeFRTask({ taskId: "B", normalizedFR: NaN }),
+    ]);
+    const result = computeOmegaForgettingPressure(fr);
+    expect(Number.isNaN(result.pressure)).toBe(true);
+    expect(result.contributions).toHaveLength(0);
+    expect(result.degenerateTaskCount).toBe(2);
+  });
+
+  it("clamps out-of-range normalizedFR to [0, 1]", () => {
+    const fr = makeFRResult([
+      makeFRTask({ taskId: "A", normalizedFR: 1.7 }), // clamps to 1
+      makeFRTask({ taskId: "B", normalizedFR: -0.3 }), // clamps to 0
+    ]);
+    const result = computeOmegaForgettingPressure(fr);
+    expect(result.pressure).toBeCloseTo(0.5, 10);
+  });
+});
+
+// ─── Time-varying series ─────────────────────────────────────────────
+
+describe("computeOmegaForgettingPressure — pressureOverTime", () => {
+  it("each epoch is the weighted sum of per-task FR-over-time values", () => {
+    const fr = makeFRResult([
+      makeFRTask({
+        taskId: "A",
+        normalizedFROverTime: [0, 0.2, 0.4],
+      }),
+      makeFRTask({
+        taskId: "B",
+        normalizedFROverTime: [0, 0.1, 0.3],
+      }),
+    ]);
+    const result = computeOmegaForgettingPressure(fr);
+    // Uniform weights 0.5 / 0.5
+    expect(result.pressureOverTime[0]).toBeCloseTo(0, 10);
+    expect(result.pressureOverTime[1]).toBeCloseTo(0.5 * 0.2 + 0.5 * 0.1, 10);
+    expect(result.pressureOverTime[2]).toBeCloseTo(0.5 * 0.4 + 0.5 * 0.3, 10);
+  });
+
+  it("epochs where every task is degenerate yield NaN", () => {
+    // All degenerate → no live tasks → series is empty → result series
+    // has length 0.
+    const fr = makeFRResult([
+      makeFRTask({
+        taskId: "A",
+        normalizedFR: NaN,
+        normalizedFROverTime: [0, 0.2],
+      }),
+    ]);
+    const result = computeOmegaForgettingPressure(fr);
+    // A is degenerate at the summary level → live map is empty → every
+    // epoch's `anyAtEpoch` is false → all NaN.
+    for (const v of result.pressureOverTime) {
+      expect(Number.isNaN(v)).toBe(true);
+    }
+  });
+});
+
+// ─── Argument validation ─────────────────────────────────────────────
+
+describe("computeOmegaForgettingPressure — argument validation", () => {
+  it("throws when the FRResult has zero tasks", () => {
+    const fr: FRResult = {
+      tasks: [],
+      sourceKind: "synthetic",
+      traceId: "empty",
+    };
+    expect(() => computeOmegaForgettingPressure(fr)).toThrow(/zero tasks/);
+  });
+});
+
+// ─── Convenience helpers ─────────────────────────────────────────────
+
+describe("peakPressure", () => {
+  it("returns the maximum value + its epoch index", () => {
+    const fr = makeFRResult([
+      makeFRTask({
+        taskId: "A",
+        normalizedFROverTime: [0, 0.3, 0.1, 0.5, 0.2],
+      }),
+    ]);
+    const result = computeOmegaForgettingPressure(fr);
+    const peak = peakPressure(result);
+    expect(peak.value).toBeCloseTo(0.5, 10);
+    expect(peak.epochIndex).toBe(3);
+  });
+
+  it("returns NaN / -1 when the series is empty or all-NaN", () => {
+    const fr = makeFRResult([
+      makeFRTask({
+        taskId: "A",
+        normalizedFR: NaN,
+        normalizedFROverTime: [0, 0.2],
+      }),
+    ]);
+    const result = computeOmegaForgettingPressure(fr);
+    const peak = peakPressure(result);
+    expect(Number.isNaN(peak.value)).toBe(true);
+    expect(peak.epochIndex).toBe(-1);
+  });
+});
+
+describe("topContributors", () => {
+  it("returns the first N contributions (already sorted)", () => {
+    const fr = makeFRResult([
+      makeFRTask({ taskId: "A", normalizedFR: 0.2 }),
+      makeFRTask({ taskId: "B", normalizedFR: 0.9 }),
+      makeFRTask({ taskId: "C", normalizedFR: 0.5 }),
+    ]);
+    const result = computeOmegaForgettingPressure(fr);
+    const top2 = topContributors(result, 2);
+    expect(top2).toHaveLength(2);
+    expect(top2[0].taskId).toBe("B");
+    expect(top2[1].taskId).toBe("C");
+  });
+
+  it("returns [] when N ≤ 0", () => {
+    const fr = makeFRResult([makeFRTask({ taskId: "A" })]);
+    const result = computeOmegaForgettingPressure(fr);
+    expect(topContributors(result, 0)).toEqual([]);
+    expect(topContributors(result, -1)).toEqual([]);
+  });
+});
+
+// ─── End-to-end on the AI Safety demo trace ──────────────────────────
+
+describe("computeOmegaForgettingPressure — AI Safety demo trace", () => {
+  it("Heartbleed dominates contributions under the canonical exposure", () => {
+    const trace = buildAISafetyDemoTrace();
+    const fr = computeFR(trace);
+    const result = computeOmegaForgettingPressure(fr, {
+      exposure: AI_SAFETY_DEMO_EXPOSURE,
+    });
+    // Heartbleed has 4x the forgettingRate of DDoS and a long off-task
+    // tail before the trace ends, so its `contribution` should be the
+    // largest entry in the sorted list even though its exposure (0.20)
+    // is the smallest.
+    expect(result.contributions[0].taskId).toBe("task_heartbleed");
+    expect(result.sourceKind).toBe("synthetic");
+    expect(result.traceId).toBe("ai-safety-demo-ids");
+    // Pressure ∈ [0, 1]
+    expect(result.pressure).toBeGreaterThanOrEqual(0);
+    expect(result.pressure).toBeLessThanOrEqual(1);
+  });
+
+  it("pressureOverTime is non-decreasing across the off-task tail", () => {
+    const trace = buildAISafetyDemoTrace();
+    const fr = computeFR(trace);
+    const result = computeOmegaForgettingPressure(fr, {
+      exposure: AI_SAFETY_DEMO_EXPOSURE,
+    });
+    // After epoch 9 the curriculum revisits DDoS only — MITM and
+    // Heartbleed are off-task and decaying. Pressure should rise
+    // (modulo noise) over that window. Compare endpoints since noise
+    // can cause local non-monotonicity.
+    const last = result.pressureOverTime[result.pressureOverTime.length - 1];
+    const atRevisitStart = result.pressureOverTime[9];
+    expect(last).toBeGreaterThanOrEqual(atRevisitStart);
+  });
+});

--- a/src/lib/discovery/ai-safety-demo-trace.ts
+++ b/src/lib/discovery/ai-safety-demo-trace.ts
@@ -1,0 +1,85 @@
+// ─── AI Safety demo TrainingTrace ───────────────────────────────────
+//
+// Canonical synthetic substrate the AI-domain UI surfaces wire onto
+// while PR 5 (real PyTorch / TF ingester) is still pending. Every
+// trace this module emits is `source.kind === "synthetic"`; UI
+// surfaces consuming derived values MUST render a SYNTHETIC badge
+// — no customer business decision runs off this data.
+//
+// The curriculum reproduces the Ghauri 2025 Ch. 8 Heartbleed archetype:
+// the IDS trains DDoS first, then MITM, then Heartbleed, then drifts
+// back to DDoS. With Heartbleed configured at a much higher
+// forgettingRate than DDoS/MITM, the trace shows the dissertation's
+// signature pattern — Heartbleed peaks high but rots fast, while
+// DDoS retention stays comfortable.
+//
+// Exposure preset:
+//   DDoS       — 0.55  (most common attack class)
+//   MITM       — 0.25
+//   Heartbleed — 0.20  (less common but high-impact when present)
+//
+// Result: Ω-FP weights Heartbleed forgetting more aggressively than
+// uniform-exposure would, which is the operationally honest reading
+// the dissertation argues for.
+
+import type { TaskRef } from "./training-trace-types";
+import {
+  buildSyntheticTrainingTrace,
+  type CurriculumWindow,
+} from "./training-trace-synthetic";
+
+/** Ordered tasks the demo trace tracks. */
+export const AI_SAFETY_DEMO_TASKS: TaskRef[] = [
+  { id: "task_ddos", label: "DDoS", scope: "attack-class" },
+  { id: "task_mitm", label: "MITM", scope: "attack-class" },
+  { id: "task_heartbleed", label: "Heartbleed", scope: "attack-class" },
+];
+
+/**
+ * Default per-task exposure used by the Ω-Forgetting Pressure surface.
+ * Normalized to sum to 1; mirrors the public IDS-class distributions
+ * the dissertation references (Ch. 8 §2). Values are illustrative —
+ * a real production deployment would override per environment.
+ */
+export const AI_SAFETY_DEMO_EXPOSURE: Record<string, number> = {
+  task_ddos: 0.55,
+  task_mitm: 0.25,
+  task_heartbleed: 0.2,
+};
+
+/**
+ * Curriculum: 3 epochs DDoS → 3 epochs MITM → 3 epochs Heartbleed →
+ * 6 epochs back to DDoS. The tail revisit on DDoS gives MITM and
+ * (especially) Heartbleed a long off-task window to decay over so
+ * the Ω-FP surface has a meaningful time-varying signal to render.
+ */
+const DEMO_CURRICULUM: CurriculumWindow[] = [
+  { taskId: "task_ddos", startEpoch: 0, endEpoch: 3 },
+  { taskId: "task_mitm", startEpoch: 3, endEpoch: 6 },
+  { taskId: "task_heartbleed", startEpoch: 6, endEpoch: 9 },
+  { taskId: "task_ddos", startEpoch: 9, endEpoch: 15 },
+];
+
+/**
+ * Build the canonical AI Safety demo trace. Always synthetic; safe to
+ * call multiple times — same seed + curriculum → bit-identical trace.
+ */
+export function buildAISafetyDemoTrace() {
+  return buildSyntheticTrainingTrace({
+    id: "ai-safety-demo-ids",
+    label: "AI Safety — IDS continual-learning demo",
+    tasks: AI_SAFETY_DEMO_TASKS,
+    curriculum: DEMO_CURRICULUM,
+    taskDynamics: {
+      task_ddos: { forgettingRate: 0.05, learningRate: 0.5 },
+      task_mitm: { forgettingRate: 0.08, learningRate: 0.5 },
+      // Heartbleed: dissertation's archetypal high-FR task — rots ~4x
+      // faster than DDoS when training moves away.
+      task_heartbleed: { forgettingRate: 0.3, learningRate: 0.4 },
+    },
+    seed: 8201,
+    noiseAmplitude: 0.015,
+    description:
+      "Synthetic continual-learning trace reproducing the Ghauri 2025 Ch. 8 Heartbleed-archetype forgetting pattern (DDoS / MITM / Heartbleed curriculum, exposure-weighted Ω-FP).",
+  });
+}

--- a/src/lib/discovery/fr-estimator.ts
+++ b/src/lib/discovery/fr-estimator.ts
@@ -1,0 +1,321 @@
+// ─── Discovery — FR (Forgetting Rate) Estimator ──────────────────────
+//
+// Phase 3 PR 3 of the Ghauri 2025 dissertation integration. Reads a
+// TrainingTrace (from PR #380) and computes per-task Forgetting Rate
+// values — how much accuracy on Task A was lost after training shifted
+// away from it.
+//
+// Why this matters for AI Safety: the dissertation's Ch. 8 catastrophic-
+// forgetting analysis argues that some attack classes (Heartbleed is
+// the archetype) get forgotten dramatically faster than others when
+// the curriculum shifts. FR is the per-task scalar that surfaces that
+// asymmetry — a high FR on Heartbleed = "the IDS just stopped catching
+// this attack class because training moved to DDoS."
+//
+// DOMAIN GATING
+// -------------
+// AI-domain only in SEMANTICS. The function signature is profile-
+// agnostic — same pattern as `computeBESTemporal` from PR #385 — and
+// gating happens upstream in the UI (PR 4 will only render FR on
+// AI_SAFETY_PROFILE). Geopolitical / T1D / other domains never invoke
+// this; their R-pillar still comes from Pearl-counterfactual recovery.
+//
+// PROVENANCE
+// ----------
+// The result forwards `source.kind` from the input trace verbatim.
+// UI surfaces displaying values derived from a synthetic result MUST
+// render a SYNTHETIC badge (preserving the contract from PR #380).
+//
+// FORMULAS
+// --------
+// For each task k tracked in the trace:
+//
+//   peakAccuracy_k       = max_t acc_{t, k}
+//   peakEpoch_k          = argmax_t acc_{t, k}
+//   finalAccuracy_k      = acc_{final, k}
+//   lastTrainedEpoch_k   = max_{t : k ∈ activeTaskIds_t} t  (or -1 if never)
+//   absoluteForgetting_k = peakAccuracy_k − finalAccuracy_k         (≥ 0)
+//   normalizedFR_k       = absoluteForgetting_k / peakAccuracy_k    (∈ [0, 1])
+//
+// And the time-varying signal that PR 4 reads to compute Ω-Forgetting
+// Pressure:
+//
+//   FR_k(t)            = max_{s ≤ t} acc_{s, k} − acc_{t, k}
+//   normalizedFR_k(t)  = FR_k(t) / max_{s ≤ t} acc_{s, k}    (or 0 when peak=0)
+//
+// Plus the empirical decay rate λ, fit on the post-peak window via
+// least-squares regression on log-residuals:
+//
+//   acc(t) − baseline = (peak − baseline) · exp(−λ · (t − peakEpoch))
+//   ⇒ log((acc(t) − baseline) / (peak − baseline)) = −λ · (t − peakEpoch)
+//
+// Linear regression on (t − peakEpoch, −log(...)) gives slope λ. Used
+// to verify the dissertation's synthetic-archetype tests (a trace
+// built with `forgettingRate: 0.30` should yield decayRate ≈ 0.30).
+// Returns NaN when there are fewer than 2 valid post-peak points
+// (insufficient data) or the task never decayed below peak (no
+// forgetting to fit).
+
+import type { TrainingTrace } from "./training-trace-types";
+
+export interface FRTaskResult {
+  taskId: string;
+  /** Highest accuracy observed for this task across the full trace. */
+  peakAccuracy: number;
+  /** Epoch index at which peakAccuracy was reached. */
+  peakEpoch: number;
+  /** Accuracy at the trace's final epoch. */
+  finalAccuracy: number;
+  /**
+   * Last epoch this task appeared in `activeTaskIds`. -1 if the task
+   * never trained — important guard: a task that never trained
+   * can't be "forgotten" in any meaningful sense.
+   */
+  lastTrainedEpoch: number;
+
+  /**
+   * Time-varying FR. `frOverTime[i]` = peak-so-far minus accuracy at
+   * epoch i. Length matches `trace.epochs.length`. Non-decreasing in
+   * the trivial sense (peak-so-far never decreases, and current
+   * accuracy can only re-establish a higher peak by replacing it,
+   * not by lowering FR).
+   */
+  frOverTime: number[];
+  /**
+   * Time-varying normalized FR ∈ [0, 1]. `normalizedFROverTime[i]`
+   * = `frOverTime[i] / peakSoFar(i)`. Zero when peakSoFar is 0
+   * (no training has happened yet for this task).
+   */
+  normalizedFROverTime: number[];
+
+  // ── Summary scalars ─────────────────────────────────────────────
+  /** peakAccuracy − finalAccuracy. ≥ 0. */
+  absoluteForgetting: number;
+  /** absoluteForgetting / peakAccuracy. ∈ [0, 1]. NaN when peakAccuracy ≤ 0. */
+  normalizedFR: number;
+  /**
+   * Empirical decay rate λ fit on the post-peak window.
+   * `acc(t) ≈ baseline + (peak − baseline) · exp(−λ · (t − peakEpoch))`.
+   * NaN when the fit is unreliable (< 2 valid post-peak points, or
+   * task never decayed below peak).
+   */
+  decayRate: number;
+}
+
+export interface FRResult {
+  tasks: FRTaskResult[];
+  /** Inherited verbatim from `trace.source.kind`. SYNTHETIC-badge gate. */
+  sourceKind: "synthetic" | "live";
+  /** Echo of the input trace id for downstream cross-reference. */
+  traceId: string;
+}
+
+export interface ComputeFROptions {
+  /**
+   * Baseline accuracy used in the decay-rate fit. The fit converges
+   * to exp(-λ·n) only when `(acc − baseline) / (peak − baseline)`
+   * stays in (0, 1]. If the caller knows the architecture's
+   * pre-training baseline, pass it here per task.
+   *
+   * Default: each task uses the minimum accuracy seen for it across
+   * the full trace as its baseline. Robust to traces where the
+   * "pre-training" epoch isn't 0.
+   */
+  baselinePerTask?: Record<string, number>;
+}
+
+// ─── Implementation helpers ─────────────────────────────────────────
+
+/**
+ * Least-squares linear regression of y on x. Returns the slope
+ * (β = Σ(x_i − x̄)(y_i − ȳ) / Σ(x_i − x̄)²). NaN when there are
+ * fewer than 2 points or all x values are identical (degenerate).
+ */
+function linRegressionSlope(xs: number[], ys: number[]): number {
+  const n = xs.length;
+  if (n < 2 || ys.length !== n) return NaN;
+  let sumX = 0;
+  let sumY = 0;
+  for (let i = 0; i < n; i++) {
+    sumX += xs[i];
+    sumY += ys[i];
+  }
+  const meanX = sumX / n;
+  const meanY = sumY / n;
+  let num = 0;
+  let den = 0;
+  for (let i = 0; i < n; i++) {
+    const dx = xs[i] - meanX;
+    num += dx * (ys[i] - meanY);
+    den += dx * dx;
+  }
+  if (den === 0) return NaN;
+  return num / den;
+}
+
+/**
+ * Fit decay rate λ on a post-peak accuracy window.
+ *
+ *   acc(t) = baseline + (peak − baseline) · exp(−λ · (t − peakEpoch))
+ *
+ * Returns NaN when the fit is unreliable (insufficient data, no
+ * decay, or numerical degenerate cases — accuracy below baseline at
+ * every post-peak point, etc.).
+ */
+function fitDecayRate(
+  epochs: number[],
+  accs: number[],
+  peakEpoch: number,
+  peakAcc: number,
+  baseline: number,
+): number {
+  if (peakAcc <= baseline) return NaN;
+  const range = peakAcc - baseline;
+  const xs: number[] = [];
+  const negLogYs: number[] = [];
+  for (let i = 0; i < epochs.length; i++) {
+    const t = epochs[i];
+    if (t <= peakEpoch) continue;
+    const dt = t - peakEpoch;
+    const y = (accs[i] - baseline) / range;
+    if (y <= 0 || y > 1) continue; // out of the model's valid range
+    xs.push(dt);
+    negLogYs.push(-Math.log(y));
+  }
+  return linRegressionSlope(xs, negLogYs);
+}
+
+// ─── Main entry point ───────────────────────────────────────────────
+
+/**
+ * Compute per-task FR values from a TrainingTrace. AI-domain semantics
+ * (gating happens upstream); profile-agnostic at the function level.
+ *
+ * Throws on empty trace — the caller should validate upstream via
+ * `validateTrainingTrace` before this point. Returns NaN entries
+ * gracefully for tasks that never trained or never decayed.
+ */
+export function computeFR(
+  trace: TrainingTrace,
+  options: ComputeFROptions = {},
+): FRResult {
+  if (trace.epochs.length === 0) {
+    throw new Error("computeFR: trace has zero epochs");
+  }
+  if (trace.tasks.length === 0) {
+    throw new Error("computeFR: trace has zero tasks");
+  }
+
+  const baselineOverride = options.baselinePerTask ?? {};
+  const taskResults: FRTaskResult[] = trace.tasks.map((task) => {
+    // ── Walk the trace once for this task. ──────────────────────
+    let peakAccuracy = -Infinity;
+    let peakEpoch = -1;
+    let lastTrainedEpoch = -1;
+    let minAccuracy = Infinity;
+    const accs: number[] = [];
+    const epochIndices: number[] = [];
+    const frOverTime: number[] = [];
+    const normalizedFROverTime: number[] = [];
+    let peakSoFar = -Infinity;
+
+    for (const epoch of trace.epochs) {
+      epochIndices.push(epoch.index);
+      const entry = epoch.accuracy.find((a) => a.taskId === task.id);
+      // Missing accuracy entries (shouldn't happen on validated traces
+      // but we defend) treat as 0 to keep the time series length
+      // consistent.
+      const acc = entry?.value ?? 0;
+      accs.push(acc);
+      if (acc > peakAccuracy) {
+        peakAccuracy = acc;
+        peakEpoch = epoch.index;
+      }
+      if (acc < minAccuracy) minAccuracy = acc;
+      if (acc > peakSoFar) peakSoFar = acc;
+      const fr = Math.max(0, peakSoFar - acc);
+      frOverTime.push(fr);
+      normalizedFROverTime.push(peakSoFar > 0 ? fr / peakSoFar : 0);
+      if (epoch.activeTaskIds.includes(task.id)) {
+        lastTrainedEpoch = epoch.index;
+      }
+    }
+
+    const finalAccuracy = accs[accs.length - 1];
+    const absoluteForgetting = Math.max(0, peakAccuracy - finalAccuracy);
+    const normalizedFR =
+      peakAccuracy > 0 ? absoluteForgetting / peakAccuracy : NaN;
+
+    // ── Decay-rate fit ─────────────────────────────────────────
+    // Default baseline: minimum accuracy observed across the trace.
+    // Override available per-task via options.
+    const baseline = baselineOverride[task.id] ?? minAccuracy;
+    const decayRate = fitDecayRate(
+      epochIndices,
+      accs,
+      peakEpoch,
+      peakAccuracy,
+      baseline,
+    );
+
+    return {
+      taskId: task.id,
+      peakAccuracy: peakAccuracy === -Infinity ? 0 : peakAccuracy,
+      peakEpoch: peakEpoch === -1 ? 0 : peakEpoch,
+      finalAccuracy,
+      lastTrainedEpoch,
+      frOverTime,
+      normalizedFROverTime,
+      absoluteForgetting,
+      normalizedFR,
+      decayRate,
+    };
+  });
+
+  return {
+    tasks: taskResults,
+    sourceKind: trace.source.kind,
+    traceId: trace.id,
+  };
+}
+
+// ─── Convenience helpers ────────────────────────────────────────────
+
+/**
+ * Rank tasks by `normalizedFR` descending. The dissertation's
+ * Heartbleed-archetype is exactly the task at the top of this list:
+ * highest fraction of peak accuracy lost. Useful for the
+ * forgetting-pressure surface (PR 4).
+ */
+export function rankTasksByNormalizedFR(result: FRResult): FRTaskResult[] {
+  // Sort with NaN at the end (NaN comparisons always return false).
+  return [...result.tasks].sort((a, b) => {
+    const an = Number.isNaN(a.normalizedFR);
+    const bn = Number.isNaN(b.normalizedFR);
+    if (an && bn) return 0;
+    if (an) return 1;
+    if (bn) return -1;
+    return b.normalizedFR - a.normalizedFR;
+  });
+}
+
+/**
+ * Aggregate per-task FR into a single trace-level scalar — the mean
+ * of `normalizedFR` across tasks that have a defined (non-NaN) value.
+ * Returns NaN when no task has a defined FR (degenerate trace).
+ *
+ * This is NOT yet the Ω-Forgetting Pressure metric — that one weights
+ * each task's FR by an exposure value (Σ exposure × FR), and exposure
+ * comes from outside the trace. PR 4 builds Ω-FP on top of this.
+ */
+export function meanNormalizedFR(result: FRResult): number {
+  let sum = 0;
+  let count = 0;
+  for (const t of result.tasks) {
+    if (!Number.isNaN(t.normalizedFR)) {
+      sum += t.normalizedFR;
+      count++;
+    }
+  }
+  return count === 0 ? NaN : sum / count;
+}

--- a/src/lib/discovery/omega-forgetting-pressure.ts
+++ b/src/lib/discovery/omega-forgetting-pressure.ts
@@ -1,0 +1,297 @@
+// ─── Discovery — Ω-Forgetting Pressure ──────────────────────────────
+//
+// Phase 3 PR 4 of the Ghauri 2025 dissertation integration. Reads an
+// FRResult (PR #396) plus a per-task exposure vector and reduces to a
+// single trace-level scalar: how much of the model's capability is
+// being lost RIGHT NOW, weighted by how exposed each task is.
+//
+// Why this matters for AI Safety: the dissertation's Ch. 8 catastrophic-
+// forgetting argument is that the R-pillar reading should NOT treat
+// every attack class equally. A Heartbleed-class attacker doesn't care
+// that the model still nails DDoS — they care that Heartbleed detection
+// rotted. Ω-Forgetting Pressure is the operator-facing scalar that says
+// "given which attack classes you actually see in production, how much
+// of your defence has rotted." It's the catastrophic-forgetting analog
+// of Ω-Bridge Density (a single [0, 1] scalar for the operator).
+//
+// FORMULAS
+// --------
+// Given:
+//   normalizedFR_k(t) = fraction of task_k's peak accuracy lost by
+//                       epoch t (from PR #396 FR estimator).
+//   w_k               = exposure / importance weight for task_k.
+//
+// Normalize the weights so they sum to 1 (when `normalizeWeights:
+// true`), then:
+//
+//   Ω-FP(t) = Σ_k w_k · clamp(normalizedFR_k(t), 0, 1)
+//
+// And the trace-level summary scalar:
+//
+//   Ω-FP_summary = Σ_k w_k · clamp(normalizedFR_k, 0, 1)
+//
+// (Where `normalizedFR_k` without `(t)` is the summary scalar from
+// `FRTaskResult` — peakAccuracy − finalAccuracy normalized.)
+//
+// NAN HANDLING
+// ------------
+// FR estimator returns NaN for tasks with peakAccuracy ≤ 0 (degenerate
+// — never trained, no accuracy ever). Those tasks DROP from the sum
+// (exposure forfeited) — they don't pollute the pressure scalar with
+// NaN. If every task is degenerate, the result is NaN (no data).
+//
+// PROVENANCE
+// ----------
+// `sourceKind` is forwarded verbatim from the FRResult (which forwards
+// from the underlying TrainingTrace). UI surfaces displaying values
+// derived from a synthetic-kind result MUST render a SYNTHETIC badge.
+// PR 4's UI is what enforces this.
+//
+// DOMAIN GATING
+// -------------
+// AI-domain only in SEMANTICS. Function signature is profile-agnostic
+// — same pattern as `computeBESTemporal` and `computeFR`. Gating
+// happens upstream in the UI surface (which only renders this on
+// AI_SAFETY_PROFILE).
+
+import type { FRResult, FRTaskResult } from "./fr-estimator";
+
+export interface OmegaForgettingPressureOptions {
+  /**
+   * Per-task exposure weights. Keyed by `FRTaskResult.taskId`. Tasks
+   * missing from this record default to `1` (uniform fallback). Tasks
+   * present with a value of 0 contribute nothing to the pressure scalar.
+   *
+   * Default: every task gets weight 1 (uniform exposure). With
+   * `normalizeWeights: true` this is equivalent to averaging the FR
+   * values, weighted equally.
+   */
+  exposure?: Record<string, number>;
+  /**
+   * Normalize the weights so they sum to 1 before computing the
+   * weighted sum. Default `true` — keeps `Ω-FP ∈ [0, 1]` regardless of
+   * the raw weight scale, which is what the UI band coloring assumes.
+   *
+   * Set to `false` if the caller wants raw weighted sums (e.g., for
+   * computing aggregate "expected forgotten capacity" across an
+   * adversary mix where the weights aren't probabilities).
+   */
+  normalizeWeights?: boolean;
+}
+
+export interface TaskContribution {
+  taskId: string;
+  /** Exposure weight actually used (after normalization, if any). */
+  exposure: number;
+  /** Summary normalizedFR for this task (NaN-stripped). */
+  normalizedFR: number;
+  /** `exposure × normalizedFR` — this task's contribution to the summary pressure. */
+  contribution: number;
+}
+
+export interface OmegaForgettingPressureResult {
+  /**
+   * Summary scalar — `Σ w_k · normalizedFR_k` where `normalizedFR_k`
+   * is the trace-level FR scalar (peak − final). With normalized
+   * weights this lies in [0, 1]. NaN when every task is degenerate.
+   */
+  pressure: number;
+  /**
+   * Time-varying pressure series — `pressureOverTime[t] = Σ w_k ·
+   * normalizedFROverTime_k[t]`. Length matches the underlying FR time
+   * series. Same `[0, 1]` range when weights are normalized.
+   */
+  pressureOverTime: number[];
+  /**
+   * Per-task breakdown of the summary pressure. Useful for the UI
+   * drill-down ("which tasks drove the reading"). Sorted by
+   * `contribution` descending.
+   */
+  contributions: TaskContribution[];
+  /** Total exposure mass across non-degenerate tasks (1 when normalized). */
+  totalExposure: number;
+  /** Number of tasks whose `normalizedFR` was NaN and excluded from the sum. */
+  degenerateTaskCount: number;
+  /** Forwarded from `frResult.sourceKind`. SYNTHETIC-badge gate. */
+  sourceKind: "synthetic" | "live";
+  /** Forwarded from `frResult.traceId`. */
+  traceId: string;
+}
+
+// ─── Implementation ─────────────────────────────────────────────────
+
+function clamp01(x: number): number {
+  if (!Number.isFinite(x)) return 0;
+  if (x < 0) return 0;
+  if (x > 1) return 1;
+  return x;
+}
+
+/**
+ * Resolve the per-task exposure used in the weighted sum. Missing
+ * tasks get weight 1 (uniform fallback); negative weights are clamped
+ * to 0; NaN/Infinity weights are treated as 0.
+ */
+function resolveExposure(
+  tasks: FRTaskResult[],
+  override: Record<string, number> | undefined,
+): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const t of tasks) {
+    const raw = override?.[t.taskId];
+    const w = raw === undefined ? 1 : raw;
+    if (!Number.isFinite(w) || w < 0) {
+      out.set(t.taskId, 0);
+    } else {
+      out.set(t.taskId, w);
+    }
+  }
+  return out;
+}
+
+/**
+ * Build the live exposure vector — exposure ONLY counted on tasks
+ * whose `normalizedFR` is defined (peakAccuracy > 0). Returned vector
+ * + total mass; if `normalizeWeights` was requested and the total
+ * mass is > 0, the per-task values are scaled to sum to 1.
+ */
+function liveExposure(
+  tasks: FRTaskResult[],
+  resolved: Map<string, number>,
+  normalize: boolean,
+): { live: Map<string, number>; total: number; degenerate: number } {
+  const live = new Map<string, number>();
+  let total = 0;
+  let degenerate = 0;
+  for (const t of tasks) {
+    const w = resolved.get(t.taskId) ?? 0;
+    if (Number.isNaN(t.normalizedFR)) {
+      degenerate++;
+      continue;
+    }
+    live.set(t.taskId, w);
+    total += w;
+  }
+  if (normalize && total > 0) {
+    for (const [k, v] of live) live.set(k, v / total);
+    total = 1;
+  }
+  return { live, total, degenerate };
+}
+
+/**
+ * Compute Ω-Forgetting Pressure on an FRResult.
+ *
+ * Throws when the FRResult has no tasks — caller should already have
+ * validated this upstream.
+ */
+export function computeOmegaForgettingPressure(
+  frResult: FRResult,
+  options: OmegaForgettingPressureOptions = {},
+): OmegaForgettingPressureResult {
+  if (frResult.tasks.length === 0) {
+    throw new Error(
+      "computeOmegaForgettingPressure: FRResult has zero tasks",
+    );
+  }
+  const normalize = options.normalizeWeights ?? true;
+  const resolved = resolveExposure(frResult.tasks, options.exposure);
+  const { live, total, degenerate } = liveExposure(
+    frResult.tasks,
+    resolved,
+    normalize,
+  );
+
+  // ── Summary scalar ──────────────────────────────────────────────
+  let pressure = 0;
+  let anyContribution = false;
+  const contributions: TaskContribution[] = [];
+  for (const t of frResult.tasks) {
+    const w = live.get(t.taskId);
+    if (w === undefined) continue; // degenerate task
+    const nfr = clamp01(t.normalizedFR);
+    const contribution = w * nfr;
+    pressure += contribution;
+    anyContribution = true;
+    contributions.push({
+      taskId: t.taskId,
+      exposure: w,
+      normalizedFR: nfr,
+      contribution,
+    });
+  }
+  contributions.sort((a, b) => b.contribution - a.contribution);
+
+  // ── Time-varying series ─────────────────────────────────────────
+  // Use the first non-degenerate task's series length as the canonical
+  // epoch count. All series in an FRResult share the same length per
+  // PR #396 shape contract.
+  let epochCount = 0;
+  for (const t of frResult.tasks) {
+    if (t.normalizedFROverTime.length > epochCount) {
+      epochCount = t.normalizedFROverTime.length;
+    }
+  }
+  const pressureOverTime: number[] = new Array(epochCount).fill(0);
+  for (let i = 0; i < epochCount; i++) {
+    let acc = 0;
+    let anyAtEpoch = false;
+    for (const t of frResult.tasks) {
+      const w = live.get(t.taskId);
+      if (w === undefined) continue;
+      const nfr = clamp01(t.normalizedFROverTime[i] ?? 0);
+      acc += w * nfr;
+      anyAtEpoch = true;
+    }
+    pressureOverTime[i] = anyAtEpoch ? acc : NaN;
+  }
+
+  return {
+    pressure: anyContribution ? pressure : NaN,
+    pressureOverTime,
+    contributions,
+    totalExposure: total,
+    degenerateTaskCount: degenerate,
+    sourceKind: frResult.sourceKind,
+    traceId: frResult.traceId,
+  };
+}
+
+// ─── Convenience helpers ────────────────────────────────────────────
+
+/**
+ * The peak pressure observed across the time-varying series. Useful
+ * for "this trace reached Ω-FP = X at its worst point" callouts.
+ * Ignores NaN entries; returns NaN if the series is all-NaN or empty.
+ */
+export function peakPressure(result: OmegaForgettingPressureResult): {
+  value: number;
+  epochIndex: number;
+} {
+  let peak = -Infinity;
+  let epochIndex = -1;
+  for (let i = 0; i < result.pressureOverTime.length; i++) {
+    const v = result.pressureOverTime[i];
+    if (!Number.isFinite(v)) continue;
+    if (v > peak) {
+      peak = v;
+      epochIndex = i;
+    }
+  }
+  if (epochIndex === -1) return { value: NaN, epochIndex: -1 };
+  return { value: peak, epochIndex };
+}
+
+/**
+ * The top-N tasks driving the current summary pressure, by absolute
+ * contribution. `contributions` is already sorted descending, so this
+ * is just a slice — convenience wrapper so callers don't have to know
+ * about the ordering invariant.
+ */
+export function topContributors(
+  result: OmegaForgettingPressureResult,
+  n: number,
+): TaskContribution[] {
+  if (n <= 0) return [];
+  return result.contributions.slice(0, n);
+}

--- a/src/lib/omega-forgetting-pressure-display.ts
+++ b/src/lib/omega-forgetting-pressure-display.ts
@@ -1,0 +1,92 @@
+// Display helpers for Ω-Forgetting Pressure on the snapshot-diagnostics
+// surface.
+//
+// The math lives in src/lib/discovery/omega-forgetting-pressure.ts.
+// This file is the UI concern: mapping the [0, 1] scalar to a color
+// band + human-readable label.
+//
+// Higher pressure = more forgetting = WORSE (opposite-polarity to
+// Ω-Bridge Density, where the value is interpreted relative to a
+// "redundant"/"nominal"/"fragile" topology spectrum). Bands:
+//
+//   pressure < 0.15      — NOMINAL: model is retaining knowledge
+//                          across all exposed tasks.
+//   0.15 ≤ pressure ≤ 0.30 — ELEVATED: some forgetting is visible;
+//                          worth watching but not yet critical.
+//   0.30 < pressure ≤ 0.60 — CRITICAL: substantial capability rot on
+//                          tasks that carry real exposure.
+//   pressure > 0.60      — CATASTROPHIC: majority of weighted task
+//                          accuracy has been lost. Retraining or
+//                          replay-buffer interventions warranted.
+//
+// Thresholds chosen to mirror Ω-Bridge Density's spacing (0.05 / 0.30 /
+// 0.60) shifted up by 0.10 — the FR scalar is a fraction of peak
+// accuracy lost, which empirically sits higher than the bridge density
+// in well-behaved traces.
+
+export interface ForgettingPressureBand {
+  /** Discrete band identifier. */
+  band: "nominal" | "elevated" | "critical" | "catastrophic";
+  /** Short human-readable label suitable for a status badge. */
+  label: string;
+  /** CSS color (uses the project's accent CSS variables). */
+  color: string;
+  /** Hover-tooltip text explaining the reading + band threshold. */
+  tooltip: string;
+}
+
+/**
+ * Map an Ω-Forgetting-Pressure value into the display band the
+ * snapshot-diagnostics card uses. Pure function — no React or DOM
+ * access; safe to unit-test directly.
+ *
+ * NaN / negative inputs return an "—" placeholder band that the UI
+ * surfaces as the "no data" state.
+ */
+export function forgettingPressureBand(
+  pressure: number,
+): ForgettingPressureBand {
+  if (!Number.isFinite(pressure) || pressure < 0) {
+    return {
+      band: "nominal",
+      label: "—",
+      color: "var(--text-muted)",
+      tooltip:
+        "Ω-Forgetting Pressure unavailable. No training trace loaded, or every task is degenerate (zero peak accuracy).",
+    };
+  }
+  if (pressure > 0.6) {
+    return {
+      band: "catastrophic",
+      label: "CATASTROPHIC",
+      color: "#ff1744",
+      tooltip:
+        "Ω-Forgetting Pressure > 0.60 — the majority of exposure-weighted task accuracy has been lost. The model has catastrophically forgotten high-exposure attack classes; replay buffers or retraining warranted.",
+    };
+  }
+  if (pressure > 0.3) {
+    return {
+      band: "critical",
+      label: "CRITICAL",
+      color: "#ff7043",
+      tooltip:
+        "Ω-Forgetting Pressure 0.30–0.60 — substantial capability rot on tasks that carry real exposure. Worth a continual-learning review of the curriculum.",
+    };
+  }
+  if (pressure > 0.15) {
+    return {
+      band: "elevated",
+      label: "ELEVATED",
+      color: "var(--accent-amber)",
+      tooltip:
+        "Ω-Forgetting Pressure 0.15–0.30 — some forgetting visible on exposed tasks. Not yet critical, but the curriculum is drifting away from where exposure sits.",
+    };
+  }
+  return {
+    band: "nominal",
+    label: "NOMINAL",
+    color: "var(--accent-green)",
+    tooltip:
+      "Ω-Forgetting Pressure < 0.15 — model is retaining knowledge across all exposed tasks. Curriculum and exposure are well-aligned.",
+  };
+}


### PR DESCRIPTION
**Stacked on #396 (FR estimator).** Diff shown here is against `claude/fr-estimator`; once #396 merges, this PR's base flips to `main`.

## Summary

- Phase 3 PR 4 of the Ghauri 2025 dissertation integration. Builds on PR #380 (TrainingTrace), PR #385 (BES temporal), and PR #396 (FR estimator). Adds the operator-facing scalar that says "given which attack classes you actually see in production, how much of your defence has rotted right now."
- `computeOmegaForgettingPressure(frResult, options)` returns a summary `pressure ∈ [0, 1]`, a time-varying `pressureOverTime` series, and a sorted `contributions[]` breakdown. Exposure model: per-task weight override with uniform default; `normalizeWeights` flag (default `true`) keeps pressure in [0, 1].
- `forgettingPressureBand()` display helper maps the scalar to four bands — NOMINAL / ELEVATED / CRITICAL / CATASTROPHIC — mirroring the Ω-Bridge Density display contract.
- New third card in `SnapshotDiagnostics`, AI-domain-only (gated via `resolveDomainProfile(selectedDomains).id === "ai-safety"`). Renders the SYNTHETIC badge prominently via the existing `CapabilityBadge` (`live-synthetic` capability) until PR 5 lands the real PyTorch / TF ingester. No customer business decision runs off this reading.

## Canonical demo trace

`src/lib/discovery/ai-safety-demo-trace.ts` reproduces the dissertation's Heartbleed archetype: DDoS / MITM / Heartbleed curriculum with `forgettingRate` 0.30 on Heartbleed vs 0.05 on DDoS. Exposure preset weights the rare-but-high-impact task more aggressively than uniform (`{DDoS 0.55, MITM 0.25, Heartbleed 0.20}`).

## Provenance contract preserved

`result.sourceKind` forwards from `frResult.sourceKind` which forwards from `trace.source.kind`. While only the synthetic demo trace is wired, the SYNTHETIC badge is always visible alongside the value. When PR 5 lands a real ingester, `source.kind = "live"` will flip the badge automatically — no UI change needed.

## Domain gating

AI-domain semantics only. Math functions are profile-agnostic (mirror `computeBESTemporal` / `computeFR` pattern). Gating happens in the UI `useMemo` — the third card simply doesn't render on non-AI-Safety domains, so the geopolitical / T1D / Saudi-energy surfaces are unaffected.

## Test plan

- [x] Shape contracts: one contribution per non-degenerate task; contributions sorted descending; `pressureOverTime` length matches FR series; provenance forwarding (`sourceKind`, `traceId`)
- [x] Default uniform exposure → arithmetic mean of `normalizedFR` values
- [x] Custom exposure: weighted sum, missing entries default to 1, zero exposure drops the task, negative / NaN exposures clamped to 0
- [x] `normalizeWeights: false` preserves raw scale
- [x] Degenerate-task handling: NaN tasks drop from the sum; all-degenerate returns NaN pressure
- [x] Out-of-range `normalizedFR` clamped to [0, 1]
- [x] Time-varying series: per-epoch weighted sum; all-degenerate epochs yield NaN
- [x] `peakPressure` / `topContributors` helpers
- [x] End-to-end on the AI Safety demo trace — Heartbleed dominates contributions under canonical exposure; pressure rises across the off-task tail
- [x] `forgettingPressureBand` threshold + tooltip pins (NaN → "—", < 0.15 → NOMINAL, 0.15–0.30 → ELEVATED, 0.30–0.60 → CRITICAL, > 0.60 → CATASTROPHIC)
- [x] Argument validation: empty `FRResult.tasks` throws

29 new tests pass. All 339 discovery tests pass. No TypeScript errors in changed files.

## What's next

- **PR 5** — Real PyTorch / TF training-log ingester. Emits `source.kind = "live"` traces, flipping the badge to LIVE for customer-facing use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
