### PR TITLE
perf(bundle): load-time round 8 — RiskPropagationFlow + ModulePanel lazy

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -30,11 +30,17 @@ This is the running log for the Rendering & Perf session. Every change pushed fr
 
 A bottom-up read of the full log still works, but for a fresh session this is the fastest way to see the current state. Newest first.
 
-**2026-05-27 round (load-time round 7)**
+**2026-05-27 round (load-time round 8)**
 
 | PR | What |
 |---|---|
-| TBD | `perf(bundle)`: split `DOMAIN_MAP` (~30 LOC lookup table) out of `domains.ts` (333 LOC) into a new `domain-map.ts`. `useFilteredGraph` (used by every critical-path component that renders a filtered graph view: RiskPropagationFlow, StructuralMetrics, NodeInspector, all four canvas surfaces) now imports from the lightweight file. `domains.ts` re-exports for backward compat. Net: ~300 LOC of DOMAIN_GROUPS catalog data dropped from the useFilteredGraph transitive chain. |
+| TBD | `perf(bundle)`: lazy-load `RiskPropagationFlow` (594 LOC) gated on `hasGraph` — empty workspace splash just rendered a collapsed toggle bar anyway. Lazy-load `ModulePanel` (842 LOC + DiscoveryRunsPanel 523 + community-detection 209 + discovery-uncertainty 106 + omega-engine 180 in transitive chain) with a column-shaped placeholder. After this round, the only static-imported page-level components are HeaderBar (167), StructuralMetrics (90), and FeedbackWidget (148). |
+
+**2026-05-27 round (load-time round 7) — _merged as #449_**
+
+| PR | What |
+|---|---|
+| #449 | `perf(bundle)`: split `DOMAIN_MAP` (~30 LOC lookup table) out of `domains.ts` (333 LOC) into a new `domain-map.ts`. `useFilteredGraph` (used by every critical-path component that renders a filtered graph view: RiskPropagationFlow, StructuralMetrics, NodeInspector, all four canvas surfaces) now imports from the lightweight file. `domains.ts` re-exports for backward compat. Net: ~300 LOC of DOMAIN_GROUPS catalog data dropped from the useFilteredGraph transitive chain. |
 
 **2026-05-27 round (load-time round 6) — _merged as #448_**
 
@@ -114,6 +120,20 @@ A bottom-up read of the full log still works, but for a fresh session this is th
 ---
 
 ## Session log
+
+### 2026-05-27 — Shipped: RiskPropagationFlow + ModulePanel lazy
+
+**PR:** TBD — round 8, deferring the two largest remaining eager components in `app/page.tsx`.
+
+**Trigger.** After rounds 2-7 the eager-bundle had been cut substantially, but `RiskPropagationFlow` (594 LOC + framer-motion + the entire useFilteredGraph chain) and `ModulePanel` (842 LOC + DiscoveryRunsPanel 523 + community-detection 209 + discovery-uncertainty 106 + omega-engine 180 in the transitive chain) were still static-imported. Both render their main content only after a workspace is loaded:
+- RiskPropagationFlow's risk cards strip is empty on an empty graph (the toggle bar shows but it's a collapsed-default thin row).
+- ModulePanel's right pane sits behind the DomainSelector modal during workspace selection — the user can't even see it.
+
+**Fix.** Both converted to `next/dynamic`. RiskPropagationFlow is gated on `hasGraph` in the render site (so the chunk only loads after the workspace launches). ModulePanel gets a column-shaped placeholder (320px wide, "LOADING MODULES…" header) so the layout doesn't jump when the chunk lands.
+
+**Verification.** vitest 1524/1524 pass. tsc clean.
+
+**State after round 8.** The only static-imported page-level components in `app/page.tsx` are `HeaderBar` (167), `StructuralMetrics` (90), and `FeedbackWidget` (148). Everything else is dynamic + gated on the right user trigger.
 
 ### 2026-05-27 — Shipped: DOMAIN_MAP split out of domains.ts
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,8 +6,6 @@ import { useApexStore } from "@/stores/useApexStore";
 import { protectGraphData } from "@/lib/data-protection";
 import { useFeedRegistry } from "@/hooks/useFeedRegistry";
 import HeaderBar from "@/components/HeaderBar";
-import RiskPropagationFlow from "@/components/RiskPropagationFlow";
-import ModulePanel from "@/components/ModulePanel";
 import StructuralMetrics from "@/components/StructuralMetrics";
 import FeedbackWidget from "@/components/FeedbackWidget";
 
@@ -58,6 +56,34 @@ const TimeSeriesOverlay = dynamic(
   () => import("@/components/TimeSeriesOverlay"),
   { ssr: false }
 );
+
+// RiskPropagationFlow (594 LOC + framer-motion) shows risk cards below
+// the canvas. On the empty-graph splash it just renders a collapsed
+// toggle bar with no cards — so we defer the chunk until the user has
+// loaded a workspace (`hasGraph`). The placeholder is the natural empty
+// state: nothing.
+const RiskPropagationFlow = dynamic(
+  () => import("@/components/RiskPropagationFlow"),
+  { ssr: false },
+);
+
+// ModulePanel (842 LOC + DiscoveryRunsPanel 523 + community-detection
+// 209 + discovery-uncertainty 106 + omega-engine 180 in transitive
+// chain) is the right pane. Visible on first paint but mostly empty
+// while the user is still in the DomainSelector modal — defer the
+// chunk with a placeholder matching the panel's fixed-width column.
+const ModulePanel = dynamic(() => import("@/components/ModulePanel"), {
+  ssr: false,
+  loading: () => (
+    <aside className="flex flex-col border-l border-border bg-surface h-full overflow-hidden" style={{ width: 320, minWidth: 320 }}>
+      <div className="px-4 py-3 border-b border-border bg-surface-elevated">
+        <div className="text-[10px] font-mono text-text-muted/60 animate-pulse">
+          LOADING MODULES…
+        </div>
+      </div>
+    </aside>
+  ),
+});
 
 // TimeDial is the largest single static-imported component on the
 // critical path (1207 LOC). It IS visible on first paint (timeline
@@ -160,6 +186,10 @@ const CausalDAGRelief = dynamic(() => import("@/components/CausalDAGRelief"), {
 export default function Home() {
   const viewMode = useApexStore((s) => s.viewMode);
   const hasPinnedSeries = useApexStore((s) => s.pinnedTimeSeriesNodes.length > 0);
+  // Gate to defer the 594-LOC RiskPropagationFlow chunk until a graph
+  // is loaded. Empty graph means risk cards are empty anyway — the
+  // collapsible toggle bar at the bottom would render an empty strip.
+  const hasGraph = useApexStore((s) => s.graphData.nodes.length > 0);
 
   // Live-data feed registry — single hook that polls every registered
   // provider on its declared cadence. Add a new provider in
@@ -258,8 +288,11 @@ export default function Home() {
                 what shape) is a UX decision we'll revisit separately. */}
           </div>
 
-          {/* Risk Propagation Flow */}
-          <RiskPropagationFlow />
+          {/* Risk Propagation Flow — lazy + gated on workspace load.
+              Empty graph renders no cards (just a collapsed toggle bar),
+              so deferring the chunk until hasGraph is true costs nothing
+              on first paint. */}
+          {hasGraph && <RiskPropagationFlow />}
 
           {/* Pinned time series comparison overlay — deferred until
               the user pins a series. The overlay returns null when


### PR DESCRIPTION
## Summary

The two largest remaining eager components in `app/page.tsx`, both deferred behind `hasGraph` or a placeholder:

### 1. RiskPropagationFlow lazy (594 LOC + transitive chain)

- The risk-cards strip is empty on an empty graph (just a collapsed toggle bar shows).
- Gated on `hasGraph` in the render site so the chunk only loads after the workspace launches.
- Converted to `next/dynamic` with `ssr: false`.

### 2. ModulePanel lazy (842 LOC + DiscoveryRunsPanel 523 + community-detection 209 + discovery-uncertainty 106 + omega-engine 180)

- Right pane sits behind the DomainSelector modal during workspace selection — the user can't see it on first paint.
- Column-shaped placeholder (320px wide, "LOADING MODULES…" header) prevents layout shift when the chunk lands.

## State after this round

The only static-imported page-level components in `app/page.tsx` are now:
- `HeaderBar` (167 LOC)
- `StructuralMetrics` (90 LOC)
- `FeedbackWidget` (148 LOC)

Everything else is dynamic + gated on the right user trigger (workspace loaded, view switched, panel opened, node selected, time-dial granularity changed, series pinned, etc.).

## Test plan

- [x] `npx vitest run` — 1524/1524 pass
- [x] `npx tsc --noEmit` — clean
- [ ] Manual prod verification: confirm the right pane appears within ~100-200ms of LAUNCH WORKSPACE; risk cards still appear at the bottom after launch; no visible layout jump

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_