### PR TITLE
feat(pareto): per-selection F·E·G·S·M — G/S/M honor lasso scope

### DIFF
--- a/src/components/modules/ParetoPanel.tsx
+++ b/src/components/modules/ParetoPanel.tsx
@@ -29,6 +29,10 @@ import {
 } from "@/lib/pareto-relevance";
 import { bootstrapRelevanceBatch } from "@/lib/pareto-relevance-bootstrap";
 import {
+  buildScopedAdjacency,
+  inducedEdgeCount,
+} from "@/lib/pareto-scoped-subgraph";
+import {
   loadRelevanceReference,
   lookupRelevanceReference,
   type ReferenceLookupResult,
@@ -516,8 +520,32 @@ function ParetoPanel({
     }
 
     const inputs: ModelRelevanceInput[] = [];
-    const edgeCount = graphData.edges.filter((e) => !e.isSevered).length;
-    const nodeCount = graphData.nodes.length;
+
+    // ── Scope-aware sub-score inputs ───────────────────────────────
+    // F and E already honor `scopedNodeIds` via `scopedOmegaSeries`
+    // (the trajectory the live estimators fit against). G, S, and M
+    // historically used the FULL graph, which made the relevance
+    // composite only partially reactive to lasso selection — exactly
+    // the gap the 2026-05-03 "per-selection model relevance"
+    // directive was calling out ("it can change based off of what the
+    // user selects using the Lasso tool, and it recalculates model
+    // relevance accordingly"). Lifting them to scope here closes that
+    // loop so all five sub-scores agree on what "the system under
+    // analysis" actually is.
+    //
+    // `scopedNodeIds` already collapses the two cases:
+    //   - Lasso active → user's selection
+    //   - No lasso     → top-N risk nodes
+    // So the relevance card is ALWAYS scoped, just to different
+    // defaults depending on whether the user has lassoed anything.
+    // S — edges that live entirely inside the scope (both endpoints
+    // selected). Honors `isSevered` for post-cut analysis: a severed
+    // edge no longer contributes to topology sufficiency. Extracted
+    // into `inducedEdgeCount` so the math is unit-testable.
+    const edgeCount = inducedEdgeCount(graphData.edges, scopedNodeIds);
+    // G — node count for topology sufficiency, scoped to the user's
+    // selection (or top-N fallback).
+    const nodeCount = scopedNodeIds.length;
 
     // Always push live estimators into the relevance batch — even when the
     // trajectory is too thin to fit. The sub-score helpers handle insufficient
@@ -583,36 +611,33 @@ function ParetoPanel({
     });
 
     // M — spatial consistency. Computed once across all models from the
-    // live T1D adjacency (binary, symmetric, row-normalised) and per-node
+    // SCOPED adjacency (binary, symmetric, row-normalised) and per-node
     // ΩF composite values. Same Moran kernel the standalone Moran card
     // already uses, so the breakdown row matches the card by construction.
-    const t1dValues: number[] = T1D_NODE_IDS.map((nid) => {
+    //
+    // Previously this was hardcoded to T1D_NODE_IDS — fine for T1D, but
+    // for any other domain (geopolitical / AI-safety / multi-domain) it
+    // was computing Moran on the WRONG subgraph. Now uses `scopedNodeIds`
+    // so:
+    //   - T1D profile with no selection → top-N T1D risk nodes (the
+    //     ones the rest of the card already analyses)
+    //   - Geopolitical profile           → top-N geopolitical risk nodes
+    //   - Lasso active                   → the user's actual selection
+    //
+    // Moran needs n ≥ 3 to compute a meaningful I + permutation test.
+    // Below that threshold spatialConsistency falls back to the neutral
+    // M = 1.0 ("no evaluable graph"), which preserves the historical
+    // behaviour at degenerate selections.
+    const scopedValues: number[] = scopedNodeIds.map((nid) => {
       const gn = graphData.nodes.find((nd) => nd.id === nid);
       return gn?.omegaFragility.composite ?? 0;
     });
-    const t1dAdjacency: number[][] = (() => {
-      const n = T1D_NODE_IDS.length;
-      const W: number[][] = Array.from({ length: n }, () =>
-        new Array(n).fill(0),
-      );
-      const idxOf = (nid: string) => T1D_NODE_IDS.indexOf(nid);
-      for (const e of graphData.edges) {
-        if (e.isSevered) continue;
-        const si = idxOf(e.source);
-        const ti = idxOf(e.target);
-        if (si >= 0 && ti >= 0) {
-          W[si][ti] = 1;
-          W[ti][si] = 1;
-        }
-      }
-      // Row-normalise.
-      return W.map((row) => {
-        const rs = row.reduce((a, b) => a + b, 0);
-        return rs > 0 ? row.map((v) => v / rs) : row;
-      });
-    })();
+    const scopedAdjacency = buildScopedAdjacency(
+      graphData.edges,
+      scopedNodeIds,
+    );
     const consistency = spatialConsistency(
-      { values: t1dValues, adjacency: t1dAdjacency },
+      { values: scopedValues, adjacency: scopedAdjacency },
       moransI,
     );
 
@@ -626,7 +651,7 @@ function ParetoPanel({
       prevCompositesRef.current.set(key, breakdown.composite);
     }
     return result;
-  }, [csdData, phData, lpplsData, bocpdData, graphData.edges, graphData.nodes, scopeLabel, activeProfile]);
+  }, [csdData, phData, lpplsData, bocpdData, graphData.edges, graphData.nodes, scopeLabel, activeProfile, scopedNodeIds]);
 
   const paretoSectionExpanded = expandedChart === "pareto";
 

--- a/src/lib/__tests__/pareto-scoped-subgraph.test.ts
+++ b/src/lib/__tests__/pareto-scoped-subgraph.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildScopedAdjacency,
+  inducedEdgeCount,
+} from "@/lib/pareto-scoped-subgraph";
+import type { CausalEdge } from "@/lib/types";
+
+// Compact edge factory — pins only the fields the helpers actually
+// read, leaves the rest to sensible defaults so test cases stay
+// readable. `weight` / `lag` / `type` / `confidence` /
+// `physicalMechanism` are required by the type but irrelevant here.
+function edge(
+  source: string,
+  target: string,
+  extra: Partial<CausalEdge> = {},
+): CausalEdge {
+  return {
+    id: `${source}__${target}`,
+    source,
+    target,
+    weight: 0.5,
+    lag: 0,
+    type: "directed",
+    confidence: 0.5,
+    isInconsistent: false,
+    physicalMechanism: "",
+    ...extra,
+  };
+}
+
+describe("inducedEdgeCount", () => {
+  it("counts only edges with both endpoints in scope", () => {
+    const edges = [
+      edge("a", "b"),
+      edge("b", "c"),
+      edge("c", "d"),
+      edge("a", "z"), // z out of scope
+    ];
+    expect(inducedEdgeCount(edges, ["a", "b", "c"])).toBe(2);
+  });
+
+  it("returns 0 for empty scope", () => {
+    expect(inducedEdgeCount([edge("a", "b")], [])).toBe(0);
+  });
+
+  it("returns 0 when no edges match (all out of scope)", () => {
+    const edges = [edge("a", "b"), edge("b", "c")];
+    expect(inducedEdgeCount(edges, ["x", "y", "z"])).toBe(0);
+  });
+
+  it("skips severed edges even when both endpoints are in scope", () => {
+    const edges = [
+      edge("a", "b"),
+      edge("b", "c", { isSevered: true }),
+      edge("c", "d"),
+    ];
+    expect(inducedEdgeCount(edges, ["a", "b", "c", "d"])).toBe(2);
+  });
+
+  it("counts a self-loop in scope once", () => {
+    // Matches the pre-extraction inline behaviour — a self-loop
+    // passes the both-endpoints-in-set check trivially.
+    expect(inducedEdgeCount([edge("a", "a")], ["a"])).toBe(1);
+  });
+
+  it("scales: large scope, no scope mismatch", () => {
+    // Sanity check that the helper handles the 348-edge geopolitical
+    // graph size without surprises.
+    const edges: CausalEdge[] = [];
+    const ids: string[] = [];
+    for (let i = 0; i < 200; i++) ids.push(`n${i}`);
+    for (let i = 0; i < 199; i++) edges.push(edge(`n${i}`, `n${i + 1}`));
+    expect(inducedEdgeCount(edges, ids)).toBe(199);
+  });
+});
+
+describe("buildScopedAdjacency", () => {
+  it("returns an empty matrix for empty scope", () => {
+    expect(buildScopedAdjacency([edge("a", "b")], [])).toEqual([]);
+  });
+
+  it("places symmetric 1s for each in-scope edge before normalisation", () => {
+    // Before row-normalisation the structural symmetry is W[i][j] = W[j][i].
+    // After row-normalisation row sums equal 1 (or 0 for isolated rows).
+    const ids = ["a", "b", "c"];
+    const W = buildScopedAdjacency([edge("a", "b"), edge("b", "c")], ids);
+    // a: one neighbour → row [0, 1, 0]
+    expect(W[0]).toEqual([0, 1, 0]);
+    // b: two neighbours → row [0.5, 0, 0.5]
+    expect(W[1]).toEqual([0.5, 0, 0.5]);
+    // c: one neighbour → row [0, 1, 0]
+    expect(W[2]).toEqual([0, 1, 0]);
+  });
+
+  it("leaves isolated rows as all zeros (S₀ = 0 handled by Moran)", () => {
+    const ids = ["a", "b", "c"];
+    // Only a–b connected; c isolated.
+    const W = buildScopedAdjacency([edge("a", "b")], ids);
+    expect(W[2]).toEqual([0, 0, 0]);
+  });
+
+  it("skips edges with an endpoint outside the scope", () => {
+    const ids = ["a", "b"];
+    const W = buildScopedAdjacency(
+      [edge("a", "b"), edge("a", "z"), edge("z", "y")],
+      ids,
+    );
+    // Only a–b should make it in.
+    expect(W).toEqual([
+      [0, 1],
+      [1, 0],
+    ]);
+  });
+
+  it("skips severed edges", () => {
+    const ids = ["a", "b", "c"];
+    const W = buildScopedAdjacency(
+      [
+        edge("a", "b"),
+        edge("b", "c", { isSevered: true }),
+      ],
+      ids,
+    );
+    // Only a–b survives. b has 1 neighbour (a) post-cut, not 2.
+    expect(W[1]).toEqual([1, 0, 0]);
+  });
+
+  it("uses scopedNodeIds order, not edge order, for row indexing", () => {
+    const ids = ["c", "a", "b"]; // reversed
+    const W = buildScopedAdjacency([edge("a", "b")], ids);
+    // Index in W follows the scopedNodeIds order:
+    //   row 0 = c, row 1 = a, row 2 = b.
+    // Only a–b is connected → W[1][2] = W[2][1] = 1.
+    expect(W[0]).toEqual([0, 0, 0]);
+    expect(W[1]).toEqual([0, 0, 1]);
+    expect(W[2]).toEqual([0, 1, 0]);
+  });
+});

--- a/src/lib/pareto-scoped-subgraph.ts
+++ b/src/lib/pareto-scoped-subgraph.ts
@@ -1,0 +1,99 @@
+/**
+ * Scoped-subgraph helpers for F·E·G·S·M relevance.
+ *
+ * The Pareto relevance composite is per-selection (per the 2026-05-03
+ * "it can change based off of what the user selects using the Lasso
+ * tool" directive). F and E honor the lasso via `scopedOmegaSeries`;
+ * G, S, and M historically used the full graph and made the composite
+ * only partially reactive. These helpers — extracted from inline
+ * `useMemo` so the math is testable — restrict the topology inputs to
+ * the user's selection (or top-N fallback when no selection is active).
+ *
+ * Symmetric with the broader pattern:
+ *  - `scopedNodeIds` is the source of truth for "what's in scope"
+ *  - `inducedEdgeCount` answers G/S's "how many edges?" question
+ *  - `buildScopedAdjacency` answers M's "what's the neighbour
+ *    structure?" question
+ *
+ * Both helpers honor `isSevered` so the post-cut analysis reflects the
+ * topology the analyst is actually working with, not the pristine graph.
+ */
+
+import type { CausalEdge } from "@/lib/types";
+
+/**
+ * Count edges that live entirely inside the scoped node set.
+ *
+ * Both endpoints must be in `scopedNodeIds`; severed edges are skipped
+ * so a cut-applied analysis sees the post-cut edge count, not the
+ * pristine baseline. This is what S (`trajectorySufficiency`) consumes.
+ *
+ * Edge cases:
+ *  - Empty scope → 0 (sufficiency saturates downward gracefully)
+ *  - All edges severed → 0
+ *  - Self-loop in scope → counted once (matches pre-extraction behaviour)
+ */
+export function inducedEdgeCount(
+  edges: ReadonlyArray<CausalEdge>,
+  scopedNodeIds: ReadonlyArray<string>,
+): number {
+  if (scopedNodeIds.length === 0) return 0;
+  const set = new Set(scopedNodeIds);
+  let count = 0;
+  for (const e of edges) {
+    if (e.isSevered) continue;
+    if (set.has(e.source) && set.has(e.target)) count++;
+  }
+  return count;
+}
+
+/**
+ * Build a row-normalised binary adjacency matrix over the scoped node
+ * set, in `scopedNodeIds` order. Used as the spatial-consistency input
+ * for M (`spatialConsistency` + Moran's I).
+ *
+ * The matrix is symmetric (each edge sets both `W[i][j]` and `W[j][i]`)
+ * before row-normalisation, matching the standalone Moran card's
+ * conventions exactly so M and the Moran card always agree.
+ *
+ * Severed edges are skipped. Rows with no neighbours stay zero — Moran's
+ * I handles the degenerate S₀ = 0 case by returning a neutral result,
+ * so we don't need to special-case it here.
+ *
+ * Returned shape: `number[][]` of size `scopedNodeIds.length` square.
+ */
+export function buildScopedAdjacency(
+  edges: ReadonlyArray<CausalEdge>,
+  scopedNodeIds: ReadonlyArray<string>,
+): number[][] {
+  const n = scopedNodeIds.length;
+  const W: number[][] = Array.from({ length: n }, () =>
+    new Array<number>(n).fill(0),
+  );
+  if (n === 0) return W;
+
+  // Precompute id → row-index once so the per-edge inner loop is O(1)
+  // instead of O(n) (matters for the 348-edge geopolitical graph).
+  const idx = new Map<string, number>();
+  for (let i = 0; i < n; i++) idx.set(scopedNodeIds[i], i);
+
+  for (const e of edges) {
+    if (e.isSevered) continue;
+    const si = idx.get(e.source);
+    const ti = idx.get(e.target);
+    if (si === undefined || ti === undefined) continue;
+    W[si][ti] = 1;
+    W[ti][si] = 1;
+  }
+
+  // Row-normalise so each row sums to 1 (or stays 0 for isolated nodes).
+  // This is the canonical Moran-input form; `spatialConsistency` does
+  // not re-normalise, so the helper must.
+  for (let i = 0; i < n; i++) {
+    const rowSum = W[i].reduce((a, b) => a + b, 0);
+    if (rowSum > 0) {
+      for (let j = 0; j < n; j++) W[i][j] /= rowSum;
+    }
+  }
+  return W;
+}


### PR DESCRIPTION
## Summary

Closes the 2026-05-03 user directive that's been outstanding ever since the F·E·G·S·M composite shipped: *"this should be a value that is, you know, it's not fixed. Right? So it can change based off of what the user selects using the Lasso tool, and it recalculates model relevance accordingly."*

Half of that was already true. **F** (fit) and **E** (epochs-to-critical) already honored `scopedNodeIds` via `scopedOmegaSeries` — the trajectory the live estimators fit against. But **G**, **S**, and **M** all used the FULL graph, so the composite `S · G · M · (0.6F + 0.4E)` moved less than the analyst expected on lasso changes.

This PR lifts G/S/M to scope. After this all five sub-scores agree on "what's the system under analysis" — namely `scopedNodeIds` (lasso selection if any, else top-N risk nodes).

## Sub-score changes

| Sub-score | Before | After |
|---|---|---|
| **G** (topologySufficiency) | `graphData.nodes.length` (192 for full geo graph) | `scopedNodeIds.length` (8 default top-N, or lasso count) |
| **S** (trajectorySufficiency) | every non-severed edge | only edges with **both** endpoints in scope (via new `inducedEdgeCount`) |
| **M** (spatialConsistency / Moran) | hardcoded `T1D_NODE_IDS` adjacency, regardless of active domain | scope-induced adjacency (via new `buildScopedAdjacency`) |

