### PR TITLE
perf: defer APSP in CDOmegaMonitor + memoize community detection on feed ticks

### DIFF
--- a/src/components/CDOmegaMonitor.tsx
+++ b/src/components/CDOmegaMonitor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useDeferredValue, useMemo, useState } from "react";
 import { OmegaState, DoomsdayState, AlertLevel, CausalGraph } from "@/lib/types";
 import { getStatusColor } from "@/lib/omega-engine";
 import { useFilteredGraph } from "@/hooks/useFilteredGraph";
@@ -113,7 +113,16 @@ export default function CDOmegaMonitor({
 
   const avgOmega = useMemo(() => computeAvgOmega(filteredGraph), [filteredGraph]);
   const maxOmega = useMemo(() => computeMaxOmega(filteredGraph), [filteredGraph]);
-  const avgPathLen = useMemo(() => computeAvgPathLength(filteredGraph), [filteredGraph]);
+  // computeAvgPathLength does BFS from every node (APSP) — O(N·(N+E)),
+  // ~121K ops on the default ~350-node graph. It used to run
+  // synchronously on every filteredGraph reference flip, which on
+  // LAUNCH WORKSPACE landed in the same tick as the canvas mount and
+  // on feed ticks would block any concurrent input. The displayed
+  // value is just a number rounded to 1-2 decimals, so a one-frame
+  // stale read is fine. `useDeferredValue` reuses the same pattern
+  // already in StructuralMetrics for omega-bridge-density.
+  const deferredGraph = useDeferredValue(filteredGraph);
+  const avgPathLen = useMemo(() => computeAvgPathLength(deferredGraph), [deferredGraph]);
   const omegaPct = useMemo(() => (hasNodes ? (avgOmega / 10) * 100 : 100), [avgOmega, hasNodes]);
   const derivedStatus = useMemo(() => (hasNodes ? deriveStatusLabel(avgOmega) : { status: "NOMINAL", color: "var(--accent-green)" }), [avgOmega, hasNodes]);
   const derivedAlert = useMemo(() => (hasNodes ? deriveAlertColor(avgOmega) : { level: "GREEN", color: "#00e676" }), [avgOmega, hasNodes]);

--- a/src/lib/community-detection.ts
+++ b/src/lib/community-detection.ts
@@ -44,10 +44,41 @@ export interface CommunityDetectionResult {
 
 const MAX_ITERATIONS = 20;
 
+// Memoize on (edges ref, node-set fingerprint). The store's
+// `applyFeedBatch` runs through `applyOmegaLiveAdjustments` on every
+// live-feed tick, which calls detectCommunities synchronously — ~2.4M
+// ops per call on the default ~350-node graph just to rediscover that
+// the topology hasn't moved. Feed ticks rebuild the nodes array (`.map`
+// to overlay liveData) but keep the edges array reference and the
+// id set untouched, so a WeakMap on edges + a fingerprint of the
+// (length, first id, last id) of the nodes array hits across the
+// common case.
+//
+// The fingerprint distinguishes the ModulePanel scoped path
+// (`allNodes.filter(...)` → different length / endpoints) from the
+// full-graph path so a scoped call doesn't read back a cached
+// full-graph result. setGraphData replaces the edges array entirely,
+// which drops the WeakMap entry. Communities also depend on
+// `node.domain` via finalize's dominantDomain pass — feeds never
+// mutate `domain`, so a same-id-set rebuild is safe.
+function fingerprintNodes(nodes: CausalNode[]): string {
+  const n = nodes.length;
+  if (n === 0) return "0";
+  return `${n}:${nodes[0].id}:${nodes[n - 1].id}`;
+}
+
+const cache = new WeakMap<
+  CausalEdge[],
+  { fingerprint: string; result: CommunityDetectionResult }
+>();
+
 export function detectCommunities(
   nodes: CausalNode[],
   edges: CausalEdge[],
 ): CommunityDetectionResult {
+  const fingerprint = fingerprintNodes(nodes);
+  const cached = cache.get(edges);
+  if (cached && cached.fingerprint === fingerprint) return cached.result;
   if (nodes.length === 0) {
     return {
       membership: new Map(),
@@ -92,7 +123,9 @@ export function detectCommunities(
   });
 
   if (m === 0) {
-    return finalize(nodes, sortedIds, membership, edges, 0, true);
+    const empty = finalize(nodes, sortedIds, membership, edges, 0, true);
+    cache.set(edges, { fingerprint, result: empty });
+    return empty;
   }
 
   let iter = 0;
@@ -155,7 +188,9 @@ export function detectCommunities(
     }
   }
 
-  return finalize(nodes, sortedIds, membership, edges, iter, converged);
+  const result = finalize(nodes, sortedIds, membership, edges, iter, converged);
+  cache.set(edges, { fingerprint, result });
+  return result;
 }
 
 function finalize(


### PR DESCRIPTION
Two related wins focused on background work that runs **per feed tick** in addition to launch.

## 1. Defer APSP avg-path-length in `CDOmegaMonitor`

`CDOmegaMonitor` renders the CDΩ value via `computeAvgPathLength(filteredGraph)` inside a `useMemo` — BFS from every node, i.e. **all-pairs shortest paths**, O(N·(N+E)). On the ~350-node default graph that's ~**121K queue ops + Map churn**, run synchronously every time `filteredGraph`'s reference flips.

Reference flips include LAUNCH WORKSPACE (canvas-mount tick) AND every `applyFeedBatch` (every poll cycle of every live-feed provider — sustained background CPU).

Fix: `useDeferredValue` for just the APSP memo. `avgOmega` / `maxOmega` stay synchronous (O(N), cheap). Same pattern `StructuralMetrics` already uses for `omegaBridgeDensity`. Display is a number rounded to 1-2 decimals; a one-frame stale read is imperceptible.

## 2. Memoize `detectCommunities` on edges ref + node fingerprint

`applyOmegaLiveAdjustments` calls `detectCommunities` synchronously inside the store's `applyFeedBatch` action — i.e. on every live-feed tick. ~**2.4M ops** per call on the default graph (Louvain phase-1, up to 20 iterations) just to rediscover that the topology hasn't moved.

Feed ticks rebuild the `nodes` array (`.map` to overlay `liveData`) but keep the `edges` array reference and the node id-set untouched. A WeakMap keyed on `edges` ref + a cheap fingerprint of `(nodes.length, first id, last id)` hits across the entire feed-tick path.

Fingerprint design:
- Includes length so `ModulePanel`'s scoped path (`allNodes.filter(...)` → shorter array) gets its own cache slot.
- Includes endpoints so a reordered call recomputes (defensive — algorithm is sorted-id deterministic anyway).
- WeakMap on `edges` means `setGraphData` (new edges ref) drops the cache automatically.

Communities also depend on `node.domain` via `finalize`'s `dominantDomain` pass — feeds never mutate `domain`, only `liveData`, so a same-id-set rebuild is safe.

**26/26 existing tests pass** (10 `community-detection` + 16 `omega-pillar-wiring`, which exercise `applyOmegaLiveAdjustments` → `detectCommunities`).

## Test plan

- [ ] LAUNCH WORKSPACE — header bar paints immediately; CDΩ catches up within ~1 frame
- [ ] Live feed tick during interaction — no input jank traceable to CDOmegaMonitor or pillar-wiring
- [ ] Domain swap via DomainSelector — CDΩ updates within a frame, community-driven C-pillar deltas recompute correctly
- [ ] Open ModulePanel with scoped selection — community list still matches the scoped subset (not full-graph cached result)
- [ ] Verified-mode tarski revalidation after feed batch — still runs and produces the same flag set

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx