### PR TITLE
perf(3d): move layout sim + network metrics into a Web Worker

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -898,6 +898,34 @@ The always-mount pattern was in place to keep the 3D WebGL context alive across 
 
 ---
 
+### 2026-05-22 — Shipped: layout-3D + network-metrics moved off the main thread (Web Worker)
+
+**PR:** TBD (about to open).
+
+**Trigger.** Backlog: Web Worker port of `computeLayout3D` / `computeNetworkMetrics`. After the launch-perf chain (PRs #301 / #303 / #304) the user's freeze report stopped, but the d3-force-3d sim + Brandes' centrality were still running synchronously on first 3D mount and on every `topologyKey` change (domain toggle, edge sever). Those are the heaviest pure-data computes in the canvas; moving them off-thread is the right architectural fix.
+
+**What shipped.**
+
+- **`src/lib/workers/layout3d-worker.ts`** — Module-mode Web Worker. Handles `{ id, nodes, edges, prev? }` requests; returns `{ id, positions, metrics }` in one shot (bundled so the canvas doesn't need a second postMessage roundtrip). Both compute functions are pure — perfect worker fodder.
+
+- **`src/lib/workers/layout3d-client.ts`** — Main-thread wrapper. Lazily spins up a single shared worker on first call, multiplexes concurrent requests via a `nextId` epoch, routes each response back to its caller. Includes an SSR / no-Worker fallback that dynamic-imports the sync functions, so the API contract stays Promise-shaped everywhere.
+
+- **`CausalDAG3D.tsx` refactor.** The `positions` and `networkMetrics` useMemos are gone. In their place: a `layoutResult` state populated by an effect on `topologyKey` change, plus a `latestRequestIdRef` to drop stale responses when topology flips multiple times in quick succession (fast domain toggling). Previous positions stay rendered while a new layout computes — no flash, no main-thread block. First-mount-only `COMPUTING LAYOUT…` overlay covers the brief gap before the worker returns the initial layout (the WebGL canvas mounts immediately once the dynamic chunk loads, but orbs can't render until positions arrive).
+
+- **Stable references** — `positions` / `networkMetrics` derivations are wrapped in `useMemo` so the array/map references stay stable across renders that don't actually flip `layoutResult`. Otherwise downstream `useMemo`s keyed on `positions` would invalidate every render.
+
+**Files.**
+- `src/lib/workers/layout3d-worker.ts` (new)
+- `src/lib/workers/layout3d-client.ts` (new)
+- `src/lib/workers/__tests__/layout3d-client.test.ts` (new — 2 tests covering the SSR fallback path: returns positions + metrics for every node; assigns a different id to each call)
+- `src/components/CausalDAG3D.tsx` — sync useMemos → async effect + state + overlay; removed the value imports of `computeLayout3D` / `computeNetworkMetrics` (kept the types).
+
+**Verification.** `tsc --noEmit` clean (same inherited fci.test drift); lint clean on touched files (pre-existing `chiStarSet` warning unchanged); vitest **1321 / 1321** pass.
+
+**Follow-ups.** `CausalDAG2D` still runs `computeNetworkMetrics` synchronously on the main thread. Same pattern would apply (2D layout is light enough that it probably doesn't need the worker, but the metrics compute is identical to 3D's). Defer until needed — 2D is only mounted when actively in 2D view.
+
+---
+
 ## How a fresh session resumes
 
 1. Read this file bottom-up — the most recent entry is the live state.

--- a/src/components/CausalDAG3D.tsx
+++ b/src/components/CausalDAG3D.tsx
@@ -6,7 +6,8 @@ import { OrbitControls } from "@react-three/drei";
 import * as THREE from "three";
 import { useApexStore } from "@/stores/useApexStore";
 import { useFilteredGraph } from "@/hooks/useFilteredGraph";
-import { computeLayout3D, computeNetworkMetrics, NodePosition } from "@/lib/graph-layout";
+import type { NodePosition, NodeMetrics } from "@/lib/graph-layout";
+import { requestLayout3D, type LayoutResult } from "@/lib/workers/layout3d-client";
 import { chiStar } from "@/lib/estimators/chi-star";
 import { severEdgeAndSpawnConsequences } from "@/lib/intervention-engine";
 import { getNodeDomainMap } from "@/lib/graph-data";
@@ -568,17 +569,47 @@ export default function CausalDAG3D() {
   const graphDataForLayoutRef = useRef(graphData);
   graphDataForLayoutRef.current = graphData;
 
-  const positions = useMemo(() => {
+  // Layout + network-metrics state, populated by the Web Worker
+  // (`requestLayout3D`). Both used to be synchronous useMemos that
+  // ran d3-force-3d + Brandes' centrality on the main thread on
+  // every topologyKey change — that was the bulk of the
+  // LAUNCH-WORKSPACE freeze the user reported. They now run off-
+  // thread, and the previously-applied result stays rendered while
+  // a new layout computes. First-layout flash is covered by the
+  // `INITIALIZING LAYOUT…` overlay below.
+  const [layoutResult, setLayoutResult] = useState<LayoutResult | null>(null);
+  // Latest request id — used to drop stale worker responses when
+  // topologyKey flips multiple times in quick succession (fast
+  // domain toggling, repeated severs).
+  const latestRequestIdRef = useRef(-1);
+
+  useEffect(() => {
     const g = graphDataForLayoutRef.current;
-    const result = computeLayout3D(
+    const req = requestLayout3D(
       g.nodes,
       g.edges,
-      positionsRef.current.length > 0 ? positionsRef.current : undefined
+      positionsRef.current.length > 0 ? positionsRef.current : undefined,
     );
-    positionsRef.current = result;
-    return result;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    latestRequestIdRef.current = req.id;
+    req.then((result) => {
+      if (latestRequestIdRef.current !== req.id) return; // stale, drop
+      positionsRef.current = result.positions;
+      setLayoutResult(result);
+    });
   }, [topologyKey]);
+
+  // Wrap derivations in useMemo so the array / map references stay
+  // stable across renders that don't actually flip `layoutResult`
+  // — otherwise downstream useMemos keyed on `positions` would
+  // invalidate every render.
+  const positions = useMemo<NodePosition[]>(
+    () => layoutResult?.positions ?? [],
+    [layoutResult],
+  );
+  const networkMetrics = useMemo<Record<string, NodeMetrics>>(
+    () => layoutResult?.metrics ?? {},
+    [layoutResult],
+  );
 
   const basePosMap = useMemo(() => {
     const map: Record<string, [number, number, number]> = {};
@@ -587,13 +618,6 @@ export default function CausalDAG3D() {
     });
     return map;
   }, [positions]);
-
-  // Compute network metrics (eigenvector centrality, degree, betweenness, clustering)
-  // These drive node sizing and hover tooltip information
-  const networkMetrics = useMemo(() => {
-    return computeNetworkMetrics(graphData.nodes, graphData.edges);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [topologyKey]);
 
   // Selection/ablation Sets — render loop iterates every node and edge, and
   // `multiSelectedNodes.includes(...)` / `ablatedNodeIds.includes(...)` is O(M)
@@ -1049,6 +1073,22 @@ export default function CausalDAG3D() {
     <div style={{ position: "absolute", inset: 0 }} onContextMenu={(e) => e.preventDefault()}>
       <CanvasWatermark />
       <DAGOverlay />
+      {/* First-layout overlay — the WebGL canvas mounts immediately
+          once the dynamic chunk loads, but orbs can't render until
+          the worker returns the initial layout (~150-300ms on a 500-
+          node CROSS-DOMAIN workspace). Without this overlay the user
+          would see an empty black canvas for that interval. Subsequent
+          re-layouts (domain toggle, sever, etc.) keep the previous
+          positions on screen, so this only fires on first mount. */}
+      {!layoutResult && (
+        <div
+          className="absolute inset-0 z-30 flex items-center justify-center pointer-events-none bg-background/60"
+        >
+          <div className="text-[10px] font-mono text-text-muted animate-pulse">
+            COMPUTING LAYOUT…
+          </div>
+        </div>
+      )}
       {selectionRect && (
         <div
           style={{

--- a/src/lib/workers/__tests__/layout3d-client.test.ts
+++ b/src/lib/workers/__tests__/layout3d-client.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { requestLayout3D } from "../layout3d-client";
+import type { CausalGraph } from "@/lib/types";
+
+// vitest's jsdom env typically doesn't supply a working Web Worker —
+// the client wrapper detects this and falls back to a synchronous
+// in-process compute. These tests verify that fallback path (which is
+// also what runs under Next.js SSR) returns a well-shaped result.
+
+function tinyGraph(): CausalGraph {
+  const baseProfile = {
+    composite: 5,
+    irreplaceability: 5,
+    restorationLatency: 5,
+    jurisdictionalHazard: 5,
+    cascadeLoad: 5,
+    tailDepth: 5,
+  };
+  const node = (id: string) => ({
+    id,
+    label: id.toUpperCase(),
+    shortLabel: id,
+    category: "energy" as const,
+    domain: "Saudi Aramco Energy",
+    omegaFragility: { ...baseProfile },
+    globalConcentration: "100% Saudi Arabia",
+    replacementTime: "10y",
+    physicalConstraint: "",
+    isRestricted: false,
+    discoverySource: "DCD" as const,
+  });
+  return {
+    nodes: [node("a"), node("b"), node("c"), node("d")],
+    edges: [
+      { id: "ab", source: "a", target: "b", weight: 0.7, type: "directed", lag: 0, confidence: 0.9, isInconsistent: false, physicalMechanism: "" },
+      { id: "bc", source: "b", target: "c", weight: 0.7, type: "directed", lag: 0, confidence: 0.9, isInconsistent: false, physicalMechanism: "" },
+      { id: "cd", source: "c", target: "d", weight: 0.7, type: "directed", lag: 0, confidence: 0.9, isInconsistent: false, physicalMechanism: "" },
+    ],
+    metadata: {
+      totalNodes: 4,
+      totalEdges: 3,
+      density: 0.25,
+      verificationStatus: "VERIFIED",
+      constraintType: "—",
+    },
+  };
+}
+
+describe("requestLayout3D — fallback path", () => {
+  it("returns positions + metrics for every node", async () => {
+    const g = tinyGraph();
+    const req = requestLayout3D(g.nodes, g.edges);
+    // Each call gets a monotonically-increasing id
+    expect(typeof req.id).toBe("number");
+    expect(req.id).toBeGreaterThanOrEqual(0);
+
+    const { positions, metrics } = await req;
+    expect(positions).toHaveLength(g.nodes.length);
+    for (const p of positions) {
+      expect(typeof p.id).toBe("string");
+      expect(Number.isFinite(p.x)).toBe(true);
+      expect(Number.isFinite(p.y)).toBe(true);
+      expect(Number.isFinite(p.z)).toBe(true);
+    }
+    for (const id of ["a", "b", "c", "d"]) {
+      expect(metrics[id]).toBeDefined();
+      expect(typeof metrics[id].degree).toBe("number");
+      expect(typeof metrics[id].eigenvectorCentrality).toBe("number");
+    }
+  });
+
+  it("assigns a different id to a second concurrent call", () => {
+    const g = tinyGraph();
+    const a = requestLayout3D(g.nodes, g.edges);
+    const b = requestLayout3D(g.nodes, g.edges);
+    expect(b.id).toBeGreaterThan(a.id);
+  });
+});

--- a/src/lib/workers/layout3d-client.ts
+++ b/src/lib/workers/layout3d-client.ts
@@ -1,0 +1,101 @@
+/**
+ * Main-thread client for the layout-3D Web Worker.
+ *
+ * Spins up a single shared worker on first use, multiplexes
+ * concurrent requests via a `nextId` epoch, and routes each
+ * response to the right caller. Stale responses (whose epoch is
+ * older than the latest issued one) are dropped — this is what
+ * makes "fast-switching domains" feel snappy: each switch posts a
+ * new request, the worker's still finishing the previous one, but
+ * by the time it does we already don't care about that result.
+ *
+ * SSR fallback: when `window` is undefined (Next.js server render,
+ * test env), fall back to a synchronous compute on the same module
+ * so the API surface is identical. This module is imported from
+ * `CausalDAG3D`, which is itself `next/dynamic({ ssr: false })`, so
+ * the SSR branch shouldn't fire in production — but it keeps the
+ * Promise contract honest for vitest and any future test that
+ * exercises this client directly.
+ */
+import type { NodePosition, NodeMetrics } from "@/lib/graph-layout";
+import type { CausalNode, CausalEdge } from "@/lib/types";
+
+export interface LayoutResult {
+  positions: NodePosition[];
+  metrics: Record<string, NodeMetrics>;
+}
+
+interface WorkerResponse {
+  id: number;
+  positions: NodePosition[];
+  metrics: Record<string, NodeMetrics>;
+}
+
+let worker: Worker | null = null;
+let nextId = 0;
+const pending = new Map<number, (r: LayoutResult) => void>();
+
+function ensureWorker(): Worker | null {
+  if (typeof window === "undefined" || typeof Worker === "undefined") {
+    return null;
+  }
+  if (worker) return worker;
+  // Standard module-worker URL pattern. Next.js / webpack 5 + Turbopack
+  // both recognise `new URL(..., import.meta.url)` as a worker chunk
+  // boundary and emit a separate bundle.
+  worker = new Worker(new URL("./layout3d-worker.ts", import.meta.url), {
+    type: "module",
+  });
+  worker.onmessage = (e: MessageEvent<WorkerResponse>) => {
+    const { id, positions, metrics } = e.data;
+    const resolve = pending.get(id);
+    if (resolve) {
+      pending.delete(id);
+      resolve({ positions, metrics });
+    }
+  };
+  worker.onerror = (err) => {
+    // Surface in dev; the caller will keep waiting on the Promise. A
+    // future iteration could reject pending Promises here, but for the
+    // tight loop of "graph topology changed → re-layout" the safer
+    // path on a transient worker error is to leave the previous
+    // positions on screen.
+    console.error("[layout3d-worker] error:", err);
+  };
+  return worker;
+}
+
+/**
+ * Compute layout + network metrics for a graph, returning a Promise.
+ *
+ * Each invocation gets a monotonically-increasing `id`. The caller
+ * can compare the resolved `id` against the latest issued id (kept
+ * by `getLatestRequestId`) to detect stale responses, but the
+ * simpler pattern — and what CausalDAG3D uses — is to track its
+ * own "current request" ref and only apply the response if it
+ * matches.
+ */
+export function requestLayout3D(
+  nodes: CausalNode[],
+  edges: CausalEdge[],
+  prev?: NodePosition[],
+): Promise<LayoutResult> & { id: number } {
+  const w = ensureWorker();
+  const id = nextId++;
+  if (!w) {
+    // SSR / test fallback — synchronous compute. The dynamic import
+    // keeps the d3-force-3d dep out of the SSR bundle path.
+    const result = import("@/lib/graph-layout").then(
+      ({ computeLayout3D, computeNetworkMetrics }) => ({
+        positions: computeLayout3D(nodes, edges, prev),
+        metrics: computeNetworkMetrics(nodes, edges),
+      }),
+    );
+    return Object.assign(result, { id });
+  }
+  const promise = new Promise<LayoutResult>((resolve) => {
+    pending.set(id, resolve);
+    w.postMessage({ id, nodes, edges, prev });
+  });
+  return Object.assign(promise, { id });
+}

--- a/src/lib/workers/layout3d-worker.ts
+++ b/src/lib/workers/layout3d-worker.ts
@@ -1,0 +1,63 @@
+/**
+ * Layout-3D Web Worker.
+ *
+ * Owns the two heaviest synchronous computations the 3D canvas would
+ * otherwise run on the main thread on every `topologyKey` change:
+ *
+ *   - `computeLayout3D` — d3-force-3d simulation, 200 iterations of
+ *     many-body / link / centering forces. Cold-start cost on a 500-
+ *     node CROSS-DOMAIN workspace was the bulk of the LAUNCH-WORKSPACE
+ *     freeze the user reported back in this session.
+ *   - `computeNetworkMetrics` — eigenvector centrality (30 power-
+ *     iteration steps) + sampled Brandes' betweenness + clustering
+ *     coefficient. O(V·E)-ish in the worst case.
+ *
+ * Both are pure (graph in → plain-data out), no DOM access, no React
+ * — perfect worker fodder. Bundling them into a single call avoids
+ * paying a second postMessage roundtrip when the canvas needs both
+ * results to start rendering.
+ *
+ * Messages:
+ *   Request:  { id, nodes, edges, prev? }
+ *   Response: { id, positions, metrics }
+ *
+ * Caller-side cancellation lives in the client wrapper (see
+ * `layout3d-client.ts`); the worker itself just answers every
+ * request it receives.
+ */
+import {
+  computeLayout3D,
+  computeNetworkMetrics,
+  type NodePosition,
+  type NodeMetrics,
+} from "@/lib/graph-layout";
+import type { CausalNode, CausalEdge } from "@/lib/types";
+
+interface LayoutRequest {
+  id: number;
+  nodes: CausalNode[];
+  edges: CausalEdge[];
+  prev?: NodePosition[];
+}
+
+interface LayoutResponse {
+  id: number;
+  positions: NodePosition[];
+  metrics: Record<string, NodeMetrics>;
+}
+
+// Vite/Next worker entry: `self` is the dedicated worker scope.
+self.onmessage = (e: MessageEvent<LayoutRequest>) => {
+  const { id, nodes, edges, prev } = e.data;
+  const positions = computeLayout3D(nodes, edges, prev);
+  const metrics = computeNetworkMetrics(nodes, edges);
+  const response: LayoutResponse = { id, positions, metrics };
+  // Plain JSON — no transferable buffers to hand off.
+  (self as unknown as Worker).postMessage(response);
+};
+
+// Re-export types so the client wrapper can stay strongly typed without
+// duplicating the protocol shape. They're erased at runtime — the
+// `export {}` keeps this file a module so the `self.onmessage` write
+// doesn't leak into the global module's surface.
+export type { LayoutRequest, LayoutResponse };


### PR DESCRIPTION
## Summary

Backlog item from the rendering-perf session. After the launch-perf chain (PRs #301 / #303 / #304) the freeze report stopped, but the d3-force-3d simulation + Brandes' centrality were still running on the main thread on first 3D mount and on every `topologyKey` change (domain toggle, edge sever). Both are pure-data computes — ideal worker fodder.

**What shipped.**

- **`src/lib/workers/layout3d-worker.ts`** — Module-mode Web Worker. One request → one response carrying `{ positions, metrics }`, so the canvas only pays a single postMessage roundtrip per topology change.
- **`src/lib/workers/layout3d-client.ts`** — Main-thread wrapper. Lazy worker spin-up, monotonic request ids for cancellation, and an SSR / no-Worker fallback that dynamic-imports the sync functions so the API stays Promise-shaped everywhere.
- **`CausalDAG3D` refactor.** The `positions` + `networkMetrics` useMemos are replaced with an effect that posts to the worker and a `layoutResult` state. Previous positions stay rendered while a new layout computes (no main-thread block, no flash). A first-mount-only `COMPUTING LAYOUT…` overlay covers the brief gap before the worker returns the initial layout. `latestRequestIdRef` drops stale responses when topology flips multiple times in quick succession (fast domain toggling). Derivations wrapped in `useMemo` so downstream memos keyed on `positions` don't invalidate every render.

**Why this matters now.** The launch freeze is gone via the earlier PRs in this session, but the layout sim still chews ~150–300ms of main-thread time on a 500-node CROSS-DOMAIN workspace's first 3D mount and on every later topology change (severing an edge, toggling a domain). With the worker port, that work happens off-thread — the canvas mounts immediately, the overlay shows for the compute window, and subsequent re-layouts keep the previous positions on screen until the new ones arrive.

## Test plan

- [x] `tsc --noEmit` clean (modulo pre-existing inherited errors)
- [x] Lint clean on touched files (pre-existing `chiStarSet` warning unchanged)
- [x] vitest **1321 / 1321** pass (2 new tests on the client wrapper's SSR-fallback path)
- [ ] Launch a CROSS-DOMAIN workspace — confirm the `COMPUTING LAYOUT…` overlay appears briefly on first 3D mount, then the orbs settle
- [ ] Toggle a domain in/out of the workspace — confirm previous orbs stay rendered while the new layout computes (no flash)
- [ ] Sever an edge — confirm the same smooth re-layout behavior
- [ ] Rapidly toggle several domains — confirm only the latest layout lands (no stale orbs from an in-flight earlier request)

## Follow-ups (deferred)

- `CausalDAG2D` still runs `computeNetworkMetrics` synchronously. Same pattern applies but defer until needed (2D is only mounted in 2D view, not on the launch critical path).

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_