### PR TITLE
fix(domain-modal): cap to viewport, scroll the middle region

### DIFF
--- a/src/components/DomainSelector.tsx
+++ b/src/components/DomainSelector.tsx
@@ -217,7 +217,19 @@ export default function DomainSelector() {
             exit={{ opacity: 0, scale: 0.95, y: 10 }}
             transition={{ duration: 0.2 }}
             data-tour="domain-selector-modal"
-            className="w-full max-w-2xl mx-4 rounded-lg border border-border bg-background shadow-2xl overflow-hidden"
+            // `max-h-[calc(100vh-2rem)] flex flex-col` caps the modal to
+            // viewport height with a 1rem gutter top/bottom. Header,
+            // persona pills, mode switch, and footer stay anchored as
+            // flex items at their natural height. The middle scrollable
+            // region (cards + DATA LAYERS + demo picker) absorbs the
+            // remaining vertical space and scrolls internally — before
+            // this, selecting many domains or expanding DATA LAYERS
+            // could push the modal taller than the viewport, and the
+            // `items-center justify-center` parent would centre it
+            // vertically, clipping equal slivers off the top AND bottom
+            // (the launch button at the bottom was the most reported
+            // casualty).
+            className="w-full max-w-2xl mx-4 rounded-lg border border-border bg-background shadow-2xl overflow-hidden max-h-[calc(100vh-2rem)] flex flex-col"
           >
             {/* Header */}
             <div className="flex items-center justify-between px-6 py-4 border-b border-border">
@@ -308,8 +320,20 @@ export default function DomainSelector() {
               )}
             </div>
 
+            {/* Middle scrollable region — wraps the domain cards,
+                DATA LAYERS accordion, and demo picker as one scroll
+                container so they grow/shrink together inside the
+                viewport-capped modal. Previously the cards section had
+                its own `max-h-[420px] overflow-y-auto` while DATA
+                LAYERS + demo picker sat outside as separate vertical
+                children of the modal, which meant expanding DATA
+                LAYERS pushed the modal taller than the viewport. With
+                this wrap the whole middle region shrinks down and a
+                single scrollbar appears at the modal edge when content
+                exceeds the available vertical space. */}
+            <div className="flex-1 min-h-0 overflow-y-auto">
             {/* Grouped Domain Cards */}
-            <div className="px-6 py-4 max-h-[420px] overflow-y-auto space-y-4">
+            <div className="px-6 py-4 space-y-4">
               {visibleGroups.map((group) => (
                 <div key={group.label}>
                   <div
@@ -496,6 +520,7 @@ export default function DomainSelector() {
                 onPick={() => setDomainSelectorOpen(false)}
               />
             </div>
+            </div>{/* /flex-1 min-h-0 overflow-y-auto — middle scrollable region */}
 
             {/* Footer */}
             <div className="px-6 py-4 border-t border-border flex items-center justify-between">


### PR DESCRIPTION
## Summary
- Cap the Domain Workspace modal to viewport height (`max-h-[calc(100vh-2rem)]`)
- Turn the modal into a flex column so header + persona row + mode switch + footer stay anchored
- Wrap (domain cards + DATA LAYERS accordion + demo picker) in a single `flex-1 min-h-0 overflow-y-auto` middle region that absorbs the remaining space and scrolls as one unit
- Drop the cards section's redundant `max-h-[420px] overflow-y-auto` (now handled by the parent)

## Why
User reported: *"when I select too many things, the modal starts to go too far down on the window... maybe keep the size of the initial domain workspace popup fixed and then everything becomes scrollable."*

The modal sat inside a parent with `items-center justify-center` but had **no height cap itself**. The body cards section was internally capped at 420px, but the surrounding sections (DATA LAYERS expansion, demo picker, persona row, mode switch, header, footer) easily exceeded viewport height combined. Once they did, vertical-centering clipped equal slivers off the top AND bottom — the LAUNCH WORKSPACE button at the bottom going off-screen was the most reported casualty.

## Behaviour after this PR

| State | Before | After |
|---|---|---|
| Few domains selected, DATA LAYERS collapsed | fits | fits (unchanged) |
| Many domains selected, DATA LAYERS expanded | overflows viewport, top/bottom clipped, LAUNCH button hidden | fits viewport; middle region scrolls; LAUNCH button always visible |
| Short viewport (zoomed in, small laptop) | always-clipped | scrolls cleanly |
| Tall viewport, ample space | fits with whitespace | unchanged (middle region just doesn't need to scroll) |

## Anchored vs scrollable
- **Always visible (flex items, natural height):** header (DOMAIN WORKSPACE title), persona pill row, single/multi mode switch, footer (selected count + LAUNCH button)
- **Scrolls as one unit:** domain cards grouped by domain, DATA LAYERS accordion (when open), demo flow picker

`min-h-0` is the standard flexbox trick to let a `flex-1` child shrink below its natural content height. Without it, the middle region would refuse to shrink and the modal would still overflow.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [ ] Vercel preview deploys
- [ ] In preview:
  - Open Domain Workspace modal — opens at natural height with whitespace as before
  - Switch to MULTI-DOMAIN NETWORK, select 6+ domains, expand DATA LAYERS — modal stays viewport-capped; middle region scrolls; LAUNCH button stays visible
  - Persona pills, mode switch, header still anchored at top
  - Demo picker still reachable by scrolling
  - Resize viewport short and tall — modal adapts cleanly, scrollbar appears/disappears at the modal edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
