### PR TITLE
feat(pareto): cross-estimator rank badge on CriticalityCard

### DIFF
--- a/src/components/modules/ParetoPanel.tsx
+++ b/src/components/modules/ParetoPanel.tsx
@@ -28,6 +28,10 @@ import {
 } from "@/lib/pareto-relevance";
 import { bootstrapRelevanceBatch } from "@/lib/pareto-relevance-bootstrap";
 import {
+  computeRelevanceCompare,
+  type RelevanceCompareEntry,
+} from "@/lib/pareto-relevance-compare";
+import {
   buildScopedAdjacency,
   inducedEdgeCount,
 } from "@/lib/pareto-scoped-subgraph";
@@ -650,6 +654,15 @@ function ParetoPanel({
     return result;
   }, [csdData, phData, lpplsData, bocpdData, graphData.edges, graphData.nodes, scopeLabel, activeProfile, scopedNodeIds]);
 
+  // Cross-estimator comparison — per-card rank + winning/lagging dim vs
+  // siblings in the same relevance batch. Used by CriticalityCard to surface
+  // a "ranked #N of M — winning F (+0.43)" badge next to the breakdown
+  // header. Cheap O(n · 5) given n is typically 2–5 active estimators.
+  const relevanceCompareMap = useMemo(
+    () => computeRelevanceCompare(relevanceMap),
+    [relevanceMap],
+  );
+
   const paretoSectionExpanded = expandedChart === "pareto";
 
   return (
@@ -678,6 +691,12 @@ function ParetoPanel({
           confidence: number;
           /** Full F·E·G·S breakdown when the model is in the relevance batch. */
           relevance?: RelevanceBreakdown;
+          /**
+           * Cross-estimator comparison vs the rest of the batch (rank,
+           * winning/lagging dim). Present whenever `relevance` is — the two
+           * are produced from the same batch in the same render.
+           */
+          relevanceCompare?: RelevanceCompareEntry;
           timeSeries: number[];
           modelSeries: number[] | undefined;
           shortDesc: string;
@@ -691,6 +710,7 @@ function ParetoPanel({
           const meta = getEstimatorMeta(id);
           if (id === "csd") {
             const rel = relevanceMap.get("csd");
+            const cmp = relevanceCompareMap.get("csd");
             return {
               key: "csd",
               abbrev: "CSD",
@@ -700,6 +720,7 @@ function ParetoPanel({
               color: getCritColor(csdEpochs),
               confidence: rel ? rel.composite : csdData.confidence,
               relevance: rel,
+              relevanceCompare: cmp,
               timeSeries: csdData.timeSeries,
               modelSeries: csdData.observedSeries ? csdData.modelSeries : undefined,
               shortDesc: meta.shortDesc,
@@ -716,6 +737,7 @@ function ParetoPanel({
           }
           if (id === "ph") {
             const rel = relevanceMap.get("ph");
+            const cmp = relevanceCompareMap.get("ph");
             return {
               key: "ph",
               abbrev: "PH",
@@ -725,6 +747,7 @@ function ParetoPanel({
               color: getCritColor(phEpochs),
               confidence: rel ? rel.composite : phData.confidence,
               relevance: rel,
+              relevanceCompare: cmp,
               timeSeries: phData.timeSeries,
               modelSeries: phData.modelSeries,
               shortDesc: meta.shortDesc,
@@ -739,6 +762,7 @@ function ParetoPanel({
           }
           if (id === "lppls") {
             const rel = relevanceMap.get("lppls");
+            const cmp = relevanceCompareMap.get("lppls");
             return {
               key: "lppls",
               abbrev: "LPPLS",
@@ -748,6 +772,7 @@ function ParetoPanel({
               color: getCritColor(lpplsEpochs),
               confidence: rel ? rel.composite : lpplsData.confidence,
               relevance: rel,
+              relevanceCompare: cmp,
               timeSeries: lpplsData.timeSeries,
               modelSeries: lpplsData.modelSeries,
               shortDesc: meta.shortDesc,
@@ -766,6 +791,7 @@ function ParetoPanel({
           // scoped Ω trajectory — same series CSD/LPPLS use) ──────────
           if (id === "bocpd") {
             const rel = relevanceMap.get("bocpd");
+            const cmp = relevanceCompareMap.get("bocpd");
             const bocpdEpochs = Math.max(
               0,
               Math.round((1 - bocpdData.peakRecent) * 200),
@@ -779,6 +805,7 @@ function ParetoPanel({
               color: getCritColor(bocpdEpochs),
               confidence: rel ? rel.composite : bocpdData.confidence,
               relevance: rel,
+              relevanceCompare: cmp,
               timeSeries: bocpdData.timeSeries,
               modelSeries: bocpdData.modelSeries,
               shortDesc: meta.shortDesc,
@@ -1013,6 +1040,7 @@ function ParetoPanel({
               chartExpanded={paretoSectionExpanded}
               confidence={selected.confidence}
               relevance={selected.relevance}
+              relevanceCompare={selected.relevanceCompare}
               referenceLookup={
                 relevanceReference && selected.relevance
                   ? lookupRelevanceReference(
@@ -1378,6 +1406,7 @@ function CriticalityCard({
   chartExpanded,
   confidence,
   relevance,
+  relevanceCompare,
   referenceLookup,
   shortDesc,
   methodology,
@@ -1397,6 +1426,12 @@ function CriticalityCard({
   chartExpanded?: boolean;
   confidence: number;
   relevance?: RelevanceBreakdown;
+  /**
+   * Cross-estimator comparison vs the rest of the active relevance batch.
+   * Drives the "ranked #N of M — winning F (+0.43)" badge next to the
+   * RELEVANCE BREAKDOWN header. Undefined when `relevance` is undefined.
+   */
+  relevanceCompare?: RelevanceCompareEntry;
   /**
    * Per-selection F → historical event-rate lookup. Computed by the parent
    * from the active profile's pre-built reference (e.g. FRED HY OAS). Null
@@ -1652,11 +1687,64 @@ function CriticalityCard({
                 <div>
                   <button
                     onClick={() => setBreakdownOpen((v) => !v)}
-                    className="w-full flex items-center justify-between mb-1 hover:brightness-125 transition-all"
+                    className="w-full flex items-center justify-between gap-2 mb-1 hover:brightness-125 transition-all"
                   >
                     <span className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted">
                       RELEVANCE BREAKDOWN
                     </span>
+                    {/* Rank badge — answers "why is THIS estimator weighted
+                        the way it is among its siblings". Rank #1 surfaces
+                        the WINNING dim (positive delta vs sibling avg);
+                        lower ranks surface the LAGGING dim (what's holding
+                        the card back). Hidden when there's no cohort to
+                        compare against (single-estimator profile). */}
+                    {relevanceCompare && relevanceCompare.total > 1 && (() => {
+                      const isLeader = relevanceCompare.rank === 1;
+                      const isLast = relevanceCompare.rank === relevanceCompare.total;
+                      const badgeColor = isLeader
+                        ? "#00e676"
+                        : isLast
+                          ? "#ff5252"
+                          : "#ffab00";
+                      const dim = isLeader
+                        ? relevanceCompare.winningDim
+                        : relevanceCompare.laggingDim;
+                      const delta = dim ? relevanceCompare.delta[dim] : 0;
+                      const sign = delta >= 0 ? "+" : "−";
+                      const deltaFmt = Math.abs(delta).toFixed(2);
+                      const title = dim
+                        ? `Composite rank ${relevanceCompare.rank} of ${
+                            relevanceCompare.total
+                          } across active estimators · ${
+                            isLeader ? "winning on" : "lagging on"
+                          } ${dim} (this estimator: ${(
+                            relevance[dim].score
+                          ).toFixed(2)}; sibling avg: ${
+                            relevanceCompare.siblingAvg[dim].toFixed(2)
+                          })`
+                        : `Composite rank ${relevanceCompare.rank} of ${relevanceCompare.total} across active estimators`;
+                      return (
+                        <span
+                          title={title}
+                          className="flex items-center gap-1.5 px-1.5 py-[1px] rounded text-[8px] font-mono tabular-nums"
+                          style={{
+                            backgroundColor: `${badgeColor}1f`,
+                            color: badgeColor,
+                            border: `1px solid ${badgeColor}33`,
+                          }}
+                        >
+                          <span className="font-[family-name:var(--font-michroma)] tracking-wider">
+                            #{relevanceCompare.rank}/{relevanceCompare.total}
+                          </span>
+                          {dim && (
+                            <span className="opacity-90">
+                              {sign}
+                              {dim} {deltaFmt}
+                            </span>
+                          )}
+                        </span>
+                      );
+                    })()}
                     <span
                       className="text-[10px] text-text-muted transition-transform duration-200"
                       style={{ transform: breakdownOpen ? "rotate(180deg)" : "rotate(0deg)" }}

--- a/src/lib/__tests__/pareto-relevance-compare.test.ts
+++ b/src/lib/__tests__/pareto-relevance-compare.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeRelevanceCompare,
+  DIM_CODES,
+  type DimCode,
+} from "../pareto-relevance-compare";
+import type { RelevanceBreakdown, SubScore } from "../pareto-relevance";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────
+
+function sub(score: number, detail = "test"): SubScore {
+  return { score, detail };
+}
+
+function breakdown(scores: Record<DimCode, number>): RelevanceBreakdown {
+  // Composite uses the existing formula: S · G · M · (0.6·F + 0.4·E).
+  const raw =
+    scores.S *
+    scores.G *
+    scores.M *
+    (0.6 * scores.F + 0.4 * scores.E);
+  return {
+    F: sub(scores.F),
+    E: sub(scores.E),
+    G: sub(scores.G),
+    S: sub(scores.S),
+    M: sub(scores.M),
+    rawComposite: raw,
+    composite: raw,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────
+
+describe("computeRelevanceCompare", () => {
+  it("returns an empty map for an empty input", () => {
+    const out = computeRelevanceCompare(new Map());
+    expect(out.size).toBe(0);
+  });
+
+  it("ranks single-entry cohort as #1 of 1 with no winning/lagging dim", () => {
+    const map = new Map<string, RelevanceBreakdown>([
+      ["a", breakdown({ F: 0.5, E: 0.5, G: 0.5, S: 0.5, M: 0.5 })],
+    ]);
+    const out = computeRelevanceCompare(map);
+    const a = out.get("a")!;
+    expect(a.rank).toBe(1);
+    expect(a.total).toBe(1);
+    expect(a.winningDim).toBeUndefined();
+    expect(a.laggingDim).toBeUndefined();
+    // Deltas should be zero (no siblings).
+    for (const d of DIM_CODES) expect(a.delta[d]).toBe(0);
+  });
+
+  it("ranks composites descending and identifies winning/lagging dims", () => {
+    // Three estimators. A is the F-leader, C is the F-laggard.
+    const map = new Map<string, RelevanceBreakdown>([
+      ["A", breakdown({ F: 0.9, E: 0.5, G: 0.8, S: 0.8, M: 0.8 })],
+      ["B", breakdown({ F: 0.5, E: 0.5, G: 0.8, S: 0.8, M: 0.8 })],
+      ["C", breakdown({ F: 0.1, E: 0.5, G: 0.8, S: 0.8, M: 0.8 })],
+    ]);
+    const out = computeRelevanceCompare(map);
+
+    expect(out.get("A")!.rank).toBe(1);
+    expect(out.get("B")!.rank).toBe(2);
+    expect(out.get("C")!.rank).toBe(3);
+
+    // A wins on F: 0.9 vs sibling mean of (0.5+0.1)/2 = 0.3, delta +0.6.
+    expect(out.get("A")!.winningDim).toBe("F");
+    expect(out.get("A")!.delta.F).toBeCloseTo(0.6, 5);
+
+    // C lags on F: 0.1 vs sibling mean (0.9+0.5)/2 = 0.7, delta -0.6.
+    expect(out.get("C")!.laggingDim).toBe("F");
+    expect(out.get("C")!.delta.F).toBeCloseTo(-0.6, 5);
+  });
+
+  it("zeroes out M deltas when M is shared across the cohort", () => {
+    // M is a system-wide property — every estimator gets the same value
+    // from computeRelevanceBatch. Compare-helper must reflect that the M
+    // dimension can never be the deciding one.
+    const M = 0.7;
+    const map = new Map<string, RelevanceBreakdown>([
+      ["A", breakdown({ F: 0.9, E: 0.5, G: 0.6, S: 0.7, M })],
+      ["B", breakdown({ F: 0.5, E: 0.5, G: 0.6, S: 0.7, M })],
+      ["C", breakdown({ F: 0.1, E: 0.5, G: 0.6, S: 0.7, M })],
+    ]);
+    const out = computeRelevanceCompare(map);
+
+    for (const id of ["A", "B", "C"] as const) {
+      // Float-precision noise from sum-minus-self can leave a 1e-16 residual;
+      // anything below 1e-10 is numerically zero for our purposes.
+      expect(out.get(id)!.delta.M).toBeCloseTo(0, 10);
+    }
+    // A still wins on F, not M.
+    expect(out.get("A")!.winningDim).toBe("F");
+  });
+
+  it("suppresses dim labels when every delta is zero (degenerate identical cohort)", () => {
+    const same = { F: 0.5, E: 0.5, G: 0.5, S: 0.5, M: 0.5 };
+    const map = new Map<string, RelevanceBreakdown>([
+      ["A", breakdown(same)],
+      ["B", breakdown(same)],
+    ]);
+    const out = computeRelevanceCompare(map);
+    expect(out.get("A")!.winningDim).toBeUndefined();
+    expect(out.get("A")!.laggingDim).toBeUndefined();
+  });
+
+  it("breaks dim-tie deterministically by DIM_CODES order", () => {
+    // A and B identical except both F and E lead by the same delta on A.
+    // Tie-break should pick F (first in DIM_CODES).
+    const map = new Map<string, RelevanceBreakdown>([
+      ["A", breakdown({ F: 0.8, E: 0.8, G: 0.5, S: 0.5, M: 0.5 })],
+      ["B", breakdown({ F: 0.2, E: 0.2, G: 0.5, S: 0.5, M: 0.5 })],
+    ]);
+    const out = computeRelevanceCompare(map);
+    expect(out.get("A")!.winningDim).toBe("F");
+  });
+
+  it("sibling averages exclude self (so a leader doesn't drag its own average down)", () => {
+    const map = new Map<string, RelevanceBreakdown>([
+      ["A", breakdown({ F: 1.0, E: 0.5, G: 0.5, S: 0.5, M: 0.5 })],
+      ["B", breakdown({ F: 0.0, E: 0.5, G: 0.5, S: 0.5, M: 0.5 })],
+      ["C", breakdown({ F: 0.0, E: 0.5, G: 0.5, S: 0.5, M: 0.5 })],
+    ]);
+    const out = computeRelevanceCompare(map);
+    // A's siblingAvg for F should be (0+0)/2 = 0, NOT (1+0+0)/3 = 0.333.
+    expect(out.get("A")!.siblingAvg.F).toBe(0);
+    expect(out.get("A")!.delta.F).toBe(1.0);
+  });
+});

--- a/src/lib/pareto-relevance-compare.ts
+++ b/src/lib/pareto-relevance-compare.ts
@@ -1,0 +1,150 @@
+// Cross-estimator comparison helper for the relevance composite.
+//
+// Each CriticalityCard renders its own F·E·G·S·M breakdown via
+// `RelevanceBreakdown` (see pareto-relevance.ts). That answers "what does
+// this estimator's score decompose into" — but not "why is THIS estimator
+// ranked the way it is among its siblings."
+//
+// This module takes the batch `Map<estimatorId, RelevanceBreakdown>` already
+// computed in ParetoPanel and produces, per estimator:
+//
+//   - rank / total — composite-sorted position in the cohort
+//   - sibling averages per dimension — the mean over the OTHER estimators
+//     (excludes self so the comparison isn't biased)
+//   - deltas per dimension — this estimator minus the sibling average
+//   - winning / lagging dimension — the dim where this estimator is most
+//     above / below the sibling average
+//
+// The card UI then surfaces "rank #1 of 4 · winning F (+0.43)" or
+// "lagging G (−0.31)" as the inline reason-for-rank badge.
+//
+// M (Moran's I) is a system-wide property in `computeRelevanceBatch` — every
+// estimator in the cohort shares the same value, so its delta is always 0
+// and it can never be the deciding dimension. No special-case needed: the
+// argmax/argmin naturally skip it once any other dim has a non-zero delta.
+
+import type { RelevanceBreakdown } from "./pareto-relevance";
+
+export type DimCode = "F" | "E" | "G" | "S" | "M";
+
+export const DIM_CODES: readonly DimCode[] = ["F", "E", "G", "S", "M"] as const;
+
+export interface RelevanceCompareEntry {
+  /** 1-indexed rank by composite (1 = highest). Ties broken by insertion order. */
+  rank: number;
+  /** Total estimators in the cohort. */
+  total: number;
+  /** Mean score per dimension across the OTHER estimators (excludes self). */
+  siblingAvg: Record<DimCode, number>;
+  /** This estimator's score minus siblingAvg per dimension. */
+  delta: Record<DimCode, number>;
+  /**
+   * Dimension where this estimator is most above the sibling average.
+   * Undefined when total === 1 (no siblings to compare against) or when
+   * every delta is zero.
+   */
+  winningDim?: DimCode;
+  /**
+   * Dimension where this estimator is most below the sibling average.
+   * Undefined when total === 1 or every delta is zero.
+   */
+  laggingDim?: DimCode;
+}
+
+/**
+ * Build per-estimator cross-comparison entries from a relevance batch.
+ *
+ * Ranking uses `composite` (the post-EMA smoothed value) so a card's rank
+ * matches the value it displays in its headline. Sibling averages and deltas
+ * use the per-dimension `score` fields (not EMA-smoothed — there's no
+ * smoothing applied to sub-scores).
+ */
+export function computeRelevanceCompare(
+  relevanceMap: Map<string, RelevanceBreakdown>,
+): Map<string, RelevanceCompareEntry> {
+  const out = new Map<string, RelevanceCompareEntry>();
+  const total = relevanceMap.size;
+  if (total === 0) return out;
+
+  // Sort by composite desc, then stable on insertion order.
+  const ranked = [...relevanceMap.entries()].sort(
+    (a, b) => b[1].composite - a[1].composite,
+  );
+  const rankById = new Map<string, number>();
+  ranked.forEach(([id], i) => rankById.set(id, i + 1));
+
+  // Per-dim totals across the whole cohort. Sibling-avg per estimator is then
+  // (totalSum − selfScore) / (total − 1), avoiding an O(n²) pass.
+  const cohortSum: Record<DimCode, number> = { F: 0, E: 0, G: 0, S: 0, M: 0 };
+  for (const [, b] of relevanceMap) {
+    cohortSum.F += b.F.score;
+    cohortSum.E += b.E.score;
+    cohortSum.G += b.G.score;
+    cohortSum.S += b.S.score;
+    cohortSum.M += b.M.score;
+  }
+
+  for (const [id, b] of relevanceMap) {
+    const siblingCount = total - 1;
+    const siblingAvg: Record<DimCode, number> =
+      siblingCount > 0
+        ? {
+            F: (cohortSum.F - b.F.score) / siblingCount,
+            E: (cohortSum.E - b.E.score) / siblingCount,
+            G: (cohortSum.G - b.G.score) / siblingCount,
+            S: (cohortSum.S - b.S.score) / siblingCount,
+            M: (cohortSum.M - b.M.score) / siblingCount,
+          }
+        : { F: 0, E: 0, G: 0, S: 0, M: 0 };
+
+    // When there are no siblings, the comparison is undefined — emit zero
+    // deltas (rather than self − 0) so the UI doesn't render a nonsensical
+    // "+0.50" badge on a solo card.
+    const delta: Record<DimCode, number> =
+      siblingCount > 0
+        ? {
+            F: b.F.score - siblingAvg.F,
+            E: b.E.score - siblingAvg.E,
+            G: b.G.score - siblingAvg.G,
+            S: b.S.score - siblingAvg.S,
+            M: b.M.score - siblingAvg.M,
+          }
+        : { F: 0, E: 0, G: 0, S: 0, M: 0 };
+
+    let winningDim: DimCode | undefined;
+    let laggingDim: DimCode | undefined;
+    if (siblingCount > 0) {
+      // Tie-break by DIM_CODES order so the result is deterministic.
+      let bestDelta = -Infinity;
+      let worstDelta = Infinity;
+      for (const dim of DIM_CODES) {
+        if (delta[dim] > bestDelta) {
+          bestDelta = delta[dim];
+          winningDim = dim;
+        }
+        if (delta[dim] < worstDelta) {
+          worstDelta = delta[dim];
+          laggingDim = dim;
+        }
+      }
+      // If every delta is exactly 0 (e.g. all cards have identical scores —
+      // unlikely but possible in synthetic data), the dim labels carry no
+      // information. Suppress them so the UI hides the badge subtitle.
+      if (bestDelta === 0 && worstDelta === 0) {
+        winningDim = undefined;
+        laggingDim = undefined;
+      }
+    }
+
+    out.set(id, {
+      rank: rankById.get(id) ?? total,
+      total,
+      siblingAvg,
+      delta,
+      winningDim,
+      laggingDim,
+    });
+  }
+
+  return out;
+}


### PR DESCRIPTION
## Summary

The F·E·G·S·M breakdown on each Pareto criticality card has been inline-visible since #135 / #415: every row shows the per-dimension score, role weight, and a one-line detail. That answers *"what does this estimator's composite decompose into."*

It doesn't answer the next question every analyst asks: ***"why is THIS estimator ranked the way it is among its siblings right now?"***

This PR adds a small inline badge next to the **RELEVANCE BREAKDOWN** header on every card that surfaces:

- **Composite rank** within the active batch (e.g. `#1/4`)
- **The deciding dimension** + signed delta vs sibling average:
  - Rank #1 → **winning dim** with `+` sign (what makes it lead)
  - Rank N (last) → **lagging dim** with `−` sign (what's holding it back)
  - Middle ranks → **lagging dim** (same intuition: what's keeping it off the top)
- **Tier-colored chip**: green (`#1`), amber (middle), red (last) — same palette the headline confidence color uses, so a quick scan of the Pareto card stack tells the analyst who's winning and on what.

Hover surfaces the full numerics:

> *Composite rank 1 of 4 across active estimators · winning on F (this estimator: 0.85; sibling avg: 0.42)*

## How

| File | Change |
|---|---|
| `src/lib/pareto-relevance-compare.ts` (new, 150 LOC) | Pure data transform: takes the `Map<estimatorId, RelevanceBreakdown>` already produced by `bootstrapRelevanceBatch` and returns per-id `{ rank, total, siblingAvg, delta, winningDim, laggingDim }` |
| `src/lib/__tests__/pareto-relevance-compare.test.ts` (new, 131 LOC) | 7 unit tests — empty input, single-entry cohort (no badge), ranking + dim ID, M-shared suppression, identical-cohort suppression, dim-tie determinism, sibling-self-exclusion |
| `src/components/modules/ParetoPanel.tsx` | `useMemo` next to existing relevance batch; new optional `relevanceCompare` field on `ModelDescriptor` populated for csd / ph / lppls / bocpd; new optional `relevanceCompare?: RelevanceCompareEntry` prop on `CriticalityCard`; badge rendered inside the breakdown-header button |

## Design notes

- **Sibling averages exclude self.** A leader doesn't drag its own average down — the comparison reads as "this card vs the others," not "this card vs everyone including itself."
- **M (Moran's I) naturally falls out of the deciding logic.** It's a system-wide property — every estimator in a batch gets the same M value, so `delta.M ≈ 0` and the argmax/argmin can never pick it. No special-case code needed.
- **Tie-break by `DIM_CODES` order** (F, E, G, S, M) for deterministic rendering.
- **Badge hidden when there's nothing to compare.** Single-estimator profiles (`total < 2`) get no badge; degenerate identical-score cohorts get `#rank/total` only, no dim label.

## Why now

The dissertation-derived snapshot work (#289 / #318 / #433) turned each criticality model into a richly inspectable card with its own F·E·G·S·M decomposition. The next layer of intelligence is the comparison **between** cards — and the data was already in hand (every batch computes all estimators together). This is the smallest possible addition that exposes that intelligence.

## Test plan

- [x] `npx tsc --noEmit` → zero new errors on changed files (15 pre-existing in unrelated test files unchanged)
- [x] `npx next build` → clean
- [x] `npm test` → 1544/1544 pass (7 new tests on the helper)
- [ ] PR-validate workflow green
- [ ] Vercel preview eyeball:
  - Open PARETO → cycle through CSD / PH / LPPLS / BOCPD cards → each shows a green/amber/red `#N/M ±dim 0.XX` badge next to RELEVANCE BREAKDOWN
  - Hover badge → full tooltip with this-estimator vs sibling-avg numbers
  - Profile with only 1 estimator → no badge
  - Lasso a subgraph → ranks should reshuffle as G/S/M scopes change

## Backwards compat

No store / API / styling-system / test-fixture changes. New module is pure data transform; UI addition is one inline IIFE inside an existing button element. New prop is optional — cards without `relevanceCompare` render identically to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
