### PR TITLE
perf(bundle): load-time round 5 — domain-profiles fully off eager bundle

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -30,11 +30,17 @@ This is the running log for the Rendering & Perf session. Every change pushed fr
 
 A bottom-up read of the full log still works, but for a fresh session this is the fastest way to see the current state. Newest first.
 
-**2026-05-27 round (load-time round 4)**
+**2026-05-27 round (load-time round 5)**
 
 | PR | What |
 |---|---|
-| TBD | `perf(bundle)`: extract `applyTarskiFlags` + `clearTarskiFlags` + the `TarskiValidationReport` type into a new lightweight `tarski-flags.ts`; dynamic-import `runTarskiValidation` (which carries the 891-LOC AXIOM_LIBRARY + 800-LOC validation engine) inside the four store actions that need it (`runTarskiWithAxioms`, `setTruthFilter`, `applyFeedBatch`, `promoteAutoBridge`). Verified mode is opt-in — the heavy chunk only loads once per session at the first verified-mode trigger. Also lazy-loads `TimeDial` (1207 LOC) from `app/page.tsx` with a placeholder matching the dial's geometry — biggest single static-imported component finally moved off the eager bundle. |
+| TBD | `perf(bundle)`: `domain-profiles.ts` (480 LOC of three profile definitions + pillar labels + estimator configs) fully off the eager bundle. Extracted `GEOPOLITICAL_MODULES` (the four tab labels) into a new `module-tabs.ts` (~40 LOC); `HeaderBar` now imports from there directly instead of pulling the full profile data. `ModulePanel`'s `isT1DDomain` check replaced with a direct `selectedDomains.some(id => id.startsWith("t1d-"))` prefix test (functionally equivalent for that use case, no profile resolution needed). `useApexStore`'s four `resolveDomainProfile` call sites are all inside the deferred Tarski `.then()` blocks already, so the import is now co-loaded with `runTarskiValidation` via a parallel `Promise.all` in `loadTarskiHelpers()`. Net: ~480 LOC dropped from initial paint; only zero-cost `import type { PillarKey }` references remain. |
+
+**2026-05-27 round (load-time round 4) — _merged as #446_**
+
+| PR | What |
+|---|---|
+| #446 | `perf(bundle)`: extract `applyTarskiFlags` + `clearTarskiFlags` + the `TarskiValidationReport` type into a new lightweight `tarski-flags.ts`; dynamic-import `runTarskiValidation` (which carries the 891-LOC AXIOM_LIBRARY + 800-LOC validation engine) inside the four store actions that need it (`runTarskiWithAxioms`, `setTruthFilter`, `applyFeedBatch`, `promoteAutoBridge`). Verified mode is opt-in — the heavy chunk only loads once per session at the first verified-mode trigger. Also lazy-loads `TimeDial` (1207 LOC) from `app/page.tsx` with a placeholder matching the dial's geometry — biggest single static-imported component finally moved off the eager bundle. |
 
 **2026-05-27 round (load-time round 3) — _merged as #445_**
 
@@ -96,6 +102,21 @@ A bottom-up read of the full log still works, but for a fresh session this is th
 ---
 
 ## Session log
