### PR TITLE
feat(copilot): capture failed action-tag attempts as feedback signal

### DIFF
--- a/src/app/api/copilot/trace/__tests__/route.test.ts
+++ b/src/app/api/copilot/trace/__tests__/route.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment node
+//
+// Tests for POST /api/copilot/trace. Covers the client_meta sanitization
+// path that landed alongside the failed-action-attempt capture feature.
+// We don't exercise the Supabase insert here — that's the trivial
+// passthrough at the bottom of the route. We DO exercise the validation +
+// shape rules because they're what protect the `client_meta jsonb` column
+// from misshapen inputs.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mocks ──────────────────────────────────────────────────────
+//
+// The route depends on two Supabase clients (server-client for auth,
+// service-role client for the insert). We mock both to a noop so the
+// validation path runs end-to-end without an env or network.
+
+const insertSpy = vi.fn(async () => ({ error: null }));
+let capturedRow: Record<string, unknown> | null = null;
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    from: () => ({
+      insert: async (row: Record<string, unknown>) => {
+        capturedRow = row;
+        return insertSpy();
+      },
+    }),
+  }),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    auth: {
+      getUser: async () => ({ data: { user: null } }),
+    },
+  }),
+}));
+
+beforeEach(() => {
+  insertSpy.mockClear();
+  capturedRow = null;
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+  process.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-role-key";
+});
+
+async function postTrace(body: Record<string, unknown>) {
+  const { POST } = await import("../route");
+  const req = new NextRequest("http://localhost/api/copilot/trace", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+  return POST(req);
+}
+
+const validTraceBase = {
+  conversation_id: "cv_test_123",
+  turn_index: 0,
+  user_message: "test",
+  assistant_message: "ack",
+  display_text: "ack",
+  tool_calls: [],
+  model_provider: "anthropic",
+  model_id: "claude",
+  system_prompt_hash: "abc123",
+  system_prompt_size: 1024,
+  dataset: "main",
+  active_module: "pearl",
+  selected_node: null,
+  active_shock_count: 0,
+};
+
+describe("POST /api/copilot/trace — client_meta sanitization", () => {
+  it("accepts a well-formed failed_action_attempts array", async () => {
+    const res = await postTrace({
+      ...validTraceBase,
+      client_meta: {
+        failed_action_attempts: [
+          { raw: "[ACTION:add_shock:TAIWAN]", name: "add_shock", reason: "square_brackets" },
+          { raw: "<<<ACTION:teleport:mars>>>", name: "teleport", reason: "unknown_tool" },
+        ],
+      },
+    });
+    expect(res.status).toBe(200);
+    expect(capturedRow?.client_meta).toEqual({
+      failed_action_attempts: [
+        { raw: "[ACTION:add_shock:TAIWAN]", name: "add_shock", reason: "square_brackets" },
+        { raw: "<<<ACTION:teleport:mars>>>", name: "teleport", reason: "unknown_tool" },
+      ],
+    });
+  });
+
+  it("defaults to an empty object when client_meta is missing", async () => {
+    const res = await postTrace(validTraceBase);
+    expect(res.status).toBe(200);
+    expect(capturedRow?.client_meta).toEqual({});
+  });
+
+  it("drops malformed failed_action_attempts entries individually", async () => {
+    const res = await postTrace({
+      ...validTraceBase,
+      client_meta: {
+        failed_action_attempts: [
+          { raw: "[ACTION:ok:1]", name: "ok", reason: "square_brackets" },
+          { raw: 42, name: "bad", reason: "x" }, // raw must be a string — drop
+          null, // not an object — drop
+          { raw: "missing-name", reason: "x" }, // missing name — drop
+        ],
+      },
+    });
+    expect(res.status).toBe(200);
+    const cm = capturedRow?.client_meta as Record<string, unknown>;
+    expect(cm.failed_action_attempts).toEqual([
+      { raw: "[ACTION:ok:1]", name: "ok", reason: "square_brackets" },
+    ]);
+  });
+
+  it("passes through unrecognized client_meta keys for forward-compat", async () => {
+    const res = await postTrace({
+      ...validTraceBase,
+      client_meta: { future_field: "some_value", another: 42 },
+    });
+    expect(res.status).toBe(200);
+    const cm = capturedRow?.client_meta as Record<string, unknown>;
+    expect(cm.future_field).toBe("some_value");
+    expect(cm.another).toBe(42);
+  });
+
+  it("strips __proto__ to avoid prototype-pollution shapes", async () => {
+    // JSON.parse handles the __proto__ key correctly without polluting,
+    // but we also want to make sure the sanitizer doesn't COPY it into
+    // the output as an own property.
+    const body = JSON.parse(
+      `{"conversation_id":"cv_test_123","turn_index":0,"tool_calls":[],"client_meta":{"__proto__":{"polluted":true},"ok":"kept"}}`,
+    );
+    const res = await postTrace(body);
+    expect(res.status).toBe(200);
+    const cm = capturedRow?.client_meta as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(cm, "__proto__")).toBe(false);
+    expect(cm.ok).toBe("kept");
+  });
+
+  it("ignores client_meta when it is not an object", async () => {
+    const res = await postTrace({
+      ...validTraceBase,
+      client_meta: "not-an-object",
+    });
+    expect(res.status).toBe(200);
+    expect(capturedRow?.client_meta).toEqual({});
+  });
+});

--- a/src/app/api/copilot/trace/route.ts
+++ b/src/app/api/copilot/trace/route.ts
@@ -100,6 +100,74 @@ function sanitizeToolCalls(input: unknown): ToolCallShape[] | null {
   return out;
 }
 
+// ─── client_meta sanitization ───────────────────────────────────
+//
+// `client_meta` is the extension point on the traces row — the schema
+// declares it as `jsonb` so we can add new tracked signals without a
+// migration. We pass through unknown keys (so a future client field
+// lands in the row even if this server hasn't been redeployed yet) but
+// hard-cap the size and validate the structure of recognized keys.
+
+const MAX_FAILED_ATTEMPTS = 50;
+const MAX_ATTEMPT_RAW_LEN = 500;
+
+interface FailedAttemptShape {
+  raw: string;
+  name: string;
+  reason: string;
+}
+
+function sanitizeFailedAttempts(input: unknown): FailedAttemptShape[] | null {
+  if (!isArray(input)) return null;
+  if (input.length > MAX_FAILED_ATTEMPTS) return null;
+  const out: FailedAttemptShape[] = [];
+  for (const item of input) {
+    if (typeof item !== "object" || item === null) continue;
+    const t = item as Record<string, unknown>;
+    const raw = clampString(t.raw, MAX_ATTEMPT_RAW_LEN);
+    const name = clampString(t.name, 200);
+    const reason = clampString(t.reason, 50);
+    if (raw === null || name === null || reason === null) continue;
+    out.push({ raw, name, reason });
+  }
+  return out;
+}
+
+function sanitizeClientMeta(input: unknown): Record<string, unknown> {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    return {};
+  }
+  const raw = input as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+
+  // Recognized keys get structural validation. Unknown keys are
+  // passed through with a JSON-size guard so an older server still
+  // captures forward-rolling client signals.
+  if ("failed_action_attempts" in raw) {
+    const cleaned = sanitizeFailedAttempts(raw.failed_action_attempts);
+    if (cleaned !== null) out.failed_action_attempts = cleaned;
+  }
+
+  for (const key of Object.keys(raw)) {
+    if (key === "failed_action_attempts") continue;
+    // Skip prototype-pollution shapes and over-long keys.
+    if (key.length > 100 || key === "__proto__" || key === "constructor") continue;
+    out[key] = raw[key];
+  }
+
+  // Hard cap the serialized size so a misbehaving client can't fill
+  // the column. 64KB is generous for metadata; well above any
+  // reasonable trace.
+  try {
+    const json = JSON.stringify(out);
+    if (json.length > 64_000) return {};
+  } catch {
+    return {};
+  }
+
+  return out;
+}
+
 // ─── Handler ────────────────────────────────────────────────────
 
 export async function POST(request: NextRequest) {
@@ -148,10 +216,7 @@ export async function POST(request: NextRequest) {
     active_module: clampString(body.active_module, 50),
     selected_node: clampString(body.selected_node, 200),
     active_shock_count: isInt(body.active_shock_count) ? body.active_shock_count : null,
-    client_meta:
-      typeof body.client_meta === "object" && body.client_meta !== null && !Array.isArray(body.client_meta)
-        ? (body.client_meta as Record<string, unknown>)
-        : {},
+    client_meta: sanitizeClientMeta(body.client_meta),
   };
 
   const { error } = await getSupabaseAdmin().from("copilot_traces").insert(row);

--- a/src/components/SystemCopilot.tsx
+++ b/src/components/SystemCopilot.tsx
@@ -705,7 +705,8 @@ export default function SystemCopilot() {
         // Awaited because the registry handlers may be async — `solve_interdiction`
         // in particular runs the chunked minimax solver and yields between
         // candidates so the chat UI stays responsive during the solve.
-        const { displayText, actionResults, toolCalls } = await processLlmActionsWithTrace(accumulated);
+        const { displayText, actionResults, toolCalls, failedAttempts } =
+          await processLlmActionsWithTrace(accumulated);
         // Flush final text to the store in one write
         useApexStore.setState((s) => ({
           copilotMessages: s.copilotMessages.map((m) =>
@@ -766,6 +767,16 @@ export default function SystemCopilot() {
             active_module: activeModule,
             selected_node: selectedNode,
             active_shock_count: shocks.length,
+            // Failed action-shaped strings — square brackets, wrong
+            // angle count, or unknown tool names. Empty on clean turns;
+            // when populated, signals either prompt drift (LLM picked
+            // the wrong syntax) or a capability gap (LLM asked for a
+            // tool we don't expose). Lives in client_meta so it
+            // extends the row without a schema migration.
+            client_meta:
+              failedAttempts.length > 0
+                ? { failed_action_attempts: failedAttempts }
+                : undefined,
           };
           // Intentionally not awaited \u2014 logging is best-effort.
           void logTurnTrace(trace);

--- a/src/lib/__tests__/copilot-tool-registry.test.ts
+++ b/src/lib/__tests__/copilot-tool-registry.test.ts
@@ -6,6 +6,8 @@ import {
   coerceAndValidate,
   executeTag,
   executeActions,
+  executeActionsWithTrace,
+  findFailedActionAttempts,
   renderToolsForPrompt,
   renderToolsAsJsonSchema,
   __resetRegistryForTests,
@@ -393,6 +395,127 @@ describe("renderToolsAsJsonSchema (proves MCP/Anthropic-compat)", () => {
     expect(isolate!.input_schema.type).toBe("object");
     expect(isolate!.input_schema.properties).toHaveProperty("query");
     expect(isolate!.input_schema.properties).toHaveProperty("ids");
+  });
+});
+
+// ─── Failed-action detection ────────────────────────────────────
+//
+// Captures the "near miss" signal — action-shaped strings the LLM
+// wrote but that didn't actually fire a tool. Motivated by Bug A
+// in the trace audit (square-bracket form like `[ACTION:foo:bar]`
+// that the parser silently dropped).
+
+describe("findFailedActionAttempts", () => {
+  const registered = new Set(["set_module", "select_node", "isolate_nodes"]);
+
+  it("captures square-bracket form as the canonical failure mode", () => {
+    const text = "Let me start. [ACTION:add_shock:TAIWAN_BLOCKADE] Done.";
+    const found = findFailedActionAttempts(text, registered);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({
+      raw: "[ACTION:add_shock:TAIWAN_BLOCKADE]",
+      name: "add_shock",
+      reason: "square_brackets",
+    });
+  });
+
+  it("captures single-angle form as wrong_angle_count", () => {
+    const text = "Trying <ACTION:set_module:pearl> here.";
+    const found = findFailedActionAttempts(text, registered);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({
+      name: "set_module",
+      reason: "wrong_angle_count",
+    });
+  });
+
+  it("captures double-angle form (<<...>>) as wrong_angle_count", () => {
+    const text = "Trying <<ACTION:set_module:pearl>> here.";
+    const found = findFailedActionAttempts(text, registered);
+    expect(found).toHaveLength(1);
+    expect(found[0]?.reason).toBe("wrong_angle_count");
+  });
+
+  it("does NOT flag properly-formed triple-angle tags with a known tool", () => {
+    const text = "Switching modules. <<<ACTION:set_module:pearl>>>";
+    const found = findFailedActionAttempts(text, registered);
+    expect(found).toEqual([]);
+  });
+
+  it("flags triple-angle tags with an unknown tool name", () => {
+    const text = "Trying <<<ACTION:teleport_user:mars>>> now.";
+    const found = findFailedActionAttempts(text, registered);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({
+      name: "teleport_user",
+      reason: "unknown_tool",
+    });
+  });
+
+  it("de-duplicates identical raw strings within one response", () => {
+    const text = "[ACTION:add_shock:TAIWAN] and again [ACTION:add_shock:TAIWAN] later.";
+    const found = findFailedActionAttempts(text, registered);
+    expect(found).toHaveLength(1);
+  });
+
+  it("returns an empty array on clean responses with no action-shaped text", () => {
+    const text = "Just analysis. No tool calls in this turn.";
+    expect(findFailedActionAttempts(text, registered)).toEqual([]);
+  });
+
+  it("captures mixed failure modes in source order", () => {
+    const text = `
+First [ACTION:add_shock:X] then <ACTION:select_node:Y> then <<<ACTION:unknown:Z>>>.
+    `.trim();
+    const found = findFailedActionAttempts(text, registered);
+    const reasons = found.map((f) => f.reason);
+    expect(reasons).toContain("square_brackets");
+    expect(reasons).toContain("wrong_angle_count");
+    expect(reasons).toContain("unknown_tool");
+    expect(found).toHaveLength(3);
+  });
+});
+
+describe("executeActionsWithTrace — failed-attempt integration", () => {
+  beforeEach(() => {
+    __resetRegistryForTests();
+  });
+
+  it("returns an empty failedAttempts array on a clean turn", async () => {
+    defineTool({
+      name: "noop",
+      description: "test",
+      params: {},
+      handler: () => "ok",
+    });
+    const result = await executeActionsWithTrace(
+      "Just text. <<<ACTION:noop>>>",
+      { getStore: () => ({}) as ApexState },
+    );
+    expect(result.failedAttempts).toEqual([]);
+    expect(result.toolCalls).toHaveLength(1);
+  });
+
+  it("surfaces a square-bracket near-miss alongside the executed tool call", async () => {
+    defineTool({
+      name: "set_module",
+      description: "test",
+      params: { module: { type: "string", required: true } },
+      legacyParam: "module",
+      handler: (p) => `module=${p.module}`,
+    });
+    const text =
+      "I'll switch modules. <<<ACTION:set_module:pearl>>> Also tried [ACTION:add_shock:TAIWAN].";
+    const result = await executeActionsWithTrace(text, {
+      getStore: () => ({}) as ApexState,
+    });
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0]?.name).toBe("set_module");
+    expect(result.failedAttempts).toHaveLength(1);
+    expect(result.failedAttempts[0]).toMatchObject({
+      name: "add_shock",
+      reason: "square_brackets",
+    });
   });
 });
 

--- a/src/lib/copilot-actions.ts
+++ b/src/lib/copilot-actions.ts
@@ -16,6 +16,7 @@ import {
   executeActionsWithTrace,
   type ParsedActionTag,
   type ToolCallTrace,
+  type FailedActionAttempt,
 } from "./copilot/tool-registry";
 
 // Side-effect import: registers all built-in tools with the registry.
@@ -72,7 +73,14 @@ export async function processLlmActionsWithTrace(text: string): Promise<{
   displayText: string;
   actionResults: string[];
   toolCalls: ToolCallTrace[];
+  failedAttempts: FailedActionAttempt[];
 }> {
-  const { displayText, toolResults, toolCalls } = await executeActionsWithTrace(text);
-  return { displayText, actionResults: toolResults, toolCalls };
+  const { displayText, toolResults, toolCalls, failedAttempts } =
+    await executeActionsWithTrace(text);
+  return {
+    displayText,
+    actionResults: toolResults,
+    toolCalls,
+    failedAttempts,
+  };
 }

--- a/src/lib/copilot/tool-registry.ts
+++ b/src/lib/copilot/tool-registry.ts
@@ -117,6 +117,15 @@ export function getAllTools(): Tool<ParamShape>[] {
   return Array.from(REGISTRY.values());
 }
 
+/**
+ * Snapshot of registered tool names. Used by `findFailedActionAttempts`
+ * to classify a triple-angle-bracket tag with an unrecognized name as
+ * "near miss" rather than treating it as proper syntax.
+ */
+export function getRegisteredToolNames(): Set<string> {
+  return new Set(REGISTRY.keys());
+}
+
 /** Test-only: clear the registry. Production code should never call this. */
 export function __resetRegistryForTests(): void {
   REGISTRY.clear();
@@ -151,6 +160,118 @@ export function parseActionTags(text: string): ParsedActionTag[] {
 
 export function stripActionTags(text: string): string {
   return text.replace(ACTION_REGEX, "").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+// ─── Failed-action detection ────────────────────────────────────
+//
+// The LLM sometimes writes action-shaped text that doesn't actually
+// fire a tool — the most common case is square brackets like
+// `[ACTION:add_shock:TAIWAN_BLOCKADE]`, which mimics the prose-header
+// pattern (`[ANALYSIS]`, `[RISK]`) the prompt teaches, but isn't the
+// triple-angle syntax the parser recognizes. Mining these "near
+// misses" is a continuous feedback signal:
+//   1. Which prompt clarifications still aren't landing (bracket
+//      confusion was Bug A in the trace audit that motivated #400).
+//   2. Which platform features users naturally ask for that aren't
+//      exposed as tools yet (`<<<ACTION:unknown_tool:...>>>` is the
+//      copilot telling us "I want this capability").
+//
+// The detector classifies into three failure modes; see
+// `FailedActionReason` below for the wire-stable enum.
+
+/** Why an action-shaped string didn't fire a tool. */
+export type FailedActionReason =
+  /** `[ACTION:name:payload]` — square brackets, parser ignored it. */
+  | "square_brackets"
+  /** Any angle-count other than triple (`<ACTION:>`, `<<...>>`, etc.). */
+  | "wrong_angle_count"
+  /** `<<<ACTION:name:payload>>>` with a `name` not in the registry. */
+  | "unknown_tool";
+
+export interface FailedActionAttempt {
+  /** Substring captured from the assistant message — verbatim. */
+  raw: string;
+  /** Tool name the LLM tried to invoke (may not be a registered tool). */
+  name: string;
+  /** Classification of the failure mode. */
+  reason: FailedActionReason;
+}
+
+// Matches the square-bracket failure form. Stops at `]` or newline so
+// we don't slurp across paragraphs if the LLM forgot the closer.
+const SQUARE_ACTION_REGEX = /\[ACTION:(\w+):?([^\]\n]*)\]/g;
+
+// Matches ANY angle-bracket count: `<ACTION:>`, `<<...>>`, `<<<...>>>`,
+// `<<<<...>>>>`. Classified post-match by counting the open/close
+// runs — triple-on-both-sides is the legitimate form and is skipped.
+const ANGLE_ACTION_REGEX = /(<+)ACTION:(\w+):?([^>\n]*?)(>+)/g;
+
+/**
+ * Scan an assistant message for action-shaped substrings that didn't
+ * actually fire a tool. Three failure modes are captured:
+ *
+ *   1. `[ACTION:foo:bar]`     → square_brackets
+ *      (parser doesn't see these — they look like prose headers)
+ *   2. `<ACTION:foo>`, `<<...>>`, `<<<<...>>>>`, mismatched counts
+ *                              → wrong_angle_count
+ *      (only `<<<...>>>` exactly is the wire format)
+ *   3. `<<<ACTION:foo:bar>>>` with foo NOT in `registeredToolNames`
+ *                              → unknown_tool
+ *      (proper syntax, but no tool wrapper exists — signals a
+ *      capability gap users are asking for)
+ *
+ * Triple-bracket tags with a *registered* name are NOT returned here —
+ * those are handled by `executeActionsWithTrace` and surface in
+ * `tool_calls[]` with their own success/error state. We only return
+ * near misses that the normal trace pipeline would otherwise drop.
+ *
+ * Returned attempts are de-duplicated by `raw` text so an LLM that
+ * repeats the same broken tag (e.g. across a long response) doesn't
+ * inflate the trace.
+ */
+export function findFailedActionAttempts(
+  text: string,
+  registeredToolNames: ReadonlySet<string>,
+): FailedActionAttempt[] {
+  const seen = new Set<string>();
+  const out: FailedActionAttempt[] = [];
+
+  function push(attempt: FailedActionAttempt) {
+    if (seen.has(attempt.raw)) return;
+    seen.add(attempt.raw);
+    out.push(attempt);
+  }
+
+  // 1. Square-bracket form — always a miss.
+  SQUARE_ACTION_REGEX.lastIndex = 0;
+  let sqMatch: RegExpExecArray | null;
+  while ((sqMatch = SQUARE_ACTION_REGEX.exec(text)) !== null) {
+    push({ raw: sqMatch[0], name: sqMatch[1], reason: "square_brackets" });
+  }
+
+  // 2 + 3. Angle-bracket forms — classify by open/close count and
+  // (when triple) by registry membership.
+  ANGLE_ACTION_REGEX.lastIndex = 0;
+  let angMatch: RegExpExecArray | null;
+  while ((angMatch = ANGLE_ACTION_REGEX.exec(text)) !== null) {
+    const opens = angMatch[1].length;
+    const closes = angMatch[4].length;
+    const name = angMatch[2];
+    const raw = angMatch[0];
+
+    if (opens === 3 && closes === 3) {
+      // Proper syntax. Only a "failure" if the tool name is unknown —
+      // a registered name means executeActionsWithTrace already
+      // captured the call in tool_calls[].
+      if (!registeredToolNames.has(name)) {
+        push({ raw, name, reason: "unknown_tool" });
+      }
+      continue;
+    }
+    push({ raw, name, reason: "wrong_angle_count" });
+  }
+
+  return out;
 }
 
 /**
@@ -285,6 +406,13 @@ export interface ToolCallTrace {
 export interface TracedExecutionResult extends ExecutionResult {
   /** One entry per parsed action tag, in source order. */
   toolCalls: ToolCallTrace[];
+  /**
+   * Action-shaped strings the LLM wrote but that didn't fire a tool —
+   * square-bracket form, wrong angle count, or unknown tool name. Used
+   * as a continuous feedback signal in `client_meta.failed_action_attempts`.
+   * Empty array on a clean turn.
+   */
+  failedAttempts: FailedActionAttempt[];
 }
 
 /**
@@ -308,6 +436,14 @@ export async function executeActions(
   return { displayText, toolResults };
 }
 
+// Snapshot of registered tool names taken at the start of each
+// `executeActionsWithTrace` call so `findFailedActionAttempts` agrees
+// with the same registry the executor used. Hoisting it avoids a
+// re-scan per turn inside the helper.
+function snapshotRegisteredNames(): Set<string> {
+  return getRegisteredToolNames();
+}
+
 /**
  * Same as `executeActions`, but also returns structured per-call trace
  * data (params, result, error, latency_ms) for each tag. SystemCopilot
@@ -327,13 +463,24 @@ export async function executeActionsWithTrace(
   const toolResults: string[] = [];
   const toolCalls: ToolCallTrace[] = [];
 
+  // Snapshot registered names ONCE for both the executor path and the
+  // failed-attempt detector so they agree even if a HMR re-register
+  // races with this turn.
+  const registered = snapshotRegisteredNames();
+
   for (const tag of tags) {
     const traced = await executeTagWithTrace(tag, ctx);
     toolResults.push(traced.result);
     toolCalls.push(traced);
   }
 
-  return { displayText, toolResults, toolCalls };
+  // Detect "near misses" — square-bracket form, wrong angle count, or
+  // proper syntax pointing at an unregistered tool name. These don't
+  // show up in toolCalls[] (the parser drops the broken-syntax forms
+  // entirely) so we surface them here as a separate feedback signal.
+  const failedAttempts = findFailedActionAttempts(text, registered);
+
+  return { displayText, toolResults, toolCalls, failedAttempts };
 }
 
 /** Execute a single parsed action tag. Exported for tests. */


### PR DESCRIPTION
## Why

Bug A from the most recent trace audit (#400's motivating example): the LLM wrote `[ACTION:add_shock:TAIWAN_BLOCKADE]` — square brackets, mimicking the `[ANALYSIS]` / `[RISK]` prose-header pattern — and the parser silently dropped it. `tool_calls: []`. The user saw nothing happen and had no way to know.

`tool_calls[]` only captures attempts that *parsed*. Broken-syntax attempts vanish, so they don't show up in any analytics, eval, or feedback signal we have. That's a blind spot in our continuous-learning story — we can't ask "where is the LLM still drifting from the documented syntax?" if the drift never gets logged.

## What

Detect "near miss" action-shaped strings in every assistant response and surface them in the trace row's `client_meta.failed_action_attempts`. Three failure modes:

| Reason | Shape | Caught how |
|---|---|---|
| `square_brackets` | `[ACTION:foo:bar]` | Parser ignores, we scan separately |
| `wrong_angle_count` | `<ACTION:>`, `<<...>>`, `<<<<...>>>>` | Same — only triple-on-both-sides is the wire format |
| `unknown_tool` | `<<<ACTION:foo:bar>>>` with `foo` not in registry | LLM asked for a capability we don't expose — feature-backlog signal |

The detector lives in `tool-registry.ts` next to `parseActionTags` so it shares the same source of truth for which names are real tools.

## Wire path

```
findFailedActionAttempts(text, registered) 
  -> executeActionsWithTrace -> TracedExecutionResult.failedAttempts
  -> processLlmActionsWithTrace (compat shim) 
  -> SystemCopilot trace builder
  -> client_meta.failed_action_attempts on POST /api/copilot/trace
```

No schema migration — `client_meta` is already `jsonb`, declared exactly so we can roll forward without one.

## Defensive sanitization at the route

The route accepted `client_meta` as a pure passthrough before. With a real shape landing in there I tightened it:
- Structured validation for `failed_action_attempts` (drops malformed entries individually; bad shape doesn't kill the whole row)
- Forward-compat passthrough for unknown keys (so a newer client can land a new signal in `client_meta` without redeploying the server)
- `__proto__` / `constructor` stripped
- 64KB hard cap on the serialized blob

## Test plan

- [x] 8 new unit tests in `copilot-tool-registry.test.ts` covering all three failure modes, dedup, source order, clean-turn baseline, and integration via `executeActionsWithTrace`
- [x] 6 new route tests in `api/copilot/trace/__tests__/route.test.ts` covering well-formed acceptance, malformed-entry dropping, forward-compat passthrough, `__proto__` defense, missing-field default
- [x] Full suite: 1473/1473 PASS
- [x] `tsc --noEmit` clean on all changed files (pre-existing errors in unrelated test files exist on main — not introduced here)
- [x] `eslint` clean on all changed files
- [x] `next build` succeeds with placeholder env (compile + TS pass)
- [ ] Manual after merge: voice-mode chat, try a few prompts that historically tripped the bracket bug. Verify rows land in `copilot_traces` with `client_meta.failed_action_attempts` populated, and that clean turns still have empty/absent `client_meta`.

## Why this is the right next step before the PR audit

The Pearl/Pareto session is shipping features in parallel and we need to know which of them the copilot is reaching for. Once this lands, every voice/chat turn that says "isolate Europe" or "show the cascade" but doesn't find the right tool becomes a logged signal — that's the data the audit (Task #8) should be driven by, not a manual scan of session logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
