### PR TITLE
feat(feeds): wire ISM PMI proxies via regional Fed manufacturing/services surveys

### DIFF
--- a/src/lib/feeds/fred.ts
+++ b/src/lib/feeds/fred.ts
@@ -95,6 +95,17 @@ export const FRED_SERIES: FredSeriesConfig[] = [
   // the graph node's mechanism comment are not publicly available, so
   // Cass is the closest free alternative.
   { id: "FRGEXPUSM649NCIS", label: "Cass Freight Expenditures Index", labelPatterns: ["shipping cost index"], unit: "", capacity: 4, mockValue: 3.4 },
+  // Regional Fed manufacturing surveys as ISM PMI proxies. ISM's PMI is
+  // proprietary (subscription-only since ~2015), so the proxy strategy
+  // uses the Philadelphia Fed Manufacturing Business Outlook Survey for
+  // manufacturing and the Dallas Fed Texas Service Sector Outlook Survey
+  // for services. Both are publicly-available diffusion indices that
+  // economists track alongside ISM and which historically correlate
+  // r=0.6-0.8 with the ISM headlines. Monthly cadence, current to 2026-04
+  // or 2026-05. Capacity 0 (diffusion indices are signed centered at 0).
+  // Mock values reflect roughly neutral readings.
+  { id: "GACDFSA066MSFRBPHI", label: "Philly Fed Manufacturing (ISM PMI proxy)", labelPatterns: ["ism manufacturing pmi"], unit: "", capacity: 0, mockValue: 0 },
+  { id: "TSSOSBACTSAMFRBDAL", label: "Dallas Fed Services (ISM PMI Services proxy)", labelPatterns: ["ism services pmi"], unit: "", capacity: 0, mockValue: 0 },
   { id: "T5YIE", label: "5-Year Breakeven Inflation Rate", labelPatterns: ["5y breakeven inflation rate"], unit: "%", capacity: 4, mockValue: 2.5 },
   { id: "CSUSHPISA", label: "Case-Shiller Home Price Index YoY", labelPatterns: ["case-shiller home price index"], unit: "%", capacity: 12, units: "pc1", mockValue: 4.8 },
   // FRED expansion (Phase 4): more macro/financial nodes from graph-data.ts


### PR DESCRIPTION
## Phase 15 batch #1 — past the ceiling

Phase 14 closed at 44% live with a comment that ISM PMI was "structurally stuck" because ISM is proprietary subscription-only since 2015. But the regional Fed manufacturing + services surveys are publicly available on FRED and historically correlate r=0.6-0.8 with the ISM headline diffusion indices — economists routinely track them as ISM proxies.

## Two new FRED entries

| FRED ID | Survey | Latest | Wires to |
|---|---|---:|---|
| **GACDFSA066MSFRBPHI** | Philly Fed Manufacturing Business Outlook | -0.4 @ 2026-05 | `mi_ism_manufacturing` |
| **TSSOSBACTSAMFRBDAL** | Dallas Fed Texas Service Sector Outlook | -2.3 @ 2026-04 | `mi_ism_services` |

Both are signed diffusion indices (centered at 0; negative = contraction, positive = expansion), monthly cadence. Capacity = 0 so the qualifier display reads as "X above avg" / "X below avg" rather than a meaningless ratio.

## Coverage delta

- 2 previously-synthetic nodes promoted to LIVE
- FRED catalog: 59 → 61 entries
- The third synthetic Macro node (`ip_nyfed_expectations`, NY Fed SCE) does NOT have a current FRED proxy — SCE is published only on the NY Fed microeconomics page, not mirrored to FRED. Could be wired as a separate batch fetch.

## The bigger point

The "practically-reachable ceiling" I claimed in Phase 14 wasn't actually a hard ceiling — it was just where I'd stopped looking. The remaining gap is partly **domain-knowledge bound** (which Philly Fed indicator proxies which ISM measure) not just **data-source bound**.

## Test plan

- [x] `npx vitest run src/lib/__tests__/feeds/fred.test.ts` — 17/17 pass
- [x] Dry-run `check:feeds` shows both entries as MISS pre-deploy
- [ ] After deploy: `mi_ism_manufacturing` shows ~-0.4 / `mi_ism_services` shows ~-2.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)