### PR TITLE
perf: three launch-frame wins (cross-domain filter, framer-motion drop, bridge tokens)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -225,6 +225,19 @@ canvas {
   animation: edge-flow 1s linear infinite;
 }
 
+/* CDOmegaMonitor CRITICAL-state pulses. Replaced two motion.div animations
+   so the header strip doesn't drag framer-motion into the launch eager
+   chunk (CDOmegaMonitor was the only static-chain importer). */
+@keyframes omega-segment-critical {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+@keyframes omega-badge-critical {
+  0%, 100% { border-color: var(--alert-color, currentColor); }
+  50% { border-color: transparent; }
+}
+
 /* Link break cursor */
 body.scissors-cursor,
 body.scissors-cursor canvas {

--- a/src/components/CDOmegaMonitor.tsx
+++ b/src/components/CDOmegaMonitor.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { motion } from "framer-motion";
 import { OmegaState, DoomsdayState, AlertLevel, CausalGraph } from "@/lib/types";
 import { getStatusColor } from "@/lib/omega-engine";
 import { useFilteredGraph } from "@/hooks/useFilteredGraph";
@@ -187,24 +186,19 @@ export default function CDOmegaMonitor({
                 : i < segments * 0.35
                   ? "var(--accent-amber)"
                   : "var(--accent-green)";
+            const isCritical =
+              filled && derivedStatus.status === "CRITICAL";
             return (
-              <motion.div
+              <div
                 key={i}
                 className="h-4 w-[6px] rounded-[1px] hidden sm:block"
                 style={{
                   backgroundColor: filled ? segColor : "var(--border)",
                   opacity: filled ? 1 : 0.3,
+                  animation: isCritical
+                    ? "omega-segment-critical 0.5s ease-in-out infinite"
+                    : undefined,
                 }}
-                animate={
-                  filled && derivedStatus.status === "CRITICAL"
-                    ? { opacity: [1, 0.3, 1] }
-                    : {}
-                }
-                transition={
-                  derivedStatus.status === "CRITICAL"
-                    ? { duration: 0.5, repeat: Infinity }
-                    : {}
-                }
               />
             );
           })}
@@ -225,23 +219,21 @@ export default function CDOmegaMonitor({
         </div>
       </div>
 
-      {/* Status Badge — always visible */}
-      <motion.div
+      {/* Status Badge — always visible. CSS keyframe replaces a
+          framer-motion animate prop; `--alert-color` lets the keyframe
+          flash between displayColor and transparent without the JS
+          animation runtime. */}
+      <div
         className="flex items-center gap-2 rounded border px-2 lg:px-3 py-1.5 shrink-0"
         style={{
           borderColor: displayColor,
           backgroundColor: `color-mix(in srgb, ${displayColor} 8%, transparent)`,
+          ["--alert-color" as string]: displayColor,
+          animation:
+            derivedStatus.status === "CRITICAL"
+              ? "omega-badge-critical 1s ease-in-out infinite"
+              : undefined,
         }}
-        animate={
-          derivedStatus.status === "CRITICAL"
-            ? { borderColor: [displayColor, "transparent", displayColor] }
-            : {}
-        }
-        transition={
-          derivedStatus.status === "CRITICAL"
-            ? { duration: 1, repeat: Infinity }
-            : {}
-        }
       >
         <div
           className="h-2 w-2 rounded-full shrink-0"
@@ -253,7 +245,7 @@ export default function CDOmegaMonitor({
         >
           {derivedStatus.status}
         </span>
-      </motion.div>
+      </div>
 
       {/* Shock Count — hidden below sm */}
       <div className="hidden sm:flex flex-col items-center shrink-0">

--- a/src/hooks/useFilteredGraph.ts
+++ b/src/hooks/useFilteredGraph.ts
@@ -38,18 +38,25 @@ export function useFilteredGraph(): CausalGraph {
         if (mapped) mapped.forEach((d) => allowedDomains.add(d));
       }
 
-      // Always include cross-domain connectors (Geopolitical, Energy Grid)
-      // if any of their upstream/downstream domains are selected
+      // Cross-domain connector inclusion used to do `nodes.find()` twice
+      // for every edge inside a 2-iteration outer loop, i.e. O(C·E·N) per
+      // call. With ~350 nodes / ~350 edges and 13+ consumers calling this
+      // hook on first render, that landed several million ops squarely on
+      // the LAUNCH WORKSPACE frame. Build an id→domain map once and the
+      // whole block drops to O(N + C·E).
+      const domainById = new Map<string, string>();
+      for (const n of nodes) domainById.set(n.id, n.domain);
+
       const crossDomainNodes = ["Geopolitical", "Energy Grid"];
       for (const cd of crossDomainNodes) {
         if (!allowedDomains.has(cd)) {
           const hasCrossEdge = edges.some((e) => {
-            const srcNode = nodes.find((n) => n.id === e.source);
-            const tgtNode = nodes.find((n) => n.id === e.target);
-            if (!srcNode || !tgtNode) return false;
+            const srcDomain = domainById.get(e.source);
+            const tgtDomain = domainById.get(e.target);
+            if (!srcDomain || !tgtDomain) return false;
             return (
-              (srcNode.domain === cd && allowedDomains.has(tgtNode.domain)) ||
-              (tgtNode.domain === cd && allowedDomains.has(srcNode.domain))
+              (srcDomain === cd && allowedDomains.has(tgtDomain)) ||
+              (tgtDomain === cd && allowedDomains.has(srcDomain))
             );
           });
           if (hasCrossEdge) allowedDomains.add(cd);

--- a/src/lib/cross-domain-bridging.ts
+++ b/src/lib/cross-domain-bridging.ts
@@ -128,10 +128,8 @@ function labelTokens(label: string): Set<string> {
   );
 }
 
-/** Jaccard similarity between two label token sets. */
-function labelTokenJaccard(labelA: string, labelB: string): number {
-  const a = labelTokens(labelA);
-  const b = labelTokens(labelB);
+/** Jaccard similarity between two pre-tokenized label sets. */
+function tokenJaccard(a: Set<string>, b: Set<string>): number {
   if (a.size === 0 || b.size === 0) return 0;
   let intersection = 0;
   for (const t of a) if (b.has(t)) intersection += 1;
@@ -140,21 +138,31 @@ function labelTokenJaccard(labelA: string, labelB: string): number {
 }
 
 /** Combined bridge score: 0.5·category + 0.3·labelOverlap + 0.2·Ω-anchor. */
-function scoreBridge(a: CausalNode, b: CausalNode): number {
+function scoreBridge(
+  a: CausalNode,
+  b: CausalNode,
+  tokensA: Set<string>,
+  tokensB: Set<string>,
+): number {
   const cat = categoryAffinity(a.category, b.category);
-  const lbl = labelTokenJaccard(a.label, b.label);
+  const lbl = tokenJaccard(tokensA, tokensB);
   const omegaAvg = (a.omegaFragility.composite + b.omegaFragility.composite) / 2;
   const omegaWeight = Math.min(1, omegaAvg / 10);
   return 0.5 * cat + 0.3 * lbl + 0.2 * omegaWeight;
 }
 
-function rationaleFor(a: CausalNode, b: CausalNode): string {
+function rationaleFor(
+  a: CausalNode,
+  b: CausalNode,
+  tokensA: Set<string>,
+  tokensB: Set<string>,
+): string {
   const parts: string[] = [];
   if (a.category === b.category) parts.push(`same category (${a.category})`);
   else if (categoryAffinity(a.category, b.category) > 0) {
     parts.push(`related categories (${a.category}↔${b.category})`);
   }
-  if (labelTokenJaccard(a.label, b.label) > 0.2) parts.push("label overlap");
+  if (tokenJaccard(tokensA, tokensB) > 0.2) parts.push("label overlap");
   parts.push(
     `Ω ${a.omegaFragility.composite.toFixed(1)}×${b.omegaFragility.composite.toFixed(1)}`,
   );
@@ -183,6 +191,17 @@ export function proposeCrossDomainBridges(
   const nodeById = new Map<string, CausalNode>();
   for (const node of graph.nodes) nodeById.set(node.id, node);
 
+  // Pre-tokenize labels once. The (i, j, A, B) cross-product below used
+  // to re-run `label.toLowerCase().split(...)` for both endpoints on
+  // every score AND every rationale — for a 2-component / ~350-node
+  // graph each label was tokenized on the order of 175 times. Cache
+  // the token sets here and the inner loop becomes O(1) per pair for
+  // the label-overlap component of the score.
+  const tokensById = new Map<string, Set<string>>();
+  for (const node of graph.nodes) {
+    tokensById.set(node.id, labelTokens(node.label));
+  }
+
   const candidates: BridgeCandidate[] = [];
   for (let i = 0; i < components.length; i++) {
     for (let j = i + 1; j < components.length; j++) {
@@ -193,13 +212,15 @@ export function proposeCrossDomainBridges(
           const b = nodeById.get(idB);
           if (!a || !b) continue;
           if (a.domain === b.domain) continue; // not a cross-domain bridge
-          const score = scoreBridge(a, b);
+          const tokensA = tokensById.get(idA)!;
+          const tokensB = tokensById.get(idB)!;
+          const score = scoreBridge(a, b, tokensA, tokensB);
           if (score < opts.minScore) continue;
           pairScores.push({
             sourceId: a.id,
             targetId: b.id,
             score,
-            rationale: rationaleFor(a, b),
+            rationale: rationaleFor(a, b, tokensA, tokensB),
             componentA: i,
             componentB: j,
           });


### PR DESCRIPTION
Three launch-path perf wins on the perf series. All three target the LAUNCH WORKSPACE flow that users keep reporting as "freezing".

## 1. `useFilteredGraph` cross-domain inclusion — O(C·E·N) → O(N + C·E)

On the critical path of 14 consumers. When `selectedDomains` is non-empty, the cross-domain connector block did:

```ts
for each cross-domain node (×2):
  edges.some(e =>
    nodes.find(n => n.id === e.source) // O(N)
    nodes.find(n => n.id === e.target) // O(N)
    ...
  )
```

i.e. **O(C·E·N) per hook call** — ~487K ops per consumer, ~**6.3M ops in the launch frame** on the default 348-node / 350-edge workspace.

Fix: build an `id → domain` Map once, look up endpoints in O(1). ~200× cheaper per consumer; ~ConsumerCount× cheaper across the tick.

## 2. Drop `framer-motion` from the launch eager bundle

`CDOmegaMonitor` was the only static-chain importer of `framer-motion`:

```
page.tsx → HeaderBar → CDOmegaMonitor → import { motion } from "framer-motion"
```

Every other importer is already behind `next/dynamic`, so removing this one source moves the whole framer-motion package off the launch eager bundle.

Both usages were cosmetic CRITICAL-state pulses (segment opacity flicker + badge border flicker). Replaced both `motion.div` with plain `div` + CSS `animation` referencing two new keyframes in `globals.css` (`omega-segment-critical`, `omega-badge-critical`). The badge keyframe consumes the dynamic `displayColor` via a `--alert-color` CSS custom property set inline.

## 3. Cache label tokens in `proposeCrossDomainBridges`

`applyCrossDomainBridges` runs synchronously inside `setGraphData` during LAUNCH WORKSPACE whenever ≥ 2 domains produce disconnected components. The inner cross-product re-tokenized BOTH labels every comparison (and re-tokenized again inside `rationaleFor` for accepted candidates):

    for component pair (i, j):
      for idA in components[i]:
        for idB in components[j]:
          scoreBridge(a, b)        // labelTokenJaccard(a.label, b.label)
          rationaleFor(a, b)       // labelTokenJaccard AGAIN

Token sets are pure functions of the label, so on a ~350-node / 2-component graph each label was tokenized ~175 times redundantly.

Fix: precompute `tokensById: Map<string, Set<string>>` once before the loops (O(N) total tokenization). `scoreBridge` and `rationaleFor` now take the cached sets directly; `labelTokenJaccard` replaced with `tokenJaccard(a: Set, b: Set)`. All four touched functions are file-internal — no public-surface change. 20/20 existing tests pass.

## Test plan

- [ ] LAUNCH WORKSPACE with a single-domain selection — feels snappier on first paint
- [ ] LAUNCH WORKSPACE with multi-domain selection that creates ≥ 2 components — auto-bridges still propose, snappier launch
- [ ] LAUNCH WORKSPACE with all domains selected — unchanged
- [ ] Switching domains via DomainSelector — same filtered nodes/edges as before
- [ ] Cross-domain connector nodes (Geopolitical, Energy Grid) still pull in when an edge bridges them to a selected domain
- [ ] **Visual** — trigger a CRITICAL-state shock and confirm the buffer-bar segments still flicker @ 0.5s and the status badge border still flashes transparent → color @ 1s. (Not yet verified in a browser by Claude — review before merging.)
- [ ] Bundle inspection — confirm `framer-motion-*.js` is no longer in the initial-paint chunk list

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx