### PR TITLE
perf(bundle): load-time round 4 — tarski-data AXIOM_LIBRARY + TimeDial off eager bundle

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -30,11 +30,17 @@ This is the running log for the Rendering & Perf session. Every change pushed fr
 
 A bottom-up read of the full log still works, but for a fresh session this is the fastest way to see the current state. Newest first.
 
-**2026-05-27 round (load-time round 3)**
+**2026-05-27 round (load-time round 4)**
 
 | PR | What |
 |---|---|
-| TBD | `perf(bundle)`: dynamic-import `temporal-data` (334 LOC, `generateTemporalData`) and `real-timeseries` (426 LOC, `loadRealTemporalData`) inside the store's `initTemporalData` action — both only fire after a workspace is loaded, so the ~760 LOC chunk defers until then. Lazy-load `NewsInterpreterPanel` (~350 LOC) — only renders on the non-default Pareto tab. Lazy-load `NodeInspector` (~630 LOC) gated on `selectedNode != null` — initial paint never has a selection so the chunk only loads after the first click. |
+| TBD | `perf(bundle)`: extract `applyTarskiFlags` + `clearTarskiFlags` + the `TarskiValidationReport` type into a new lightweight `tarski-flags.ts`; dynamic-import `runTarskiValidation` (which carries the 891-LOC AXIOM_LIBRARY + 800-LOC validation engine) inside the four store actions that need it (`runTarskiWithAxioms`, `setTruthFilter`, `applyFeedBatch`, `promoteAutoBridge`). Verified mode is opt-in — the heavy chunk only loads once per session at the first verified-mode trigger. Also lazy-loads `TimeDial` (1207 LOC) from `app/page.tsx` with a placeholder matching the dial's geometry — biggest single static-imported component finally moved off the eager bundle. |
+
+**2026-05-27 round (load-time round 3) — _merged as #445_**
+
+| PR | What |
+|---|---|
+| #445 | `perf(bundle)`: dynamic-import `temporal-data` (334 LOC, `generateTemporalData`) and `real-timeseries` (426 LOC, `loadRealTemporalData`) inside the store's `initTemporalData` action — both only fire after a workspace is loaded, so the ~760 LOC chunk defers until then. Lazy-load `NewsInterpreterPanel` (~350 LOC) — only renders on the non-default Pareto tab. Lazy-load `NodeInspector` (~630 LOC) gated on `selectedNode != null` — initial paint never has a selection so the chunk only loads after the first click. |
 
 **2026-05-24 round (load-time round 2) — _merged as #444_**
 
@@ -90,6 +96,26 @@ A bottom-up read of the full log still works, but for a fresh session this is th
 ---
 
 ## Session log
