### PR TITLE
feat(feeds): wire Brazil + China Sovereign Risk PWT nodes via WB proxies

### DIFF
--- a/src/lib/feeds/world-bank.ts
+++ b/src/lib/feeds/world-bank.ts
@@ -179,6 +179,68 @@ export const WB_SERIES: WbSeriesConfig[] = [
     capacity: 1500,
     mockValue: 1100,
   },
+  // Phase 14 — Sovereign Risk PWT proxies. The 8 PWT (Penn World Table)
+  // nodes for Brazil + China (Capital Stock, TFP Index, MPK, K/L Ratio)
+  // were historical-only — PWT publishes annually with a ~3y lag and has
+  // no public REST API. WB has reasonable annual proxies for two of the
+  // four dimensions:
+  //
+  //   - Capital Stock → NE.GDI.TOTL.KD (Gross Capital Formation, constant
+  //     2015 USD). FLOW not STOCK, but the closest WB-published annual
+  //     measure of capital accumulation. Annual cadence matches PWT.
+  //
+  //   - TFP Index → SL.GDP.PCAP.EM.KD (GDP per person employed, constant
+  //     2017 PPP $). LABOR PRODUCTIVITY proxy — captures the output-per-
+  //     worker dimension that TFP approximates. Not strict Solow-residual
+  //     TFP (which requires capital + labor decomposition), but the
+  //     closest WB single-series proxy.
+  //
+  // MPK (Marginal Product of Capital) and K/L Ratio are derived quantities
+  // — they require K and L jointly. Better wired via the `derivations`
+  // provider in a future PR. For now they stay historical-only.
+  //
+  // Capacities calibrated against current 2024 values: BRA capital 364B,
+  // CHN capital 7.24T, BRA productivity $41.4k, CHN productivity $45.8k.
+  {
+    country: "BRA",
+    indicator: "NE.GDI.TOTL.KD",
+    label: "Brazil Gross Capital Formation (constant 2015 US$)",
+    labelPatterns: ["brazil capital stock"],
+    scale: 1e9,
+    unit: "$B",
+    capacity: 500,
+    mockValue: 364,
+  },
+  {
+    country: "CHN",
+    indicator: "NE.GDI.TOTL.KD",
+    label: "China Gross Capital Formation (constant 2015 US$)",
+    labelPatterns: ["china capital stock"],
+    scale: 1e12,
+    unit: "$T",
+    capacity: 10,
+    mockValue: 7.24,
+  },
+  {
+    country: "BRA",
+    indicator: "SL.GDP.PCAP.EM.KD",
+    label: "Brazil GDP per Employed Person (constant 2017 PPP $)",
+    labelPatterns: ["brazil tfp index"],
+    scale: 1,
+    unit: "$",
+    capacity: 50000,
+    mockValue: 41441,
+  },
+  {
+    country: "CHN",
+    indicator: "SL.GDP.PCAP.EM.KD",
+    label: "China GDP per Employed Person (constant 2017 PPP $)",
+    labelPatterns: ["china tfp index"],
+    scale: 1,
+    unit: "$",
+    capacity: 55000,
+    mockValue: 45842,
+  },
   // WGI — World Governance Indicators — REMOVED 2026-05-22.
   // Every WGI indicator (RL.EST = Rule of Law, GE.EST = Government
   // Effectiveness, CC.EST = Control of Corruption, PV.EST = Political


### PR DESCRIPTION
## Phase 14 batch #2

The 8 PWT (Penn World Table) sovereign-risk nodes for Brazil + China (Capital Stock, TFP Index, MPK, K/L Ratio) were historical-only. PWT publishes annually with a ~3y lag and has no public REST API. WB has reasonable annual proxies for the first two of the four dimensions — wired here, MPK + K/L deferred to a derivations PR.

## 4 new WB_SERIES entries

| Tuple | Wires to | Latest |
|---|---|---:|
| BRA/NE.GDI.TOTL.KD | `sr_brazil_capital` | 364 B$ @ 2024 |
| CHN/NE.GDI.TOTL.KD | `sr_china_capital` | 7.24 T$ @ 2024 |
| BRA/SL.GDP.PCAP.EM.KD | `sr_brazil_tfp` | $41,441 @ 2024 |
| CHN/SL.GDP.PCAP.EM.KD | `sr_china_tfp` | $45,842 @ 2024 |

## Proxy semantics

- **Capital Stock → Gross Capital Formation.** FLOW not STOCK, but the closest WB-published annual measure of capital accumulation. Probed all FTOT variants; `NE.GDI.FTOT.KD` returns null for CHN, so used the broader TOTL series which is available for both countries.
- **TFP Index → GDP per Employed Person.** Labor productivity, not strict Solow-residual TFP. The closest single-series WB proxy for the output-per-worker dimension TFP approximates.

MPK + K/L are DERIVED quantities (require K and L jointly), better wired via the `derivations` provider in a follow-up. Left historical-only for now.

## Coverage delta

- **Sovereign Risk**: 4/12 → **8/12 live** (33% → 67%)
- WB catalog: 13 → 17 entries
- Overall live coverage: 38% → 40%

## Test plan

- [x] `npx vitest run src/lib/__tests__/feeds/world-bank.test.ts` — 13/13 pass
- [x] Dry-run `check:feeds` shows the 4 new entries as MISS pre-deploy (expected)
- [ ] After deploy: 4 entries flip to LIVE; sovereign-risk graph nodes show their respective values

🤖 Generated with [Claude Code](https://claude.com/claude-code)