### PR TITLE
feat(pearl): WHY? explain-this-cut affordance on interdiction results

### DIFF
--- a/src/components/modules/CopilotInterdictionResults.tsx
+++ b/src/components/modules/CopilotInterdictionResults.tsx
@@ -7,6 +7,7 @@
 
 import { useCallback, useMemo, useState } from "react";
 import { useApexStore } from "@/stores/useApexStore";
+import { explainIntervention } from "@/lib/interdiction-explain";
 
 function CopilotInterdictionResults() {
   const lastResult = useApexStore((s) => s.lastInterdictionResult);
@@ -34,6 +35,13 @@ function CopilotInterdictionResults() {
   const ablatedNodeIds = useApexStore((s) => s.ablatedNodeIds);
   const severedEdges = useApexStore((s) => s.severedEdges);
   const [appliedIds, setAppliedIds] = useState<Set<string>>(new Set());
+  // Index of the row currently expanded into its "WHY THIS CUT?"
+  // narrative, or null for "all collapsed". Single-expansion (not
+  // multi) so the card stays compact; opening a new row collapses
+  // the prior expansion. Defensibility matters more than visual
+  // density here — commercial buyers click WHY? to read prose,
+  // they don't compare three explanations at once.
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
 
   // Affected node set. Memoised on the interdiction result + graph
   // edge list so toggling isolate doesn't recompute it. Edge-cut
@@ -204,37 +212,98 @@ function CopilotInterdictionResults() {
             const isApplied = appliedIds.has(iv.target.id);
             const actionLabel = iv.target.type === "edge" ? "SEVER" : "ABLATE";
             const appliedLabel = iv.target.type === "edge" ? "SEVERED" : "ABLATED";
+            const isExpanded = expandedIndex === i;
+            // Greedy-walk + mechanism narrative for this cut. The
+            // fallback (structural-vulnerability) path uses proxy
+            // scores instead of real marginal damage deltas, so the
+            // "Worst-case damage X → Y" line would be misleading
+            // there — suppress the WHY? affordance for that case.
+            const explanation =
+              !isFallback ? explainIntervention(lastResult, i, graphData) : null;
             return (
               <div
                 key={iv.target.id}
-                className="flex items-center gap-2 p-1.5 rounded border border-border bg-surface-elevated"
+                className="rounded border border-border bg-surface-elevated"
               >
-                <span className="text-[8px] font-mono text-accent-cyan w-4 shrink-0">{i + 1}.</span>
-                <div className="flex-1 min-w-0">
-                  <div className="text-[8px] font-mono text-foreground truncate">{iv.target.label}</div>
-                  <div className="text-[7px] font-mono text-text-muted">
-                    {iv.target.type} — {rankLabel} {iv.marginalReduction.toFixed(1)}{rankUnit}
+                <div className="flex items-center gap-2 p-1.5">
+                  <span className="text-[8px] font-mono text-accent-cyan w-4 shrink-0">{i + 1}.</span>
+                  <div className="flex-1 min-w-0">
+                    <div className="text-[8px] font-mono text-foreground truncate">{iv.target.label}</div>
+                    <div className="text-[7px] font-mono text-text-muted">
+                      {iv.target.type} — {rankLabel} {iv.marginalReduction.toFixed(1)}{rankUnit}
+                    </div>
                   </div>
+                  {/* WHY THIS CUT? — expands a per-row narrative
+                      block underneath. Pure read affordance; doesn't
+                      modify any store state. Hidden on the fallback
+                      path (proxy scores, not real damage deltas).
+                      Single-expansion: opening one collapses any
+                      other open row to keep the card compact. */}
+                  {explanation && (
+                    <button
+                      onClick={() =>
+                        setExpandedIndex(isExpanded ? null : i)
+                      }
+                      className={`px-1.5 py-0.5 rounded text-[7px] font-[family-name:var(--font-michroma)] tracking-wider transition-colors shrink-0 border ${
+                        isExpanded
+                          ? "border-accent-cyan/40 text-accent-cyan bg-accent-cyan/5"
+                          : "border-border text-text-muted hover:text-accent-cyan hover:border-accent-cyan/40"
+                      }`}
+                      title={isExpanded ? "Hide explanation" : "Why was this cut recommended?"}
+                      aria-expanded={isExpanded}
+                    >
+                      {isExpanded ? "HIDE" : "WHY?"}
+                    </button>
+                  )}
+                  <button
+                    onClick={() => {
+                      if (isApplied) return;
+                      if (iv.target.type === "edge") {
+                        severEdge(iv.target.id);
+                      } else {
+                        toggleAblatedNode(iv.target.id);
+                      }
+                      setAppliedIds((prev) => new Set([...prev, iv.target.id]));
+                    }}
+                    disabled={isApplied}
+                    className={`px-2 py-0.5 rounded text-[7px] font-[family-name:var(--font-michroma)] tracking-wider transition-colors shrink-0 ${
+                      isApplied
+                        ? "text-accent-green border border-accent-green/30 bg-accent-green/5"
+                        : "text-accent-red border border-accent-red/30 hover:bg-accent-red/10"
+                    }`}
+                  >
+                    {isApplied ? appliedLabel : actionLabel}
+                  </button>
                 </div>
-                <button
-                  onClick={() => {
-                    if (isApplied) return;
-                    if (iv.target.type === "edge") {
-                      severEdge(iv.target.id);
-                    } else {
-                      toggleAblatedNode(iv.target.id);
-                    }
-                    setAppliedIds((prev) => new Set([...prev, iv.target.id]));
-                  }}
-                  disabled={isApplied}
-                  className={`px-2 py-0.5 rounded text-[7px] font-[family-name:var(--font-michroma)] tracking-wider transition-colors shrink-0 ${
-                    isApplied
-                      ? "text-accent-green border border-accent-green/30 bg-accent-green/5"
-                      : "text-accent-red border border-accent-red/30 hover:bg-accent-red/10"
-                  }`}
-                >
-                  {isApplied ? appliedLabel : actionLabel}
-                </button>
+                {/* Expanded narrative block — three paragraphs:
+                    rank (where this cut sits in the greedy walk),
+                    damage delta (before / after / % reduction this
+                    step contributes), and mechanism (what this cut
+                    actually does, sourced from the edge's
+                    physicalMechanism field or the node's
+                    incoming/outgoing degree). Renders only when
+                    `expandedIndex === i` and an explanation was
+                    computed (i.e. not the fallback path). */}
+                {isExpanded && explanation && (
+                  <div className="border-t border-border/40 px-2 py-1.5 space-y-1.5 bg-surface/30">
+                    <div className="text-[7px] font-mono text-text-muted leading-relaxed">
+                      <span className="text-accent-amber">RANK </span>
+                      {explanation.rank}
+                    </div>
+                    <div className="text-[7px] font-mono text-text-muted leading-relaxed">
+                      <span className="text-accent-amber">DAMAGE </span>
+                      {explanation.damageDelta}
+                    </div>
+                    <div className="text-[7px] font-mono text-text-muted leading-relaxed space-y-0.5">
+                      <div>
+                        <span className="text-accent-amber">MECHANISM</span>
+                      </div>
+                      {explanation.mechanism.map((line, j) => (
+                        <div key={j}>{line}</div>
+                      ))}
+                    </div>
+                  </div>
+                )}
               </div>
             );
           })}

