### PR TITLE
perf(canvases): defer + topology-gate chiStar across all five consumers

### DIFF
--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { createContext, useCallback, useContext, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import ReactFlow, {
   Node,
   Edge,
@@ -873,6 +873,11 @@ function CausalDAG2DInner() {
     () => graphSignature(graphData.nodes, graphData.edges),
     [graphData.nodes, graphData.edges],
   );
+  // Deferred topology fingerprint for the chiStar memo below (round 16).
+  // Switches the chiStar memo from `[graphData]` (re-fires on every feed
+  // tick) to a topology-stable key, AND lets the launch commit paint
+  // before the ~120K-op Brandes pass lands.
+  const deferredSig = useDeferredValue(sig);
   // Layout + network-metrics both come from the layout Web Worker
   // (`requestLayout2D`). Both used to be synchronous useMemos that
   // ran d3-force-2d + Brandes' centrality on the main thread, which
@@ -1090,8 +1095,10 @@ function CausalDAG2DInner() {
   // χ★ result on the live filtered graph. Powers (a) the violet halo
   // behind χ★ edges in EmphasizedEdge below, and (b) the per-edge
   // BES + bridge-vs-top-k context surfaced by the EdgeInspector.
-  // Brandes' BES is O(V·E); memoised on graphData so it runs only
-  // when the graph changes, not on selection / hover.
+  // Brandes' BES is O(V·E). Keyed on `deferredSig` (round 16): a
+  // topology-stable fingerprint so feed-tick liveData mutations don't
+  // re-run the pass, AND deferred so the launch commit paints before
+  // the bridge/chi-star tier styling lands.
   const chiStarInfo = useMemo(() => {
     if (graphData.edges.length === 0) {
       return {
@@ -1114,7 +1121,8 @@ function CausalDAG2DInner() {
       bes: r.bes,
       rank,
     };
-  }, [graphData]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deferredSig]);
 
   // Edges carry only structural / replay / truth-filter state. Hover and
   // single-select emphasis are computed inside `EmphasizedEdge` itself, so

--- a/src/components/CausalDAG3D.tsx
+++ b/src/components/CausalDAG3D.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import { Canvas, useThree, useFrame } from "@react-three/fiber";
 import { OrbitControls } from "@react-three/drei";
 import * as THREE from "three";
@@ -690,6 +690,18 @@ export default function CausalDAG3D() {
   // Memoised on topologyKey so it only recomputes when the graph
   // structure actually changes — Brandes' BES is O(V·E) and
   // re-running every render would be wasteful.
+  // Defer the chi-star computation behind topologyKey. chiStar runs a full
+  // Brandes' edge-betweenness pass (O(V·E)) — ~120K queue/Map ops on the
+  // default ~350-node / ~350-edge graph — and used to run synchronously in
+  // the same React commit as the canvas mount on LAUNCH WORKSPACE. The
+  // result only drives visual edge-tier styling (bridge / chi-star /
+  // regular), so a one-frame lag where new edges briefly render at the
+  // default tier before popping into bridge styling is imperceptible. By
+  // keying the memo on `deferredTopologyKey` instead of `topologyKey`, the
+  // commit that introduces a new topology paints first with the prior
+  // chiStarInfo, then a follow-up commit lands with the recomputed sets —
+  // identical pattern to round 13's APSP deferral in CDOmegaMonitor.
+  const deferredTopologyKey = useDeferredValue(topologyKey);
   const chiStarInfo = useMemo(() => {
     if (graphData.edges.length === 0) {
       return {
@@ -713,7 +725,7 @@ export default function CausalDAG3D() {
       rank,
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [topologyKey]);
+  }, [deferredTopologyKey]);
   const chiStarSet = chiStarInfo.chiStarSet;
 
   // Store baseline omega scores (live/initial values) as a reference point.

--- a/src/components/CausalDAGMap.tsx
+++ b/src/components/CausalDAGMap.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo, useCallback, useRef, useEffect, useState } from "react";
+import React, { useDeferredValue, useMemo, useCallback, useRef, useEffect, useState } from "react";
 import { Map as MapGL, Source, Layer, Popup, type MapRef } from "@vis.gl/react-maplibre";
 import type { MapLayerMouseEvent } from "@vis.gl/react-maplibre";
 import type { FeatureCollection, Point, LineString, Feature } from "geojson";
@@ -11,6 +11,7 @@ import { getDomainColor } from "@/lib/graph-color";
 import { getDomainCardColor } from "@/lib/domains";
 import { getNodeCoordinates } from "@/lib/geo-coordinates";
 import { chiStar } from "@/lib/estimators/chi-star";
+import { graphSignature } from "@/lib/graph-layout-2d";
 import { useFilteredGraph } from "@/hooks/useFilteredGraph";
 import DAGOverlay from "@/components/dag3d/DAGOverlay";
 import EdgeInspector from "@/components/EdgeInspector";
@@ -229,6 +230,16 @@ function CausalDAGMapInner() {
   // χ★ result on the live filtered graph. Powers (a) the violet halo
   // GeoJSON layer that renders behind the main edge lines, and (b)
   // the per-edge BES + bridge / top-k context surfaced by the
+  // Topology-stable fingerprint so the chiStar Brandes pass below
+  // (~120K ops on the default graph) doesn't fire on every feed-tick
+  // graphData mutation, AND defers off the launch commit (round 16,
+  // matching CausalDAG3D / CausalDAG2D / CausalDAGRelief).
+  const sig = useMemo(
+    () => graphSignature(activeGraph.nodes, activeGraph.edges),
+    [activeGraph.nodes, activeGraph.edges],
+  );
+  const deferredSig = useDeferredValue(sig);
+
   // EdgeInspector — same data flow as CausalDAG3D / CausalDAG2D.
   const chiStarInfo = useMemo(() => {
     if (activeGraph.edges.length === 0) {
@@ -252,7 +263,8 @@ function CausalDAGMapInner() {
       bes: r.bes,
       rank,
     };
-  }, [activeGraph]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deferredSig]);
 
   const { solidEdgeGeoJSON, dashedEdgeGeoJSON, chiStarOutlineGeoJSON } = useMemo(() => {
     const nodeMap = new Map<string, [number, number]>();

--- a/src/components/CausalDAGRelief.tsx
+++ b/src/components/CausalDAGRelief.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Component, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { Component, useCallback, useDeferredValue, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { Canvas, useThree, type ThreeEvent } from "@react-three/fiber";
 import { Html, OrbitControls } from "@react-three/drei";
 import * as THREE from "three";
@@ -925,6 +925,8 @@ function CausalDAGReliefInner() {
     () => graphSignature(graphData.nodes, graphData.edges),
     [graphData.nodes, graphData.edges],
   );
+  // Deferred topology fingerprint for the chiStar memo below (round 16).
+  const deferredSig = useDeferredValue(sig);
   const layout = useMemo(
     () => compute2DForceLayout(graphData.nodes, graphData.edges),
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1087,7 +1089,13 @@ function CausalDAGReliefInner() {
     }
     return out;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sig, activeField, isEmpty, layout]);
+    // chiStar runs a full Brandes' edge-betweenness pass (~120K ops on
+    // the default graph). Keying on `useDeferredValue(sig)` instead of
+    // `sig` lets the relief surface mount first and the bridge/chi-star
+    // overlay catch up in a follow-up concurrent commit — same pattern
+    // round 15 applied to CausalDAG3D's chiStarInfo.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deferredSig, activeField, isEmpty, layout]);
 
   // Click handler — convert the mesh-local hit point to nearest node id
   // and dispatch into the store. Same selection signal the rest of the app

--- a/src/components/NodeInspector.tsx
+++ b/src/components/NodeInspector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useDeferredValue, useMemo, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useApexStore } from "@/stores/useApexStore";
 import { getCategoryColor, getDomainColor, getCategoryLabel } from "@/lib/graph-color";
@@ -9,6 +9,7 @@ import type { NodeTemporalState } from "@/lib/temporal-data";
 import { getNodeDataDescription } from "@/lib/real-timeseries";
 import { resolveDomainProfile, type PillarKey } from "@/lib/domain-profiles";
 import { chiStar } from "@/lib/estimators/chi-star";
+import { graphSignature } from "@/lib/graph-layout-2d";
 import { buildContextualReview } from "@/lib/contextual-review";
 
 function getBarColor(value: number): string {
@@ -217,7 +218,15 @@ export default function NodeInspector() {
   // = how many of this node's edges are in χ★ — answers "is this
   // node embedded in the load-bearing skeleton?". Computed once
   // per graph (Brandes O(V·E)), independent of which node is
-  // selected, so node-flip is free.
+  // selected, so node-flip is free. Keyed on `deferredSig` (round 16):
+  // a topology-stable fingerprint so feed-tick liveData mutations don't
+  // re-run the ~120K-op Brandes pass, and deferred so the inspector
+  // mounts before chi-star tier highlighting catches up.
+  const sig = useMemo(
+    () => graphSignature(graphData.nodes, graphData.edges),
+    [graphData.nodes, graphData.edges],
+  );
+  const deferredSig = useDeferredValue(sig);
   const chiStarSet = useMemo(() => {
     if (graphData.edges.length === 0) return new Set<string>();
     const r = chiStar({
@@ -226,7 +235,8 @@ export default function NodeInspector() {
       metadata: graphData.metadata,
     });
     return new Set(r.chiStar);
-  }, [graphData]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deferredSig]);
   const bridgeCentrality = useMemo(
     () => connectedEdges.filter((e) => chiStarSet.has(e.id)).length,
     [connectedEdges, chiStarSet],


### PR DESCRIPTION
Two related rounds, applied to all five `chiStar` consumers.

## Round 15: defer `chiStar` in `CausalDAG3D`

3D's `chiStarInfo` ran a full **Brandes' edge-betweenness pass** (O(V·E), ~120K ops on the default ~350-node graph) synchronously in the same React commit as the canvas mount on LAUNCH WORKSPACE. Result only drives visual edge-tier styling (bridge / chi-star / regular). Switched the memo key from `topologyKey` to `useDeferredValue(topologyKey)`: launch paints first, bridge highlighting catches up in a follow-up concurrent commit.

## Round 16: same fix for the other four consumers

The other four `chiStar` callers had a worse problem: most ran on **every feed tick**, not just launch.

| File | Old deps | New deps |
|---|---|---|
| `CausalDAG2D` | `[graphData]` (fires per feed tick) | `[deferredSig]` |
| `CausalDAGMap` | `[activeGraph]` (fires per feed tick) | `[deferredSig]` |
| `CausalDAGRelief` | `[sig, …]` (already topology-gated) | `[deferredSig, …]` |
| `NodeInspector` | `[graphData]` (fires per feed tick) | `[deferredSig]` |

`sig` is the existing `graphSignature(nodes, edges)` helper from `graph-layout-2d` (already used by 2D and Relief; imported into Map and NodeInspector here). Two wins per file:

1. **Topology-stable gating** — feed-tick `liveData` mutations leave `sig === sig` so the memo skips entirely. No more sustained background chiStar churn on live workspaces.
2. **Launch-frame deferral** — same `useDeferredValue` pattern as round 13 (`CDOmegaMonitor` APSP), round 15 (3D), and the pre-existing `omegaBridgeDensity` wrap in `StructuralMetrics`.

## Trade-off (pre-existing 3D behaviour, now consistent)

`sig` ignores `isSevered`, so severing an edge no longer triggers chi-star recomputation in the four touched canvases. This already matched 3D's `topologyKey` semantics, so this PR makes the behaviour **uniform** rather than introducing a new asymmetry.

## Concrete impact estimate

Only one of {2D, Map, Relief} is mounted at a time (page-level `viewMode` routing), so per session:
- **Launch frame:** ~120K ops deferred in 3D + ~120K ops in the active alt-canvas
- **Per feed tick on live workspace:** **one ~120K-op Brandes pass eliminated** (was running on the mounted alt-canvas every tick)
- **NodeInspector:** wins whenever the user has a focused node during feed activity

## Checks

- `tsc`: unchanged — 15 pre-existing test-file errors only
- ESLint: clean on all five changed files; remaining warning is pre-existing on `CausalDAG2D:1091` (unrelated `visibleNodes` unused-disable comment)

## Test plan

- [ ] LAUNCH WORKSPACE in each view mode (3D / 2D / Map / Relief) — feels snappier; bridge/chi-star tinting catches up within a frame
- [ ] Switch view modes — chi-star highlighting re-applies correctly per canvas
- [ ] Live feed tick while viewing 2D or Map — no input jank traceable to chiStar (verify with React DevTools profiler if curious)
- [ ] Open NodeInspector by clicking a node — first paint shows inspector chrome, chi-star membership badge catches up within a frame
- [ ] Known limitation to verify: severing an edge does NOT refresh chi-star tinting in any of the canvases (this was already 3D's behaviour, now uniform). If unexpected, that's a separate fix on top.

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx