### PR TITLE
feat(timeseries): consolidate bottom dock into one watchlist + chart panel

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,24 +47,13 @@ const SpotlightTour = dynamic(
   { ssr: false }
 );
 
-// TimeSeriesOverlay is ~1000 LOC and renders null when no node is
-// pinned. The initial paint never has pinned series, so we defer the
-// chunk and only mount the component after the user pins something.
-// Once mounted the gate keeps it alive across unpin → repin cycles so
-// we don't pay the import cost twice.
+// ΩF Time Series dock (watchlist + comparison chart, ~1000 LOC + the
+// folded-in discovery logic). Deferred until a workspace is loaded
+// (`hasGraph`); the empty splash has nothing to chart. This single dock
+// replaces the former RiskPropagationFlow strip + pinned-overlay pair.
 const TimeSeriesOverlay = dynamic(
   () => import("@/components/TimeSeriesOverlay"),
   { ssr: false }
-);
-
-// RiskPropagationFlow (594 LOC + framer-motion) shows risk cards below
-// the canvas. On the empty-graph splash it just renders a collapsed
-// toggle bar with no cards — so we defer the chunk until the user has
-// loaded a workspace (`hasGraph`). The placeholder is the natural empty
-// state: nothing.
-const RiskPropagationFlow = dynamic(
-  () => import("@/components/RiskPropagationFlow"),
-  { ssr: false },
 );
 
 // ModulePanel (842 LOC + DiscoveryRunsPanel 523 + community-detection
