### PR TITLE
feat(canvas): dial-scrub contraction round 2 — visible at typical historical omegas

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -34,7 +34,8 @@ A bottom-up read of the full log still works, but for a fresh session this is th
 
 | PR | What |
 |---|---|
-| TBD | `feat(edges)`: new `"flow"` edge type (teal-green solid + animated arrow, distinct from `"directed"` claim and `"temporal"` lag) + per-edge-type visibility toggle chip strip in DAGOverlay across 2D / 3D / Map |
+| TBD | `feat(canvas)`: dial-scrub contraction round 2 — 2D CONTRACTION 0.35 → 0.55 and stress-curve ramp pushed up (4→8 instead of 5→10) for both 2D and 3D so typical historical omegas (5-7) actually produce visible orb movement on scrub |
+| #439 | `feat(edges)`: new `"flow"` edge type (teal-green solid + animated arrow, distinct from `"directed"` claim and `"temporal"` lag) + per-edge-type visibility toggle chip strip in DAGOverlay across 2D / 3D / Map |
 | #435 | `feat(timedial)`: granularity picker collapses to a single chip; click to expand, pick-to-collapse |
 | #432 | `perf(bundle)`: lazy `SystemCopilot` chunk + lazy `buildGraphFromDomains` / `AXIOM_LIBRARY` inside copilot tool handlers — pulls ~6.8 K LOC off the initial-paint bundle |
 | #427 | `feat(2d)`: dial-scrub now moves orbs via historical-omega contraction (matched 3D's already-shipped fallback); CONTRACTION 0.18 → 0.35 for visibility |
@@ -66,7 +67,7 @@ A bottom-up read of the full log still works, but for a fresh session this is th
 
 - **Flow edge type + edge-type visibility toggles.** _Infrastructure shipped — 2026-05-22._ `"flow"` edge type wired across all four canvas surfaces with teal-green solid + animated arrow visual; per-type visibility chip strip in DAGOverlay (CAUSAL / TEMP / CONF / FLOW) hides/shows each type instantly. Open: data-team alignment on what `"flow"` means semantically + which existing edges should be re-tagged (no edge in the loaded datasets carries `type: "flow"` yet).
 - **Time-dial range-selector collapsible (NEW).** The 1H / 1Y / 5Y / ALL preset row at the bottom of the dial currently takes a fixed slice of horizontal space. User wants it collapsible so the dial itself can take the full width when the user isn't picking a range.
-- **Distance measures on dial scrub — verify in production (NEW).** User reports that after PR #427 the orbs still don't appear to move during dial scrub. The fix is in main; possible causes: (a) deployment hasn't picked up yet, (b) temporal data isn't actually populating `graphData.nodes[].omegaFragility.composite` per scrub tick for the user's loaded workspace, (c) the contraction magnitude is still too subtle to read at this user's typical omega distribution, (d) 3D path's `(omega - 5) / 4` mapping doesn't actually trigger because temporal omegas don't drift far from neutral. Investigation step: confirm `useTemporalGraph` is wired correctly into `useFilteredGraph` for the user's loaded domain set, and instrument the contraction to log how much the centroid pull actually displaces typical orbs per tick.
+- **Distance measures on dial scrub — round 2 shipped — 2026-05-22.** Traced end-to-end: wiring was correct (temporal graph → filtered graph → both contraction paths), the gap was stress magnitude. Synthetic temporal data drifts within ±0.5 of base, so typical historical omegas sit in the 5-7 band — and the old `(omega-5)/5` / `(omega-5)/4` stress curves produced stress 0.1-0.3 → pull 3-14 % of distance, invisible. Bumped 2D CONTRACTION 0.35 → 0.55 and stress curves on both surfaces (4 → 8 instead of 5 → 10) so typical omegas land in stress 0.25-0.75 → pull 14-41 %. Production verification still needed: confirm the dial-scrub now reads as cluster-pinching motion.
 - **Platform load-time deep-dive.** _Round 1 shipped — 2026-05-22 (PR #432: lazy SystemCopilot + lazy heavy copilot-tool deps)._ Remaining candidates: split `graph-data.ts` (3413 LOC) into a tiny `graph-color.ts` (just `getCategoryColor` / `getDomainColor` / `getCategoryLabel` / `EMPTY_GRAPH`) and a separate heavy data file — ~13 consumers only need the helpers but currently pull the whole module; lazy-load AXIOM_LIBRARY behind a getter in `copilot-engine.ts` + `copilot-context.ts` (same pattern as `tools.ts` but harder since the helpers are sync); audit `TimeSeriesOverlay` (987 LOC) + `TimeDial` (1179 LOC) for dynamic-loadability; `framer-motion` tree-shake check; real `ANALYZE=true next build` run.
 - **Time-dial-driven positional response (round 1).** _Shipped — 2026-05-22 (PR #427)._ 2D contraction now handles both cascade replay AND dial-scrub (historical-omega fallback); CONTRACTION 0.18 → 0.35 for visibility. 3D already had the historical-fallback path. Map relies on omega-scaled radius. Production verification queued above.
 - **TOPO compute-shader port for real-time scrub perf.** Deferred since PR #303 (4σ truncation) covered the headline cost. Only worth doing if real-time scrub still drops frames in production.
@@ -1028,6 +1029,26 @@ Estimator-lib audit (the other backlog candidate) turned out to be a no-op in pr
 **Verification.** `tsc --noEmit` clean (same pre-existing inherited errors); lint clean on touched files; vitest 1322 / 1322 pass.
 
 ---
+
+### 2026-05-22 — Shipped: dial-scrub contraction round 2 — visible at typical historical omegas
+
+**PR:** TBD (about to open).
+
+**Trigger.** User reported PR #427 still wasn't moving orbs on dial scrub. Traced end-to-end and the wiring was correct (`useTemporalGraph` injects per-tick omega values into `graphData.nodes[].omegaFragility.composite`; `useFilteredGraph` passes the temporal graph through; both 2D and 3D consume it in their contraction passes). The actual gap was **stress magnitude**: synthetic temporal data's random walk drifts within ±0.5 of base, so typical historical omegas sit in the 5–7 band. The old `(omega-5)/5` (2D) and `(omega-5)/4` (3D) stress curves only produced stress 0.1–0.3 at those levels → centroid pulls of 3–14 % of distance — visible if you stare, invisible otherwise.
+
+**What shipped.**
+
+- **2D `CONTRACTION` 0.35 → 0.55** and **stress curve `(omega-5)/5` → `(omega-4)/4`** (both the self branch and the `neighborStressOf` branch). Typical omegas 5–7 now produce stress 0.25–0.75 → pull 14–41 % of distance to the stressed-neighbour centroid. Visibly readable.
+
+- **3D historical stress curve `(omega-5)/4` → `(omega-4)/3`.** Bracketed by the existing `PULL_MAX=0.45` and `PUSH_MAX=0.25`. Typical omegas now produce stress 0.33–1.0 instead of 0.25–0.5 — visibly tighter contraction on stressed nodes and visibly more dispersion on relaxed ones.
+
+Cascade-replay path (using `currentSnapshot.shockIntensity`) is unchanged — that path always had access to the proper full-range stress signal.
+
+**Files.**
+- `src/components/CausalDAG2D.tsx` — CONTRACTION + both stress curves bumped.
+- `src/components/CausalDAG3D.tsx` — historical stress curve bumped.
+
+**Verification.** `tsc --noEmit` clean; vitest 1522 / 1522 pass.
 
 ### 2026-05-22 — Shipped: `flow` edge type + per-type visibility toggle row
 

--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -819,11 +819,15 @@ function CausalDAG2DInner() {
   );
 
   // Replay contraction magnitude. 0.18 was the original — visually
-  // subtle even at peak shock (~0.18 × max-pull-distance per tick).
-  // 0.35 is the new floor: pinches stressed clusters tight enough
-  // to *see* as the cascade rolls, matching the visual budget the
-  // user expects when scrubbing the time dial.
-  const CONTRACTION = 0.35;
+  // subtle even at peak shock. Pushed to 0.35 in the first revision;
+  // then production showed dial-scrub *still* feeling positionally
+  // frozen because synthetic temporal data only varies omega by
+  // ±0.5 around base, and the old `(omega-5)/5` stress mapping
+  // produced stress 0.1-0.3 at typical levels → pull 3-10% of
+  // distance, imperceptible. Pushed to 0.55 here paired with a
+  // steeper stress curve below to make the historical-mode signal
+  // actually readable.
+  const CONTRACTION = 0.55;
 
   // Force-directed layout. Cached positions come from a one-shot offline
   // simulation per graph signature; live positions are written by the rAF
@@ -1005,15 +1009,28 @@ function CausalDAG2DInner() {
           currentSnapshot.nodeStates[nbId]?.shockIntensity ?? 0;
       } else {
         // Historical / dial-scrub mode — stress as a unit fraction of
-        // how far the node's ΩF sits above neutral 5/10. Caps at 1.0
-        // for omega ≥ 10. Below neutral the node doesn't contract.
+        // how far the node's ΩF sits above a low-water mark. Caps at
+        // 1.0 for omega ≥ 8. Below the low-water mark the node
+        // doesn't contract.
+        //
+        // Earlier we used `(omega-5)/5` which only crossed 1.0 at
+        // omega 10 — but synthetic temporal data drifts within ±0.5
+        // of base, so typical historical omegas sit in the 5-7 band
+        // and the old curve produced stress 0.1-0.3 → pull 3-10% of
+        // distance, basically invisible. The 4 → 8 ramp below makes
+        // typical historical omegas (5-7) produce stress 0.25-0.75
+        // → pull 14-41% of distance with the new CONTRACTION=0.55.
+        // That's the difference between "the dial scrub is broken"
+        // and "I can see the cluster pinching as the cascade rolls."
         const omega = n.omegaFragility?.composite ?? 0;
-        stress = Math.max(0, Math.min(1, (omega - 5) / 5));
+        stress = Math.max(0, Math.min(1, (omega - 4) / 4));
         neighborStressOf = (nbId) => {
           const nb = nodeById.get(nbId);
           if (!nb) return 0;
           const nbOmega = nb.omegaFragility?.composite ?? 0;
-          return Math.max(0, Math.min(1, (nbOmega - 5) / 5));
+          // Same 4 → 8 ramp as the self branch above so neighbours
+          // contribute weight in lockstep with the contracting node.
+          return Math.max(0, Math.min(1, (nbOmega - 4) / 4));
         };
       }
       if (stress > 0.01) {

--- a/src/components/CausalDAG3D.tsx
+++ b/src/components/CausalDAG3D.tsx
@@ -751,14 +751,19 @@ export default function CausalDAG3D() {
         return state ? state.shockIntensity : 0;
       }
       // Historical mode: use the temporal omega value directly
-      // High omega (>5) = stressed, pulls inward
-      // Low omega (<5) = relaxed, pushes outward
+      // High omega (>4) = stressed, pulls inward
+      // Low omega (<4) = relaxed, pushes outward
       // Use O(1) nodeById lookup (item #10) instead of O(N) find
       const node = nodeById.get(nodeId);
       if (!node) return 0;
       const omega = node.omegaFragility.composite;
-      // Map 0-10 omega to -1 to +1 stress (5 = neutral)
-      return Math.max(-1, Math.min(1, (omega - 5) / 4));
+      // Map omega → [-1, +1] stress with a steeper curve around the
+      // mid-band so synthetic temporal data's typical ±0.5 drift
+      // around omega 5-7 actually moves the orb. Old `(omega-5)/4`
+      // produced stress 0.25-0.5 at typical levels; new ramp puts
+      // it at 0.5-0.75 — paired with the 2D CONTRACTION push, the
+      // dial scrub finally reads as "the cluster is breathing."
+      return Math.max(-1, Math.min(1, (omega - 4) / 3));
     };
 
     // Compute network centroid


### PR DESCRIPTION
## Summary

User reported PR #427 still wasn't moving orbs on dial scrub. Traced the pipeline end-to-end — **the wiring was correct**:

- `useTemporalGraph` correctly transforms each node's `omegaFragility.composite` to the historical value at `timelinePosition`.
- `useFilteredGraph` correctly passes the temporal graph through when `isTemporalActive` is true.
- Both 2D's `nodes` useMemo and 3D's `posMap` useMemo correctly consume the temporal omegas via their stress curves.

**The gap was stress magnitude.** Synthetic temporal data does a random walk of ±0.15 noise / day with 0.05 mean-reversion → typical historical omegas drift within ±0.5 of base. So most nodes' historical omegas sit in the 5–7 band. The old stress curves:

- 2D: `(omega - 5) / 5` → omega 6 = stress 0.2, omega 7 = stress 0.4
- 3D: `(omega - 5) / 4` → omega 6 = stress 0.25, omega 7 = stress 0.5

…combined with the previous `CONTRACTION = 0.35`, produced centroid pulls of **3–14 %** of distance to the stressed-neighbour centroid. Visible if you stare; invisible during a scrub.

## What shipped

- **2D**: `CONTRACTION 0.35 → 0.55`. Stress curve `(omega - 5) / 5 → (omega - 4) / 4` on both the self branch and the `neighborStressOf` branch. Typical omegas 5–7 now produce stress 0.25–0.75 → pull 14–41 % of distance.

- **3D**: historical stress curve `(omega - 5) / 4 → (omega - 4) / 3`. Bracketed by existing `PULL_MAX = 0.45` and `PUSH_MAX = 0.25`. Typical omegas now produce stress 0.33–1.0 instead of 0.25–0.5 → visibly tighter contraction on stressed nodes and visibly more dispersion on relaxed ones.

Cascade-replay path (which uses `currentSnapshot.shockIntensity`) is unchanged — that path always had access to the proper full-range stress signal.

## Test plan

- [x] `tsc --noEmit` clean (modulo pre-existing inherited errors)
- [x] vitest **1522 / 1522** pass
- [ ] Load a workspace with temporal data, switch to 2D, scrub the dial back-and-forth — confirm visible orb movement (high-Ω orbs visibly pulling toward stressed neighbours and back as the underlying omega rises/falls).
- [ ] Switch to 3D, scrub same range — confirm visible orb movement (push/pull around domain centroid, more dramatic than before).
- [ ] Trigger a cascade replay — confirm the replay contraction is unchanged (uses `currentSnapshot.shockIntensity`, not the historical-omega curve).
- [ ] Verify there's no regression on a graph with all-neutral omegas (~5) — contraction should still be near-zero.

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_