### PR TITLE
perf(bundle): load-time round 7 — DOMAIN_MAP split out of domains.ts

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -30,11 +30,17 @@ This is the running log for the Rendering & Perf session. Every change pushed fr
 
 A bottom-up read of the full log still works, but for a fresh session this is the fastest way to see the current state. Newest first.
 
-**2026-05-27 round (load-time round 6)**
+**2026-05-27 round (load-time round 7)**
 
 | PR | What |
 |---|---|
-| TBD | `perf(bundle)`: pull the 1311-LOC `node-timeseries-map.ts` + 145-LOC `generateTemporalData` synthetic generator off the eager bundle. `RiskPropagationFlow` (critical path) dynamic-loads `getNodeDataDescription` via effect+state — the 6px data-label badges briefly absent on first paint, then appear when the chunk lands. New `temporal-state-helpers.ts` (~130 LOC) houses the lightweight readers (`getNodeStateAt` / `getEdgeStateAt` / `getEventsInRange` / `getVisibleNodesAt` + types) so `useTemporalGraph` (used by RiskPropagationFlow, ModulePanel, etc.) stops transitively pulling the synthetic-data generator. `temporal-data.ts` re-exports for backward compat. |
+| TBD | `perf(bundle)`: split `DOMAIN_MAP` (~30 LOC lookup table) out of `domains.ts` (333 LOC) into a new `domain-map.ts`. `useFilteredGraph` (used by every critical-path component that renders a filtered graph view: RiskPropagationFlow, StructuralMetrics, NodeInspector, all four canvas surfaces) now imports from the lightweight file. `domains.ts` re-exports for backward compat. Net: ~300 LOC of DOMAIN_GROUPS catalog data dropped from the useFilteredGraph transitive chain. |
+
+**2026-05-27 round (load-time round 6) — _merged as #448_**
+
+| PR | What |
+|---|---|
+| #448 | `perf(bundle)`: pull the 1311-LOC `node-timeseries-map.ts` + 145-LOC `generateTemporalData` synthetic generator off the eager bundle. `RiskPropagationFlow` (critical path) dynamic-loads `getNodeDataDescription` via effect+state — the 6px data-label badges briefly absent on first paint, then appear when the chunk lands. New `temporal-state-helpers.ts` (~130 LOC) houses the lightweight readers (`getNodeStateAt` / `getEdgeStateAt` / `getEventsInRange` / `getVisibleNodesAt` + types) so `useTemporalGraph` (used by RiskPropagationFlow, ModulePanel, etc.) stops transitively pulling the synthetic-data generator. `temporal-data.ts` re-exports for backward compat. |
 
 **2026-05-27 round (load-time round 5) — _merged as #447_**
 
@@ -108,6 +114,16 @@ A bottom-up read of the full log still works, but for a fresh session this is th
 ---
 
 ## Session log
+
+### 2026-05-27 — Shipped: DOMAIN_MAP split out of domains.ts
+
+**PR:** TBD — round 7, single-file targeted win.
+
+**Trigger.** Audit after #448 showed `useFilteredGraph` (which is called from EVERY critical-path component with a filtered-graph view — RiskPropagationFlow, StructuralMetrics, NodeInspector, ModulePanel, CausalDAG2D/3D/Map/Relief) imported `DOMAIN_MAP` from `@/lib/domains` — a 333-LOC file. The hook only needs the ~30-LOC lookup table itself; the rest is `DOMAIN_GROUPS` (170 LOC of card metadata + descriptions + icon names) and the `DOMAIN_TO_CARD` reverse-lookup.
+
+**Fix.** New `src/lib/domain-map.ts` (~40 LOC) houses just the `DOMAIN_MAP` constant. `domains.ts` re-imports it and re-exports for backward compat. `useFilteredGraph` now imports from the lightweight file directly.
+
+**Verification.** vitest 1524/1524 pass. tsc clean.
 
 ### 2026-05-27 — Shipped: node-timeseries-map + synthetic generator off eager bundle
 

--- a/src/hooks/useFilteredGraph.ts
+++ b/src/hooks/useFilteredGraph.ts
@@ -2,11 +2,13 @@ import { useMemo } from "react";
 import { useApexStore } from "@/stores/useApexStore";
 import { useTemporalGraph } from "./useTemporalGraph";
 import type { CausalGraph } from "@/lib/types";
-import { DOMAIN_MAP } from "@/lib/domains";
+// DOMAIN_MAP lives in its own lightweight file so this hook (used by
+// every critical-path component with a filtered-graph view) doesn't
+// drag the full 333-LOC `domains.ts` catalog into the eager bundle.
+import { DOMAIN_MAP } from "@/lib/domain-map";
 
