### PR TITLE
refactor(pareto): drop scenario-injection preset buttons — PEARL owns scenarios

### DIFF
--- a/src/components/ModulePanel.tsx
+++ b/src/components/ModulePanel.tsx
@@ -168,9 +168,9 @@ export default function ModulePanel() {
         {activeModule === "pareto" && (
           <div className="p-4 space-y-3">
             <div className="text-[8px] font-mono text-text-muted p-2 border border-border/50 rounded bg-surface-elevated">
-              Criticality observation. Inject shocks and read the model
-              relevance cards to see which estimators trust the regime.
-              Defensive cuts and scenario interdiction live in{" "}
+              Sensing layer. Read the criticality cards + snapshot
+              diagnostics to see how the system is reading. Inject
+              scenarios and run defensive cuts from{" "}
               <button
                 type="button"
                 onClick={() => setActiveModule("pearl")}
@@ -178,7 +178,8 @@ export default function ModulePanel() {
               >
                 PEARL {"\u2192"}
               </button>
-              .
+              \u2014 whatever shocks live in the store flow back here as
+              shifts in the relevance + snapshot readings.
             </div>
             <SnapshotIndicator />
             <ParetoPanel expandedChart={expandedChart} setExpandedChart={setExpandedChart} />

--- a/src/components/modules/ParetoPanel.tsx
+++ b/src/components/modules/ParetoPanel.tsx
@@ -9,7 +9,6 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useApexStore } from "@/stores/useApexStore";
-import { getPresetShocks } from "@/lib/omega-engine";
 import { getEngineProvider } from "@/lib/engines";
 import { getDomainColor } from "@/lib/graph-data";
 import { resolveDomainProfile, type EstimatorId } from "@/lib/domain-profiles";
@@ -86,7 +85,6 @@ function ParetoPanel({
   setExpandedChart: (id: string | null) => void;
 }) {
   const shocks = useApexStore((s) => s.shocks);
-  const addShock = useApexStore((s) => s.addShock);
   const removeShock = useApexStore((s) => s.removeShock);
   const graphData = useApexStore((s) => s.graphData);
   const selectedNode = useApexStore((s) => s.selectedNode);
@@ -122,7 +120,6 @@ function ParetoPanel({
   }, [activeProfile.relevanceReferenceId]);
 
   const engine = useMemo(() => getEngineProvider(), []);
-  const presetShocks = useMemo(() => getPresetShocks(), []);
   const omegaState = useMemo(() => engine.scanTailRisk(shocks), [engine, shocks]);
 
   // During replay, derive buffer from current epoch snapshot for dynamic T=
@@ -1115,36 +1112,16 @@ function ParetoPanel({
         </div>
       )}
 
-      {/* Scenario Injector */}
-      <div className="mt-3">
-        <div className="font-[family-name:var(--font-michroma)] text-[9px] tracking-wider text-accent-red mb-1">
-          SCENARIO INJECTION
-        </div>
-        <div className="text-[8px] font-mono text-text-muted mb-1.5">
-          Activate disruption scenarios to stress-test the network. Each scenario shifts all three criticality horizons.
-        </div>
-        <div className="space-y-1 max-h-36 overflow-y-auto">
-          {presetShocks.map((shock) => {
-            const isActive = shocks.some((s) => s.id === shock.id);
-            return (
-              <button
-                key={shock.id}
-                onClick={() => !isActive && addShock(shock)}
-                disabled={isActive}
-                className="w-full text-left text-[8px] font-mono p-1.5 border rounded transition-colors disabled:opacity-30"
-                style={{
-                  borderColor: isActive ? "rgba(255,23,68,0.3)" : "var(--border)",
-                  backgroundColor: isActive ? "rgba(255,23,68,0.05)" : "transparent",
-                  color: isActive ? "var(--accent-red)" : "var(--text-muted)",
-                }}
-              >
-                {shock.name}
-                <span className="opacity-60 ml-1">SEV:{(shock.severity * 100).toFixed(0)}%</span>
-              </button>
-            );
-          })}
-        </div>
-      </div>
+      {/* Scenario injection (preset shock buttons) intentionally
+          removed from PARETO. PEARL's `ScenarioInput` is now the
+          canonical scenario entry — either NL ("simulate a Hormuz
+          closure") routed through the copilot's `solve_interdiction`
+          tool, or `add_shock` invoked directly from chat. PARETO is
+          purely the sensing layer: it shows how criticality estimators
+          read against whatever shock state is in the store, no matter
+          how it got there. The ACTIVE SCENARIOS readout above stays
+          so an analyst working on PARETO can see + dismiss active
+          shocks without context-switching to PEARL. */}
     </>
   );
 }


### PR DESCRIPTION
## Summary

User-reported architectural smell during the PARETO/PEARL design review:

> *"Scenario injection is a bit odd... it almost seems to be a redundancy. The Pearl engine has the scenario interdiction, which I think is supposed to be what that is. So I don't even know if scenario injection makes sense anymore under Pareto."*

Right. There were two ways to put a scenario into the store:

1. **PARETO scenario injection** — preset shock buttons (`TAIWAN_BLOCKADE`, `GRID_CASCADE`, etc) → `addShock()` → `store.shocks`
2. **PEARL ScenarioInput** (PR #369) — NL textbox → copilot → either `add_shock` or `solve_interdiction` → same `store.shocks`

Both flowed into the same place. The PEARL flow is the canonical one we've trained the demo on. PARETO's preset buttons predate ScenarioInput; the redundancy now muddies the mental model.

**Clean separation, one direction:** PARETO is the sensing layer ("how is the system reading?"). PEARL is the intervention layer ("what do I do about it?"). PARETO shouldn't own a scenario-entry surface.

## Changes

- **Delete the SCENARIO INJECTION block** from `ParetoPanel.tsx`. Drops the preset shock buttons, the "Activate disruption scenarios..." caption, and the associated `max-h-36` scroll container (~30 lines).
- Drop the now-unused `addShock` store hook and `presetShocks` / `getPresetShocks` import.
- **Keep ACTIVE SCENARIOS readout.** Passive view of the current `store.shocks` state with a `✕` remove button — useful for an analyst working on PARETO to see + dismiss active shocks without context-switching to PEARL.
- **Update the PARETO header copy** in `ModulePanel.tsx`:

| | Before | After |
|---|---|---|
| Copy | *"Criticality observation. Inject shocks and read the model relevance cards... Defensive cuts and scenario interdiction live in PEARL →"* | *"Sensing layer. Read the criticality cards + snapshot diagnostics to see how the system is reading. Inject scenarios and run defensive cuts from PEARL → — whatever shocks live in the store flow back here as shifts in the relevance + snapshot readings."* |

## Backwards compat

**Preset shocks are still available.** `add_shock` is a registered copilot tool — typing "inject Taiwan blockade" or "add the GRID_CASCADE shock" in chat does exactly what the button row did. Anything the PARETO buttons could do, PEARL's ScenarioInput → copilot still does. No functionality lost; just consolidated.

No store / API / test changes. Frees visual real estate in PARETO for the SnapshotDiagnostics enrichment in the follow-up PR.

## Files

| File | Change |
|---|---|
| `src/components/modules/ParetoPanel.tsx` | Delete SCENARIO INJECTION block; drop `addShock`, `presetShocks`, `getPresetShocks` |
| `src/components/ModulePanel.tsx` | Rewrite PARETO header copy to reflect sensing/intervention split |

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx next build` clean
- [ ] PR-validate workflow green
- [ ] Vercel preview eyeball:
  - Open PARETO → scenario buttons row is gone; ACTIVE SCENARIOS still shows (when shocks are active) with a working ✕ remove
  - Type "inject Taiwan blockade" in PEARL's ScenarioInput → copilot adds the shock → PARETO criticality cards shift
  - The PARETO header copy now reads "sensing layer" framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
