### PR TITLE
feat(feeds): derive fc_cb_policy_rate from live Fed Funds Target Range

### DIFF
--- a/src/lib/__tests__/feeds/derivations.test.ts
+++ b/src/lib/__tests__/feeds/derivations.test.ts
@@ -270,6 +270,22 @@ describe("derivationsProvider.matchPayload — Phase 14 composites", () => {
     expect(mena.source).toContain("mean MENA FX depreciation");
   });
 
+  it("emits CB Policy Rate Regime as pass-through from live Fed Funds Target Range", () => {
+    const nodes = [
+      makeNode({
+        id: "fed_target",
+        label: "Fed Funds Target Range",
+        liveData: [{ ...liveIndicator(5.5, 6, "FRED · DFEDTARU"), unit: "%" }],
+      }),
+      makeNode({ id: "cb_policy", label: "CB Policy Rate Regime" }),
+    ];
+    const batch = derivationsProvider.matchPayload({ trigger: "now" }, nodes);
+    const cb = batch.updates.find((u) => u.nodeId === "cb_policy")!.point;
+    expect(cb.value).toBe(5.5);
+    expect(cb.unit).toBe("%");
+    expect(cb.source).toContain("US Fed Funds Target Range (global anchor for EM CB policy)");
+  });
+
   it("does not emit K/L or MPK when capital + GDP primitives are missing", () => {
     const nodes = [
       makeNode({ id: "br_kl", label: "Brazil K/L Ratio" }),

--- a/src/lib/feeds/providers/derivations.ts
+++ b/src/lib/feeds/providers/derivations.ts
@@ -112,6 +112,34 @@ export const derivationsProvider: FeedProvider<DerivationsTrigger> = {
       }
     }
 
+    // CB Policy Rate Regime (Financial Contagion) — pass-through from
+    // the live Fed Funds Target Range node. The US Fed policy rate is
+    // the global anchor for emerging-market CB policy decisions (per
+    // the existing edge `fc_em_fx_reserves__fc_cb_policy_rate`), so
+    // surfacing the US rate as the CB Policy Rate Regime signal gives
+    // the Financial Contagion domain a live policy-rate anchor without
+    // requiring a separate EM-CB-rate aggregation pipeline (which would
+    // need bespoke data from Bloomberg / Reuters that isn't free).
+    const fedTargetNode = findByLabel(nodes, "fed funds target range");
+    const cbPolicyNode = findByLabel(nodes, "cb policy rate");
+    if (fedTargetNode && cbPolicyNode) {
+      const fedSignal = fedTargetNode.liveData?.find((p) => p.kind === "indicator");
+      if (fedSignal) {
+        updates.push({
+          nodeId: cbPolicyNode.id,
+          point: {
+            kind: "indicator",
+            value: fedSignal.value,
+            capacity: fedSignal.capacity,
+            unit: fedSignal.unit,
+            observedAt: fedSignal.observedAt,
+            source: `Derived · US Fed Funds Target Range (global anchor for EM CB policy)${fedSignal.source.toLowerCase().includes("(mock") ? " (mock — primitive is mocked)" : ""}`,
+          },
+        });
+        affectedNodeIds.push(cbPolicyNode.id);
+      }
+    }
+
     // Sovereign Risk: K/L Ratio + MPK for Brazil and China, derived
     // from the live Capital Formation + Real GDP primitives (WB,
     // both wired via #411 and the original WB_SERIES).


### PR DESCRIPTION
## Phase 15 batch #2 — one more historical → live via derivations

`fc_cb_policy_rate` (Financial Contagion domain, label "CB Policy Rate Regime") was historical-only via pimco_sovereign snapshot. Pass-through derivation from the already-live US Fed Funds Target Range gives Financial Contagion domain access to the global-anchor policy rate signal without needing a bespoke EM-CB-rate aggregation pipeline (which would require Bloomberg / Reuters subscription data).

## Semantics

Per the graph edge `fc_em_fx_reserves__fc_cb_policy_rate`: *"Reserve levels constrain central bank policy options between rate defense and growth support"* — the node represents the EM central bank policy rate that gets pushed up to defend the currency. The US Fed Funds Target Range is the global anchor that EM CBs respond to.

## Coverage delta

- **Financial Contagion**: +1 live node
- Tests: 15 → 16 (new test confirms pass-through math)

## Test plan

- [x] 16/16 derivations tests pass
- [ ] After deploy: `fc_cb_policy_rate` node shows ~5.5% with source `Derived · US Fed Funds Target Range (global anchor for EM CB policy)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)