### PR TITLE
feat(feeds): wire 10y real interest rate to FRED DFII10 (TIPS yield)

### DIFF
--- a/src/lib/feeds/fred.ts
+++ b/src/lib/feeds/fred.ts
@@ -61,6 +61,14 @@ export const FRED_SERIES: FredSeriesConfig[] = [
   { id: "CPIAUCSL", label: "CPI-U Year-over-Year", labelPatterns: ["cpi-u year-over-year"], unit: "%", capacity: 5, units: "pc1", mockValue: 3.2 },
   { id: "CPILFESL", label: "Core CPI Year-over-Year", labelPatterns: ["core cpi year-over-year"], unit: "%", capacity: 5, units: "pc1", mockValue: 3.4 },
   { id: "T10YIE", label: "10-Year Breakeven Inflation Rate", labelPatterns: ["10y breakeven inflation rate"], unit: "%", capacity: 4, mockValue: 2.4 },
+  // DFII10 = 10-Year Treasury Inflation-Indexed (TIPS) yield. The
+  // canonical FRED-published real rate, daily cadence. Wires the
+  // `ip_real_rate_10y` graph node which was previously historical-only
+  // with a synthetic proxy. Per the inline comment on the
+  // `ip_real_rate_10y__ip_dxy` edge in graph-data.ts: "Literature-cited
+  // until FRED DFII10 (TIPS yield) becomes reachable." It is now
+  // reachable since the FRED_API_KEY landed 2026-05-21.
+  { id: "DFII10", label: "10-Year Treasury TIPS Yield (Real Rate)", labelPatterns: ["10y real interest rate"], unit: "%", capacity: 3, mockValue: 2.0 },
   { id: "T5YIE", label: "5-Year Breakeven Inflation Rate", labelPatterns: ["5y breakeven inflation rate"], unit: "%", capacity: 4, mockValue: 2.5 },
   { id: "CSUSHPISA", label: "Case-Shiller Home Price Index YoY", labelPatterns: ["case-shiller home price index"], unit: "%", capacity: 12, units: "pc1", mockValue: 4.8 },
   // FRED expansion (Phase 4): more macro/financial nodes from graph-data.ts


### PR DESCRIPTION
## Single-line wiring — Phase 14 opener

Wires the previously-historical-only `ip_real_rate_10y` graph node to FRED `DFII10` (10-Year Treasury Inflation-Indexed Securities yield, daily cadence).

The graph data already explicitly noted this target in an inline comment on the `ip_real_rate_10y__ip_dxy` edge:

> "Literature-cited until FRED DFII10 (TIPS yield) becomes reachable."

DFII10 became reachable on 2026-05-21 when `FRED_API_KEY` landed on prod. Verified via direct FRED API probe:

```
DFII10 = 2.18 % at 2026-05-21 (daily)
```

## Coverage delta

- **Macro Impact: Inflation & Policy** moves from 25/27 → **26/27** live (96%)
- Only synthetic remaining in this domain: NY Fed SCE (`ip_nyfed_expectations`) — not on FRED, would need a separate batch fetch
- FRED catalog: 55 → 56 entries

## Test plan

- [x] `npx vitest run src/lib/__tests__/feeds/fred.test.ts` — 16/16 pass
- [x] Dry-run `check:feeds` shows DFII10 as MISS pre-deploy (expected)
- [ ] After deploy: DFII10 flips to LIVE with ~2.18% value
- [ ] After deploy: `ip_real_rate_10y` node on the canvas shows the live value with source `FRED · DFII10 (period 2026-05-21)`

## Context — Phase 14 of the live-data push

Per the post-EIA-closure pipeline audit, the geopolitical/macro session's coverage stands at 38% live / 46% historical / 13% synthetic / 3% bare. This PR is the first of a small batch targeting the most actionable historical-only nodes. Next planned items:

1. ✅ `ip_real_rate_10y` (this PR)
2. Sovereign Risk PWT → WB annual proxies (~8 nodes)
3. Financial Contagion derivations (~8 nodes via the derivations provider)

🤖 Generated with [Claude Code](https://claude.com/claude-code)