--- a/src/lib/__tests__/interdiction-explain.test.ts
+++ b/src/lib/__tests__/interdiction-explain.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  damageDeltaNarrative,
+  explainIntervention,
+  mechanismNarrative,
+  rankNarrative,
+  stepContextForIntervention,
+} from "@/lib/interdiction-explain";
+import type {
+  InterdictionCandidate,
+  InterdictionResult,
+} from "@/lib/interdiction-engine";
+import type { CausalEdge, CausalGraph, CausalNode } from "@/lib/types";
+
+// ─── Fixtures ─────────────────────────────────────────────────────
+
+function node(id: string, extra: Partial<CausalNode> = {}): CausalNode {
+  return {
+    id,
+    label: `Node ${id}`,
+    shortLabel: id.toUpperCase(),
+    category: "manufacturing",
+    omegaFragility: {
+      composite: 5,
+      irreplaceability: 5,
+      restorationLatency: 5,
+      jurisdictionalHazard: 5,
+      cascadeLoad: 5,
+      tailDepth: 5,
+    },
+    globalConcentration: "",
+    replacementTime: "",
+    domain: "Test",
+    discoverySource: "merged",
+    isConfounded: false,
+    isRestricted: false,
+    ...extra,
+  };
+}
+
+function edge(
+  source: string,
+  target: string,
+  extra: Partial<CausalEdge> = {},
+): CausalEdge {
+  return {
+    id: `${source}__${target}`,
+    source,
+    target,
+    weight: 0.5,
+    lag: 0,
+    type: "directed",
+    confidence: 0.5,
+    isInconsistent: false,
+    physicalMechanism: `${source} drives ${target}`,
+    ...extra,
+  };
+}
+
+function graph(nodes: CausalNode[], edges: CausalEdge[]): CausalGraph {
+  return {
+    nodes,
+    edges,
+    metadata: {
+      density: 0.1,
+      constraintType: "test",
+      verificationStatus: "UNVERIFIED",
+      totalNodes: nodes.length,
+      totalEdges: edges.length,
+      inconsistentEdges: 0,
+      restrictedNodes: 0,
+    },
+  };
+}
+
+function ivEdge(
+  edgeId: string,
+  damage: number,
+  marginalReduction: number,
+): InterdictionCandidate {
+  return {
+    target: { type: "edge", id: edgeId, label: edgeId },
+    damage,
+    marginalReduction,
+  };
+}
+
+function ivNode(
+  nodeId: string,
+  damage: number,
+  marginalReduction: number,
+): InterdictionCandidate {
+  return {
+    target: { type: "node", id: nodeId, label: nodeId.toUpperCase() },
+    damage,
+    marginalReduction,
+  };
+}
+
+function result(
+  baseline: number,
+  ivs: InterdictionCandidate[],
+): InterdictionResult {
+  return {
+    interventions: ivs,
+    baselineDamage: baseline,
+    bestDamage: ivs.length > 0 ? ivs[ivs.length - 1].damage : baseline,
+    reductionPct: 0,
+  };
+}
+
+// ─── stepContextForIntervention ───────────────────────────────────
+
+describe("stepContextForIntervention", () => {
+  it("uses baselineDamage as damageBefore for the first step", () => {
+    const r = result(80, [ivEdge("a__b", 60, 20)]);
+    const ctx = stepContextForIntervention(r, 0);
+    expect(ctx).not.toBeNull();
+    expect(ctx!.damageBefore).toBe(80);
+    expect(ctx!.damageAfter).toBe(60);
+    expect(ctx!.marginalReduction).toBe(20);
+    expect(ctx!.step).toBe(1);
+    expect(ctx!.totalSteps).toBe(1);
+  });
+
+  it("uses prior step's damage as damageBefore for subsequent steps", () => {
+    const r = result(80, [
+      ivEdge("a__b", 60, 20),
+      ivEdge("c__d", 45, 15),
+      ivEdge("e__f", 40, 5),
+    ]);
+    const ctx2 = stepContextForIntervention(r, 1);
+    expect(ctx2!.damageBefore).toBe(60); // prior step's damage
+    expect(ctx2!.damageAfter).toBe(45);
+    expect(ctx2!.marginalReduction).toBe(15);
+    expect(ctx2!.step).toBe(2);
+    expect(ctx2!.totalSteps).toBe(3);
+
+    const ctx3 = stepContextForIntervention(r, 2);
+    expect(ctx3!.damageBefore).toBe(45);
+    expect(ctx3!.damageAfter).toBe(40);
+  });
+
+  it("computes stepReductionPct as a fraction of damageBefore, not baseline", () => {
+    // Step 2: damageBefore=60, marginal=15 → 25% of remaining damage,
+    // NOT 18.75% (which would be 15/80, the wrong denominator).
+    const r = result(80, [ivEdge("a__b", 60, 20), ivEdge("c__d", 45, 15)]);
+    const ctx2 = stepContextForIntervention(r, 1);
+    expect(ctx2!.stepReductionPct).toBeCloseTo(25, 1);
+  });
+
+  it("returns null for out-of-range index", () => {
+    const r = result(80, [ivEdge("a__b", 60, 20)]);
+    expect(stepContextForIntervention(r, 1)).toBeNull();
+    expect(stepContextForIntervention(r, -1)).toBeNull();
+  });
+
+  it("returns 0 stepReductionPct when damageBefore is 0", () => {
+    // Defensive — solver shouldn't emit this, but guarantees no div-by-zero
+    // surfaces in the UI.
+    const r = result(0, [ivEdge("a__b", 0, 0)]);
+    const ctx = stepContextForIntervention(r, 0);
+    expect(ctx!.stepReductionPct).toBe(0);
+  });
+});
+
+// ─── rankNarrative ────────────────────────────────────────────────
+
+describe("rankNarrative", () => {
+  it("step 1 reads as 'highest-impact'", () => {
+    const r = result(80, [ivEdge("a__b", 60, 20), ivEdge("c__d", 45, 15)]);
+    const ctx = stepContextForIntervention(r, 0)!;
+    expect(rankNarrative(ctx).toLowerCase()).toContain("highest-impact");
+  });
+
+  it("last step in a multi-step result explains the conditional ranking", () => {
+    const r = result(80, [
+      ivEdge("a__b", 60, 20),
+      ivEdge("c__d", 45, 15),
+      ivEdge("e__f", 40, 5),
+    ]);
+    const ctx = stepContextForIntervention(r, 2)!;
+    // Should reference the prior cuts driving damage down.
+    expect(rankNarrative(ctx).toLowerCase()).toMatch(/prior.*cuts|drove.*down|already/);
+  });
+
+  it("single-step result reads as highest-impact (not 'best remaining')", () => {
+    // Step 1 of 1 — the "last step" branch must NOT fire and produce
+    // the "prior cuts already drove damage down" phrasing, because
+    // there were no prior cuts.
+    const r = result(80, [ivEdge("a__b", 60, 20)]);
+    const ctx = stepContextForIntervention(r, 0)!;
+    expect(rankNarrative(ctx).toLowerCase()).toContain("highest-impact");
+    expect(rankNarrative(ctx).toLowerCase()).not.toMatch(/prior.*cuts/);
+  });
+
+  it("middle steps describe the conditional pick without claiming 'last'", () => {
+    const r = result(80, [
+      ivEdge("a__b", 60, 20),
+      ivEdge("c__d", 45, 15),
+      ivEdge("e__f", 40, 5),
+    ]);
+    const ctx = stepContextForIntervention(r, 1)!;
+    const text = rankNarrative(ctx).toLowerCase();
+    expect(text).toContain("step 2 of 3");
+    expect(text).toContain("conditional");
+  });
+});
+
+// ─── damageDeltaNarrative ─────────────────────────────────────────
+
+describe("damageDeltaNarrative", () => {
+  it("includes the before, after, and saving amounts", () => {
+    const r = result(80, [ivEdge("a__b", 60, 20)]);
+    const ctx = stepContextForIntervention(r, 0)!;
+    const text = damageDeltaNarrative(ctx);
+    expect(text).toContain("80.0");
+    expect(text).toContain("60.0");
+    expect(text).toContain("20.0");
+  });
+
+  it("includes the % reduction line when damageBefore > 0", () => {
+    const r = result(80, [ivEdge("a__b", 60, 20)]);
+    const ctx = stepContextForIntervention(r, 0)!;
+    expect(damageDeltaNarrative(ctx)).toMatch(/25%/);
+  });
+
+  it("omits the % reduction when damageBefore is 0", () => {
+    const r = result(0, [ivEdge("a__b", 0, 0)]);
+    const ctx = stepContextForIntervention(r, 0)!;
+    // No '%' substring at all when the denominator is 0.
+    expect(damageDeltaNarrative(ctx)).not.toContain("%");
+  });
+});
+
+// ─── mechanismNarrative ───────────────────────────────────────────
+
+describe("mechanismNarrative", () => {
+  it("edge cut surfaces source/target labels, weight, and mechanism prose", () => {
+    const g = graph(
+      [node("a"), node("b")],
+      [edge("a", "b", { weight: 0.84, physicalMechanism: "powers downstream load" })],
+    );
+    const iv = ivEdge("a__b", 60, 20);
+    const lines = mechanismNarrative(iv, g);
+    expect(lines[0]).toContain("0.84");
+    expect(lines[0]).toContain("A");
+    expect(lines[0]).toContain("B");
+    expect(lines[1]).toContain("powers downstream load");
+  });
+
+  it("edge cut without physicalMechanism omits the mechanism line", () => {
+    const g = graph(
+      [node("a"), node("b")],
+      [edge("a", "b", { physicalMechanism: "" })],
+    );
+    const lines = mechanismNarrative(ivEdge("a__b", 60, 20), g);
+    expect(lines.length).toBe(1);
+    expect(lines[0]).toContain("0.50");
+  });
+
+  it("node ablation counts outgoing + incoming non-severed edges", () => {
+    const g = graph(
+      [node("hub"), node("a"), node("b"), node("c")],
+      [
+        edge("hub", "a"),
+        edge("hub", "b"),
+        edge("c", "hub"),
+      ],
+    );
+    const lines = mechanismNarrative(ivNode("hub", 60, 20), g);
+    expect(lines[0]).toContain("Node hub");
+    expect(lines[1]).toMatch(/2 outgoing/);
+    expect(lines[1]).toMatch(/1 incoming/);
+  });
+
+  it("severed edges are not counted in the outgoing/incoming totals", () => {
+    const g = graph(
+      [node("hub"), node("a"), node("b")],
+      [
+        edge("hub", "a"),
+        edge("hub", "b", { isSevered: true }),
+        edge("a", "hub", { isSevered: true }),
+      ],
+    );
+    const lines = mechanismNarrative(ivNode("hub", 60, 20), g);
+    expect(lines[1]).toMatch(/1 outgoing/);
+    expect(lines[1]).toMatch(/0 incoming/);
+  });
+
+  it("falls back gracefully when the target id isn't in the graph", () => {
+    // Solver wrote a candidate referencing a node/edge that's since been
+    // removed from the graph (edge case but defensive). UI should still
+    // render something useful instead of crashing.
+    const g = graph([node("a")], []);
+    expect(mechanismNarrative(ivEdge("ghost__edge", 60, 20), g).length).toBeGreaterThan(0);
+    expect(mechanismNarrative(ivNode("ghost_node", 60, 20), g).length).toBeGreaterThan(0);
+  });
+});
+
+// ─── explainIntervention (bundle) ─────────────────────────────────
+
+describe("explainIntervention", () => {
+  it("returns rank + damageDelta + mechanism for a valid index", () => {
+    const g = graph(
+      [node("a"), node("b")],
+      [edge("a", "b", { physicalMechanism: "powers grid" })],
+    );
+    const r = result(80, [ivEdge("a__b", 60, 20)]);
+    const explanation = explainIntervention(r, 0, g);
+    expect(explanation).not.toBeNull();
+    expect(explanation!.rank).toBeTruthy();
+    expect(explanation!.damageDelta).toContain("80");
+    expect(explanation!.mechanism[1]).toContain("powers grid");
+  });
+
+  it("returns null for out-of-range index", () => {
+    const g = graph([node("a")], []);
+    const r = result(80, []);
+    expect(explainIntervention(r, 0, g)).toBeNull();
+  });
+});