+
+### 2026-05-27 — Shipped: tarski-data 891-LOC AXIOM_LIBRARY off eager bundle + TimeDial lazy
+
+**PR:** TBD — the big one. Extracts the heaviest remaining critical-path imports.
+
+**Trigger.** After rounds 2 + 3 (#444, #445), the two largest remaining single-import deps on the eager bundle were:
+1. `tarski-data.ts` (1727 LOC: 891-LOC AXIOM_LIBRARY + 800-LOC validation engine + helpers) — eagerly imported by `useApexStore` for `runTarskiValidation` + `applyTarskiFlags` + `clearTarskiFlags`.
+2. `TimeDial` (1207 LOC) — eagerly imported by `app/page.tsx`; the largest single component on the critical path.
+
+**Fix (tarski-data split).** Created `src/lib/tarski-flags.ts` housing the two pure graph transforms (`applyTarskiFlags`, `clearTarskiFlags`) and the `TarskiValidationReport` type — total 76 LOC, no AXIOM_LIBRARY reference. `tarski-data.ts` now re-exports these for any straggler import paths but no longer defines them locally. `useApexStore` imports the lightweight trio from `tarski-flags` eagerly, and dynamic-imports `runTarskiValidation` via a new `loadRunTarskiValidation()` helper. The four call sites (`runTarskiWithAxioms`, `setTruthFilter`, `applyFeedBatch`, `promoteAutoBridge`) were rewritten:
+- `runTarskiWithAxioms` + `setTruthFilter("verified")` paths: simple `void load…().then((fn) => set(…))` wrapping — these are explicit user clicks, so the first-load ~50-100ms delay is acceptable.
+- `applyFeedBatch` + `promoteAutoBridge`: split into two phases — phase 1 applies the mutation + omega adjustments synchronously (atomic non-tarski state update), phase 2 trails the tarski revalidation only if `truthFilter === "verified"`. Each phase-2 block checks `s.truthFilter` again at fire-time so a mid-flight toggle to "raw" doesn't apply stale flags. The verified-mode user has already triggered the load via `setTruthFilter` so the dynamic-import resolves from the ES-module cache (microtask hop only).
+
+**Fix (TimeDial lazy).** Converted `TimeDial` to `dynamic(() => import("@/components/TimeDial"), { ssr: false, loading: <placeholder /> })`. The placeholder matches the dial's actual height (72px) and border style so the layout doesn't jump when the chunk lands. The dial is briefly unscrubbable (~50-100ms) but the canvas above is the user's first-paint focus and the dial sits at the bottom.
+
+**Verification.** vitest 1524/1524 pass. tsc clean.
+
+**Why this matters.** This was the single biggest remaining win — the tarski-data chunk alone is ~1700 LOC, the largest eager block left after rounds 2-3. Combined with TimeDial (1207 LOC) this round shaves ~2900 LOC off the initial-paint bundle. After this, the only eagerly-imported heavy components on `page.tsx` are HeaderBar (167), RiskPropagationFlow (594), ModulePanel (842 host + dynamic subpanels), StructuralMetrics (90), FeedbackWidget (148). The store's remaining eager deps are `applyOmegaLiveAdjustments` (220), `applyCrossDomainBridges` (305), `resolveDomainProfile` (480) — all hot-path, can't defer without UX cost.
+
+**Trade-off.** verified-mode feed events now show one render of un-flagged graph state before the tarski validation lands (one microtask hop). For most users this is imperceptible; only power-users in verified mode + watching feed events closely would see it. Mitigated by the cached ES-module fast-path on second+ verified-mode trigger.
 
 ### 2026-05-27 — Shipped: temporal-data lazy + NewsInterpreterPanel lazy + NodeInspector lazy
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,6 @@ import HeaderBar from "@/components/HeaderBar";
 import RiskPropagationFlow from "@/components/RiskPropagationFlow";
 import ModulePanel from "@/components/ModulePanel";
 import StructuralMetrics from "@/components/StructuralMetrics";
-import TimeDial from "@/components/TimeDial";
 import FeedbackWidget from "@/components/FeedbackWidget";
 
 // SystemCopilot pulls a heavy dep tree on its static-import chain:
@@ -59,6 +58,23 @@ const TimeSeriesOverlay = dynamic(
   () => import("@/components/TimeSeriesOverlay"),
   { ssr: false }
 );
+
+// TimeDial is the largest single static-imported component on the
+// critical path (1207 LOC). It IS visible on first paint (timeline
+// scrubber at the bottom) but the canvas above is the user's focus,
+// and the dial can land ~50-100ms later without breaking flow. A
+// static placeholder matches the dial's geometry so the layout
+// doesn't jump when the real chunk lands.
+const TimeDial = dynamic(() => import("@/components/TimeDial"), {
+  ssr: false,
+  loading: () => (
+    <div className="relative flex items-center gap-3 px-4 py-2 border-t border-border bg-surface-elevated/90 backdrop-blur-sm h-[72px]">
+      <div className="text-[8px] font-mono text-text-muted/60 animate-pulse">
+        LOADING TIMELINE…
+      </div>
+    </div>
+  ),
+});
 
 // DomainSelector + DemoFlowPlayerHost both transitively pull the
 // four large graph-data modules (~3000 lines combined) via

--- a/src/lib/tarski-data.ts
+++ b/src/lib/tarski-data.ts
@@ -1,4 +1,17 @@
 import { TarskiAxiom, ProofTrace, CausalGraph, CausalEdge, CausalNode, getLiveSignal } from "./types";
+import type { TarskiValidationReport } from "./tarski-flags";
+
+// `applyTarskiFlags`, `clearTarskiFlags`, and the `TarskiValidationReport`
+// type live in the lightweight `tarski-flags.ts` so consumers that only
+// need to flag/clear a graph (or carry the type signature) don't pull the
+// 891-LOC AXIOM_LIBRARY + 800-LOC validation engine below. Re-exported
+// here to keep existing callers working — new code should import from
+// `tarski-flags` directly to stay off the heavy chunk.
+export {
+  applyTarskiFlags,
+  clearTarskiFlags,
+  type TarskiValidationReport,
+} from "./tarski-flags";
 
 // ─── Axiom Library (Domain-Specific: Middle East Energy & Petrochemical) ──
 
@@ -462,13 +475,6 @@ export function scoreAxiomRelevance(graph: CausalGraph, activeProfileId?: string
 // ─── Dynamic Tarski Validation Engine ─────────────────────────────
 // Runs axiom checks against real graph data and returns flagged edges/nodes
 
-export interface TarskiValidationReport {
-  inconsistentEdgeIds: Set<string>;
-  restrictedNodeIds: Set<string>;
-  proofTraces: ProofTrace[];
-  totalViolations: number;
-}
-
 export function runTarskiValidation(
   graph: CausalGraph,
   enabledAxiomIds?: Set<string>,
@@ -816,66 +822,6 @@ export function runTarskiValidation(
     totalViolations: inconsistentEdgeIds.size + restrictedNodeIds.size,
   };
 }
-
-// ─── Apply Validation to Graph ────────────────────────────────────
-// Returns a new graph with isInconsistent/isRestricted flags set
-
-export function applyTarskiFlags(
-  graph: CausalGraph,
-  report: TarskiValidationReport
-): CausalGraph {
-  const nodes = graph.nodes.map((n) => ({
-    ...n,
-    isRestricted: report.restrictedNodeIds.has(n.id),
-  }));
-
-  const edges = graph.edges.map((e) => ({
-    ...e,
-    isInconsistent: report.inconsistentEdgeIds.has(e.id),
-  }));
-
-  const inconsistentEdges = edges.filter((e) => e.isInconsistent).length;
-  const restrictedNodes = nodes.filter((n) => n.isRestricted).length;
-
-  return {
-    nodes,
-    edges,
-    metadata: {
-      ...graph.metadata,
-      inconsistentEdges,
-      restrictedNodes,
-      verificationStatus: inconsistentEdges > 0 || restrictedNodes > 0
-        ? "INCONSISTENCIES_FOUND"
-        : "VERIFIED",
-    },
-  };
-}
-
-// ─── Clear Tarski Flags (reset to RAW) ────────────────────────────
-
-export function clearTarskiFlags(graph: CausalGraph): CausalGraph {
-  const nodes = graph.nodes.map((n) => ({
-    ...n,
-    isRestricted: false,
-  }));
-
-  const edges = graph.edges.map((e) => ({
-    ...e,
-    isInconsistent: false,
-  }));
-
-  return {
-    nodes,
-    edges,
-    metadata: {
-      ...graph.metadata,
-      inconsistentEdges: 0,
-      restrictedNodes: 0,
-      verificationStatus: "UNVERIFIED" as const,
-    },
-  };
-}
-
 // ─── Legacy Proof Traces (kept for backward compat) ───────────────
 // These are now generated dynamically by runTarskiValidation()
 export const PROOF_TRACES: ProofTrace[] = [];

--- a/src/lib/tarski-flags.ts
+++ b/src/lib/tarski-flags.ts
@@ -1,0 +1,74 @@
+// Lightweight Tarski helpers — extracted from `tarski-data.ts` so the
+// `useApexStore` (eagerly imported by every page surface) can reference
+// the `TarskiValidationReport` type and the two pure graph transforms
+// without dragging the 891-LOC AXIOM_LIBRARY + 800-LOC validation engine
+// into the critical-path bundle. The heavy `runTarskiValidation` stays
+// in `tarski-data.ts` and is dynamic-imported at the few sites that
+// actually need to run validation.
+
+import type { CausalGraph, ProofTrace } from "./types";
+
+export interface TarskiValidationReport {
+  inconsistentEdgeIds: Set<string>;
+  restrictedNodeIds: Set<string>;
+  proofTraces: ProofTrace[];
+  totalViolations: number;
+}
+
+// Apply flags from a validation report to a graph. Returns a new graph
+// with `isInconsistent` / `isRestricted` flags set and the metadata's
+// `verificationStatus` updated accordingly.
+export function applyTarskiFlags(
+  graph: CausalGraph,
+  report: TarskiValidationReport,
+): CausalGraph {
+  const nodes = graph.nodes.map((n) => ({
+    ...n,
+    isRestricted: report.restrictedNodeIds.has(n.id),
+  }));
+
+  const edges = graph.edges.map((e) => ({
+    ...e,
+    isInconsistent: report.inconsistentEdgeIds.has(e.id),
+  }));
+
+  const inconsistentEdges = edges.filter((e) => e.isInconsistent).length;
+  const restrictedNodes = nodes.filter((n) => n.isRestricted).length;
+
+  return {
+    nodes,
+    edges,
+    metadata: {
+      ...graph.metadata,
+      inconsistentEdges,
+      restrictedNodes,
+      verificationStatus: inconsistentEdges > 0 || restrictedNodes > 0
+        ? "INCONSISTENCIES_FOUND"
+        : "VERIFIED",
+    },
+  };
+}
+
+// Reset all Tarski flags on a graph (back to RAW).
+export function clearTarskiFlags(graph: CausalGraph): CausalGraph {
+  const nodes = graph.nodes.map((n) => ({
+    ...n,
+    isRestricted: false,
+  }));
+
+  const edges = graph.edges.map((e) => ({
+    ...e,
+    isInconsistent: false,
+  }));
+
+  return {
+    nodes,
+    edges,
+    metadata: {
+      ...graph.metadata,
+      inconsistentEdges: 0,
+      restrictedNodes: 0,
+      verificationStatus: "UNVERIFIED" as const,
+    },
+  };
+}

--- a/src/stores/useApexStore.ts
+++ b/src/stores/useApexStore.ts
@@ -18,12 +18,17 @@ import type { FeedDispatchBatch } from "@/lib/feeds/providers/types";
 import type { InterdictionResult } from "@/lib/interdiction-engine";
 import type { TrialPrior } from "@/lib/trial-prior";
 import type { SystemStateSnapshot } from "@/lib/snapshots/types";
+// `applyTarskiFlags`, `clearTarskiFlags`, and the `TarskiValidationReport`
+// type live in the lightweight `tarski-flags.ts`. `runTarskiValidation`
+// stays in `tarski-data.ts` next to the 891-LOC AXIOM_LIBRARY +
+// 800-LOC validation engine and is dynamic-imported below — verified
+// mode is opt-in (user clicks the truth filter), so the heavy chunk
+// only loads once per session at the first verified-mode trigger.
 import {
-  runTarskiValidation,
   applyTarskiFlags,
   clearTarskiFlags,
   type TarskiValidationReport,
-} from "@/lib/tarski-data";
+} from "@/lib/tarski-flags";
 import { applyOmegaLiveAdjustments } from "@/lib/omega-pillar-wiring";
 import { applyCrossDomainBridges, AUTO_BRIDGE_ID_PREFIX } from "@/lib/cross-domain-bridging";
 import { resolveDomainProfile, type PillarKey } from "@/lib/domain-profiles";
@@ -120,6 +125,16 @@ async function loadGenerateTemporalData() {
 async function loadLoadRealTemporalData() {
   const mod = await import("@/lib/real-timeseries");
   return mod.loadRealTemporalData;
+}
+
+// `runTarskiValidation` (and the AXIOM_LIBRARY it depends on) live in
+// `tarski-data.ts` — ~1700 LOC total. Verified mode is opt-in (user
+// clicks the truth filter), so the chunk is dynamic-imported the first
+// time it's actually needed. Subsequent calls hit the resolved-cache
+// (ES module import caching) and are sync-fast.
+async function loadRunTarskiValidation() {
+  const mod = await import("@/lib/tarski-data");
+  return mod.runTarskiValidation;
 }
 
 // Drop pinned time-series ids that no longer exist in the graph. Returns the
@@ -481,20 +496,26 @@ export const useApexStore = create<ApexState>((set, get) => ({
   tarskiReport: null,
   enabledAxioms: new Set<string>(),
   setEnabledAxioms: (axioms) => set({ enabledAxioms: axioms }),
-  runTarskiWithAxioms: () =>
-    set((s) => {
-      // Clear previous flags first
-      const cleanGraph = clearTarskiFlags(s.graphData);
-      const profileId = resolveDomainProfile(s.selectedDomains).id;
-      const report = runTarskiValidation(
-        cleanGraph,
-        s.enabledAxioms.size > 0 ? s.enabledAxioms : undefined,
-        profileId,
-      );
-      const flaggedGraph = applyTarskiFlags(cleanGraph, report);
-      return { truthFilter: "verified" as TruthFilter, graphData: flaggedGraph, tarskiReport: report };
-    }),
-  applyFeedBatch: (batch) =>
+  runTarskiWithAxioms: () => {
+    void loadRunTarskiValidation().then((runTarskiValidation) => {
+      set((s) => {
+        // Clear previous flags first
+        const cleanGraph = clearTarskiFlags(s.graphData);
+        const profileId = resolveDomainProfile(s.selectedDomains).id;
+        const report = runTarskiValidation(
+          cleanGraph,
+          s.enabledAxioms.size > 0 ? s.enabledAxioms : undefined,
+          profileId,
+        );
+        const flaggedGraph = applyTarskiFlags(cleanGraph, report);
+        return { truthFilter: "verified" as TruthFilter, graphData: flaggedGraph, tarskiReport: report };
+      });
+    });
+  },
+  applyFeedBatch: (batch) => {
+    // Phase 1: apply feed mutation + omega adjustments synchronously. The
+    // non-verified path is complete here. Verified mode trails phase 2.
+    let needsTarskiRevalidation = false;
     set((s) => {
       const { signalKinds, updates, event, providerId } = batch;
       // Stamp the providerId onto each emitted point so cleanup later
@@ -556,8 +577,23 @@ export const useApexStore = create<ApexState>((set, get) => ({
         : null;
 
       const base: Partial<ApexState> = nextTemporal ? { temporalData: nextTemporal } : {};
-      if (s.truthFilter === "verified") {
-        const cleanGraph = clearTarskiFlags(nextGraph);
+      // ΩF pillar wiring: refresh live deltas after the feed mutation
+      // (sanctions / centrality may have shifted).
+      const adjusted = applyOmegaLiveAdjustments(nextGraph);
+      // Verified mode needs a tarski revalidation after the mutation; that
+      // step runs in phase 2 (async dynamic-import) so the tarski-data
+      // chunk doesn't ride into the eager bundle. Verified is opt-in, so
+      // the user has already triggered the load via setTruthFilter — the
+      // import call below resolves from the ES-module cache.
+      needsTarskiRevalidation = s.truthFilter === "verified";
+      return { ...base, graphData: adjusted };
+    });
+
+    if (!needsTarskiRevalidation) return;
+    void loadRunTarskiValidation().then((runTarskiValidation) => {
+      set((s) => {
+        if (s.truthFilter !== "verified") return s; // bailed mid-flight
+        const cleanGraph = clearTarskiFlags(s.graphData);
         const profileId = resolveDomainProfile(s.selectedDomains).id;
         const report = runTarskiValidation(
           cleanGraph,
@@ -565,20 +601,25 @@ export const useApexStore = create<ApexState>((set, get) => ({
           profileId,
         );
         const flaggedGraph = applyTarskiFlags(cleanGraph, report);
-        // ΩF pillar wiring: refresh live deltas after the feed mutation
-        // (sanctions / centrality may have shifted).
         const adjusted = applyOmegaLiveAdjustments(flaggedGraph);
-        return { ...base, graphData: adjusted, tarskiReport: report };
-      }
-      // Same wiring on the non-verified path so the overlay stays current
-      // whether or not Tarski validation is being recomputed.
-      const adjusted = applyOmegaLiveAdjustments(nextGraph);
-      return { ...base, graphData: adjusted };
-    }),
-  setTruthFilter: (f) =>
-    set((s) => {
-      if (f === "verified") {
-        // Dynamically run Tarski validation against the live graph
+        return { graphData: adjusted, tarskiReport: report };
+      });
+    });
+  },
+  setTruthFilter: (f) => {
+    if (f !== "verified") {
+      // Clear-flags path is sync — no AXIOM_LIBRARY needed.
+      set((s) => {
+        const cleanGraph = clearTarskiFlags(s.graphData);
+        return { truthFilter: f, graphData: cleanGraph, tarskiReport: null };
+      });
+      return;
+    }
+    // Verified path dynamic-imports the validation engine; subsequent
+    // verified-mode operations (applyFeedBatch, severEdge) hit the
+    // ES-module cache.
+    void loadRunTarskiValidation().then((runTarskiValidation) => {
+      set((s) => {
         const profileId = resolveDomainProfile(s.selectedDomains).id;
         const report = runTarskiValidation(
           s.graphData,
@@ -587,12 +628,9 @@ export const useApexStore = create<ApexState>((set, get) => ({
         );
         const flaggedGraph = applyTarskiFlags(s.graphData, report);
         return { truthFilter: f, graphData: flaggedGraph, tarskiReport: report };
-      } else {
-        // Clear all flags when switching back to RAW
-        const cleanGraph = clearTarskiFlags(s.graphData);
-        return { truthFilter: f, graphData: cleanGraph, tarskiReport: null };
-      }
-    }),
+      });
+    });
+  },
 
   // Selected node
   selectedNode: null,
@@ -611,7 +649,8 @@ export const useApexStore = create<ApexState>((set, get) => ({
   // Selected edge
   selectedEdgeId: null,
   setSelectedEdgeId: (edgeId) => set({ selectedEdgeId: edgeId }),
-  promoteAutoBridge: (edgeId) =>
+  promoteAutoBridge: (edgeId) => {
+    let needsTarskiRevalidation = false;
     set((s) => {
       const idx = s.graphData.edges.findIndex((e) => e.id === edgeId);
       if (idx === -1) return s;
@@ -632,20 +671,29 @@ export const useApexStore = create<ApexState>((set, get) => ({
       newEdges[idx] = promoted;
       const newGraph: CausalGraph = { ...s.graphData, edges: newEdges };
 
-      if (s.truthFilter !== "verified") return { graphData: newGraph };
+      needsTarskiRevalidation = s.truthFilter === "verified";
+      return { graphData: newGraph };
+    });
 
-      // VERIFIED mode: refresh the Tarski report so the previously-
-      // FLAGGED R-04 violation on this edge clears.
-      const cleanGraph = clearTarskiFlags(newGraph);
-      const profileId = resolveDomainProfile(s.selectedDomains).id;
-      const report = runTarskiValidation(
-        cleanGraph,
-        s.enabledAxioms.size > 0 ? s.enabledAxioms : undefined,
-        profileId,
-      );
-      const flaggedGraph = applyTarskiFlags(cleanGraph, report);
-      return { graphData: flaggedGraph, tarskiReport: report };
-    }),
+    if (!needsTarskiRevalidation) return;
+    // VERIFIED mode: refresh the Tarski report so the previously-
+    // FLAGGED R-04 violation on this edge clears. Dynamic-imported so
+    // the AXIOM_LIBRARY stays off the eager bundle.
+    void loadRunTarskiValidation().then((runTarskiValidation) => {
+      set((s) => {
+        if (s.truthFilter !== "verified") return s; // bailed mid-flight
+        const cleanGraph = clearTarskiFlags(s.graphData);
+        const profileId = resolveDomainProfile(s.selectedDomains).id;
+        const report = runTarskiValidation(
+          cleanGraph,
+          s.enabledAxioms.size > 0 ? s.enabledAxioms : undefined,
+          profileId,
+        );
+        const flaggedGraph = applyTarskiFlags(cleanGraph, report);
+        return { graphData: flaggedGraph, tarskiReport: report };
+      });
+    });
+  },
 
   // Multi-selection
   selectedNodes: [],


### PR DESCRIPTION
## Summary

The two largest remaining critical-path imports after rounds 2 + 3 (#444, #445):

### 1. `tarski-data` split (~1700 LOC AXIOM_LIBRARY + validation engine deferred)

- **New `src/lib/tarski-flags.ts`** (76 LOC) houses the two pure graph transforms (`applyTarskiFlags`, `clearTarskiFlags`) and the `TarskiValidationReport` type. None of these touch AXIOM_LIBRARY.
- `tarski-data.ts` re-exports these for backward compat but no longer defines them locally.
- `useApexStore` imports the lightweight trio from `tarski-flags` eagerly. `runTarskiValidation` is dynamic-imported via a new `loadRunTarskiValidation()` helper.
- **Four call sites converted:**
  - `runTarskiWithAxioms` + `setTruthFilter("verified")` — simple `void load…().then((fn) => set(…))` wrap. These are explicit user clicks; the first-load ~50-100ms delay is acceptable.
  - `applyFeedBatch` + `promoteAutoBridge` — split into two phases: sync mutation + omega adjustments first, async tarski revalidation after (gated on `s.truthFilter` still being verified at fire-time).
- **Trade-off:** verified-mode feed events show one render of un-flagged state before tarski revalidates (microtask hop only; cached after first load).

### 2. `TimeDial` lazy (1207 LOC deferred)

- Largest single static-imported component on the critical path.
- Converted to `next/dynamic` with a placeholder matching the dial's actual height (72px) + border style so the layout doesn't jump when the chunk lands.
- Dial is briefly unscrubbable (~50-100ms) but the canvas above is the user's first-paint focus.

## Net impact

~2900 LOC moved off the initial-paint bundle this round, bringing the total across rounds 2-4 to roughly 9400 LOC of deferred-or-eliminated critical-path code.

After this, the only eagerly-imported heavy components on `page.tsx` are `HeaderBar` (167), `RiskPropagationFlow` (594), `ModulePanel` (842 host + dynamic subpanels), `StructuralMetrics` (90), and `FeedbackWidget` (148). The store's remaining eager deps (`applyOmegaLiveAdjustments`, `applyCrossDomainBridges`, `resolveDomainProfile`) are hot-path — can't defer without UX cost.

## Test plan

- [x] `npx vitest run` — 1524/1524 pass
- [x] `npx tsc --noEmit` — clean across touched files
- [ ] Manual prod verification: confirm verified mode still works (TRUTH FILTER toggle); confirm time-dial still appears within ~100ms of first paint; confirm feed events still update the graph in verified mode (one render flicker is expected — feed event arrives → graph updates → microtask later tarski flags land)

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_