### PR TITLE
polish(theme): close out token-stray hunt — TimeDial track background tracks var(--border)

### DIFF
--- a/src/components/TimeDial.tsx
+++ b/src/components/TimeDial.tsx
@@ -776,7 +776,7 @@ export default function TimeDial() {
           ref={trackRef}
           data-timedial-track="true"
           className="relative h-6 cursor-crosshair rounded"
-          style={{ backgroundColor: "rgba(26,28,46,0.8)" }}
+          style={{ backgroundColor: "color-mix(in srgb, var(--border) 80%, transparent)" }}
           onPointerDown={handlePointerDown}
           onPointerMove={handlePointerMove}
           onPointerUp={handlePointerUp}


### PR DESCRIPTION
## Summary
- 1 stale `rgba(26,28,46,0.8)` site (`src/components/TimeDial.tsx:751`) migrated to `color-mix(in srgb, var(--border) 80%, transparent)`
- Closes the legibility-token-stray hunt that PRs #390, #402, and #428 ran

## Why
PR #402 migrated 5 obvious hardcoded `#1a1c2e` occurrences when lifting `--border` from `#1a1c2e` to `#2d3047`. This one slipped through because it was written in rgba form (rgb tuple `26, 28, 46`) instead of hex. The TimeDial track background was reading visibly darker than the surrounding lifted borders.

Found during the full audit pass done while waiting on PR #428's Vercel previews.

## Audit summary (what's NOT changed)
The same audit also checked for other forms of stale references — all came back clean:

| Pattern | Result |
|---|---|
| `#1a1c2e` (old `--border` hex) | 0 strays — PR #402 caught all |
| `#2a2d45` (old `--border-bright` hex) | 0 strays |
| `rgba(42, 45, 69, ...)` (rgb of old `--border-bright`) | 0 strays |
| `rgba(200, 200, 220, ...)` | 8 sites in chart code — **intentional** bluer-than-foreground tint for chart aesthetics, not stale |
| `rgba(148, 153, 173, ...)` (rgb of NEW `--text-muted`) | 0 — nobody preemptively hardcoded the new value |
| `rgba(45, 48, 71, ...)` (rgb of NEW `--border`) | 0 |
| `rgba(232, 234, 238, ...)` (rgb of NEW `--foreground`) | 0 |

So with this PR + #428, every hardcoded reference to one of the three lifted token values (`--foreground`, `--text-muted`, `--border`) is now either using `var(--token)` (full opacity) or `color-mix(in srgb, var(--token) N%, transparent)` (partial). Future variable changes cascade everywhere.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on the touched file (only one pre-existing unrelated warning)
- [ ] Vercel preview deploys (may queue if rate-limit still active)
- [ ] On preview / prod: TimeDial track background tone matches the surrounding lifted border colour, not the old darker tint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
