### PR TITLE
perf(bundle): load-time round 3 — temporal-data + NewsInterpreterPanel + NodeInspector lazy

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -30,7 +30,13 @@ This is the running log for the Rendering & Perf session. Every change pushed fr
 
 A bottom-up read of the full log still works, but for a fresh session this is the fastest way to see the current state. Newest first.
 
-**2026-05-24 round (load-time round 2)**
+**2026-05-27 round (load-time round 3)**
+
+| PR | What |
+|---|---|
+| TBD | `perf(bundle)`: dynamic-import `temporal-data` (334 LOC, `generateTemporalData`) and `real-timeseries` (426 LOC, `loadRealTemporalData`) inside the store's `initTemporalData` action — both only fire after a workspace is loaded, so the ~760 LOC chunk defers until then. Lazy-load `NewsInterpreterPanel` (~350 LOC) — only renders on the non-default Pareto tab. Lazy-load `NodeInspector` (~630 LOC) gated on `selectedNode != null` — initial paint never has a selection so the chunk only loads after the first click. |
+
+**2026-05-24 round (load-time round 2) — _merged as #444_**
 
 | PR | What |
 |---|---|
@@ -84,6 +90,26 @@ A bottom-up read of the full log still works, but for a fresh session this is th
 ---
 
 ## Session log
+
+### 2026-05-27 — Shipped: temporal-data lazy + NewsInterpreterPanel lazy + NodeInspector lazy
+
+**PR:** TBD — three more bundle-shape wins after #444 (load-time round 2) merged.
+
+**Trigger.** With round 2 merged, the next set of high-leverage candidates were:
+1. `useApexStore` still eagerly imported `generateTemporalData` (334 LOC, synthetic timeline fallback) and `loadRealTemporalData` (426 LOC, network fetcher) for `initTemporalData`. Both only fire after a workspace is loaded.
+2. `ModulePanel` still statically imported `NewsInterpreterPanel` (~350 LOC) and `NodeInspector` (~630 LOC). Pareto is a non-default tab so NewsInterpreterPanel never renders on first paint. NodeInspector renders `null` inside `<AnimatePresence>` when no node is selected — also never visible on first paint.
+
+**Fix.**
+- Added `loadGenerateTemporalData()` and `loadLoadRealTemporalData()` helpers at the top of `useApexStore` (same pattern as the previous round's `loadSimulateCascadeAsync` / `loadMergeGraphs` / `loadValidateSnapshot`). `initTemporalData` now wraps both calls in `void load…().then((fn) => …)` chains. The early-out check (`if (state.temporalData) return`) was duplicated inside the synthetic-data `.then()` so a concurrent call during the chunk load doesn't double-set state.
+- `NewsInterpreterPanel` → `dynamic(() => import("./NewsInterpreterPanel"), { ssr: false, loading: PANEL_LOADER })`. Renders behind the Pareto tab.
+- `NodeInspector` → `dynamic(() => import("./NodeInspector"), { ssr: false })` plus `{selectedNode && <NodeInspector />}` gate at the render site. The component itself already returned `null` when `selectedNode` was empty via its internal `<AnimatePresence>{node && (<motion.div>...)}</AnimatePresence>`, so the parent gate is behaviour-preserving on first paint and only adds a ~50-100ms chunk load on the first node click. Subsequent clicks hit the chunk cache.
+
+**Verification.** vitest 1524/1524 pass. tsc clean.
+
+**Out of scope / next round.**
+- `tarski-data.ts` (891 LOC of AXIOM_LIBRARY + 800 LOC of validation logic) is still eagerly imported by `useApexStore`. It's used in 5 store action paths but conditionally — only when `truthFilter === "verified"`. Converting to dynamic-import would require restructuring the sync `set((s) => …)` updaters into `loadTarski().then((helpers) => set(…))` chains for all 5. Doable but invasive; the `applyFeedBatch` case in particular currently combines tarski work with omega-pillar work in a single atomic update, so the refactor would break that atomicity (the user might see a brief flicker of unflagged graph before the tarski flags land).
+- `applyOmegaLiveAdjustments` (220 LOC) and `applyCrossDomainBridges` (305 LOC) are hot-path — every graph mutation calls them. Same fire-and-forget refactor would degrade UX visibly. Leave eager.
+- `domain-profiles.ts` (480 LOC) is mostly profile-data constants used everywhere. Splitting wouldn't help.
 
 ### 2026-05-24 — Shipped: EngineProvider future-stubs stripped + mergeGraphs/validateSnapshot deferred
 

--- a/src/components/ModulePanel.tsx
+++ b/src/components/ModulePanel.tsx
@@ -9,8 +9,6 @@ import { summarizeDiscoveryUncertainty } from "@/lib/discovery-uncertainty";
 import dynamic from "next/dynamic";
 import TrinityPanel from "./TrinityPanel";
 import DiscoveryRunsPanel from "./DiscoveryRunsPanel";
-import NewsInterpreterPanel from "./NewsInterpreterPanel";
-import NodeInspector from "./NodeInspector";
 
 // Tab-gated sub-panels lazy-loaded so the default Spirtes tab doesn't
 // pull their JS on first paint. The first wave (added PR #300) covered
@@ -30,6 +28,20 @@ const PANEL_LOADER = (
 const TissueCohortView = dynamic(
   () => import("./scientist/TissueCohortView"),
   { ssr: false, loading: () => PANEL_LOADER },
+);
+// NewsInterpreterPanel (~350 LOC) only renders on the Pareto tab, which
+// isn't the default. Defer the chunk until the tab is opened.
+const NewsInterpreterPanel = dynamic(
+  () => import("./NewsInterpreterPanel"),
+  { ssr: false, loading: () => PANEL_LOADER },
+);
+// NodeInspector (~630 LOC, pulls chi-star + framer-motion) renders null
+// inside its AnimatePresence wrapper when no node is selected. Initial
+// paint never has a selection — gate the entire dynamic import on
+// `selectedNode != null` so the chunk only loads after the first click.
+const NodeInspector = dynamic(
+  () => import("./NodeInspector"),
+  { ssr: false },
 );
 const MonteCarloForecast = dynamic(
   () => import("./MonteCarloForecast"),
@@ -75,6 +87,10 @@ export default function ModulePanel() {
   const activeModule = useApexStore((s) => s.activeModule);
   const setActiveModule = useApexStore((s) => s.setActiveModule);
   const setInterventionMode = useApexStore((s) => s.setInterventionMode);
+  // Used only to gate the dynamic-imported NodeInspector below — the
+  // component renders null without a selection, so deferring the chunk
+  // costs nothing on first paint.
+  const selectedNode = useApexStore((s) => s.selectedNode);
   // Scientist-mode aware: Tissue Cohort view mounts only when a T1D
   // domain is loaded, so it doesn't pollute non-life-sciences flows.
   const selectedDomainsForView = useApexStore((s) => s.selectedDomains);
@@ -127,8 +143,9 @@ export default function ModulePanel() {
         </div>
       </div>
 
-      {/* Node Inspector (persistent across modules) */}
-      <NodeInspector />
+      {/* Node Inspector (persistent across modules; lazy-loaded — only
+          mounts once a node is selected since it renders null otherwise) */}
+      {selectedNode && <NodeInspector />}
 
       {/* Module Content — pb-16 reserves space for the fixed FEEDBACK button
           so the bottom of the last panel never sits under it at full scroll. */}

--- a/src/stores/useApexStore.ts
+++ b/src/stores/useApexStore.ts
@@ -77,7 +77,6 @@ async function loadValidateSnapshot() {
 import type { LLMProvider } from "@/lib/llm-providers";
 import type { TimeGranularity, TemporalDataset, TemporalEvent } from "@/lib/temporal-data";
 import type { TrainingTrace } from "@/lib/discovery/training-trace-types";
-import { generateTemporalData } from "@/lib/temporal-data";
 
 /** Cap on how many feed-emitted events we retain in temporalData.events.
  *  Events are de-duped by id, so monthly/weekly upstream cadences mean this
@@ -107,7 +106,21 @@ function appendFeedEvent(
   const rangeStart = eventMs < current.rangeStart.getTime() ? event.date : current.rangeStart;
   return { ...current, events: trimmed, rangeStart, rangeEnd };
 }
-import { loadRealTemporalData } from "@/lib/real-timeseries";
+
+// `temporal-data` (334 LOC, `generateTemporalData` — synthetic timeline
+// fallback) and `real-timeseries` (426 LOC, `loadRealTemporalData` —
+// network fetcher + per-node history hydration) are only used by
+// `initTemporalData` below, which fires once after the user lands on a
+// workspace (graph mutation triggers the call). Lazy-import both so they
+// don't ride along on the initial-paint bundle.
+async function loadGenerateTemporalData() {
+  const mod = await import("@/lib/temporal-data");
+  return mod.generateTemporalData;
+}
+async function loadLoadRealTemporalData() {
+  const mod = await import("@/lib/real-timeseries");
+  return mod.loadRealTemporalData;
+}
 
 // Drop pinned time-series ids that no longer exist in the graph. Returns the
 // same array when nothing changes so Zustand subscribers don't re-render.
@@ -1267,15 +1280,27 @@ export const useApexStore = create<ApexState>((set, get) => ({
   initTemporalData: () => {
     const state = get();
     if (state.temporalData) return;
-    // Set synthetic data immediately as fallback while real data loads
-    const syntheticData = generateTemporalData(state.graphData.nodes, state.graphData.edges, 60);
-    set({
-      temporalData: syntheticData,
-      timelineRange: {
-        start: syntheticData.rangeStart.getTime(),
-        end: syntheticData.rangeEnd.getTime(),
-      },
-      timelinePosition: syntheticData.rangeEnd.getTime(),
+    // Set synthetic data immediately as fallback while real data loads.
+    // Both helpers are dynamic-imported — they total ~760 LOC and are
+    // never needed before a workspace is loaded.
+    void loadGenerateTemporalData().then((generateTemporalData) => {
+      const current = get();
+      // Re-check the early-out: another call may have populated the
+      // store while the synthetic helper chunk was loading.
+      if (current.temporalData) return;
+      const syntheticData = generateTemporalData(
+        current.graphData.nodes,
+        current.graphData.edges,
+        60,
+      );
+      set({
+        temporalData: syntheticData,
+        timelineRange: {
+          start: syntheticData.rangeStart.getTime(),
+          end: syntheticData.rangeEnd.getTime(),
+        },
+        timelinePosition: syntheticData.rangeEnd.getTime(),
+      });
     });
     // Load real analyst-collected data asynchronously, then replace synthetic.
     // Retry until graphData is populated (it may be empty on first mount).
@@ -1286,7 +1311,8 @@ export const useApexStore = create<ApexState>((set, get) => ({
         setTimeout(doLoad, 500);
         return;
       }
-      loadRealTemporalData(nodes, edges)
+      void loadLoadRealTemporalData()
+        .then((loadRealTemporalData) => loadRealTemporalData(nodes, edges))
         .then((realData) => {
           if (realData.nodes.size > 0) {
             set({


### PR DESCRIPTION
## Summary

Three more bundle-shape wins continuing from #444. ~1300 LOC moved off the initial-paint bundle:

- **`temporal-data` + `real-timeseries` lazy in store** (~760 LOC). `generateTemporalData` (synthetic fallback) and `loadRealTemporalData` (network fetcher) only fire from `initTemporalData`, which runs after a workspace is loaded. Same `load…().then(…)` pattern as #444's `loadSimulateCascadeAsync` / `loadMergeGraphs` / `loadValidateSnapshot`. Added a re-check of the `temporalData` early-out inside the synthetic `.then()` so concurrent calls during chunk load don't double-set state.
- **`NewsInterpreterPanel` lazy** (~350 LOC). Only renders on the Pareto tab — not the default. Converted to `next/dynamic` with the shared `PANEL_LOADER`.
- **`NodeInspector` lazy + selection-gated** (~630 LOC). Renders `null` inside its `<AnimatePresence>` wrapper when no node is selected, so first paint never needs it. Converted to `next/dynamic` and gated the render site on `selectedNode != null`. The animation still plays correctly on first node click — `motion.div`'s `initial={...}` triggers when the element first appears, regardless of whether the parent component was just lazy-loaded.

## Test plan

- [x] `npx vitest run` — 1524/1524 pass
- [x] `npx tsc --noEmit` — clean across touched files
- [ ] Manual prod verification: confirm first node click still animates the inspector open; Pareto tab still renders NewsInterpreterPanel; LAUNCH WORKSPACE still populates the timeline within the usual delay

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_