-// DOMAIN_MAP now lives next to DOMAIN_CARDS / DOMAIN_GROUPS in
-// `@/lib/domains`. Re-exported here so existing callers (DAGOverlay,
-// dataset tests, etc.) don't break.
+// Re-exported so existing callers (DAGOverlay, dataset tests, etc.)
+// don't break.
 export { DOMAIN_MAP };
 
 /**

--- a/src/lib/domain-map.ts
+++ b/src/lib/domain-map.ts
@@ -1,0 +1,40 @@
+// Domain-card ID → raw node.domain strings. Lives in its own file (~30
+// LOC) so `useFilteredGraph` (used by every critical-path component:
+// RiskPropagationFlow, StructuralMetrics, NodeInspector, CausalDAG2D/3D/
+// Map/Relief, etc.) doesn't transitively pull the 333-LOC `domains.ts`
+// — which carries DOMAIN_GROUPS (~170 LOC of full domain-card metadata),
+// PERSONAS / PERSONA_GROUPS, and the DOMAIN_TO_CARD reverse-lookup —
+// just to filter node sets by selected domain group.
+//
+// `domains.ts` re-imports this map so DOMAIN_TO_CARD stays in sync.
+export const DOMAIN_MAP: Record<string, string[]> = {
+  "energy-systems": ["Saudi Aramco Energy", "QatarEnergy LNG"],
+  "manufacturing": ["QAFCO Fertilizer", "Ma'aden Phosphate"],
+  "financial-contagion": ["Financial Contagion"],
+  "sovereign-risk": ["Sovereign Risk"],
+  "supply-chain": ["Supply Chain Food Security"],
+  "infrastructure": ["Undersea Cable Infrastructure"],
+  "macro-labor": ["Macro Impact: Labor, Growth & Housing"],
+  "macro-inflation": ["Macro Impact: Inflation & Policy"],
+  "defense-isr": [
+    "Drone Swarms",
+    "SATCOM",
+    "ISR Fusion",
+    "Chip Embargo",
+    "Secure Compute",
+    "Kill Chain",
+  ],
+  "frontier-science": ["Frontier Science"],
+  "t1d-beta-cell": [
+    "T1D Autoimmune",
+    "T1D β-cell Biology",
+    "T1D Metabolic",
+    "T1D Intervention",
+    "T1D Complications",
+  ],
+  "t1d-vx880": ["T1D VX-880"],
+  // AI Safety / IDS — continual-learning intrusion detection substrate
+  // from Ghauri 2025 D.Eng. dissertation. 17 nodes (3 datasets, 9 attack
+  // classes, 5 IDS components) all carry domain "AI Safety / IDS".
+  "ai-safety-ids": ["AI Safety / IDS"],
+};

--- a/src/lib/domains.ts
+++ b/src/lib/domains.ts
@@ -9,6 +9,12 @@
 // that already need them (DomainSelector, copilot-actions, etc.).
 
 import type { DomainIconName } from "@/components/DomainIcon";
+// DOMAIN_MAP lives in its own lightweight file so `useFilteredGraph`
+// (critical-path) can import the lookup without dragging the full
+// DOMAIN_GROUPS dataset. Re-exported here so existing callers keep
+// working; new code should import from `domain-map` directly.
+import { DOMAIN_MAP } from "./domain-map";
+export { DOMAIN_MAP };
 
 export interface DomainCard {
   id: string;
@@ -266,37 +272,6 @@ export const DOMAIN_CARDS = DOMAIN_GROUPS.flatMap((g) => g.domains);
  *
  * `useFilteredGraph` re-exports this so existing callers keep working.
  */
-export const DOMAIN_MAP: Record<string, string[]> = {
-  "energy-systems": ["Saudi Aramco Energy", "QatarEnergy LNG"],
-  "manufacturing": ["QAFCO Fertilizer", "Ma'aden Phosphate"],
-  "financial-contagion": ["Financial Contagion"],
-  "sovereign-risk": ["Sovereign Risk"],
-  "supply-chain": ["Supply Chain Food Security"],
-  "infrastructure": ["Undersea Cable Infrastructure"],
-  "macro-labor": ["Macro Impact: Labor, Growth & Housing"],
-  "macro-inflation": ["Macro Impact: Inflation & Policy"],
-  "defense-isr": [
-    "Drone Swarms",
-    "SATCOM",
-    "ISR Fusion",
-    "Chip Embargo",
-    "Secure Compute",
-    "Kill Chain",
-  ],
-  "frontier-science": ["Frontier Science"],
-  "t1d-beta-cell": [
-    "T1D Autoimmune",
-    "T1D β-cell Biology",
-    "T1D Metabolic",
-    "T1D Intervention",
-    "T1D Complications",
-  ],
-  "t1d-vx880": ["T1D VX-880"],
-  // AI Safety / IDS — continual-learning intrusion detection substrate
-  // from Ghauri 2025 D.Eng. dissertation. 17 nodes (3 datasets, 9 attack
-  // classes, 5 IDS components) all carry domain "AI Safety / IDS".
-  "ai-safety-ids": ["AI Safety / IDS"],
-};
 
 /**
  * Reverse lookup: raw `n.domain` string → the DomainCard whose mapped


### PR DESCRIPTION
## Summary

`useFilteredGraph` (called from every critical-path component with a filtered-graph view — RiskPropagationFlow, StructuralMetrics, NodeInspector, ModulePanel, CausalDAG2D/3D/Map/Relief) imported `DOMAIN_MAP` from `@/lib/domains` — a 333-LOC file. The hook only needs the ~30-LOC lookup table; the rest is `DOMAIN_GROUPS` (170 LOC of card metadata + descriptions + icon names) and the `DOMAIN_TO_CARD` reverse-lookup.

New `src/lib/domain-map.ts` (~40 LOC) houses just the `DOMAIN_MAP` constant. `domains.ts` re-imports it and re-exports for backward compat. `useFilteredGraph` now imports from the lightweight file directly.

Net: ~300 LOC of catalog metadata dropped from the `useFilteredGraph` transitive chain, which propagates to every critical-path graph consumer.

## Test plan

- [x] `npx vitest run` — 1524/1524 pass
- [x] `npx tsc --noEmit` — clean
- [ ] Manual prod verification: domain filtering still works (filtering the canvas to a single domain card; cross-domain bridge edges still appear/disappear correctly)

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_