### PR TITLE
perf(bundle): load-time round 9 — @supabase/ssr deferred from HeaderBar + FeedbackWidget

### DIFF
--- a/docs/sessions/rendering-perf.md
+++ b/docs/sessions/rendering-perf.md
@@ -30,11 +30,17 @@ This is the running log for the Rendering & Perf session. Every change pushed fr
 
 A bottom-up read of the full log still works, but for a fresh session this is the fastest way to see the current state. Newest first.
 
-**2026-05-27 round (load-time round 8)**
+**2026-05-27 round (load-time round 9)**
 
 | PR | What |
 |---|---|
-| TBD | `perf(bundle)`: lazy-load `RiskPropagationFlow` (594 LOC) gated on `hasGraph` — empty workspace splash just rendered a collapsed toggle bar anyway. Lazy-load `ModulePanel` (842 LOC + DiscoveryRunsPanel 523 + community-detection 209 + discovery-uncertainty 106 + omega-engine 180 in transitive chain) with a column-shaped placeholder. After this round, the only static-imported page-level components are HeaderBar (167), StructuralMetrics (90), and FeedbackWidget (148). |
+| TBD | `perf(bundle)`: defer the `@supabase/ssr` chunk off the eager bundle. Both `HeaderBar` and `FeedbackWidget` (the only two critical-path components that pulled `supabase/client`) now dynamic-import `createClient` inside their respective callbacks — HeaderBar's `handleSignOut` (explicit user click) and FeedbackWidget's mount-time email lookup (effect with cancellation guard). |
+
+**2026-05-27 round (load-time round 8) — _merged as #450_**
+
+| PR | What |
+|---|---|
+| #450 | `perf(bundle)`: lazy-load `RiskPropagationFlow` (594 LOC) gated on `hasGraph` — empty workspace splash just rendered a collapsed toggle bar anyway. Lazy-load `ModulePanel` (842 LOC + DiscoveryRunsPanel 523 + community-detection 209 + discovery-uncertainty 106 + omega-engine 180 in transitive chain) with a column-shaped placeholder. After this round, the only static-imported page-level components are HeaderBar (167), StructuralMetrics (90), and FeedbackWidget (148). |
 
 **2026-05-27 round (load-time round 7) — _merged as #449_**
 
@@ -120,6 +126,20 @@ A bottom-up read of the full log still works, but for a fresh session this is th
 ---
 
 ## Session log
+
+### 2026-05-27 — Shipped: @supabase/ssr deferred from HeaderBar + FeedbackWidget
+
+**PR:** TBD — round 9, deferring the supabase auth chunk.
+
+**Trigger.** After round 8, the only remaining eager critical-path components were `HeaderBar` (167 LOC) and `FeedbackWidget` (148 LOC). Both small in their own right but both eagerly pulled `@/lib/supabase/client` — which transitively imports `@supabase/ssr` (auth + cookie handling + browser/server client logic, several hundred KB unminified).
+
+**Fix.**
+- **HeaderBar.handleSignOut**: lazy-import `createClient` inside the callback. The sign-out flow is an explicit user click, so the extra microtask to dynamic-import the auth client is invisible.
+- **FeedbackWidget mount effect**: lazy-import inside the existing `useEffect`. The email-lookup that populates the feedback form's "from" field happens once after mount; the cancellation guard handles fast unmount during the dynamic import. Submit-time fetch is unchanged (uses the `/api/feedback` endpoint, no client-side auth needed there).
+
+**Verification.** vitest 1524/1524 pass. tsc clean.
+
+**Final eager critical path.** `page.tsx` static imports: `useApexStore`, `protectGraphData` (95 LOC), `useFeedRegistry` (registry lazy-loads providers inside effect), `HeaderBar` (167), `StructuralMetrics` (90), `FeedbackWidget` (148). Everything else — including the 3000-LOC graph dataset, 1700-LOC tarski-data, 1311-LOC node-timeseries-map, 1207-LOC TimeDial, 987-LOC TimeSeriesOverlay, 842-LOC ModulePanel + transitive subpanels, 633-LOC NodeInspector, 594-LOC RiskPropagationFlow, 480-LOC domain-profiles, 446-LOC cascade-simulator, ~38KB feed-registry chain, and the `@supabase/ssr` chunk — loads on-demand behind a real user gate.
 
 ### 2026-05-27 — Shipped: RiskPropagationFlow + ModulePanel lazy
 