--- a/src/lib/interdiction-explain.ts
+++ b/src/lib/interdiction-explain.ts
@@ -1,0 +1,179 @@
+/**
+ * Narrative explainers for interdiction-solver outputs.
+ *
+ * The interdiction card surfaces each recommended cut as a row with a
+ * `marginalReduction` number ("saves 2.4 pts") and a SEVER/ABLATE
+ * button. That's enough for an expert reader but a commercial buyer
+ * who clicks the card wants the *why* in prose:
+ *   - Where does this cut sit in the greedy walk?
+ *   - What was the baseline damage before this cut, and after?
+ *   - What's the underlying causal mechanism being severed?
+ *
+ * This module produces that narrative from the existing
+ * `InterdictionResult.interventions[i]` data + the source graph (no
+ * solver changes). Pure functions so the UI can call them inline and
+ * the math stays unit-testable.
+ */
+
+import type { CausalEdge, CausalGraph, CausalNode } from "@/lib/types";
+import type {
+  InterdictionCandidate,
+  InterdictionResult,
+} from "@/lib/interdiction-engine";
+
+/**
+ * Per-step context derived from a candidate's position in the greedy walk.
+ * The solver picks one cut per step and accumulates them — so the damage
+ * AT THE START of step i is whichever damage existed after step i-1
+ * (or the baseline for step 0).
+ */
+export interface InterdictionStepContext {
+  /** 1-indexed step number in the greedy walk. */
+  step: number;
+  /** Total intervention count (matches `interventions.length`). */
+  totalSteps: number;
+  /** Damage entering this step (baseline for step 1, prior step's `damage` after). */
+  damageBefore: number;
+  /** Damage exiting this step (the candidate's `damage` field). */
+  damageAfter: number;
+  /** `damageBefore - damageAfter`. Matches `marginalReduction` to within rounding. */
+  marginalReduction: number;
+  /** % reduction from this step alone, vs damageBefore. */
+  stepReductionPct: number;
+}
+
+/**
+ * Build the per-step context for an intervention. Returns null if the
+ * index is out of range. Callers in the UI typically iterate the
+ * `interventions` array and pass `(result, i)` for each row.
+ *
+ * Why baseline-vs-prior matters in the narrative: a cut that ranks #3
+ * isn't necessarily weak. It's the best cut GIVEN that #1 and #2 are
+ * already applied. Surfacing the per-step damage delta defends "why
+ * didn't you pick X instead?" questions from skeptical readers.
+ */
+export function stepContextForIntervention(
+  result: InterdictionResult,
+  index: number,
+): InterdictionStepContext | null {
+  const iv = result.interventions[index];
+  if (!iv) return null;
+  const damageBefore =
+    index === 0 ? result.baselineDamage : result.interventions[index - 1].damage;
+  const damageAfter = iv.damage;
+  const marginalReduction = damageBefore - damageAfter;
+  const stepReductionPct =
+    damageBefore > 0 ? (marginalReduction / damageBefore) * 100 : 0;
+  return {
+    step: index + 1,
+    totalSteps: result.interventions.length,
+    damageBefore,
+    damageAfter,
+    marginalReduction,
+    stepReductionPct,
+  };
+}
+
+/**
+ * Mechanism narrative — the plain-prose answer to "what is this cut
+ * actually doing?". For edges, surfaces the source/target labels, the
+ * weight, and the `physicalMechanism` text already on the edge. For
+ * nodes, the label + a count of downstream edges this ablation would
+ * sever indirectly.
+ *
+ * Returns short prose paragraphs, NOT formatted UI markup — the caller
+ * decides how to render. Empty string-valued fields are skipped so the
+ * caller can `.filter(Boolean)` and not render blank rows.
+ */
+export function mechanismNarrative(
+  candidate: InterdictionCandidate,
+  graph: CausalGraph,
+): string[] {
+  if (candidate.target.type === "edge") {
+    const edge = graph.edges.find((e) => e.id === candidate.target.id);
+    if (!edge) return [`Cut: ${candidate.target.label}`];
+    const source = graph.nodes.find((n) => n.id === edge.source);
+    const target = graph.nodes.find((n) => n.id === edge.target);
+    const sourceLabel = source?.shortLabel ?? edge.source;
+    const targetLabel = target?.shortLabel ?? edge.target;
+    const lines: string[] = [
+      `Severs the ${edge.weight.toFixed(2)}-weight causal link from ${sourceLabel} to ${targetLabel}.`,
+    ];
+    if (edge.physicalMechanism) {
+      lines.push(`Mechanism: ${edge.physicalMechanism}`);
+    }
+    return lines;
+  }
+  // node ablation
+  const node = graph.nodes.find((n) => n.id === candidate.target.id);
+  if (!node) return [`Ablate: ${candidate.target.label}`];
+  const outEdges = graph.edges.filter(
+    (e) => e.source === node.id && !e.isSevered,
+  );
+  const inEdges = graph.edges.filter(
+    (e) => e.target === node.id && !e.isSevered,
+  );
+  return [
+    `Ablates ${node.label} (${node.domain || node.category}).`,
+    `Removes ${outEdges.length} outgoing influence${outEdges.length === 1 ? "" : "s"} and ${inEdges.length} incoming dependenc${inEdges.length === 1 ? "y" : "ies"} from the cascade.`,
+  ];
+}
+
+/**
+ * Greedy-walk rank narrative — one line explaining where this cut sits
+ * in the priority ordering. Returns a single sentence the UI can drop
+ * in as-is. The phrasing changes by position so a #1 cut reads
+ * differently from a #3 cut.
+ */
+export function rankNarrative(ctx: InterdictionStepContext): string {
+  if (ctx.step === 1) {
+    return `Highest-impact cut available — picked first in the greedy walk because no other single intervention reduced worst-case damage more.`;
+  }
+  if (ctx.step === ctx.totalSteps && ctx.totalSteps > 1) {
+    return `Step ${ctx.step} of ${ctx.totalSteps}. Lower marginal save than the earlier cuts because the prior ${ctx.totalSteps - 1} interventions already drove damage down — this is the best remaining cut given those.`;
+  }
+  return `Step ${ctx.step} of ${ctx.totalSteps} in the greedy walk. Chosen as the best cut conditional on steps 1–${ctx.step - 1} already being applied.`;
+}
+
+/**
+ * Damage-delta narrative — one line in plain prose describing the
+ * before/after damage scores and the % reduction this step alone
+ * contributes. Skips % when damageBefore is 0 (degenerate baseline).
+ */
+export function damageDeltaNarrative(ctx: InterdictionStepContext): string {
+  const pct =
+    ctx.damageBefore > 0
+      ? ` (${ctx.stepReductionPct.toFixed(0)}% of remaining damage)`
+      : "";
+  return `Worst-case cascade damage: ${ctx.damageBefore.toFixed(1)} → ${ctx.damageAfter.toFixed(1)}, saving ${ctx.marginalReduction.toFixed(1)} pts${pct}.`;
+}
+
+/**
+ * Convenience bundle — full narrative ready to render. Combines rank +
+ * damage + mechanism into a single struct so the caller doesn't have
+ * to wire each helper individually. Returns null when the index is out
+ * of range.
+ */
+export interface InterdictionExplanation {
+  rank: string;
+  damageDelta: string;
+  mechanism: string[];
+}
+
+export function explainIntervention(
+  result: InterdictionResult,
+  index: number,
+  graph: CausalGraph,
+): InterdictionExplanation | null {
+  const ctx = stepContextForIntervention(result, index);
+  if (!ctx) return null;
+  return {
+    rank: rankNarrative(ctx),
+    damageDelta: damageDeltaNarrative(ctx),
+    mechanism: mechanismNarrative(result.interventions[index], graph),
+  };
+}
+
+// Re-export the supporting types so callers don't have to dual-import
+// from interdiction-engine.ts and this module separately.
+export type { InterdictionCandidate, InterdictionResult, CausalEdge, CausalNode };


