### PR TITLE
perf(2d): move layout sim + network metrics into the layout Web Worker

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -958,6 +958,30 @@ In `ModulePanel.tsx`:
 
 ---
 
+### 2026-05-22 — Shipped: 2D layout sim moves off the main thread (Worker reuse)
+
+**PR:** TBD (about to open).
+
+**Trigger.** Continuation of the load-time arc. PR #404 moved the 3D layout + centrality off the main thread; 2D was still running both synchronously inside the same component. After PR #304 made `CausalDAG2D` lazy + conditional, that compute no longer hits launch — but the first user-initiated 2D-tab visit was still paying ~150-300ms of main-thread block on a 500-node CROSS-DOMAIN workspace.
+
+Estimator-lib audit (the other backlog candidate) turned out to be a no-op in production — the heavy libs (`lppls-fit`, `ph-fit`, `pareto-relevance-bootstrap`) are only reachable from `modules/ParetoPanel.tsx` after PR #406, so they already ship only in the Pareto chunk. The `csd-fit-hypo-calibrator.ts` consumer is reachable only from a test fixture, not the runtime bundle. Closed that ticket as already-done.
+
+**What shipped.**
+
+- **Worker generalised.** `src/lib/workers/layout3d-worker.ts` now dispatches on a `kind: "layout3d" | "layout2d"` discriminator. 3D path unchanged; 2D path runs `compute2DForceLayout(nodes, edges)` + `computeNetworkMetrics(nodes, edges)` and posts back `{ positions2d: Map<string, Position2D>, metrics }`. Both layouts share one worker instance.
+- **Client wrapper got a `requestLayout2D` sibling** to `requestLayout3D`. Same epoch-cancellation pattern, same SSR-fallback path (dynamic-imports the sync functions when `Worker` is unavailable).
+- **`CausalDAG2D` refactor.** The synchronous `compute2DForceLayout` + `computeNetworkMetrics` useMemos are gone. In their place: a `useEffect` keyed on the graph `sig` that posts to the worker, plus `cachedLayout` / `networkMetrics` state populated when the response lands. `latestRequestIdRef` drops stale responses on fast topology changes — same epoch pattern as `CausalDAG3D`. Previously-rendered orbs stay put while a new layout computes.
+
+**Files.**
+- `src/lib/workers/layout3d-worker.ts` — kind discriminator, 2D dispatch arm.
+- `src/lib/workers/layout3d-client.ts` — `requestLayout2D` export + shared worker bookkeeping.
+- `src/lib/workers/__tests__/layout3d-client.test.ts` — added one fallback-path test for `requestLayout2D`.
+- `src/components/CausalDAG2D.tsx` — imports trimmed, sync useMemos → async effect + state.
+
+**Verification.** `tsc --noEmit` clean (same pre-existing inherited errors); lint clean on touched files; vitest 1322 / 1322 pass.
+
+---
+
 ## How a fresh session resumes
 
 1. Read this file bottom-up — the most recent entry is the live state.

--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -33,13 +33,13 @@ import CanvasWatermark from "./CanvasWatermark";
 import { useReplayTickDOM } from "@/lib/useReplayTick";
 import type { CausalEdge, EpochSnapshot } from "@/lib/types";
 import {
-  compute2DForceLayout,
   create2DLiveSimulation,
   graphSignature,
   type LiveSimulation,
   type Position2D,
 } from "@/lib/graph-layout-2d";
-import { computeNetworkMetrics, type NodeMetrics } from "@/lib/graph-layout";
+import { type NodeMetrics } from "@/lib/graph-layout";
+import { requestLayout2D } from "@/lib/workers/layout3d-client";
 import { cascadeActivationOrder } from "@/lib/cascade-activation-order";
 import { AnimatePresence } from "framer-motion";
 
@@ -812,23 +812,37 @@ function CausalDAG2DInner() {
     () => graphSignature(graphData.nodes, graphData.edges),
     [graphData.nodes, graphData.edges],
   );