@@ -185,10 +174,8 @@ const CausalDAGRelief = dynamic(() => import("@/components/CausalDAGRelief"), {
 
 export default function Home() {
   const viewMode = useApexStore((s) => s.viewMode);
-  const hasPinnedSeries = useApexStore((s) => s.pinnedTimeSeriesNodes.length > 0);
-  // Gate to defer the 594-LOC RiskPropagationFlow chunk until a graph
-  // is loaded. Empty graph means risk cards are empty anyway — the
-  // collapsible toggle bar at the bottom would render an empty strip.
+  // Gate to defer the ΩF Time Series dock chunk until a graph is loaded.
+  // An empty workspace has nothing to watch, suggest, or chart.
   const hasGraph = useApexStore((s) => s.graphData.nodes.length > 0);
 
   // Live-data feed registry — single hook that polls every registered
@@ -288,17 +275,13 @@ export default function Home() {
                 what shape) is a UX decision we'll revisit separately. */}
           </div>
 
-          {/* Risk Propagation Flow — lazy + gated on workspace load.
-              Empty graph renders no cards (just a collapsed toggle bar),
-              so deferring the chunk until hasGraph is true costs nothing
-              on first paint. */}
-          {hasGraph && <RiskPropagationFlow />}
-
-          {/* Pinned time series comparison overlay — deferred until
-              the user pins a series. The overlay returns null when
-              empty anyway, so gating on length here saves the
-              ~1000 LOC chunk on first paint. */}
-          {hasPinnedSeries && <TimeSeriesOverlay />}
+          {/* ΩF Time Series dock — consolidated watchlist + comparison
+              chart (replaces the old separate risk-card strip and the
+              pinned-comparison overlay). Gated on workspace load: the
+              empty graph has nothing to watch or chart. The left rail
+              surfaces suggestions so the panel is useful before anything
+              is pinned. */}
+          {hasGraph && <TimeSeriesOverlay />}
 
           {/* Time Dial — persistent timeline scrubber */}
           <TimeDial />

--- a/src/components/TimeSeriesOverlay.tsx
+++ b/src/components/TimeSeriesOverlay.tsx
@@ -114,6 +114,11 @@ export default function TimeSeriesOverlay() {
   const timelinePosition = useApexStore((s) => s.timelinePosition);
   const isLive = useApexStore((s) => s.isLive);
   const timelineDragging = useApexStore((s) => s.timelineDragging);
+  // Watchlist discovery inputs — the consolidated dock surfaces "suggested"
+  // series to pin (selected → live-fed → top-Ω) directly in the left rail,
+  // folding in what the old standalone risk-card row used to do.
+  const selectedNode = useApexStore((s) => s.selectedNode);
+  const selectedNodes = useApexStore((s) => s.selectedNodes);
 
   const [hoverX, setHoverX] = useState<number | null>(null);
   // X-axis zoom mode.
@@ -285,6 +290,73 @@ export default function TimeSeriesOverlay() {
       })
       .filter(Boolean) as { nodeId: string; label: string; domain: string }[];
   }, [pinnedNodes, curves, temporalData, graphData]);
+
+  // Watchlist rows for the left rail — one per pinned node, in pin order.
+  // Prefer the rich curve data (color + current value + unit); fall back to
+  // a bare label for pinned nodes that carry no plottable history yet so the
+  // user can still see and unpin them.
+  const pinnedRows = useMemo(() => {
+    const curveById = new Map(curves.map((c) => [c.nodeId, c]));
+    return pinnedNodes
+      .map((id) => {
+        const curve = curveById.get(id);
+        if (curve) {
+          return {
+            nodeId: id,
+            label: curve.label,
+            color: curve.color,
+            omega: curve.currentOmega,
+            unit: curve.sourceUnit,
+            hasData: true,
+          };
+        }
+        const node = graphData.nodes.find((n) => n.id === id);
+        if (!node) return null;
+        return {
+          nodeId: id,
+          label: node.label,
+          color: getDomainColor(node.domain),
+          omega: node.omegaFragility.composite,
+          unit: null as string | null,
+          hasData: false,
+        };
+      })
+      .filter(Boolean) as {
+      nodeId: string;
+      label: string;
+      color: string;
+      omega: number;
+      unit: string | null;
+      hasData: boolean;
+    }[];
+  }, [pinnedNodes, curves, graphData]);
+
+  // Suggested series to pin: explicit selection first, then live-fed nodes,
+  // then the highest-Ω nodes — minus anything already pinned. Capped so the
+  // rail stays scannable. This is the discovery path that used to live in
+  // the separate risk-card strip.
+  const suggestions = useMemo(() => {
+    const seen = new Set(pinnedNodes);
+    const out: { nodeId: string; label: string; color: string; omega: number }[] = [];
+    const push = (id: string) => {
+      if (seen.has(id)) return;
+      const n = graphData.nodes.find((x) => x.id === id);
+      if (!n) return;
+      seen.add(id);
+      out.push({
+        nodeId: n.id,
+        label: n.label,
+        color: getDomainColor(n.domain),
+        omega: n.omegaFragility.composite,
+      });
+    };
+    for (const id of [selectedNode, ...selectedNodes]) if (id) push(id);
+    for (const n of graphData.nodes) if (n.liveData && n.liveData.length > 0) push(n.id);
+    [...graphData.nodes]
+      .sort((a, b) => b.omegaFragility.composite - a.omegaFragility.composite)
+      .forEach((n) => push(n.id));
+    return out.slice(0, 6);
+  }, [graphData, pinnedNodes, selectedNode, selectedNodes]);
 
   // Per-curve scale: each pinned curve normalizes to its OWN min/max so
   // curves with mismatched units (Ω 0-10, %, mb/d, USD/ton, programs)
@@ -529,19 +601,133 @@ export default function TimeSeriesOverlay() {
     [plotInset],
   );
 
-  if (pinnedNodes.length === 0) return null;
+  // Render nothing only when there's genuinely nothing to show — no pinned
+  // series and no candidates to suggest (e.g. empty workspace). Page-level
+  // gating on `hasGraph` is the primary guard; this is the safety net.
+  if (pinnedRows.length === 0 && suggestions.length === 0) return null;
+
+  const hasPinned = pinnedRows.length > 0;
+  const liveCount = curves.filter((c) => c.sourceLabel?.startsWith("LIVE")).length;
 
   return (
-    <div ref={containerRef} className="border-t border-border bg-surface-elevated">
+    <div
+      ref={containerRef}
+      className="border-t border-border bg-surface-elevated flex items-stretch"
+      data-tour="risk-flow"
+    >
+      {/* LEFT: watchlist rail — pinned series + suggestions. Doubles as the
+          chart legend (each pinned row is a curve) and the discovery surface
+          (suggested rows pin with one click). Replaces the old standalone
+          risk-card strip and the chart's bottom legend chips. */}
+      <div className="w-56 flex-shrink-0 border-r border-border flex flex-col">
+        <div className="flex items-center justify-between px-3 py-1 border-b border-border">
+          <span className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-accent-cyan">
+            WATCHLIST
+          </span>
+          <div className="flex items-center gap-2">
+            {liveCount > 0 && (
+              <span className="flex items-center gap-1 text-[7px] font-mono text-accent-green">
+                <span className="w-1.5 h-1.5 rounded-full bg-accent-green animate-pulse" />
+                {liveCount} LIVE
+              </span>
+            )}
+            {hasPinned && (
+              <button
+                onClick={clearPinned}
+                className="text-[7px] font-mono text-text-muted hover:text-accent-red transition-colors"
+                title="Unpin all series"
+              >
+                CLEAR
+              </button>
+            )}
+          </div>
+        </div>
+        <div className="flex-1 overflow-y-auto px-2 py-1.5 space-y-0.5 max-h-[180px]">
+          {hasPinned && (
+            <div className="text-[7px] font-mono text-text-muted/50 px-1 pb-0.5 tracking-wider">
+              PINNED · {pinnedRows.length}
+            </div>
+          )}
+          {pinnedRows.map((row) => (
+            <button
+              key={row.nodeId}
+              onClick={() => togglePinned(row.nodeId)}
+              className="w-full flex items-center gap-2 px-1.5 py-1 rounded hover:bg-surface transition-colors group text-left"
+              title={`${row.label} — click to unpin`}
+            >
+              <span className="text-[9px] leading-none text-accent-cyan group-hover:text-accent-red transition-colors flex-shrink-0">
+                ◉
+              </span>
+              <span
+                className="w-1.5 h-1.5 rounded-full flex-shrink-0"
+                style={{ backgroundColor: row.color, opacity: row.hasData ? 1 : 0.4 }}
+              />
+              <span className="text-[9px] font-mono text-foreground truncate flex-1">
+                {row.label}
+              </span>
+              {row.hasData ? (
+                <span
+                  className="text-[9px] font-mono font-bold tabular-nums flex-shrink-0"
+                  style={{ color: getLineColor(row.omega) }}
+                >
+                  {row.omega.toFixed(1)}
+                </span>
+              ) : (
+                <span className="text-[6px] font-mono text-text-muted/40 flex-shrink-0">
+                  NO DATA
+                </span>
+              )}
+            </button>
+          ))}
+          {suggestions.length > 0 && (
+            <div className="text-[7px] font-mono text-text-muted/50 px-1 pt-1.5 pb-0.5 tracking-wider">
+              SUGGESTED
+            </div>
+          )}
+          {suggestions.map((s) => (
+            <button
+              key={s.nodeId}
+              onClick={() => togglePinned(s.nodeId)}
+              className="w-full flex items-center gap-2 px-1.5 py-1 rounded hover:bg-surface transition-colors group text-left"
+              title={`${s.label} — click to pin to chart`}
+            >
+              <span className="text-[9px] leading-none text-text-muted/50 group-hover:text-accent-cyan transition-colors flex-shrink-0">
+                ○
+              </span>
+              <span
+                className="w-1.5 h-1.5 rounded-full flex-shrink-0"
+                style={{ backgroundColor: s.color }}
+              />
+              <span className="text-[9px] font-mono text-text-muted group-hover:text-foreground transition-colors truncate flex-1">
+                {s.label}
+              </span>
+              <span
+                className="text-[9px] font-mono tabular-nums flex-shrink-0"
+                style={{ color: getLineColor(s.omega) }}
+              >
+                {s.omega.toFixed(1)}
+              </span>
+            </button>
+          ))}
+          {!hasPinned && (
+            <div className="text-[7px] font-mono text-text-muted/40 px-1 pt-1.5 leading-relaxed">
+              Click ○ to add a series, or select a node on the canvas.
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* RIGHT: header + comparison chart */}
+      <div className="flex-1 min-w-0 flex flex-col">
       {/* Header */}
       <div className="flex items-center gap-3 px-4 py-1">
-        <div className="min-w-[72px] flex-shrink-0 flex items-center justify-center">
+        <div className="hidden">
           <span className="text-[9px] font-mono text-accent-cyan">
             {"\u2261"}
           </span>
         </div>
         <span className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted flex-1">
-          {"\u03A9"}F COMPARISON — {curves.length} CURVE{curves.length !== 1 ? "S" : ""}
+          {"\u03A9"}F TIME SERIES
           {xAxisMode === "data" && (
             <span className="ml-2 text-accent-cyan/80">
               {"·"} ZOOMED {new Date(xStart).getFullYear()}{"–"}{new Date(xEnd).getFullYear()}
@@ -562,19 +748,13 @@ export default function TimeSeriesOverlay() {
             }`}
             title={
               xAxisMode === "data"
-                ? "Showing data span. Click to return to dial-aligned x-axis (matches TimeDial scrubber below)."
-                : "Some curves have history older than the dial window. Click to zoom out and show their full span (chart cursor will decouple from TimeDial)."
+                ? "Showing each series' full history. Click to snap the x-axis back to the timeline scrubber below."
+                : "Some series have history older than the timeline window. Click to zoom out and show their full span."
             }
           >
-            FIT: {xAxisMode === "data" ? "DATA" : "DIAL"}
+            {xAxisMode === "data" ? "SYNC TO TIMELINE" : "FIT TO DATA"}
           </button>
         )}
-        <button
-          onClick={clearPinned}
-          className="text-[8px] font-mono text-text-muted hover:text-accent-red transition-colors px-1.5 py-0.5 rounded border border-border hover:border-accent-red/30"
-        >
-          CLEAR ALL
-        </button>
       </div>
 
       {/* Chart area */}
@@ -591,14 +771,17 @@ export default function TimeSeriesOverlay() {
                 units share an axis without one dominating the others. */}
             <div className="min-w-[72px] flex-shrink-0 flex flex-col justify-between py-1">
               <span className="text-[7px] font-mono text-text-muted/60">100%</span>
-              {gridLines.map((v) => (
+              {/* Grid labels render top→bottom, so sort descending to read
+                  100 / 75 / 50 / 25 / 0 down the axis (previously printed
+                  in ascending order, giving the nonsensical 100/25/50/75/0). */}
+              {[...gridLines].sort((a, b) => b - a).map((v) => (
                 <span key={v} className="text-[7px] font-mono text-text-muted/60">
                   {Math.round(v * 100)}%
                 </span>
               ))}
               <span className="text-[7px] font-mono text-text-muted/60">0%</span>
               <span className="text-[6px] font-mono text-text-muted/40 tracking-wider mt-0.5">
-                NORM
+                % OF RANGE
               </span>
             </div>
 
@@ -869,8 +1052,13 @@ export default function TimeSeriesOverlay() {
             </div>
           </div>
 
-          {/* Legend */}
-          <div className="flex items-center gap-2 px-4 pb-2 flex-wrap">
+          {/* Legend retired — the left WATCHLIST rail now serves as the
+              chart legend (one row per pinned curve, with its colour swatch
+              and current value). Kept rendered-but-hidden to preserve the
+              per-curve range/sparsity tooltips without a larger refactor;
+              `false &&` strips it from the tree entirely. */}
+          {false && (
+          <div className="hidden">
             <div className="min-w-[72px] flex-shrink-0" />
             {curves.map((curve) => {
               const isSparse = curve.pointCount < SPARSE_POINT_THRESHOLD;
@@ -980,8 +1168,10 @@ export default function TimeSeriesOverlay() {
               </button>
             ))}
           </div>
+          )}
         </motion.div>
       </AnimatePresence>
+      </div>
     </div>
   );
 }

--- a/src/components/TimeSeriesOverlay.tsx
+++ b/src/components/TimeSeriesOverlay.tsx
@@ -277,19 +277,9 @@ export default function TimeSeriesOverlay() {
     }[];
   }, [pinnedNodes, temporalData, graphData]);
 
-  // Pinned nodes that have zero history entries — truly no temporal data
-  // (nodes with ≥ 1 history point are now included in curves above)
-  const noDataNodes = useMemo(() => {
-    if (!temporalData) return [];
-    const curveIds = new Set(curves.map((c) => c.nodeId));
-    return pinnedNodes
-      .filter((id) => !curveIds.has(id))
-      .map((id) => {
-        const node = graphData.nodes.find((n) => n.id === id);
-        return node ? { nodeId: id, label: node.label, domain: node.domain } : null;
-      })
-      .filter(Boolean) as { nodeId: string; label: string; domain: string }[];
-  }, [pinnedNodes, curves, temporalData, graphData]);
+  // (Pinned nodes with no plottable history are surfaced directly in the
+  // watchlist rail below via each row's `hasData: false` branch, so the
+  // old separate `noDataNodes` list is no longer needed.)
 
   // Watchlist rows for the left rail — one per pinned node, in pin order.
   // Prefer the rich curve data (color + current value + unit); fall back to
@@ -387,31 +377,6 @@ export default function TimeSeriesOverlay() {
     return scales;
   }, [curves]);
 
-  // Per-curve RAW range — used by the legend chip so it reads in the
-  // actual unit (e.g. "0.50–11.20 %" for food inflation) instead of
-  // pasting the omega-scale min/max next to the raw unit. Falls back
-  // to curveScales when a curve has no rawValue (synthetic-omega
-  // nodes, edges with derived omega histories).
-  const curveRawScales = useMemo(() => {
-    const scales = new Map<string, { min: number; max: number }>();
-    for (const curve of curves) {
-      let lo = Infinity;
-      let hi = -Infinity;
-      for (const h of curve.history) {
-        if (h.rawValue === undefined) continue;
-        if (h.rawValue < lo) lo = h.rawValue;
-        if (h.rawValue > hi) hi = h.rawValue;
-      }
-      if (!Number.isFinite(lo)) continue; // no rawValue → omit; legend will fall through
-      if (lo === hi) {
-        hi = lo + Math.max(Math.abs(lo) * 0.01, 1e-6);
-        lo = lo - Math.max(Math.abs(lo) * 0.01, 1e-6);
-      }
-      scales.set(curve.nodeId, { min: lo, max: hi });
-    }
-    return scales;
-  }, [curves]);
-
   // Compute dynamic y-axis range from actual data with padding.
   // (When normalized, the chart axis is 0..1; gridLines reflect that.)
   // Kept for the rare single-curve case where global scale is meaningful.
@@ -466,24 +431,6 @@ export default function TimeSeriesOverlay() {
     }
     return { xStart: timelineRange.start, xEnd: timelineRange.end };
   }, [xAxisMode, timelineRange, dataXBounds]);
-
-  // Per-curve count of history points that fall inside the visible x-range.
-  // Used by the legend's "OUT OF WINDOW" badge — when this is 0, the curve
-  // is rendering as a pure hold-forward line at the latest value with no
-  // intra-window detail, and the user should be told to widen the dial
-  // rather than think the data is broken. The hold-forward render itself
-  // stays correct; this is purely a UX signal.
-  const inWindowCounts = useMemo(() => {
-    const m = new Map<string, number>();
-    for (const c of curves) {
-      let n = 0;
-      for (const h of c.history) {
-        if (h.timestamp >= xStart && h.timestamp <= xEnd) n++;
-      }
-      m.set(c.nodeId, n);
-    }
-    return m;
-  }, [curves, xStart, xEnd]);
 
   // Convert data coordinates to SVG coordinates. Per-curve normalization:
   // when curveId is provided, the value is mapped to its own 0..1 range
@@ -757,7 +704,18 @@ export default function TimeSeriesOverlay() {
         )}
       </div>
 
-      {/* Chart area */}
+      {/* Chart area — show a prompt until at least one series is pinned,
+          rather than an empty grid. */}
+      {!hasPinned ? (
+        <div
+          className="flex items-center justify-center px-4"
+          style={{ minHeight: CHART_HEIGHT }}
+        >
+          <span className="text-[9px] font-mono text-text-muted/50 text-center">
+            Pin a series from the watchlist to chart it here.
+          </span>
+        </div>
+      ) : (
       <AnimatePresence initial={false}>
         <motion.div
           initial={{ height: 0, opacity: 0 }}
@@ -1052,125 +1010,9 @@ export default function TimeSeriesOverlay() {
             </div>
           </div>
 
-          {/* Legend retired — the left WATCHLIST rail now serves as the
-              chart legend (one row per pinned curve, with its colour swatch
-              and current value). Kept rendered-but-hidden to preserve the
-              per-curve range/sparsity tooltips without a larger refactor;
-              `false &&` strips it from the tree entirely. */}
-          {false && (
-          <div className="hidden">
-            <div className="min-w-[72px] flex-shrink-0" />
-            {curves.map((curve) => {
-              const isSparse = curve.pointCount < SPARSE_POINT_THRESHOLD;
-              const inWindow = inWindowCounts.get(curve.nodeId) ?? 0;
-              const outOfWindow = inWindow === 0;
-              const tooltipParts: string[] = [];
-              if (curve.sourceLabel) tooltipParts.push(`${curve.sourceLabel}${curve.sourceUnit ? ` (${curve.sourceUnit})` : ""}`);
-              tooltipParts.push(isSparse ? `${curve.pointCount} published timepoint${curve.pointCount !== 1 ? "s" : ""} — hold-forward rendering` : `${curve.pointCount} datapoints`);
-              if (outOfWindow) {
-                tooltipParts.push("⚠ no data inside the current dial window — widen the dial (1W / 1M / ZOOM OUT) to see this curve's shape");
-              }
-              tooltipParts.push("Click to remove");
-              return (
-                <button
-                  key={curve.nodeId}
-                  onClick={() => togglePinned(curve.nodeId)}
-                  className="flex items-center gap-1.5 px-2 py-0.5 rounded border border-border hover:border-accent-red/40 transition-colors group"
-                  title={tooltipParts.join(" · ")}
-                >
-                  {/* Swatch — dashed for sparse series to match the chart line style */}
-                  <span
-                    className="w-3 flex-shrink-0"
-                    style={{
-                      height: "1.5px",
-                      backgroundColor: isSparse ? "transparent" : curve.color,
-                      borderTop: isSparse ? `1.5px dashed ${curve.color}` : "none",
-                    }}
-                  />
-                  <span className="text-[8px] font-mono text-foreground group-hover:text-accent-red transition-colors truncate max-w-[100px]">
-                    {curve.label}
-                  </span>
-                  {/* Per-curve value-range chip — shows the actual unit-bearing
-                      range so the normalized 0-100% chart isn't ambiguous about
-                      what shape corresponds to what magnitude. Prefers the raw
-                      range when the curve carries underlying values (food
-                      inflation %, oil $/bbl); falls back to the omega range. */}
-                  {(() => {
-                    const rawScale = curveRawScales.get(curve.nodeId);
-                    const scale = rawScale ?? curveScales.get(curve.nodeId);
-                    if (!scale) return null;
-                    const u = rawScale ? (curve.sourceUnit ?? "") : "";
-                    const unitSep = u ? " " : "";
-                    return (
-                      <span className="text-[7px] font-mono text-text-muted/70 tabular-nums shrink-0">
-                        {formatRawValue(scale.min)}–{formatRawValue(scale.max)}{unitSep}{u}
-                      </span>
-                    );
-                  })()}
-                  {/* Sparsity badge — shown for sparse real data */}
-                  {isSparse && (
-                    <span
-                      className="text-[6px] font-[family-name:var(--font-michroma)] tracking-wide px-1 py-px rounded flex-shrink-0"
-                      style={{
-                        color: curve.color,
-                        backgroundColor: `${curve.color}18`,
-                        border: `1px solid ${curve.color}40`,
-                        opacity: 0.85,
-                      }}
-                    >
-                      {curve.pointCount === 1 ? "STATIC" : `${curve.pointCount}PT`}
-                    </span>
-                  )}
-                  {/* Out-of-window badge — zero history points fall inside
-                      the dial's visible range, so the curve is rendering as
-                      a flat hold-forward line at the latest value with no
-                      intra-window shape. Tells the user this is a cadence
-                      issue (window too tight for this signal's cadence),
-                      not broken data. Hidden in "data" x-axis mode since
-                      that mode by definition zooms to encompass all points. */}
-                  {outOfWindow && xAxisMode === "dial" && (
-                    <span
-                      className="text-[6px] font-[family-name:var(--font-michroma)] tracking-wide px-1 py-px rounded flex-shrink-0"
-                      style={{
-                        color: "var(--accent-amber, #ffb454)",
-                        backgroundColor: "rgba(255, 180, 84, 0.10)",
-                        border: "1px solid rgba(255, 180, 84, 0.40)",
-                      }}
-                      title="No data points inside the dial window — curve is hold-forward only. Widen the dial to see this signal's actual shape."
-                    >
-                      OUT OF WINDOW
-                    </span>
-                  )}
-                  <span className="text-[7px] text-text-muted group-hover:text-accent-red transition-colors">
-                    {"\u2715"}
-                  </span>
-                </button>
-              );
-            })}
-            {noDataNodes.map((nd) => (
-              <button
-                key={nd.nodeId}
-                onClick={() => togglePinned(nd.nodeId)}
-                className="flex items-center gap-1.5 px-2 py-0.5 rounded border border-border/50 hover:border-accent-red/40 transition-colors group opacity-50"
-                title={`${nd.label} — no time series data available`}
-              >
-                <span
-                  className="w-2 h-0.5 rounded-full flex-shrink-0 border border-text-muted/30"
-                  style={{ backgroundColor: "transparent" }}
-                />
-                <span className="text-[8px] font-mono text-text-muted group-hover:text-accent-red transition-colors truncate max-w-[100px]">
-                  {nd.label}
-                </span>
-                <span className="text-[6px] font-mono text-text-muted/40 ml-0.5">NO DATA</span>
-                <span className="text-[7px] text-text-muted group-hover:text-accent-red transition-colors">
-                  {"\u2715"}
-                </span>
-              </button>
-            ))}
-          </div>
-          )}
         </motion.div>
       </AnimatePresence>
+      )}
       </div>
     </div>
   );


### PR DESCRIPTION
## What & why

You flagged the bottom of the workspace as clunky / not client-usable. It was **four stacked bands**: the risk-card strip (`ΩF TIME SERIES — SELECTED NODE`), the comparison chart (`ΩF COMPARISON — N CURVES`), the TimeDial, and the stats footer. The first two both plot ΩF over time → redundant, and a trader can't tell which to use.

This consolidates the two time-series bands into **one `ΩF TIME SERIES` dock: a left WATCHLIST rail + one comparison chart.**

## The new dock

**Left rail (watchlist):**
- `PINNED` — each row is unpin toggle ◉ · colour swatch · name · current value. This row *is* the chart's legend now, so the cryptic bottom legend chips (`1SPT` / `STATIC` / raw-range captions) are gone.
- `SUGGESTED` — selected → live-fed → top-Ω candidates (minus already-pinned), one-click ○ to pin. This folds in the discovery job the old risk-card strip did, right where you pin.
- Empty-state hint when nothing's pinned.
- `LIVE` count + `CLEAR` live in the rail header.

**Right:** the existing comparison chart, plotting logic unchanged.

## Also fixed / cleaned

- **Real bug:** the chart's Y-axis labels read `100 / 25 / 50 / 75 / 0` top-to-bottom (gridLines `[0.25,0.5,0.75]` rendered ascending into a top-down column). Now sorted descending → `100 / 75 / 50 / 25 / 0`.
- **De-jargoned labels:** `ΩF COMPARISON — N CURVES` → `ΩF TIME SERIES`; `NORM` → `% OF RANGE`; `FIT: DIAL/DATA` → `FIT TO DATA` / `SYNC TO TIMELINE` with plain-language tooltips.

## Wiring

Dock now renders on `hasGraph` (was `hasPinnedSeries`); the standalone `RiskPropagationFlow` band is removed from the main workspace. `RiskPropagationFlow` itself is untouched — the `/client` sandbox route still imports it.

## 👀 Please review on the Vercel preview

This is a visual change — eyeball the preview deploy this PR generates. I built it without a live render loop, so I want your eyes on it before merge.

**Known v1 follow-ups (easy to iterate):**
- When nothing is pinned, the chart area shows an empty grid rather than a prompt.
- The retired legend block is kept rendered-but-stripped (`false &&`) to preserve its per-curve range tooltips without a bigger refactor — can remove fully next pass.
- Bundle note: the dock chunk now loads on workspace launch instead of first-pin (offset by dropping the separate RiskPropagationFlow band from the main page).

## Checks
- `tsc` clean (only pre-existing test-file errors).
- ESLint clean on both changed files (the single reported error is the pre-existing `xAxisMode` reset effect already on `main`).
- `next build` passes TS + lint locally; only fails fetching Google Fonts in the sandbox (no network) — fine on Vercel.

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_