### PR TITLE
feat(feeds): wire Fertilizer Price Index to FRED PCU3253132531

### DIFF
--- a/src/lib/feeds/fred.ts
+++ b/src/lib/feeds/fred.ts
@@ -69,6 +69,13 @@ export const FRED_SERIES: FredSeriesConfig[] = [
   // until FRED DFII10 (TIPS yield) becomes reachable." It is now
   // reachable since the FRED_API_KEY landed 2026-05-21.
   { id: "DFII10", label: "10-Year Treasury TIPS Yield (Real Rate)", labelPatterns: ["10y real interest rate"], unit: "%", capacity: 3, mockValue: 2.0 },
+  // Fertilizer Manufacturing PPI — wires `sc_fertilizer_price_index`
+  // (Supply Chain Food Security domain). Previously historical-only via
+  // `bunge_food_security` snapshot. FRED PCU3253132531 is the BLS PPI by
+  // Industry for fertilizer manufacturing, monthly cadence, current to
+  // 2026-04 = 302.87. Capacity 350 = "elevated regime" threshold (PPI
+  // typically peaks around 320-350 in fertilizer supply shocks like 2022).
+  { id: "PCU3253132531", label: "Fertilizer Manufacturing PPI", labelPatterns: ["fertilizer price index"], unit: "", capacity: 350, mockValue: 302 },
   { id: "T5YIE", label: "5-Year Breakeven Inflation Rate", labelPatterns: ["5y breakeven inflation rate"], unit: "%", capacity: 4, mockValue: 2.5 },
   { id: "CSUSHPISA", label: "Case-Shiller Home Price Index YoY", labelPatterns: ["case-shiller home price index"], unit: "%", capacity: 12, units: "pc1", mockValue: 4.8 },
   // FRED expansion (Phase 4): more macro/financial nodes from graph-data.ts


### PR DESCRIPTION
## Phase 14 batch #3

Wires the historical-only `sc_fertilizer_price_index` node (Supply Chain Food Security domain) to FRED Fertilizer Manufacturing PPI.

| FRED ID | Latest | Wires to |
|---|---:|---|
| **PCU3253132531** | 302.87 @ 2026-04 | `sc_fertilizer_price_index` |

Probed multiple FRED fertilizer series — `PCU3253132531` is the headline industry PPI covering both nitrogenous (`PCU325311325311A`) and phosphatic (`PCU325312325312A`) sub-industries. Right aggregate for a graph node named generically "Fertilizer Price Index."

## Coverage delta

- **Supply Chain Food Security**: 3/10 → 4/10 live (30% → 40%)
- FRED catalog: 56 → 57 entries

## Test plan

- [x] `npx vitest run src/lib/__tests__/feeds/fred.test.ts` — 16/16 pass
- [x] Dry-run `check:feeds` shows entry as MISS pre-deploy (expected)
- [ ] After deploy: `sc_fertilizer_price_index` node on the canvas shows ~302 with source string `FRED · PCU3253132531 (period 2026-04)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)