## Side-effect fix

M previously used `T1D_NODE_IDS` even when the active profile was geopolitical or AI Safety — Moran's I was running against the wrong subgraph for those domains. Now M follows the scope, so the row matches whatever subset the rest of the card is analysing. The standalone Moran card already used scope-aware computation, so this also fixes a latent disagreement between the two surfaces.

## Extracted helpers (testable)

The Moran adjacency + induced edge count were inline in a 200-line `useMemo`. Pulled them out into `src/lib/pareto-scoped-subgraph.ts`:

- `inducedEdgeCount(edges, scopedNodeIds)` — both-endpoints-in-scope edge count, honors `isSevered`
- `buildScopedAdjacency(edges, scopedNodeIds)` — row-normalised binary adjacency in `scopedNodeIds` order

12 new tests covering: empty scope, all-out-of-scope, severed-edge skipped, self-loop counted once, large scope (199 edges no false positives), empty-matrix edge case, isolated row stays zero, row-normalisation correctness, order preservation when `scopedNodeIds` is reversed.

## Behaviour at edge cases

- **Default state (top-8 risk nodes):** G saturates at 8/N_min instead of 192/N_min; S counts edges within the 8-node induced subgraph; M's Moran adjacency is the 8-node subgraph
- **Lasso 20 nodes:** all three reflect the 20-node induced subgraph; F and E already did
- **Tiny selection (1-2 nodes):** G/S clamp gracefully toward 0; `spatialConsistency` returns the neutral M = 1.0 fallback when n < 3, matching pre-extraction behaviour
- **Post-cut analysis (severed edges):** still excluded — topology metrics reflect what the analyst is working with, not the pristine graph