-  const networkMetrics = useMemo(
-    () => computeNetworkMetrics(graphData.nodes, graphData.edges),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- pin to sig
-    [sig],
-  );
-  const [prevSig, setPrevSig] = useState<string>("");
+  // Layout + network-metrics both come from the layout Web Worker
+  // (`requestLayout2D`). Both used to be synchronous useMemos that
+  // ran d3-force-2d + Brandes' centrality on the main thread, which
+  // blocked the FIRST 2D-tab visit by ~150-300ms on a 500-node
+  // CROSS-DOMAIN workspace. They now run off-thread; previously-
+  // applied positions stay rendered while a new layout computes, so
+  // re-layouts on graph swap are smooth. First-visit cold-start is
+  // still ~that long but it doesn't block any interaction.
+  //
+  // The `latestRequestIdRef` epoch drops stale worker responses
+  // when sig flips multiple times in quick succession (e.g. fast
+  // domain toggling).
   const [cachedLayout, setCachedLayout] = useState<Map<string, Position2D>>(
     () => new Map(),
   );
+  const [networkMetrics, setNetworkMetrics] = useState<Record<string, NodeMetrics>>({});
   const [livePositions, setLivePositions] = useState<Map<string, Position2D> | null>(
     null,
   );
-  if (sig !== prevSig) {
-    setPrevSig(sig);
-    setCachedLayout(compute2DForceLayout(graphData.nodes, graphData.edges));
-    setLivePositions(null);
-  }
+  const latestRequestIdRef = useRef(-1);
+  useEffect(() => {
+    const req = requestLayout2D(graphData.nodes, graphData.edges);
+    latestRequestIdRef.current = req.id;
+    req.then((result) => {
+      if (latestRequestIdRef.current !== req.id) return; // stale
+      setCachedLayout(result.positions2d);
+      setLivePositions(null);
+      setNetworkMetrics(result.metrics);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pin to sig
+  }, [sig]);
   // Defensive selector. The simple `livePositions ?? cachedLayout` was
   // vulnerable to two edge cases that left every node rendered at
   // (0, 0) — a stack-of-169-nodes-at-origin which reads as "empty

--- a/src/lib/workers/__tests__/layout3d-client.test.ts
+++ b/src/lib/workers/__tests__/layout3d-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { requestLayout3D } from "../layout3d-client";
+import { requestLayout3D, requestLayout2D } from "../layout3d-client";
 import type { CausalGraph } from "@/lib/types";
 
 // vitest's jsdom env typically doesn't supply a working Web Worker —
@@ -77,5 +77,23 @@ describe("requestLayout3D — fallback path", () => {
     const a = requestLayout3D(g.nodes, g.edges);
     const b = requestLayout3D(g.nodes, g.edges);
     expect(b.id).toBeGreaterThan(a.id);
+  });
+});
+
+describe("requestLayout2D — fallback path", () => {
+  it("returns a positions2d Map + metrics for every node", async () => {
+    const g = tinyGraph();
+    const req = requestLayout2D(g.nodes, g.edges);
+    expect(typeof req.id).toBe("number");
+
+    const { positions2d, metrics } = await req;
+    expect(positions2d).toBeInstanceOf(Map);
+    for (const id of ["a", "b", "c", "d"]) {
+      const p = positions2d.get(id);
+      expect(p).toBeDefined();
+      expect(Number.isFinite(p!.x)).toBe(true);
+      expect(Number.isFinite(p!.y)).toBe(true);
+      expect(metrics[id]).toBeDefined();
+    }
   });
 });

--- a/src/lib/workers/layout3d-client.ts
+++ b/src/lib/workers/layout3d-client.ts
@@ -1,79 +1,81 @@
 /**
- * Main-thread client for the layout-3D Web Worker.
+ * Main-thread client for the layout Web Worker.
  *
- * Spins up a single shared worker on first use, multiplexes
- * concurrent requests via a `nextId` epoch, and routes each
- * response to the right caller. Stale responses (whose epoch is
- * older than the latest issued one) are dropped — this is what
- * makes "fast-switching domains" feel snappy: each switch posts a
- * new request, the worker's still finishing the previous one, but
- * by the time it does we already don't care about that result.
+ * Exposes two request functions:
+ *   - `requestLayout3D` — d3-force-3d simulation + network metrics
+ *   - `requestLayout2D` — d3-force-2d simulation + network metrics
+ *
+ * Both share a single worker instance (lazily spun up on first use)
+ * and multiplex concurrent requests via a monotonic `nextId`. Stale
+ * responses (whose epoch is older than the caller's latest issued id)
+ * are dropped — this is what makes fast topology switches feel
+ * snappy: each switch posts a new request, the worker's still
+ * finishing the previous one, but by the time it does we already
+ * don't care about that result.
  *
  * SSR fallback: when `window` is undefined (Next.js server render,
- * test env), fall back to a synchronous compute on the same module
- * so the API surface is identical. This module is imported from
- * `CausalDAG3D`, which is itself `next/dynamic({ ssr: false })`, so
- * the SSR branch shouldn't fire in production — but it keeps the
- * Promise contract honest for vitest and any future test that
- * exercises this client directly.
+ * test env), fall back to a synchronous compute via dynamic import.
+ * This module is imported from `CausalDAG3D` / `CausalDAG2D`, both
+ * of which are themselves `next/dynamic({ ssr: false })`, so the
+ * SSR branch shouldn't fire in production — but it keeps the
+ * Promise contract honest under vitest jsdom.
  */
 import type { NodePosition, NodeMetrics } from "@/lib/graph-layout";