### PR DESCRIPTION
## Summary

The interdiction card today surfaces each recommended cut as a row with a "saves 2.4 pts" number and a SEVER/ABLATE button. That's enough for an expert reader but a commercial buyer — especially on the AON-style geopolitical demo — clicks the card wanting the *why* in prose. "Why this cut? Why not X instead? How much of that damage reduction is from this one cut vs the earlier ones?"

This PR adds a per-row **WHY?** toggle next to SEVER/ABLATE that expands a narrative block with three paragraphs:

| Paragraph | Content |
|---|---|
| **RANK** | Where this cut sits in the greedy walk. Step 1 reads as "highest-impact cut available — picked first because no other single intervention reduced damage more." Last step in a multi-step result reads as "best remaining cut given the prior N-1 interventions drove damage down." Middle steps explain the conditional pick. |
| **DAMAGE** | "Worst-case cascade damage: 67.3 → 23.1, saving 44.2 pts (66% of remaining damage)." The % is per-step against `damageBefore`, not the original baseline, so a step-3 cut that saves 5 pts off a 20-pt remaining damage reads as "25% of remaining damage" — accurate to what the step actually accomplished. |
| **MECHANISM** | For edge cuts: "Severs the 0.84-weight causal link from FOO to BAR" + the edge's `physicalMechanism` text. For node ablations: "Ablates BAR (Energy). Removes N outgoing influences and M incoming dependencies from the cascade." |