## Why this matters for clients

The relevance composite is the headline number on the Pareto card. Before this PR, if a buyer lassoed the 20 Hormuz-relevant nodes from a 192-node geopolitical graph, the relevance number would barely shift — G/S/M kept the global graph in the math. After this PR, the composite genuinely reflects "the relevance of this estimator to *the subsystem you've selected*," which is what the directive asked for two weeks ago.

## Files

| File | Change |
|---|---|
| `src/lib/pareto-scoped-subgraph.ts` (new) | `inducedEdgeCount` + `buildScopedAdjacency` helpers |
| `src/lib/__tests__/pareto-scoped-subgraph.test.ts` (new) | 12 tests on the two helpers |
| `src/components/modules/ParetoPanel.tsx` | Replace inline G/S/M computations with the helpers; add `scopedNodeIds` to the `useMemo` deps |

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/lib/__tests__/pareto-scoped-subgraph.test.ts` — 12/12 passing
- [x] `npx next build` clean
- [ ] PR-validate workflow green
- [ ] Vercel preview eyeball:
  - Open PARETO card with no selection → "scope: top 8 risk nodes · n=…" header (unchanged)
  - Lasso a region → "scope: 20 selected nodes · n=…" + the relevance numbers actually change (not just F, but G/S/M too — visible by clicking BREAKDOWN on the card)
  - Switch domain to T1D → relevance still computes correctly
  - Sever an edge in PEARL → relevance recomputes against the post-cut topology

## Backwards compat

No store / API / data changes. Existing tests pass. Suite grows by 12. `T1D_NODE_IDS` import retained in ParetoPanel because it's still used elsewhere in the same file (lines ~821 / ~855 — unrelated CSD trajectory work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