+import type { Position2D } from "@/lib/graph-layout-2d";
 import type { CausalNode, CausalEdge } from "@/lib/types";
 
 export interface LayoutResult {
   positions: NodePosition[];
   metrics: Record<string, NodeMetrics>;
 }
+export interface Layout2DResult {
+  positions2d: Map<string, Position2D>;
+  metrics: Record<string, NodeMetrics>;
+}
 
 interface WorkerResponse {
   id: number;
-  positions: NodePosition[];
+  kind: "layout3d" | "layout2d";
+  positions?: NodePosition[];
+  positions2d?: Map<string, Position2D>;
   metrics: Record<string, NodeMetrics>;
 }
 
 let worker: Worker | null = null;
 let nextId = 0;
-const pending = new Map<number, (r: LayoutResult) => void>();
+// Promise resolvers, keyed by request id. Untyped because we route on
+// the response's `kind` field — the public API guarantees the right
+// shape comes back per call.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const pending = new Map<number, (r: any) => void>();
 
 function ensureWorker(): Worker | null {
   if (typeof window === "undefined" || typeof Worker === "undefined") {
     return null;
   }
   if (worker) return worker;
-  // Standard module-worker URL pattern. Next.js / webpack 5 + Turbopack
-  // both recognise `new URL(..., import.meta.url)` as a worker chunk
-  // boundary and emit a separate bundle.
   worker = new Worker(new URL("./layout3d-worker.ts", import.meta.url), {
     type: "module",
   });
   worker.onmessage = (e: MessageEvent<WorkerResponse>) => {
-    const { id, positions, metrics } = e.data;
+    const { id, kind } = e.data;
     const resolve = pending.get(id);
-    if (resolve) {
-      pending.delete(id);
-      resolve({ positions, metrics });
+    if (!resolve) return;
+    pending.delete(id);
+    if (kind === "layout3d") {
+      resolve({ positions: e.data.positions!, metrics: e.data.metrics });
+    } else {
+      resolve({ positions2d: e.data.positions2d!, metrics: e.data.metrics });
     }
   };
   worker.onerror = (err) => {
-    // Surface in dev; the caller will keep waiting on the Promise. A
-    // future iteration could reject pending Promises here, but for the
-    // tight loop of "graph topology changed → re-layout" the safer
-    // path on a transient worker error is to leave the previous
-    // positions on screen.
-    console.error("[layout3d-worker] error:", err);
+    console.error("[layout-worker] error:", err);
   };
   return worker;
 }
 
 /**
- * Compute layout + network metrics for a graph, returning a Promise.
- *
- * Each invocation gets a monotonically-increasing `id`. The caller
- * can compare the resolved `id` against the latest issued id (kept
- * by `getLatestRequestId`) to detect stale responses, but the
- * simpler pattern — and what CausalDAG3D uses — is to track its
- * own "current request" ref and only apply the response if it
- * matches.
+ * Compute 3D layout + network metrics, off the main thread.
  */
 export function requestLayout3D(
   nodes: CausalNode[],
@@ -83,8 +85,6 @@ export function requestLayout3D(
   const w = ensureWorker();
   const id = nextId++;
   if (!w) {
-    // SSR / test fallback — synchronous compute. The dynamic import
-    // keeps the d3-force-3d dep out of the SSR bundle path.
     const result = import("@/lib/graph-layout").then(
       ({ computeLayout3D, computeNetworkMetrics }) => ({
         positions: computeLayout3D(nodes, edges, prev),
@@ -95,7 +95,37 @@ export function requestLayout3D(
   }
   const promise = new Promise<LayoutResult>((resolve) => {
     pending.set(id, resolve);
-    w.postMessage({ id, nodes, edges, prev });
+    w.postMessage({ id, kind: "layout3d", nodes, edges, prev });
+  });
+  return Object.assign(promise, { id });
+}
+
+/**
+ * Compute 2D layout + network metrics, off the main thread.
+ *
+ * 2D doesn't support a warm-start `prev` argument (its sim is
+ * cheaper to run cold than to incrementally update for one
+ * topology change), so the signature stays minimal.
+ */
+export function requestLayout2D(
+  nodes: CausalNode[],
+  edges: CausalEdge[],
+): Promise<Layout2DResult> & { id: number } {
+  const w = ensureWorker();
+  const id = nextId++;
+  if (!w) {
+    const result = import("@/lib/graph-layout-2d").then(async ({ compute2DForceLayout }) => {
+      const { computeNetworkMetrics } = await import("@/lib/graph-layout");
+      return {
+        positions2d: compute2DForceLayout(nodes, edges),
+        metrics: computeNetworkMetrics(nodes, edges),
+      };
+    });
+    return Object.assign(result, { id });
+  }
+  const promise = new Promise<Layout2DResult>((resolve) => {
+    pending.set(id, resolve);
+    w.postMessage({ id, kind: "layout2d", nodes, edges });
   });
   return Object.assign(promise, { id });
 }

--- a/src/lib/workers/layout3d-worker.ts
+++ b/src/lib/workers/layout3d-worker.ts
@@ -1,29 +1,19 @@
 /**
- * Layout-3D Web Worker.
+ * Layout Web Worker — handles both the 3D force-directed layout
+ * (`computeLayout3D` + `computeNetworkMetrics`) and the 2D force-
+ * directed layout (`compute2DForceLayout` + `computeNetworkMetrics`).
  *
- * Owns the two heaviest synchronous computations the 3D canvas would
- * otherwise run on the main thread on every `topologyKey` change:
+ * Both layouts run pure-data computes (no DOM, no React) so they're
+ * perfect worker fodder. Bundling each layout's metrics into the same
+ * response avoids a second postMessage roundtrip when the canvas
+ * needs both to start rendering.
  *
- *   - `computeLayout3D` — d3-force-3d simulation, 200 iterations of
- *     many-body / link / centering forces. Cold-start cost on a 500-
- *     node CROSS-DOMAIN workspace was the bulk of the LAUNCH-WORKSPACE
- *     freeze the user reported back in this session.
- *   - `computeNetworkMetrics` — eigenvector centrality (30 power-
- *     iteration steps) + sampled Brandes' betweenness + clustering
- *     coefficient. O(V·E)-ish in the worst case.
+ * Message kinds:
+ *   - "layout3d" → { positions: NodePosition[], metrics }
+ *   - "layout2d" → { positions2d: Map<id, Position2D>, metrics }
  *
- * Both are pure (graph in → plain-data out), no DOM access, no React
- * — perfect worker fodder. Bundling them into a single call avoids
- * paying a second postMessage roundtrip when the canvas needs both
- * results to start rendering.
- *
- * Messages:
- *   Request:  { id, nodes, edges, prev? }
- *   Response: { id, positions, metrics }
- *
- * Caller-side cancellation lives in the client wrapper (see
- * `layout3d-client.ts`); the worker itself just answers every
- * request it receives.
+ * Caller-side cancellation lives in the client wrapper
+ * (`layout-client.ts`); the worker itself just answers every request.
  */
 import {
   computeLayout3D,
@@ -31,33 +21,57 @@ import {
   type NodePosition,
   type NodeMetrics,
 } from "@/lib/graph-layout";
+import { compute2DForceLayout, type Position2D } from "@/lib/graph-layout-2d";
 import type { CausalNode, CausalEdge } from "@/lib/types";
 
-interface LayoutRequest {
+interface BaseRequest {
   id: number;
   nodes: CausalNode[];
   edges: CausalEdge[];
+}
+interface Layout3DRequest extends BaseRequest {
+  kind: "layout3d";
   prev?: NodePosition[];
 }
+interface Layout2DRequest extends BaseRequest {
+  kind: "layout2d";
+}
+type LayoutRequest = Layout3DRequest | Layout2DRequest;
 
-interface LayoutResponse {
+interface Layout3DResponse {
   id: number;
+  kind: "layout3d";
   positions: NodePosition[];
   metrics: Record<string, NodeMetrics>;
 }
+interface Layout2DResponse {
+  id: number;
+  kind: "layout2d";
+  positions2d: Map<string, Position2D>;
+  metrics: Record<string, NodeMetrics>;
+}
+type LayoutResponse = Layout3DResponse | Layout2DResponse;
 
-// Vite/Next worker entry: `self` is the dedicated worker scope.
 self.onmessage = (e: MessageEvent<LayoutRequest>) => {
-  const { id, nodes, edges, prev } = e.data;
-  const positions = computeLayout3D(nodes, edges, prev);
-  const metrics = computeNetworkMetrics(nodes, edges);
-  const response: LayoutResponse = { id, positions, metrics };
-  // Plain JSON — no transferable buffers to hand off.
+  const req = e.data;
+  const metrics = computeNetworkMetrics(req.nodes, req.edges);
+  let response: LayoutResponse;
+  if (req.kind === "layout3d") {
+    response = {
+      id: req.id,
+      kind: "layout3d",
+      positions: computeLayout3D(req.nodes, req.edges, req.prev),
+      metrics,
+    };
+  } else {
+    response = {
+      id: req.id,
+      kind: "layout2d",
+      positions2d: compute2DForceLayout(req.nodes, req.edges),
+      metrics,
+    };
+  }
   (self as unknown as Worker).postMessage(response);
 };
 
-// Re-export types so the client wrapper can stay strongly typed without
-// duplicating the protocol shape. They're erased at runtime — the
-// `export {}` keeps this file a module so the `self.onmessage` write
-// doesn't leak into the global module's surface.
-export type { LayoutRequest, LayoutResponse };
+export type { LayoutRequest, LayoutResponse, Layout3DResponse, Layout2DResponse };


### PR DESCRIPTION
## Summary

Continuation of the load-time arc. PR #404 moved the 3D layout + centrality off the main thread; 2D was still synchronous. After PR #304 made `CausalDAG2D` lazy + conditional, that compute no longer hits launch — but the first user-initiated 2D-tab visit was paying ~150–300ms of main-thread block on a 500-node CROSS-DOMAIN workspace.

The estimator-lib audit (the other backlog candidate) is a **no-op** now: `lppls-fit` / `ph-fit` / `pareto-relevance-bootstrap` are only reachable from `modules/ParetoPanel.tsx` after PR #406, so they already ship only in the Pareto chunk; the `csd-fit-hypo-calibrator` consumer is test-fixture-only. Closed that ticket as already-done.

## What shipped

- **Worker generalised.** `src/lib/workers/layout3d-worker.ts` now dispatches on a `kind: "layout3d" | "layout2d"` discriminator. 3D path unchanged; 2D path runs `compute2DForceLayout(nodes, edges)` + `computeNetworkMetrics(nodes, edges)` and posts back `{ positions2d: Map<string, Position2D>, metrics }`. Both layouts share one worker instance.
- **Client wrapper got a `requestLayout2D` sibling** to `requestLayout3D`. Same epoch-cancellation pattern, same SSR-fallback path.
- **`CausalDAG2D` refactor.** Synchronous `compute2DForceLayout` + `computeNetworkMetrics` useMemos replaced with a `useEffect` keyed on the graph `sig` that posts to the worker, plus `cachedLayout` / `networkMetrics` state populated when the response lands. `latestRequestIdRef` drops stale responses on fast topology changes — same epoch pattern as `CausalDAG3D`. Previously-rendered orbs stay put while a new layout computes.

## Test plan

- [x] `tsc --noEmit` clean (modulo pre-existing inherited errors)
- [x] Lint clean on touched files
- [x] vitest **1322 / 1322** pass (one new fallback-path test for `requestLayout2D`)
- [ ] Launch a CROSS-DOMAIN workspace, switch to 2D tab — confirm the orbs settle in without a main-thread block. The first 2D visit still costs the cold layout compute, but the canvas thread stays interactive.
- [ ] Toggle a domain in/out while on the 2D tab — confirm previous orbs stay rendered while the new layout computes (no flash to (0, 0)).
- [ ] Rapidly switch between 2D and 3D — confirm both views' previously-rendered orbs stay put across switches (each tab has its own latestRequestIdRef and state).

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_