+
+### 2026-05-27 — Shipped: domain-profiles fully off eager bundle (module-tabs split + lazy resolveDomainProfile)
+
+**PR:** TBD — final cleanup pass on the store + critical-path components.
+
+**Trigger.** After round 4 (#446) the only meaningful eager dep left in `useApexStore` was `resolveDomainProfile` from `domain-profiles.ts` (480 LOC). `HeaderBar` and `ModulePanel` were also pulling the full file for tiny needs.
+
+**Fix.**
+- **`module-tabs.ts` extraction.** `HeaderBar` was importing `GEOPOLITICAL_PROFILE` from domain-profiles just to map four module-tab labels (the SPIRTES / TARSKI / PEARL / PARETO chips). Moved the 4-entry `ManifoldModule[]` array into a new `src/lib/module-tabs.ts` (~50 LOC) with no profile data. `domain-profiles.ts` re-imports the array as `GEOPOLITICAL_MODULES` so the GEOPOLITICAL_PROFILE.modules field stays in sync. HeaderBar now pulls only the lightweight constant.
+- **`ModulePanel` t1d check.** Replaced `resolveDomainProfile(selectedDomains).id === "t1d"` (which required the full profile data) with `selectedDomains.some(id => id.startsWith("t1d-"))` — functionally equivalent for the "should we mount TissueCohortView?" gate, no profile resolution needed.
+- **`useApexStore` co-load.** The store's four `resolveDomainProfile` call sites were all inside the deferred `loadRunTarskiValidation().then(...)` blocks from round 4. Replaced the standalone `loadRunTarskiValidation` helper with `loadTarskiHelpers()` that parallel-imports both `tarski-data` and `domain-profiles` via `Promise.all`. Single network round-trip, both modules cached after first verified-mode trigger. The eager `import { resolveDomainProfile }` is replaced with a zero-cost `import type { PillarKey }`.
+
+**Verification.** vitest 1524/1524 pass. tsc clean.
+
+**State after round 5.** The eager `useApexStore` import graph is now: zustand, tarski-flags (lightweight), omega-pillar-wiring (hot path), cross-domain-bridging (hot path), graph-color, and types. All the heavy modules (tarski-data, domain-profiles, temporal-data, real-timeseries, cascade-simulator, mergeGraphs, validateSnapshot, snapshots/tarski-validator) load on-demand.
 
 ### 2026-05-27 — Shipped: tarski-data 891-LOC AXIOM_LIBRARY off eager bundle + TimeDial lazy
 

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -11,12 +11,12 @@ import TextSizeToggle from "./TextSizeToggle";
 import { ModuleId } from "@/lib/types";
 import { DOMAIN_CARDS } from "@/lib/domains";
 import DomainIcon from "./DomainIcon";
-import { GEOPOLITICAL_PROFILE } from "@/lib/domain-profiles";
+import { MODULE_TABS as GEOPOLITICAL_TABS } from "@/lib/module-tabs";
 
 // Top-bar tabs are pinned to the four canonical labels regardless of active
 // domain profile. Profile-scoped vocabulary lives in the right panel / pillar
 // bars / methodology popup only.
-const MODULE_TABS = GEOPOLITICAL_PROFILE.modules.map((m) => ({
+const MODULE_TABS = GEOPOLITICAL_TABS.map((m) => ({
   id: m.id as ModuleId,
   label: m.name,
   icon: m.icon,

--- a/src/components/ModulePanel.tsx
+++ b/src/components/ModulePanel.tsx
@@ -3,7 +3,6 @@
 import { useDeferredValue, useEffect, useMemo, useState } from "react";
 import { useApexStore } from "@/stores/useApexStore";
 import { getEngineProvider } from "@/lib/engines";
-import { resolveDomainProfile } from "@/lib/domain-profiles";
 import { detectCommunities } from "@/lib/community-detection";
 import { summarizeDiscoveryUncertainty } from "@/lib/discovery-uncertainty";
 import dynamic from "next/dynamic";
@@ -93,9 +92,13 @@ export default function ModulePanel() {
   const selectedNode = useApexStore((s) => s.selectedNode);
   // Scientist-mode aware: Tissue Cohort view mounts only when a T1D
   // domain is loaded, so it doesn't pollute non-life-sciences flows.
+  // Direct prefix check rather than `resolveDomainProfile(...).id === "t1d"`
+  // so we don't pull the 480-LOC domain-profiles data into the critical-
+  // path bundle — the only thing ModulePanel needs here is "is any t1d-*
+  // domain selected?" and `t1d-` is the documented prefix for those.
   const selectedDomainsForView = useApexStore((s) => s.selectedDomains);
   const isT1DDomain = useMemo(
-    () => resolveDomainProfile(selectedDomainsForView).id === "t1d",
+    () => selectedDomainsForView.some((id) => id.startsWith("t1d-")),
     [selectedDomainsForView],
   );
   const [expandedChart, setExpandedChart] = useState<string | null>(null);

--- a/src/lib/domain-profiles.ts
+++ b/src/lib/domain-profiles.ts
@@ -8,6 +8,11 @@
 // without forking the codebase.
 
 import type { ManifoldModule } from "./types";
+// GEOPOLITICAL_MODULES used to be defined inline here; HeaderBar (on the
+// critical-path bundle) was pulling all 480 LOC of profile data just to
+// render the four tab labels. The constant now lives in `module-tabs.ts`
+// (~40 LOC) and HeaderBar imports from there directly.
+import { MODULE_TABS as GEOPOLITICAL_MODULES } from "./module-tabs";
 
 export type EstimatorId =
   // Criticality engines (graph-derived)
@@ -79,44 +84,6 @@ export interface DomainProfile {
 
 // ─── Geopolitical / financial (current default) ─────────────────────
 
-const GEOPOLITICAL_MODULES: ManifoldModule[] = [
-  {
-    id: "spirtes",
-    name: "SPIRTES",
-    subtitle: "Structure Discovery",
-    description: "Causal DAG learning from observational data",
-    icon: "\u25C7",
-    color: "var(--accent-cyan)",
-    status: "ACTIVE",
-  },
-  {
-    id: "tarski",
-    name: "TARSKI",
-    subtitle: "Truth Verification",
-    description: "Physical constraint validation \u2014 reject hallucinations",
-    icon: "\u22A2",
-    color: "var(--accent-green)",
-    status: "ACTIVE",
-  },
-  {
-    id: "pearl",
-    name: "PEARL",
-    subtitle: "Counterfactual Engine",
-    description: "do-calculus reasoning \u2014 interventional queries",
-    icon: "\u27D0",
-    color: "var(--accent-amber)",
-    status: "STANDBY",
-  },
-  {
-    id: "pareto",
-    name: "PARETO",
-    subtitle: "Criticality Warning",
-    description: "Strategic risk & \u03A9-fragility assessment",
-    icon: "\u26A0",
-    color: "var(--accent-red)",
-    status: "ALERT",
-  },
-];
 
 const GEOPOLITICAL_PILLARS: PillarLabels = {
   composite: "\u03A9-FRAGILITY",

--- a/src/lib/module-tabs.ts
+++ b/src/lib/module-tabs.ts
@@ -1,0 +1,48 @@
+import type { ManifoldModule } from "./types";
+
+// The default module tab list shown in HeaderBar. Lives in its own
+// lightweight file (~40 LOC) so `HeaderBar` — on the critical-path
+// bundle — doesn't pull the 480-LOC `domain-profiles.ts` (three full
+// profile definitions with pillar labels + detail copy + estimator
+// configs) just to render the four tab labels.
+//
+// `domain-profiles.ts` re-imports this constant so the GEOPOLITICAL
+// profile's `modules` field stays in sync.
+export const MODULE_TABS: ManifoldModule[] = [
+  {
+    id: "spirtes",
+    name: "SPIRTES",
+    subtitle: "Structure Discovery",
+    description: "Causal DAG learning from observational data",
+    icon: "◇",
+    color: "var(--accent-cyan)",
+    status: "ACTIVE",
+  },
+  {
+    id: "tarski",
+    name: "TARSKI",
+    subtitle: "Truth Verification",
+    description: "Physical constraint validation — reject hallucinations",
+    icon: "⊢",
+    color: "var(--accent-green)",
+    status: "ACTIVE",
+  },
+  {
+    id: "pearl",
+    name: "PEARL",
+    subtitle: "Counterfactual Engine",
+    description: "do-calculus reasoning — interventional queries",
+    icon: "⟐",
+    color: "var(--accent-amber)",
+    status: "STANDBY",
+  },
+  {
+    id: "pareto",
+    name: "PARETO",
+    subtitle: "Criticality Warning",
+    description: "Strategic risk & Ω-fragility assessment",
+    icon: "⚠",
+    color: "var(--accent-red)",
+    status: "ALERT",
+  },
+];

--- a/src/stores/useApexStore.ts
+++ b/src/stores/useApexStore.ts
@@ -31,7 +31,12 @@ import {
 } from "@/lib/tarski-flags";
 import { applyOmegaLiveAdjustments } from "@/lib/omega-pillar-wiring";
 import { applyCrossDomainBridges, AUTO_BRIDGE_ID_PREFIX } from "@/lib/cross-domain-bridging";
-import { resolveDomainProfile, type PillarKey } from "@/lib/domain-profiles";
+// `resolveDomainProfile` lives in `domain-profiles.ts` (480 LOC of profile
+// data: three big profile objects + pillar labels + estimator configs).
+// The store's four use sites are all inside the deferred Tarski `.then()`
+// blocks below — combine the imports so the heavy profile data only
+// loads when tarski validation is actually needed.
+import type { PillarKey } from "@/lib/domain-profiles";
 
 export interface ImportedDataset {
   id: string;
@@ -127,14 +132,20 @@ async function loadLoadRealTemporalData() {
   return mod.loadRealTemporalData;
 }
 
-// `runTarskiValidation` (and the AXIOM_LIBRARY it depends on) live in
-// `tarski-data.ts` — ~1700 LOC total. Verified mode is opt-in (user
-// clicks the truth filter), so the chunk is dynamic-imported the first
-// time it's actually needed. Subsequent calls hit the resolved-cache
-// (ES module import caching) and are sync-fast.
-async function loadRunTarskiValidation() {
-  const mod = await import("@/lib/tarski-data");
-  return mod.runTarskiValidation;
+// `runTarskiValidation` (AXIOM_LIBRARY + validation engine, ~1700 LOC)
+// and `resolveDomainProfile` (480 LOC of profile data) are both only
+// needed when the user enables verified mode. Co-load them so both
+// chunks defer until first use. Parallel `Promise.all` keeps the
+// first-load latency to a single network round-trip.
+async function loadTarskiHelpers() {
+  const [tarski, profiles] = await Promise.all([
+    import("@/lib/tarski-data"),
+    import("@/lib/domain-profiles"),
+  ]);
+  return {
+    runTarskiValidation: tarski.runTarskiValidation,
+    resolveDomainProfile: profiles.resolveDomainProfile,
+  };
 }
 
 // Drop pinned time-series ids that no longer exist in the graph. Returns the
@@ -497,7 +508,7 @@ export const useApexStore = create<ApexState>((set, get) => ({
   enabledAxioms: new Set<string>(),
   setEnabledAxioms: (axioms) => set({ enabledAxioms: axioms }),
   runTarskiWithAxioms: () => {
-    void loadRunTarskiValidation().then((runTarskiValidation) => {
+    void loadTarskiHelpers().then(({ runTarskiValidation, resolveDomainProfile }) => {
       set((s) => {
         // Clear previous flags first
         const cleanGraph = clearTarskiFlags(s.graphData);
@@ -590,7 +601,7 @@ export const useApexStore = create<ApexState>((set, get) => ({
     });
 
     if (!needsTarskiRevalidation) return;
-    void loadRunTarskiValidation().then((runTarskiValidation) => {
+    void loadTarskiHelpers().then(({ runTarskiValidation, resolveDomainProfile }) => {
       set((s) => {
         if (s.truthFilter !== "verified") return s; // bailed mid-flight
         const cleanGraph = clearTarskiFlags(s.graphData);
@@ -618,7 +629,7 @@ export const useApexStore = create<ApexState>((set, get) => ({
     // Verified path dynamic-imports the validation engine; subsequent
     // verified-mode operations (applyFeedBatch, severEdge) hit the
     // ES-module cache.
-    void loadRunTarskiValidation().then((runTarskiValidation) => {
+    void loadTarskiHelpers().then(({ runTarskiValidation, resolveDomainProfile }) => {
       set((s) => {
         const profileId = resolveDomainProfile(s.selectedDomains).id;
         const report = runTarskiValidation(
@@ -679,7 +690,7 @@ export const useApexStore = create<ApexState>((set, get) => ({
     // VERIFIED mode: refresh the Tarski report so the previously-
     // FLAGGED R-04 violation on this edge clears. Dynamic-imported so
     // the AXIOM_LIBRARY stays off the eager bundle.
-    void loadRunTarskiValidation().then((runTarskiValidation) => {
+    void loadTarskiHelpers().then(({ runTarskiValidation, resolveDomainProfile }) => {
       set((s) => {
         if (s.truthFilter !== "verified") return s; // bailed mid-flight
         const cleanGraph = clearTarskiFlags(s.graphData);


### PR DESCRIPTION
## Summary

After round 4 (#446) the only meaningful eager dep left in `useApexStore` was `resolveDomainProfile` from `domain-profiles.ts` (480 LOC of three profile definitions + pillar labels + estimator configs). `HeaderBar` and `ModulePanel` were also pulling the full file for tiny needs.

### Changes

1. **`module-tabs.ts` extracted** (~50 LOC). HeaderBar was importing `GEOPOLITICAL_PROFILE.modules` just to render the four tab labels. Moved the 4-entry `ManifoldModule[]` array into its own lightweight file. `domain-profiles.ts` re-imports it as `GEOPOLITICAL_MODULES` so the profile's `modules` field stays in sync. HeaderBar now pulls only the tiny constant.

2. **`ModulePanel` t1d check simplified.** Replaced `resolveDomainProfile(selectedDomains).id === "t1d"` (required full profile data) with `selectedDomains.some(id => id.startsWith("t1d-"))`. Functionally equivalent for the "should we mount TissueCohortView?" gate.

3. **`useApexStore` co-load.** The four `resolveDomainProfile` call sites are all inside the deferred Tarski `.then()` blocks from round 4. Combined the loader into `loadTarskiHelpers()` that parallel-imports `tarski-data` + `domain-profiles` via `Promise.all`. Single round-trip, both modules cached after first verified-mode trigger. The eager `import { resolveDomainProfile }` is replaced with a zero-cost `import type { PillarKey }`.

## State after this round

The `useApexStore` eager-import graph is now: `zustand`, `tarski-flags` (lightweight), `omega-pillar-wiring` (hot path), `cross-domain-bridging` (hot path), `graph-color`, and types. All heavy data modules load on-demand:

| Module | LOC | Trigger |
|---|---|---|
| `graph-data` | 3413 | DomainSelector / build-domain-graph (lazy) |
| `tarski-data` | 1727 | Verified-mode toggle |
| `cascade-simulator` | 446 | Replay click |
| `domain-profiles` | 480 | Verified-mode toggle (co-loaded with tarski) |
| `real-timeseries` | 426 | initTemporalData (after workspace load) |
| `temporal-data` | 334 | Same as above |
| `mergeGraphs` | 71 | ImportModal submit |
| `validateSnapshot` | 204 | SnapshotIndicator save |
| `feed registry` chain | ~38KB | hasGraph (workspace loaded) |
| `TimeSeriesOverlay` | 987 | First pin |
| `NodeInspector` | 633 | First node click |
| `NewsInterpreterPanel` | 350 | Pareto tab open |
| `TimeDial` | 1207 | ~50-100ms after first paint |

## Test plan

- [x] `npx vitest run` — 1524/1524 pass
- [x] `npx tsc --noEmit` — clean across touched files
- [ ] Manual prod verification: confirm HeaderBar tabs still render correctly; confirm T1D domain selection still triggers TissueCohortView mount; confirm verified mode still works (tarski + profile co-load)

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_