### PR TITLE
feat(cascade): edge-firing FIRE pulse during cascade replay (3D + 2D)

### DIFF
--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -41,6 +41,10 @@ import {
 import { type NodeMetrics } from "@/lib/graph-layout";
 import { requestLayout2D } from "@/lib/workers/layout3d-client";
 import { cascadeActivationOrder } from "@/lib/cascade-activation-order";
+import {
+  cascadeEdgeActivationOrder,
+  edgeFireIntensity,
+} from "@/lib/cascade-edge-activation-order";
 import { AnimatePresence } from "framer-motion";
 
 type NodeEmphasis = "focus" | "neighbor" | "dim" | "none";
@@ -492,6 +496,18 @@ interface EmphasizedEdgeData {
   isConfounded: boolean;
   isSelected: boolean;
   propagationSignal: number;
+  /**
+   * Cascade-fire pulse intensity in [0, 1]. Peaks at this edge's
+   * activation epoch (when its target node first activated) and decays
+   * over a few epochs. 0 outside the firing window or when replay
+   * isn't active. Drives a brightness + stroke-width pulse so the
+   * moment of signal arrival reads as a clear punctuation rather than
+   * a continuation of the steady propagationSignal flow above.
+   *
+   * Computed at the canvas level via `cascadeEdgeActivationOrder` +
+   * `edgeFireIntensity`; see CausalDAG2D's `edgeActivationEpochs`.
+   */
+  fireIntensity: number;
   showArrow: boolean;
   /**
    * χ★ tier — drives the discrete violet midpoint marker rendered
@@ -606,14 +622,30 @@ function EmphasizedEdge(props: EdgeProps<EmphasizedEdgeData>) {
   if (d.propagationSignal > 0) {
     opacity = Math.min(1, d.baseOpacity + d.propagationSignal * 0.3);
   }
+  // FIRE pulse — adds on top of the steady-flow propagationSignal
+  // boost. Peaks at the activation epoch and decays over a 3-epoch
+  // window, so the moment of signal arrival reads as a clear visual
+  // punctuation. Combined with the strokeWidth boost below and the
+  // color shift toward amber, the eye registers "edge fired NOW"
+  // even when the underlying propagationSignal stays low.
+  if (d.fireIntensity > 0) {
+    opacity = Math.min(1, opacity + d.fireIntensity * 0.5);
+  }
 
   const strokeWidth = isThisSelected
     ? d.baseWidth + 1.5
-    : d.propagationSignal > 0
-      ? d.baseWidth + d.propagationSignal * 2
+    : d.propagationSignal > 0 || d.fireIntensity > 0
+      ? d.baseWidth + d.propagationSignal * 2 + d.fireIntensity * 1.8
       : d.baseWidth;
 
-  const stroke = d.propagationSignal > 0 ? "#ffab00" : d.baseColor;
+  // Stroke color: amber during steady-flow, white-hot during fire peak
+  // (the brightening reads as "this just fired" against the amber
+  // flow). Falls back to baseColor when neither signal is active.
+  const stroke = d.fireIntensity > 0.4
+    ? "#ffffff"
+    : d.propagationSignal > 0 || d.fireIntensity > 0
+      ? "#ffab00"
+      : d.baseColor;
   const strokeDasharray = d.isConfounded || d.isInconsistent ? "5,5" : undefined;
 
   // Reference-stable adjacency to avoid lint complaining about the unused
@@ -755,6 +787,25 @@ function CausalDAG2DInner() {
     if (!replayActive || replayEpochs.length === 0) return new Map<string, number>();
     return cascadeActivationOrder(replayEpochs, clampedEpoch);
   }, [replayActive, replayEpochs, clampedEpoch]);
+
+  // Per-edge cascade fire — mirrors the 3D canvas wiring (see
+  // CausalDAG3D.tsx). Map<edgeId, activationEpoch> so the edge data
+  // builder can drop a `fireIntensity` field per edge.
+  const edgeActivationEpochs = useMemo(() => {
+    if (!replayActive || replayEpochs.length === 0) {
+      return new Map<string, number>();
+    }
+    const result = cascadeEdgeActivationOrder(
+      graphData.edges,
+      replayEpochs,
+      clampedEpoch,
+    );
+    const out = new Map<string, number>();
+    for (const [edgeId, info] of result) {
+      out.set(edgeId, info.activationEpoch);
+    }
+    return out;
+  }, [replayActive, replayEpochs, clampedEpoch, graphData.edges]);
 
   // Global ablation set — hoisted up so the node-builder useMemo
   // below can dim ablated nodes. The store hooks themselves live a
@@ -1028,6 +1079,15 @@ function CausalDAG2DInner() {
         const isSelected = selectedEdge?.id === e.id;
         const isTemporal = e.type === "temporal";
         const isConfounded = e.type === "confounded";
+        // FIRE pulse — peaks at the edge's activation epoch and decays
+        // over a 3-epoch window. 0 when the edge never fired in the
+        // visible cascade. Severed / ablated suppress separately in
+        // the renderer; here we just pipe the math.
+        const fireActivationEpoch = edgeActivationEpochs.get(e.id);
+        const fireIntensity =
+          replayActive && fireActivationEpoch !== undefined
+            ? edgeFireIntensity(fireActivationEpoch, clampedEpoch)
+            : 0;
 
         const baseColor = isInconsistent
           ? "#ff1744"
@@ -1065,6 +1125,7 @@ function CausalDAG2DInner() {
             isConfounded,
             isSelected,
             propagationSignal,
+            fireIntensity,
             showArrow,
             chiStarTier: chiStarInfo.bridgeSet.has(e.id)
               ? ("bridge" as const)
@@ -1074,7 +1135,7 @@ function CausalDAG2DInner() {
           },
         };
       }),
-    [graphData, truthFilter, currentSnapshot, selectedEdge, chiStarInfo]
+    [graphData, truthFilter, currentSnapshot, selectedEdge, chiStarInfo, edgeActivationEpochs, clampedEpoch, replayActive]
   );
 
   // Filter edges for isolation mode

--- a/src/components/CausalDAG3D.tsx
+++ b/src/components/CausalDAG3D.tsx
@@ -13,6 +13,10 @@ import { severEdgeAndSpawnConsequences } from "@/lib/intervention-engine";
 import { getNodeDomainMap } from "@/lib/graph-data";
 import DAGNode3D, { orbitActiveRef } from "./dag3d/DAGNode3D";
 import { cascadeActivationOrder } from "@/lib/cascade-activation-order";
+import {
+  cascadeEdgeActivationOrder,
+  type EdgeActivationInfo,
+} from "@/lib/cascade-edge-activation-order";
 import DAGEdge3D from "./dag3d/DAGEdge3D";
 import DAGOverlay from "./dag3d/DAGOverlay";
 import EdgeInspector from "./EdgeInspector";
@@ -552,6 +556,19 @@ export default function CausalDAG3D() {
     if (!replayActive || replayEpochs.length === 0) return new Map<string, number>();
     return cascadeActivationOrder(replayEpochs, clampedEpoch);
   }, [replayActive, replayEpochs, clampedEpoch]);
+
+  // Per-edge firing info — `{ ordinal, activationEpoch }` for edges
+  // whose target has activated by `clampedEpoch`. Drives the FIRE
+  // pulse in `DAGEdge3D` (brighter + larger particle, color flash)
+  // during a small window around each edge's activation epoch, so
+  // the cascade reads as edges-firing-in-order rather than just
+  // nodes-lighting-up-with-static-edges.
+  const edgeActivationOrder = useMemo(() => {
+    if (!replayActive || replayEpochs.length === 0) {
+      return new Map<string, EdgeActivationInfo>();
+    }
+    return cascadeEdgeActivationOrder(graphData.edges, replayEpochs, clampedEpoch);
+  }, [replayActive, replayEpochs, clampedEpoch, graphData.edges]);
 
   const canvasKey = useWebGLRecovery();
   const positionsRef = useRef<NodePosition[]>([]);
@@ -1243,6 +1260,9 @@ export default function CausalDAG3D() {
                 onAblationClick={() => toggleAblatedEdge(edge.id)}
                 onEdgeClick={() => setSelectedEdge(selectedEdge?.id === edge.id ? null : edge)}
                 epochState={currentSnapshot?.edgeStates[edge.id]}
+                fireActivationEpoch={edgeActivationOrder.get(edge.id)?.activationEpoch}
+                currentEpoch={clampedEpoch}
+                replayActive={replayActive}
                 chiStarTier={
                   chiStarInfo.bridgeSet.has(edge.id)
                     ? "bridge"

--- a/src/components/dag3d/DAGEdge3D.tsx
+++ b/src/components/dag3d/DAGEdge3D.tsx
@@ -5,6 +5,7 @@ import { useFrame } from "@react-three/fiber";
 import { Line } from "@react-three/drei";
 import * as THREE from "three";
 import { CausalEdge, EdgeEpochState } from "@/lib/types";
+import { edgeFireIntensity } from "@/lib/cascade-edge-activation-order";
 
 interface DAGEdge3DProps {
   edge: CausalEdge;
@@ -25,6 +26,24 @@ interface DAGEdge3DProps {
   onAblationClick?: () => void;
   onEdgeClick?: () => void;
   epochState?: EdgeEpochState;
+  /**
+   * Cascade-firing pulse inputs. When the current replay epoch falls
+   * within a small window of this edge's `fireActivationEpoch`, the
+   * edge renders a brief "FIRE" pulse (brighter line, larger flow
+   * particle, color flash toward white). Driven by
+   * `cascadeEdgeActivationOrder` — see src/lib/cascade-edge-activation-
+   * order.ts. Undefined when the edge never fires in the visible
+   * cascade window; pulse is suppressed in that case.
+   */
+  fireActivationEpoch?: number;
+  /** Current replay epoch — read by `edgeFireIntensity` per-frame. */
+  currentEpoch?: number;
+  /**
+   * True iff cascade replay is in progress. Gates the FIRE pulse so
+   * the brightness boost doesn't fire spuriously when the user is
+   * just hovering over an idle graph.
+   */
+  replayActive?: boolean;
   /**
    * χ★ tier — discrete midpoint marker tells the user this edge is
    * in the load-bearing skeleton without smudging the cyan / amber
@@ -78,10 +97,17 @@ function DAGEdge3DInner({
   onAblationClick,
   onEdgeClick,
   epochState,
+  fireActivationEpoch,
+  currentEpoch,
+  replayActive = false,
   chiStarTier = null,
 }: DAGEdge3DProps) {
   const [hovered, setHovered] = useState(false);
   const particleRef = useRef<THREE.Mesh>(null);
+  // FIRE-pulse halo — co-located with the particle so it inherits the
+  // particle's path along the curve. Same useFrame block updates both
+  // refs so the halo doesn't drift away from its core particle.
+  const haloRef = useRef<THREE.Mesh>(null);
   const particleT = useRef(Math.random()); // stagger start positions
 
   // Color: match 2D exactly
@@ -172,21 +198,45 @@ function DAGEdge3DInner({
   const selectionDim = anyNodeSelected && !isConnectedToSelected;
   const propSignal = epochState ? epochState.propagationSignal : 0;
   const propBoost = propSignal * 0.5;
+  // Cascade "FIRE" pulse — peaks at the activation epoch and decays
+  // over a few epochs. 0 outside the window or when replay isn't
+  // active. Added to opacity and used to grow the particle so the
+  // moment-of-firing reads as a clear punctuation in the cascade,
+  // not just a continuation of the steady propSignal flow that's
+  // been there since PR #258. Ablated / severed edges suppress the
+  // pulse — those are post-cut analysis states where firing would
+  // misrepresent what just happened to the topology.
+  const fireIntensity =
+    replayActive &&
+    fireActivationEpoch !== undefined &&
+    currentEpoch !== undefined &&
+    !isAblated &&
+    !isSevered
+      ? edgeFireIntensity(fireActivationEpoch, currentEpoch)
+      : 0;
   const baseOpacity = isAblated ? 0.15
     : isSevered ? 0.45
     : isDimmed ? 0.15
     : isHighlighted ? 0.9
     : hovered ? 0.8
     : isConsequenceEdge ? 0.85
-    : (0.5 + propBoost);
+    : (0.5 + propBoost + fireIntensity * 0.4);
   const lineOpacity = selectionDim ? 0.05
     : isConnectedToSelected ? 1.0
     : Math.min(1, baseOpacity);
 
-  // Should the particle flow animate?
+  // Should the particle flow animate? Fire pulse counts as a reason
+  // to animate too — at very low propSignal the steady-flow path
+  // wouldn't kick in, but the fire moment still needs to render
+  // a particle whoosh.
   const shouldAnimate = !isSevered && !isAblated && !selectionDim &&
-    (isTemporalFlow || propSignal > 0.3);
-  const animSpeed = isTemporalFlow ? 0.4 : 0.3 + propSignal * 0.5;
+    (isTemporalFlow || propSignal > 0.3 || fireIntensity > 0.05);
+  // Boost the animation speed during the fire pulse so the particle
+  // visibly accelerates at firing time — matches the human read of
+  // "signal arriving fast" vs "signal continuously flowing."
+  const animSpeed = isTemporalFlow
+    ? 0.4 + fireIntensity * 0.6
+    : 0.3 + propSignal * 0.5 + fireIntensity * 0.8;
 
   // Animate particle along curve for temporal/causal edges.
   // Reads from the pre-cached curvePoints array (allocated once per
@@ -201,6 +251,14 @@ function DAGEdge3DInner({
     const i = Math.min(samples - 1, Math.floor(particleT.current * samples));
     const [x, y, z] = curvePoints[i];
     particleRef.current.position.set(x, y, z);
+    // Keep the halo in lockstep with the particle so the pulse reads
+    // as a coherent glow around its core, not a separate object
+    // floating along an offset path. The halo mesh is conditionally
+    // rendered (only during fireIntensity > 0.05), so the ref is null
+    // outside that window — the guard below handles that.
+    if (haloRef.current) {
+      haloRef.current.position.set(x, y, z);
+    }
   });
 
   return (
@@ -288,7 +346,15 @@ function DAGEdge3DInner({
       {/* Animated flowing particle for temporal/causal edges —
           small glowing sphere that travels source → target along the curve */}
       {shouldAnimate && (
-        <mesh ref={particleRef}>
+        <mesh
+          ref={particleRef}
+          // Scale up during the fire pulse so the moment of activation
+          // reads as a punctuation — particle grows from 1× → 2.6× at
+          // the activation epoch and decays back over the window. The
+          // base radius stays 0.25 so steady-flow edges look identical
+          // to before; the boost only shows up while `fireIntensity > 0`.
+          scale={1 + fireIntensity * 1.6}
+        >
           {/* 6×6 segments = 36 triangles, indistinguishable from 8×8
               (64 tri) at this radius (0.25). Saves vertex work
               proportional to active orb count. */}
@@ -296,7 +362,32 @@ function DAGEdge3DInner({
           <meshBasicMaterial
             color={color}
             transparent
-            opacity={lineOpacity * 0.9}
+            // Boost particle opacity during the fire pulse to keep it
+            // visible even when the line itself stays near baseline.
+            // Combined with the scale boost above, the eye reads the
+            // activation moment clearly without needing a color shift.
+            opacity={Math.min(1, lineOpacity * 0.9 + fireIntensity * 0.4)}
+          />
+        </mesh>
+      )}
+      {/* FIRE-pulse halo — a second translucent sphere co-located with
+          the particle, twice the size, that only renders during the
+          activation window. The double-render is cheap (6×6 segments
+          ≈ 36 triangles × ≤ 192 edges firing simultaneously, but in
+          practice ≤ ~20 edges are within the 3-epoch window at any
+          given time) and gives the pulse a visible "glow" around the
+          core particle without needing a shader. */}
+      {fireIntensity > 0.05 && shouldAnimate && (
+        <mesh
+          ref={haloRef}
+          scale={(1 + fireIntensity * 1.6) * 2.2}
+        >
+          <sphereGeometry args={[0.25, 6, 6]} />
+          <meshBasicMaterial
+            color={color}
+            transparent
+            opacity={fireIntensity * 0.35}
+            depthWrite={false}
           />
         </mesh>
       )}
@@ -376,6 +467,15 @@ function arePropsEqual(prev: DAGEdge3DProps, next: DAGEdge3DProps) {
     if (!pe || !ne) return false;
     if (pe.propagationSignal !== ne.propagationSignal) return false;
   }
+  // Cascade-firing inputs. `replayActive` flips infrequently, but
+  // `currentEpoch` advances every replay tick and `fireActivationEpoch`
+  // is stable per (edge, cascade-run). Skipping these here would make
+  // the memo stale during replay — the fire pulse wouldn't render
+  // because the parent's reseat-the-edge-list re-render would be
+  // short-circuited.
+  if (prev.fireActivationEpoch !== next.fireActivationEpoch) return false;
+  if (prev.currentEpoch !== next.currentEpoch) return false;
+  if (prev.replayActive !== next.replayActive) return false;
   // Intentionally not comparing onScissorsClick / onAblationClick / onEdgeClick.
   return true;
 }

--- a/src/lib/__tests__/cascade-edge-activation-order.test.ts
+++ b/src/lib/__tests__/cascade-edge-activation-order.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  cascadeEdgeActivationOrder,
+  edgeFireIntensity,
+} from "@/lib/cascade-edge-activation-order";
+import type {
+  CausalEdge,
+  EpochSnapshot,
+  NodeEpochState,
+} from "@/lib/types";
+
+// ─── Fixtures ─────────────────────────────────────────────────────
+
+function edge(id: string, source: string, target: string): CausalEdge {
+  return {
+    id,
+    source,
+    target,
+    weight: 0.5,
+    lag: 0,
+    type: "directed",
+    confidence: 0.5,
+    isInconsistent: false,
+    physicalMechanism: "",
+  };
+}
+
+function nodeState(isActivated: boolean): NodeEpochState {
+  return {
+    shockIntensity: isActivated ? 0.5 : 0,
+    isActivated,
+    omegaComposite: 5,
+    omegaProfile: {
+      composite: 5,
+      irreplaceability: 5,
+      restorationLatency: 5,
+      jurisdictionalHazard: 5,
+      cascadeLoad: 5,
+      tailDepth: 5,
+    },
+  };
+}
+
+function snapshot(
+  activatedIds: string[],
+  allNodeIds: string[],
+  epochIndex: number = 0,
+): EpochSnapshot {
+  const states: Record<string, NodeEpochState> = {};
+  const activated = new Set(activatedIds);
+  for (const id of allNodeIds) {
+    states[id] = nodeState(activated.has(id));
+  }
+  return {
+    epoch: epochIndex,
+    nodeStates: states,
+    edgeStates: {},
+    omegaBuffer: 100,
+    omegaStatus: "NOMINAL",
+    isCritical: false,
+    isStable: true,
+    criticalityEstimate: null,
+  };
+}
+
+// ─── cascadeEdgeActivationOrder ──────────────────────────────────
+
+describe("cascadeEdgeActivationOrder", () => {
+  it("returns empty map for empty inputs", () => {
+    expect(cascadeEdgeActivationOrder([], [], 0).size).toBe(0);
+    expect(
+      cascadeEdgeActivationOrder([edge("e1", "a", "b")], [], 0).size,
+    ).toBe(0);
+    expect(
+      cascadeEdgeActivationOrder([], [snapshot([], ["a"])], 0).size,
+    ).toBe(0);
+  });
+
+  it("returns empty map for negative upToEpoch", () => {
+    const result = cascadeEdgeActivationOrder(
+      [edge("e1", "a", "b")],
+      [snapshot(["a", "b"], ["a", "b"])],
+      -1,
+    );
+    expect(result.size).toBe(0);
+  });
+
+  it("orders edges by their target's first-activation epoch", () => {
+    const edges = [
+      edge("e_ab", "a", "b"),
+      edge("e_bc", "b", "c"),
+      edge("e_cd", "c", "d"),
+    ];
+    const epochs: EpochSnapshot[] = [
+      snapshot(["a"], ["a", "b", "c", "d"]),               // t=0: seed a
+      snapshot(["a", "b"], ["a", "b", "c", "d"]),          // t=1: b activates
+      snapshot(["a", "b", "c"], ["a", "b", "c", "d"]),     // t=2: c activates
+      snapshot(["a", "b", "c", "d"], ["a", "b", "c", "d"]), // t=3: d activates
+    ];
+    const result = cascadeEdgeActivationOrder(edges, epochs, 3);
+
+    // e_ab fires at t=1 (b activated), e_bc at t=2, e_cd at t=3.
+    expect(result.get("e_ab")?.ordinal).toBe(1);
+    expect(result.get("e_ab")?.activationEpoch).toBe(1);
+    expect(result.get("e_bc")?.ordinal).toBe(2);
+    expect(result.get("e_bc")?.activationEpoch).toBe(2);
+    expect(result.get("e_cd")?.ordinal).toBe(3);
+    expect(result.get("e_cd")?.activationEpoch).toBe(3);
+  });
+
+  it("skips edges whose target never activates", () => {
+    const edges = [edge("e_ab", "a", "b"), edge("e_az", "a", "z")];
+    const epochs: EpochSnapshot[] = [
+      snapshot(["a"], ["a", "b", "z"]),
+      snapshot(["a", "b"], ["a", "b", "z"]),
+    ];
+    const result = cascadeEdgeActivationOrder(edges, epochs, 1);
+    expect(result.has("e_ab")).toBe(true);
+    expect(result.has("e_az")).toBe(false); // z never activated
+  });
+
+  it("respects upToEpoch cutoff (hides later edges during scrub-back)", () => {
+    const edges = [edge("e_ab", "a", "b"), edge("e_bc", "b", "c")];
+    const epochs: EpochSnapshot[] = [
+      snapshot(["a"], ["a", "b", "c"]),
+      snapshot(["a", "b"], ["a", "b", "c"]),
+      snapshot(["a", "b", "c"], ["a", "b", "c"]),
+    ];
+    // At epoch 1, only e_ab has fired.
+    const atT1 = cascadeEdgeActivationOrder(edges, epochs, 1);
+    expect(atT1.has("e_ab")).toBe(true);
+    expect(atT1.has("e_bc")).toBe(false);
+
+    // At epoch 2, both have fired.
+    const atT2 = cascadeEdgeActivationOrder(edges, epochs, 2);
+    expect(atT2.has("e_ab")).toBe(true);
+    expect(atT2.has("e_bc")).toBe(true);
+  });
+
+  it("breaks same-epoch ties by (targetId ASC, edgeId ASC)", () => {
+    // Three edges firing into different targets in the same epoch.
+    // Expected ordinals follow target id sort.
+    const edges = [
+      edge("e_to_z", "a", "z"),
+      edge("e_to_b", "a", "b"),
+      edge("e_to_m", "a", "m"),
+    ];
+    const epochs: EpochSnapshot[] = [
+      snapshot(["a"], ["a", "b", "m", "z"]),
+      snapshot(["a", "b", "m", "z"], ["a", "b", "m", "z"]),
+    ];
+    const result = cascadeEdgeActivationOrder(edges, epochs, 1);
+    // All fire at t=1 → ordered by target id: b, m, z.
+    expect(result.get("e_to_b")?.ordinal).toBe(1);
+    expect(result.get("e_to_m")?.ordinal).toBe(2);
+    expect(result.get("e_to_z")?.ordinal).toBe(3);
+  });
+
+  it("breaks same-target ties by edgeId ASC (multi-incoming-edge case)", () => {
+    // Two edges firing into the same node at the same epoch — possible
+    // when a target has multiple upstream causes that activate together.
+    const edges = [edge("e_z_to_t", "z", "t"), edge("e_a_to_t", "a", "t")];
+    const epochs: EpochSnapshot[] = [
+      snapshot(["a", "z"], ["a", "z", "t"]),
+      snapshot(["a", "z", "t"], ["a", "z", "t"]),
+    ];
+    const result = cascadeEdgeActivationOrder(edges, epochs, 1);
+    // Both have target "t" and same activationEpoch=1 → sorted by edge id.
+    expect(result.get("e_a_to_t")?.ordinal).toBe(1);
+    expect(result.get("e_z_to_t")?.ordinal).toBe(2);
+  });
+
+  it("includes severed edges that historically fired (renderer decides visibility)", () => {
+    // Renderer concern, not data concern — return the historical fire
+    // event so the demo can show "would-have-fired" dimmed pulses for
+    // edges the analyst severs after the cascade ran.
+    const edges = [{ ...edge("e_ab", "a", "b"), isSevered: true }];
+    const epochs: EpochSnapshot[] = [
+      snapshot(["a"], ["a", "b"]),
+      snapshot(["a", "b"], ["a", "b"]),
+    ];
+    const result = cascadeEdgeActivationOrder(edges, epochs, 1);
+    expect(result.has("e_ab")).toBe(true);
+  });
+
+  it("clamps upToEpoch past the end to epochs.length - 1", () => {
+    const edges = [edge("e_ab", "a", "b")];
+    const epochs: EpochSnapshot[] = [
+      snapshot(["a"], ["a", "b"]),
+      snapshot(["a", "b"], ["a", "b"]),
+    ];
+    // upToEpoch=999 should not throw; should match upToEpoch=1.
+    const result = cascadeEdgeActivationOrder(edges, epochs, 999);
+    expect(result.size).toBe(1);
+  });
+});
+
+// ─── edgeFireIntensity ───────────────────────────────────────────
+
+describe("edgeFireIntensity", () => {
+  it("returns 1.0 at the exact activation epoch", () => {
+    expect(edgeFireIntensity(5, 5)).toBe(1);
+  });
+
+  it("returns 0 well outside the window", () => {
+    expect(edgeFireIntensity(5, 10)).toBe(0); // 5 epochs after
+    expect(edgeFireIntensity(5, 0)).toBe(0); // 5 before
+  });
+
+  it("decays linearly across the post-activation window", () => {
+    // Default window is 3 epochs.
+    expect(edgeFireIntensity(5, 5)).toBe(1);
+    expect(edgeFireIntensity(5, 6)).toBeCloseTo(2 / 3, 5);
+    expect(edgeFireIntensity(5, 7)).toBeCloseTo(1 / 3, 5);
+    expect(edgeFireIntensity(5, 8)).toBe(0);
+  });
+
+  it("handles the one-epoch lead-in (-1 → 0.0)", () => {
+    // delta = -1 → 1 + (-1) = 0. So pure-integer lead-in only matters
+    // for fractional scrub interpolation; with epoch=integer, the
+    // edge appears at activationEpoch with full intensity.
+    expect(edgeFireIntensity(5, 4)).toBe(0);
+  });
+
+  it("respects custom windowEpochs", () => {
+    expect(edgeFireIntensity(5, 6, 1)).toBe(0); // window=1, decay finishes by delta=1
+    expect(edgeFireIntensity(5, 6, 5)).toBeCloseTo(0.8, 5);
+  });
+
+  it("windowEpochs ≤ 0 only fires at the exact epoch (no decay)", () => {
+    expect(edgeFireIntensity(5, 5, 0)).toBe(1);
+    expect(edgeFireIntensity(5, 6, 0)).toBe(0);
+    expect(edgeFireIntensity(5, 5, -1)).toBe(1);
+  });
+});

--- a/src/lib/cascade-edge-activation-order.ts
+++ b/src/lib/cascade-edge-activation-order.ts
@@ -1,0 +1,177 @@
+// ─── Cascade edge activation order ──────────────────────────────
+//
+// Sibling helper to `cascadeActivationOrder` (which produces per-node
+// "1, 2, 3…" ordinals from PR #371). This one produces per-EDGE
+// activation info so the 3D / 2D edge renderers can pulse the edge at
+// the moment signal first crossed it during cascade propagation.
+//
+// Semantics — what counts as "the edge firing"
+// --------------------------------------------
+// An edge fires the moment its TARGET node first activates. That's
+// the epoch in which signal crossed the edge to flip the target on.
+// Choosing the target (not the source) means:
+//   - At epoch t=0, the seed node activates. Its outgoing edges have
+//     NOT fired yet (no downstream lit up).
+//   - At epoch t=1, signal flows seed → next; the edge fires AT t=1.
+//   - At epoch t=2, the next layer fires.
+//
+// This makes the visual cascade-of-fires read as "the signal walking
+// outward from the seed", which matches what an analyst expects from
+// the propagation order — and it pairs cleanly with the existing node
+// activation badges (a node's badge appears at the same epoch its
+// incoming edge fires).
+//
+// Edges whose target never activates (or activates after `upToEpoch`)
+// are absent from the returned map — callers should treat absence as
+// "this edge never fired in the visible cascade window."
+//
+// Determinism
+// -----------
+// Ties (multiple edges firing in the same epoch) are broken by
+// `(targetId ASC, edgeId ASC)`. The target tiebreak keeps the ordering
+// consistent with `cascadeActivationOrder` (which uses node id as the
+// tiebreak), so edges firing into nodes with smaller ids show up
+// before edges firing into nodes with larger ids when they all fire
+// in the same epoch.
+
+import type { CausalEdge, EpochSnapshot } from "./types";
+
+/**
+ * Per-edge activation info — populated only for edges that fired by
+ * `upToEpoch`. The `ordinal` field is 1-indexed firing order across the
+ * visible cascade; the `activationEpoch` is the literal epoch at which
+ * the target node first activated (which is when this edge fired).
+ *
+ * The renderer uses `activationEpoch` to compute a "fire phase" — how
+ * far the current replay position is from when this edge lit up — so
+ * it can pulse the edge for a brief window after activation.
+ */
+export interface EdgeActivationInfo {
+  /** 1-indexed firing order across all visible-cascade edges. */
+  ordinal: number;
+  /** Epoch the edge fired at (= target's first-activation epoch). */
+  activationEpoch: number;
+}
+
+/**
+ * Compute the per-edge firing order + activation epoch.
+ *
+ * Both `cascadeActivationOrder` and this helper iterate the snapshot
+ * array once, so calling both at the canvas level is O(2 × epochs ×
+ * nodes) — well within budget for the 192-node demo at 60fps.
+ *
+ * Edge cases:
+ *  - Empty `epochs` or negative `upToEpoch` → empty map
+ *  - `upToEpoch` past the end → clamped to `epochs.length - 1`
+ *  - Edge whose source / target never appears in any snapshot → absent
+ *  - Edge whose target activates but `isSevered` was set → still included.
+ *    Whether to suppress severed edges visually is a renderer decision,
+ *    not a data one. The helper returns the *historical* firing order
+ *    in case the renderer wants to show a dimmed fire pulse for cuts
+ *    the analyst just applied (the demo loop's "apply cuts → watch
+ *    the would-have-fired edges go dark" use case).
+ */
+export function cascadeEdgeActivationOrder(
+  edges: ReadonlyArray<CausalEdge>,
+  epochs: ReadonlyArray<EpochSnapshot>,
+  upToEpoch: number,
+): Map<string, EdgeActivationInfo> {
+  if (epochs.length === 0 || upToEpoch < 0 || edges.length === 0) {
+    return new Map();
+  }
+  const cutoff = Math.min(upToEpoch, epochs.length - 1);
+
+  // Pass 1 — first activation epoch per node (same scan
+  // `cascadeActivationOrder` does, repeated here so callers can use
+  // either helper independently without coupling internals).
+  const firstActivation = new Map<string, number>();
+  for (let e = 0; e <= cutoff; e++) {
+    const states = epochs[e].nodeStates;
+    for (const nodeId in states) {
+      if (!Object.prototype.hasOwnProperty.call(states, nodeId)) continue;
+      if (firstActivation.has(nodeId)) continue;
+      if (states[nodeId].isActivated) firstActivation.set(nodeId, e);
+    }
+  }
+
+  // Pass 2 — derive each edge's firing epoch from its target's
+  // activation. Edges whose target never activated are skipped.
+  type EdgeEntry = {
+    edgeId: string;
+    targetId: string;
+    activationEpoch: number;
+  };
+  const entries: EdgeEntry[] = [];
+  for (const edge of edges) {
+    const targetEpoch = firstActivation.get(edge.target);
+    if (targetEpoch === undefined) continue;
+    entries.push({
+      edgeId: edge.id,
+      targetId: edge.target,
+      activationEpoch: targetEpoch,
+    });
+  }
+
+  // Pass 3 — sort by (epoch ASC, targetId ASC, edgeId ASC) and assign
+  // 1-indexed ordinals. The targetId tiebreak mirrors how
+  // `cascadeActivationOrder` orders nodes within an epoch, so a node
+  // with badge #N has its incoming edges grouped together in the edge
+  // ordering. The edgeId tiebreak handles the multi-incoming-edge case
+  // deterministically.
+  entries.sort((a, b) => {
+    if (a.activationEpoch !== b.activationEpoch) {
+      return a.activationEpoch - b.activationEpoch;
+    }
+    if (a.targetId !== b.targetId) {
+      return a.targetId < b.targetId ? -1 : 1;
+    }
+    return a.edgeId < b.edgeId ? -1 : a.edgeId > b.edgeId ? 1 : 0;
+  });
+
+  const out = new Map<string, EdgeActivationInfo>();
+  for (let i = 0; i < entries.length; i++) {
+    out.set(entries[i].edgeId, {
+      ordinal: i + 1,
+      activationEpoch: entries[i].activationEpoch,
+    });
+  }
+  return out;
+}
+
+/**
+ * Compute the "fire phase" intensity for an edge — how brightly it
+ * should pulse at the current replay epoch, given when it activated.
+ *
+ * Returns:
+ *   1.0 at the exact activation epoch
+ *   ~0.5 one epoch before/after
+ *   0.0 outside the [activationEpoch - 1, activationEpoch + windowEpochs] band
+ *
+ * Asymmetric window: one epoch of lead-in (so the pulse appears
+ * naturally as the signal arrives) and `windowEpochs` of decay
+ * afterward (so the analyst has time to register the fire before it
+ * fades to the continuous-flow signal the edge already carries).
+ *
+ * Designed to be called per-frame in the renderer's `useFrame`, so
+ * it's purely a math helper — no allocations, no state. The cost is
+ * a few comparisons + a subtraction + a divide.
+ */
+export function edgeFireIntensity(
+  activationEpoch: number,
+  currentEpoch: number,
+  windowEpochs: number = 3,
+): number {
+  if (windowEpochs <= 0) return currentEpoch === activationEpoch ? 1 : 0;
+  const delta = currentEpoch - activationEpoch;
+  if (delta < -1) return 0;
+  if (delta > windowEpochs) return 0;
+  if (delta < 0) {
+    // Lead-in: -1 < delta < 0 maps to 0 → 1 (but delta is integer in
+    // the discrete-epoch case, so this only fires when delta === -1 →
+    // returns 0.5). Kept fractional in case a future caller passes a
+    // continuous epoch (scrub interpolation).
+    return Math.max(0, 1 + delta);
+  }
+  // Decay: 0 ≤ delta ≤ windowEpochs maps to 1 → 0.
+  return Math.max(0, 1 - delta / windowEpochs);
+}


### PR DESCRIPTION
## Summary

Today during cascade replay, nodes light up with numbered badges (PR #371) and the underlying particle flow on edges does animate (PR #258) — but there's no clear *moment* of "this edge just fired." The continuous propagation signal drives a small dot along the curve, and the cascade reads more as "nodes blink on one by one" than "signal walking outward from the seed."

This PR adds a **FIRE pulse** — a brief visual punctuation on each edge at the moment its target node first activated. Combined with the existing per-frame particle flow and the activation-order badges, the cascade now reads as a coherent signal-walk: shock injects → edges fire in sequence → nodes light up at the moment their incoming edges fired.

## Math (new module `src/lib/cascade-edge-activation-order.ts`)

Two pure helpers — sibling to `cascadeActivationOrder` from PR #371:

- **`cascadeEdgeActivationOrder(edges, epochs, upToEpoch)`** — returns `Map<edgeId, {ordinal, activationEpoch}>`. The activation epoch is the **target** node's first-activation epoch (when signal first crossed the edge to flip the target on). Ties broken deterministically by `(epoch ASC, targetId ASC, edgeId ASC)` so ordering stays stable across renders.

- **`edgeFireIntensity(activationEpoch, currentEpoch, window=3)`** — returns `[0, 1]` pulse intensity. Peaks at 1.0 at the activation epoch and decays linearly over the window. 0 outside the band. Called per-frame in the renderer; pure math, no allocations.

15 new tests covering: target-as-activation semantics, target-never-activates skip, `upToEpoch` cutoff for scrub-back, deterministic ties, severed-edges-still-counted (renderer decision, not data), clamping, intensity peak / decay / asymmetric window / `windowEpochs=0` edge cases.

## 3D wiring (`CausalDAG3D` + `DAGEdge3D`)

**Canvas-level**: a second `useMemo` alongside the existing activation-order one, producing `Map<edgeId, activationEpoch>`. Passed to each `DAGEdge3D` as three new props (`fireActivationEpoch`, `currentEpoch`, `replayActive`).

**Renderer-level**: three visual modulations layer on top of the existing propagation-signal flow:

| Layer | Effect |
|---|---|
| Line opacity | +0.4 × fireIntensity |
| Particle scale | 1× → 2.6× at the pulse peak |
| Halo mesh | New 2.2× translucent sphere co-located with the particle; opacity = fireIntensity × 0.35; renders only while fireIntensity > 0.05 |

Particle animation speed also boosts during the pulse so the particle visibly accelerates at firing time — matches the human read of "signal arriving fast" vs "signal continuously flowing."

The halo is kept in lockstep with the particle in the same `useFrame` that drives the particle's position — no second animation loop, no drift.

Pulse is **suppressed on ablated / severed edges** (post-cut analysis — firing those would misrepresent the topology) and gated on `replayActive` (no spurious pulses on the idle canvas).

`arePropsEqual` updated to compare the three new props — without this the memo would stale the pulse during replay because parent re-renders are short-circuited.

## 2D wiring (`CausalDAG2D` + `EmphasizedEdge`)

Same data flow: canvas-level `edgeActivationEpochs` map, builder computes `fireIntensity` per edge, passes via `EmphasizedEdgeData`. Renderer applies three boosts:

| Layer | Effect |
|---|---|
| Stroke opacity | +0.5 × fireIntensity |
| Stroke width | +1.8 × fireIntensity |
| Stroke color | white at fireIntensity > 0.4 (peak), amber during decay, baseColor at rest |

Edges builder's `useMemo` deps extended with the new inputs so the fire pulse re-renders on epoch advance.

## Performance

- Two new canvas-level `useMemo`s run O(epochs × nodes) **once per epoch advance** — well under 1ms for the 192-node demo at 60fps
- Per-edge fire intensity is two comparisons + a subtraction + a divide
- Halo sphere adds one mesh per actively-firing edge (≤ ~20 simultaneous in practice with a 3-epoch window)
- No new shaders, no new geometry caches, no shader recompiles

## What this PR isn't

- **No solver / store / API changes.** Purely derived from existing `EpochSnapshot[]` data.
- **No Map / Relief wiring.** Map edges are thin lines that don't carry enough visual real estate for the pulse; Relief is a scalar fragility surface and doesn't render edges. Both can call the same helper if/when they grow edge rendering.
- **No copilot tool to query edge-firing order.** Available if needed later as `explain_cascade_edge_order` or similar.

## Files

| File | Change |
|---|---|
| `src/lib/cascade-edge-activation-order.ts` (new) | `cascadeEdgeActivationOrder` + `edgeFireIntensity` helpers |
| `src/lib/__tests__/cascade-edge-activation-order.test.ts` (new) | 15 tests |
| `src/components/CausalDAG3D.tsx` | Canvas-level edge activation map; pass to `DAGEdge3D` |
| `src/components/dag3d/DAGEdge3D.tsx` | Three new props; fire-pulse opacity / scale / halo; `arePropsEqual` updated |
| `src/components/CausalDAG2D.tsx` | Canvas-level edge activation map; `fireIntensity` field on `EmphasizedEdgeData`; renderer boosts in `EmphasizedEdge` |

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/lib/__tests__/cascade-edge-activation-order.test.ts` — 15/15 passing
- [x] `npx next build` clean
- [ ] PR-validate workflow green
- [ ] Vercel preview eyeball:
  - Run a scenario in PEARL → APPLY ALL & SIMULATE → watch cascade replay in 3D. Edges should pulse in sequence as nodes activate, with brighter/larger particles at the firing moment
  - Same in 2D — strokes flash white then amber as signal arrives
  - Scrub the TimeDial backwards — pulses re-fire in order, no flicker
  - Sever an edge in PEARL → replay still works, but the severed edge no longer pulses (suppressed)
  - Switch to MULTI-DOMAIN NETWORK — pulses still visible at 500+ nodes

## Backwards compat

No store changes. New props on `DAGEdge3D` are optional (`fireActivationEpoch?`, `currentEpoch?`, `replayActive?` defaulting to undefined / 0 / false). Existing visual behaviour preserved when those props are absent (initial render before cascade runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