Single-expansion (opening one row collapses any other) so the card stays compact. **Suppressed on the structural-vulnerability fallback path** because that uses proxy scores (edge weight × 10, ΩF composite) instead of true marginal damage deltas — surfacing a "damage 67 → 23" line there would be misleading.

## Math, derived from existing data

Zero solver changes. Each `InterdictionCandidate` already carries `damage` (after this cut applied on top of the prior cuts) and `marginalReduction` (improvement vs not applying). The "damage before this step" is just:
- `baselineDamage` for step 1
- prior step's `damage` for step 2+

This is the greedy-walk invariant — exposing it in prose just makes the math the solver already does legible to the reader.

## Extraction (testable)

Narrative helpers live in a new `src/lib/interdiction-explain.ts`:

- `stepContextForIntervention(result, i)` — derives `damageBefore`, `damageAfter`, `marginalReduction`, `stepReductionPct`, step number, total steps
- `rankNarrative(ctx)` — prose for greedy-walk position
- `damageDeltaNarrative(ctx)` — prose for the damage transition
- `mechanismNarrative(candidate, graph)` — multi-line prose for what the cut actually does
- `explainIntervention(result, i, graph)` — bundle helper for the typical UI call

## Tests

**19 new tests** in `src/lib/__tests__/interdiction-explain.test.ts`:

