### PR TITLE
feat(edges): edge-provenance registry — cite once, reference many

### DIFF
--- a/src/components/EdgeInspector.tsx
+++ b/src/components/EdgeInspector.tsx
@@ -7,8 +7,8 @@ import {
   EDGE_SOURCE_DESCRIPTION,
   EDGE_SOURCE_LABEL,
   hasProvenanceDetail,
-  resolveEdgeAttributeSource,
 } from "@/lib/edge-provenance";
+import { resolveEdgeSource } from "@/lib/edge-provenance-registry";
 import {
   extractAutoBridgeScore,
   bridgeStatus,
@@ -65,11 +65,18 @@ export default function EdgeInspector({
         ? "CONFOUNDED"
         : "DIRECTED";
 
-  // Resolve provenance once. Missing fields fall back to author so the
-  // analyst always sees *some* signal — silence would be a worse UX
-  // than a muted AUTHOR badge.
-  const weightSource = resolveEdgeAttributeSource(edge.weightSource);
-  const confidenceSource = resolveEdgeAttributeSource(edge.confidenceSource);
+  // Resolve provenance once. Inline source wins; else a registry ref is
+  // expanded against the edge-provenance catalog; else missing fields fall
+  // back to author so the analyst always sees *some* signal — silence would
+  // be a worse UX than a muted AUTHOR badge.
+  const weightSource = resolveEdgeSource(
+    edge.weightSource,
+    edge.weightSourceRef,
+  );
+  const confidenceSource = resolveEdgeSource(
+    edge.confidenceSource,
+    edge.confidenceSourceRef,
+  );
 
   return (
     <motion.div

--- a/src/lib/__tests__/edge-provenance-registry.test.ts
+++ b/src/lib/__tests__/edge-provenance-registry.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildProvenanceIndex,
+  resolveEdgeSourceWith,
+  validateEdgeProvenanceRefs,
+  getEdgeProvenanceEntry,
+  getEdgeProvenanceCatalog,
+  allEdgeProvenanceEntries,
+  type EdgeProvenanceEntry,
+} from "../edge-provenance-registry";
+import { DEFAULT_AUTHOR_SOURCE } from "../edge-provenance";
+import type { EdgeAttributeSource } from "../types";
+
+// Real graph datasets — used by the forward-looking guard test that asserts
+// every edge ref in shipped data resolves. Trivially passes today (no edge
+// carries a ref yet) and becomes a real typo-guard once the audit lands.
+import { MAIN_GRAPH } from "../graph-data";
+import { ATHENA_GRAPH, BRIDGE_EDGES } from "../athena-graph-data";
+import { T1D_GRAPH } from "../t1d-graph-data";
+import { VX880_GRAPH } from "../t1d-vx880-graph-data";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────
+
+const FIXTURE: Record<string, EdgeProvenanceEntry[]> = {
+  t1d: [
+    {
+      id: "fixture-dcct",
+      domain: "t1d",
+      kind: "literature",
+      citation: "Fixture DCCT citation",
+      note: "test entry",
+    },
+  ],
+  geopolitical: [
+    {
+      id: "fixture-eia",
+      domain: "geopolitical",
+      kind: "literature",
+      citation: "Fixture EIA citation",
+    },
+  ],
+};
+
+// ─── buildProvenanceIndex ───────────────────────────────────────────────
+
+describe("buildProvenanceIndex", () => {
+  it("flattens a multi-domain catalog into an id-keyed index", () => {
+    const index = buildProvenanceIndex(FIXTURE);
+    expect(index.size).toBe(2);
+    expect(index.get("fixture-dcct")?.domain).toBe("t1d");
+    expect(index.get("fixture-eia")?.domain).toBe("geopolitical");
+  });
+
+  it("throws on a duplicate id across domains", () => {
+    const dup: Record<string, EdgeProvenanceEntry[]> = {
+      a: [{ id: "collide", domain: "a", kind: "literature" }],
+      b: [{ id: "collide", domain: "b", kind: "regression" }],
+    };
+    expect(() => buildProvenanceIndex(dup)).toThrow(/Duplicate edge-provenance id "collide"/);
+  });
+
+  it("handles an empty catalog", () => {
+    const index = buildProvenanceIndex({});
+    expect(index.size).toBe(0);
+  });
+});
+
+// ─── resolveEdgeSourceWith (precedence) ─────────────────────────────────
+
+describe("resolveEdgeSourceWith", () => {
+  const index = buildProvenanceIndex(FIXTURE);
+
+  it("returns the inline source when present (inline wins over ref)", () => {
+    const inline: EdgeAttributeSource = {
+      kind: "regression",
+      rSquared: 0.82,
+    };
+    const out = resolveEdgeSourceWith(index, inline, "fixture-dcct");
+    expect(out).toBe(inline);
+    expect(out.kind).toBe("regression");
+  });
+
+  it("expands a registry ref when no inline source is given", () => {
+    const out = resolveEdgeSourceWith(index, undefined, "fixture-dcct");
+    expect(out.kind).toBe("literature");
+    expect(out.citation).toBe("Fixture DCCT citation");
+  });
+
+  it("strips the registry bookkeeping fields from the resolved source", () => {
+    const out = resolveEdgeSourceWith(index, undefined, "fixture-dcct");
+    expect("id" in out).toBe(false);
+    expect("domain" in out).toBe(false);
+  });
+
+  it("falls back to author for an unresolved ref (no throw)", () => {
+    const out = resolveEdgeSourceWith(index, undefined, "does-not-exist");
+    expect(out).toBe(DEFAULT_AUTHOR_SOURCE);
+    expect(out.kind).toBe("author");
+  });
+
+  it("falls back to author when neither inline nor ref is given", () => {
+    const out = resolveEdgeSourceWith(index, undefined, undefined);
+    expect(out.kind).toBe("author");
+  });
+});
+
+// ─── validateEdgeProvenanceRefs ─────────────────────────────────────────
+
+describe("validateEdgeProvenanceRefs", () => {
+  const index = buildProvenanceIndex(FIXTURE);
+
+  it("returns [] when every ref resolves", () => {
+    const missing = validateEdgeProvenanceRefs(
+      ["fixture-dcct", "fixture-eia", undefined],
+      index,
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it("returns the unresolved refs only", () => {
+    const missing = validateEdgeProvenanceRefs(
+      ["fixture-dcct", "typo-ref", undefined, "another-typo"],
+      index,
+    );
+    expect(missing).toEqual(["typo-ref", "another-typo"]);
+  });
+});
+
+// ─── Live registry accessors (catalog is empty until the audit) ─────────
+
+describe("live registry", () => {
+  it("is empty in the mechanism PR — undefined lookups, empty lists", () => {
+    expect(getEdgeProvenanceEntry("anything")).toBeUndefined();
+    expect(getEdgeProvenanceCatalog("t1d")).toEqual([]);
+    expect(allEdgeProvenanceEntries()).toEqual([]);
+  });
+});
+
+// ─── Forward-looking guard over real shipped graph data ─────────────────
+
+describe("real graph data ref integrity", () => {
+  it("every edge weight/confidence ref in shipped data resolves", () => {
+    const allEdges = [
+      ...MAIN_GRAPH.edges,
+      ...ATHENA_GRAPH.edges,
+      ...BRIDGE_EDGES,
+      ...T1D_GRAPH.edges,
+      ...VX880_GRAPH.edges,
+    ];
+    const refs = allEdges.flatMap((e) => [
+      e.weightSourceRef,
+      e.confidenceSourceRef,
+    ]);
+    // Passes trivially today (no edge carries a ref). Becomes a real guard
+    // as the per-domain audit tags edges — a typo'd ref fails here.
+    expect(validateEdgeProvenanceRefs(refs)).toEqual([]);
+  });
+});

--- a/src/lib/edge-provenance-registry.ts
+++ b/src/lib/edge-provenance-registry.ts
@@ -1,0 +1,180 @@
+/**
+ * Edge-provenance registry — a per-domain catalog of reusable, named
+ * `EdgeAttributeSource` entries.
+ *
+ * Before this module, the only way to attach provenance to an edge was to
+ * type an inline `EdgeAttributeSource` object on `edge.weightSource` /
+ * `edge.confidenceSource` in the domain graph-data files. That works, but
+ * the per-domain audit (T1D → DCCT/NEJM, geopolitical-energy → IEA/EIA)
+ * would re-type the same citation across dozens of edges — no single source
+ * of truth, and a typo in one copy silently diverges from the others.
+ *
+ * The registry fixes that: a citation is authored ONCE as a catalog entry
+ * with a stable `id`, and edges reference it via `weightSourceRef` /
+ * `confidenceSourceRef`. The resolver expands the ref at read time.
+ *
+ * Resolution precedence (see `resolveEdgeSource`):
+ *   1. inline `weightSource` object        — author override, wins
+ *   2. `weightSourceRef` → catalog entry   — the registry path
+ *   3. `{kind:"author"}` backfill          — nothing recorded
+ *
+ * The catalog is intentionally EMPTY in the PR that introduces this
+ * mechanism. The per-domain audit populates `CATALOGS` (and tags edges with
+ * refs) as a follow-up — no change to this module's logic is required for
+ * that, only data. Keeping the two PRs separate keeps the mechanism review
+ * clean and avoids shipping any unverified citation as part of the plumbing.
+ *
+ * Convention matches `criticality-registry.ts` (static const dict + pure
+ * accessors) rather than a runtime `register()` call, so the full catalog is
+ * statically analysable and tree-shakes predictably.
+ */
+
+import type { EdgeAttributeSource } from "@/lib/types";
+import { DEFAULT_AUTHOR_SOURCE } from "@/lib/edge-provenance";
+
+/**
+ * A catalog entry: an `EdgeAttributeSource` plus the registry bookkeeping
+ * fields (`id`, `domain`). The extra fields are stripped before the source
+ * is handed to the display layer so `id`/`domain` never leak into the UI.
+ */
+export interface EdgeProvenanceEntry extends EdgeAttributeSource {
+  /** Stable id referenced from CausalEdge.weightSourceRef / confidenceSourceRef. */
+  id: string;
+  /**
+   * Owning domain (e.g. "t1d", "geopolitical", "finance"). Organizational
+   * only — resolution is by global `id`, so a ref doesn't need to know which
+   * domain it came from. Use "shared" for cross-domain sources.
+   */
+  domain: string;
+}
+
+/**
+ * The catalog, grouped by domain for authoring clarity. EMPTY until the
+ * per-domain provenance audit populates it. Example shape (for the audit
+ * PR — not live data):
+ *
+ *   t1d: [
+ *     {
+ *       id: "dcct-1993",
+ *       domain: "t1d",
+ *       kind: "literature",
+ *       citation: "DCCT Research Group, N Engl J Med 1993;329:977-986",
+ *       note: "Intensive glycemic control vs complications — landmark RCT",
+ *     },
+ *   ],
+ */
+const CATALOGS: Record<string, EdgeProvenanceEntry[]> = {};
+
+/**
+ * Build an id → entry index from a catalog map. Pure — separated from the
+ * live index so tests can exercise it with fixtures.
+ *
+ * Throws on a duplicate id across the whole catalog: ids are the global
+ * resolution key, so a collision would make resolution order-dependent and
+ * silently shadow one citation with another. Better to fail loudly at module
+ * load (and in the audit author's test run) than to mis-attribute an edge.
+ */
+export function buildProvenanceIndex(
+  catalogs: Record<string, EdgeProvenanceEntry[]>,
+): Map<string, EdgeProvenanceEntry> {
+  const index = new Map<string, EdgeProvenanceEntry>();
+  for (const [domain, entries] of Object.entries(catalogs)) {
+    for (const entry of entries) {
+      if (index.has(entry.id)) {
+        const existing = index.get(entry.id)!;
+        throw new Error(
+          `Duplicate edge-provenance id "${entry.id}" (in domain "${domain}"; ` +
+            `already registered under domain "${existing.domain}"). ` +
+            `Provenance ids must be globally unique.`,
+        );
+      }
+      index.set(entry.id, entry);
+    }
+  }
+  return index;
+}
+
+/** Live index, built once at module load from the static catalog. */
+const INDEX: Map<string, EdgeProvenanceEntry> = buildProvenanceIndex(CATALOGS);
+
+/** Look up a catalog entry by id. Undefined if the id isn't registered. */
+export function getEdgeProvenanceEntry(
+  id: string,
+): EdgeProvenanceEntry | undefined {
+  return INDEX.get(id);
+}
+
+/** All entries for one domain, in authoring order. Empty array if none. */
+export function getEdgeProvenanceCatalog(
+  domain: string,
+): readonly EdgeProvenanceEntry[] {
+  return CATALOGS[domain] ?? [];
+}
+
+/** Every registered entry across all domains. */
+export function allEdgeProvenanceEntries(): readonly EdgeProvenanceEntry[] {
+  return [...INDEX.values()];
+}
+
+/**
+ * Strip the registry-only bookkeeping fields, leaving a plain
+ * `EdgeAttributeSource` suitable for the display layer.
+ */
+function toAttributeSource(entry: EdgeProvenanceEntry): EdgeAttributeSource {
+  const { id: _id, domain: _domain, ...source } = entry;
+  void _id;
+  void _domain;
+  return source;
+}
+
+/**
+ * Resolve an (inline, ref) pair against a given index. Pure — the bound
+ * `resolveEdgeSource` below uses the live index; tests inject fixtures.
+ *
+ * Precedence: inline object > registry ref > author backfill. A ref that
+ * doesn't resolve falls through to the backfill rather than throwing — a
+ * stale ref on an edge should degrade to "AUTHOR / not validated", not crash
+ * the inspector. (`validateEdgeProvenanceRefs` is the loud guard for catching
+ * stale refs in a test, where failing fast is the right call.)
+ */
+export function resolveEdgeSourceWith(
+  index: Map<string, EdgeProvenanceEntry>,
+  inline: EdgeAttributeSource | undefined,
+  ref: string | undefined,
+): EdgeAttributeSource {
+  if (inline) return inline;
+  if (ref) {
+    const entry = index.get(ref);
+    if (entry) return toAttributeSource(entry);
+  }
+  return DEFAULT_AUTHOR_SOURCE;
+}
+
+/**
+ * Resolve an edge attribute's provenance against the live registry. This is
+ * the call EdgeInspector (and any future provenance surface) makes.
+ */
+export function resolveEdgeSource(
+  inline: EdgeAttributeSource | undefined,
+  ref: string | undefined,
+): EdgeAttributeSource {
+  return resolveEdgeSourceWith(INDEX, inline, ref);
+}
+
+/**
+ * Return the subset of refs in `refs` that don't resolve against a given
+ * index. Intended for a test that scans the real graph data once the audit
+ * tags edges with refs — an unresolved ref is almost always a typo. Returns
+ * `[]` when everything resolves (the current state: no edge carries a ref
+ * yet, so this trivially passes and becomes a real guard as the audit lands).
+ */
+export function validateEdgeProvenanceRefs(
+  refs: ReadonlyArray<string | undefined>,
+  index: Map<string, EdgeProvenanceEntry> = INDEX,
+): string[] {
+  const missing: string[] = [];
+  for (const ref of refs) {
+    if (ref && !index.has(ref)) missing.push(ref);
+  }
+  return missing;
+}

--- a/src/lib/edge-provenance.ts
+++ b/src/lib/edge-provenance.ts
@@ -20,6 +20,13 @@
  * patches, Saudi energy → literature point estimates) happens in
  * follow-up PRs that just *populate* the new fields — no code change in
  * this module is required for that.
+ *
+ * Citations that recur across many edges live in the edge-provenance
+ * *registry* (src/lib/edge-provenance-registry.ts): authored once as a
+ * named catalog entry and referenced from edges by id, instead of re-typed
+ * inline. That module builds on this one's `DEFAULT_AUTHOR_SOURCE` for its
+ * backfill, and `resolveEdgeSource` there supersedes the inline-only
+ * `resolveEdgeAttributeSource` below for callers that also accept refs.
  */
 
 import type {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -352,6 +352,16 @@ export interface CausalEdge {
   weightSource?: EdgeAttributeSource;
   /** Where the `confidence` value came from. Same semantics as weightSource. */
   confidenceSource?: EdgeAttributeSource;
+  /**
+   * Registry reference for weight provenance — the id of an entry in the
+   * edge-provenance registry (src/lib/edge-provenance-registry.ts). Lets a
+   * single citation (e.g. "dcct-1993") be authored once and referenced from
+   * many edges instead of re-typed inline on each. Resolved at read time;
+   * an inline `weightSource` takes precedence over the ref if both are set.
+   */
+  weightSourceRef?: string;
+  /** Registry reference for confidence provenance. Same semantics as weightSourceRef. */
+  confidenceSourceRef?: string;
 }
 
 export interface GraphMetadata {


### PR DESCRIPTION
## Summary

Today the only way to attach provenance to an edge is an inline `EdgeAttributeSource` object on `edge.weightSource` / `edge.confidenceSource` in the domain graph-data files. That works for one-offs, but the planned **per-domain provenance audit** (T1D → DCCT/NEJM, geopolitical-energy → IEA/EIA) would re-type the same citation across dozens of edges — no single source of truth, and a typo in one copy silently diverges from the rest.

This PR adds a **registry** so a citation is authored **once** as a named catalog entry with a stable id, and edges reference it by id. The resolver expands the ref at read time. It's the mechanism that makes the audit *"register sources, tag edges"* instead of *"copy-paste a citation onto every edge."*

## Resolution precedence

```
1. inline edge.weightSource object   → author override, wins
2. edge.weightSourceRef → catalog    → the registry path
3. {kind:"author"} backfill          → nothing recorded
```

A stale/unknown ref degrades to the muted AUTHOR badge rather than throwing — the inspector never crashes on bad data. (`validateEdgeProvenanceRefs` is the loud guard for catching typos in a test, where failing fast is correct.)

## Why the catalog is empty here

This PR ships the **plumbing only** — `CATALOGS` is intentionally empty. The citations land in the per-domain audit follow-up. Keeping them apart keeps this review clean and, per the project's "real data only" rule, avoids shipping any unverified citation as part of the mechanism. The registry is proven end-to-end by tests against fixtures.

## Files

| File | Change |
|---|---|
| `src/lib/edge-provenance-registry.ts` (new, 180 LOC) | `EdgeProvenanceEntry`, empty `CATALOGS`, pure `buildProvenanceIndex` (dup-id guard), `resolveEdgeSource` / `resolveEdgeSourceWith`, `validateEdgeProvenanceRefs`, `get`/`getCatalog`/`all` accessors |
| `src/lib/__tests__/edge-provenance-registry.test.ts` (new, 158 LOC) | 12 tests — see below |
| `src/lib/types.ts` | `CausalEdge` gains optional `weightSourceRef` / `confidenceSourceRef` |
| `src/components/EdgeInspector.tsx` | resolves via `resolveEdgeSource(inline, ref)` instead of inline-only `resolveEdgeAttributeSource` |
| `src/lib/edge-provenance.ts` | header comment points at the registry as the recurring-citation mechanism |

## Design notes

- **Global id resolution, domain grouping.** Refs resolve by global `id`; `domain` is organizational (groups entries for authoring + the audit). So an edge ref doesn't need to know which domain a citation came from.
- **Duplicate-id guard at module load.** Ids are the resolution key — a collision would make resolution order-dependent and silently shadow one citation with another. `buildProvenanceIndex` throws on dup, so the audit author finds out at test time, not in production.
- **Bookkeeping stripped before display.** The resolved value handed to EdgeInspector is a plain `EdgeAttributeSource`; `id`/`domain` never leak into the UI.
- **Matches `criticality-registry.ts` convention** — static const dict + pure accessors, not a runtime `register()` call. Statically analysable, tree-shakes predictably.
- **Fully back-compat.** Inline source still wins; no existing edge changes behaviour; both new type fields are optional.

## Test plan

- [x] `npx tsc --noEmit` → zero new errors on changed files (15 pre-existing in unrelated test files unchanged)
- [x] `npx next build` → clean
- [x] `npm test` → 1556/1556 pass (12 new)
- [x] Forward-looking guard scans every edge in real shipped graph data (MAIN / ATHENA / BRIDGE / T1D / VX880) and asserts all refs resolve — passes trivially now, becomes a real typo-guard as the audit lands
- [ ] PR-validate workflow green

## What this unblocks

The per-domain provenance audit (next PR): populate `CATALOGS` with real, verifiable citations per domain and tag edges with `weightSourceRef` / `confidenceSourceRef`. No further change to this module is needed — only data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