--- a/src/components/FeedbackWidget.tsx
+++ b/src/components/FeedbackWidget.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { createClient } from "@/lib/supabase/client";
 
 const REQUEST_TYPES = [
   { value: "feedback", label: "FEEDBACK" },
@@ -19,10 +18,20 @@ export default function FeedbackWidget() {
   const [userEmail, setUserEmail] = useState<string | null>(null);
 
   useEffect(() => {
-    const supabase = createClient();
-    supabase.auth.getUser().then(({ data: { user } }) => {
-      if (user?.email) setUserEmail(user.email);
+    // Lazy-import the supabase client so the @supabase/ssr chunk stays
+    // off the eager bundle. We only need it for the email lookup on
+    // mount; the result populates the feedback form's "from" field.
+    let cancelled = false;
+    import("@/lib/supabase/client").then(({ createClient }) => {
+      if (cancelled) return;
+      const supabase = createClient();
+      supabase.auth.getUser().then(({ data: { user } }) => {
+        if (!cancelled && user?.email) setUserEmail(user.email);
+      });
     });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   async function handleSubmit(e: React.FormEvent) {

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -4,7 +4,6 @@ import { useMemo, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useApexStore } from "@/stores/useApexStore";
 import { computeOmegaState, computeDoomsdayState, computeAlertLevel } from "@/lib/omega-engine";
-import { createClient } from "@/lib/supabase/client";
 import CDOmegaMonitor from "./CDOmegaMonitor";
 import ImportButton from "./import/ImportButton";
 import TextSizeToggle from "./TextSizeToggle";
@@ -47,6 +46,11 @@ export default function HeaderBar() {
   const alertLevel = useMemo(() => computeAlertLevel(state.status, doomsday), [state.status, doomsday]);
   const router = useRouter();
   const handleSignOut = useCallback(async () => {
+    // Lazy-import supabase client so the @supabase/ssr chunk stays off
+    // the eager bundle. The only place HeaderBar uses it is this
+    // sign-out callback — an explicit user click that can afford the
+    // extra microtask.
+    const { createClient } = await import("@/lib/supabase/client");
     const supabase = createClient();
     await supabase.auth.signOut();
     router.push("/login");


### PR DESCRIPTION
## Summary

After #450 (round 8), the only remaining eager critical-path components were `HeaderBar` (167 LOC) and `FeedbackWidget` (148 LOC). Both small in their own right but both eagerly pulled `@/lib/supabase/client` — which transitively imports `@supabase/ssr` (auth + cookie handling + browser/server client logic, several hundred KB unminified).

### HeaderBar.handleSignOut

Lazy-import `createClient` inside the callback. Sign-out is an explicit user click, so the extra microtask to dynamic-import the auth client is invisible.

### FeedbackWidget mount effect

Lazy-import inside the existing `useEffect` with a cancellation guard. The email-lookup that populates the feedback form's "from" field happens once after mount; submit-time fetch goes to `/api/feedback` (no client-side auth needed), so that path is unchanged.

## Final eager critical path

`page.tsx` static imports after round 9:
- `useApexStore`
- `protectGraphData` (95 LOC, sync deep-freeze helper)
- `useFeedRegistry` (registry lazy-loaded inside effect — round 2)
- `HeaderBar` (167 LOC, supabase deferred this round)
- `StructuralMetrics` (90 LOC)
- `FeedbackWidget` (148 LOC, supabase deferred this round)

Everything else — including the 3000-LOC graph dataset, 1700-LOC tarski-data, 1311-LOC node-timeseries-map, 1207-LOC TimeDial, 987-LOC TimeSeriesOverlay, 842-LOC ModulePanel + transitive subpanels, 633-LOC NodeInspector, 594-LOC RiskPropagationFlow, 480-LOC domain-profiles, 446-LOC cascade-simulator, ~38KB feed-registry chain, and the `@supabase/ssr` chunk — loads on-demand behind a real user gate.

## Test plan

- [x] `npx vitest run` — 1524/1524 pass
- [x] `npx tsc --noEmit` — clean
- [ ] Manual prod verification: sign-out flow still works from the HeaderBar dropdown; feedback widget still pre-populates the user's email after a brief delay (one effect tick)

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_