- `damageBefore` correctly uses `baselineDamage` for step 1 and the prior step's `damage` for step 2+
- `stepReductionPct` is computed against `damageBefore` (not the original baseline) so the % reflects what the step contributes, not what was already saved
- Out-of-range index returns `null` (no crash on stale solver outputs)
- Single-step results read as "highest-impact" — the "last step" phrasing doesn't fire when there are no prior cuts to reference
- Middle-step phrasing reads as "step 2 of 3" with "conditional" wording
- `damageDeltaNarrative` omits the `%` reduction when `damageBefore` is 0 (defensive)
- Edge mechanism narrative surfaces source/target labels, weight, and `physicalMechanism` text
- Mechanism line omitted when `physicalMechanism` is empty (no blank rows in the UI)
- Node ablation counts only non-severed outgoing + incoming edges
- Severed edges excluded from the count
- Falls back gracefully when the target id has since been removed from the graph
- Bundle helper returns the combined `{ rank, damageDelta, mechanism }` struct

## Files

| File | Change |
|---|---|
| `src/lib/interdiction-explain.ts` (new) | All narrative helpers + types |
| `src/lib/__tests__/interdiction-explain.test.ts` (new) | 19 tests |
| `src/components/modules/CopilotInterdictionResults.tsx` | New `expandedIndex` state, WHY? toggle button per row, expansion block rendering the three narrative paragraphs |

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/lib/__tests__/interdiction-explain.test.ts` — 19/19 passing
- [x] `npx next build` clean
- [ ] PR-validate workflow green
- [ ] Vercel preview eyeball:
  - Run a scenario in PEARL → click WHY? on cut #1 → see "highest-impact" rank + damage delta + mechanism
  - Click WHY? on cut #2 → cut #1's expansion collapses, cut #2's opens
  - Click HIDE → expansion collapses
  - Run a scenario that triggers the structural-vulnerability fallback → WHY? buttons NOT shown
  - Verify the mechanism paragraph quotes the actual `physicalMechanism` text from the underlying edge

## Backwards compat

No store changes. No solver changes. New state (`expandedIndex`) is local-component. New module is opt-in. The fallback path's UI is untouched. The existing SEVER/ABLATE behaviour, ISOLATE AFFECTED, APPLY ALL & SIMULATE, and DISMISS buttons are all unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
