### PR TITLE
perf(chi-star): content-fingerprint cache around chiStar()

### DIFF
--- a/src/lib/estimators/chi-star.ts
+++ b/src/lib/estimators/chi-star.ts
@@ -231,6 +231,51 @@ export function bridgeEdgeStrength(graph: CausalGraph): Map<string, number> {
   return bes;
 }
 
+// Module-level fingerprint cache. chiStar is O(V·E) (Brandes' edge
+// betweenness inside `bridgeEdgeStrength`) — ~120K ops on the default
+// ~350-node graph. The result is a pure function of the input graph
+// (plus topK), so we can intern it across callers.
+//
+// Why a content-fingerprint cache instead of a WeakMap on `graph.edges`:
+// every canvas-class caller passes `graphData.edges.filter((e) => !e.isSevered)`,
+// which is a fresh array reference per render. A WeakMap on that array
+// would miss on every call. A fingerprint built from (length, first id,
+// last id) of each input array hits across:
+//   - Per-component re-renders where the same canvas's useMemo keying
+//     would have already short-circuited anyway.
+//   - View-mode switches (3D → 2D → 3D) — round 16's per-canvas
+//     useMemo dies with the unmount; this cache survives, so the
+//     remount returns the cached result without re-running Brandes.
+//   - Live-feed ticks — graphData.nodes is rebuilt via `.map` (new ref,
+//     same id set and same first/last ids), so a feed tick that
+//     doesn't touch topology produces an identical fingerprint.
+//
+// Severing edges is correctly invalidated: a sever monotonically
+// shortens the filtered edges array, so `edges.length` (part of the
+// fingerprint) shifts and we miss → recompute → cache.
+//
+// Cache is bounded to MAX_ENTRIES with FIFO eviction (cheap and
+// adequate for the 5 chiStar consumers we have). Set order in JS is
+// insertion order, so deleting the first key on overflow gives an
+// LRU-ish policy without extra bookkeeping.
+const MAX_ENTRIES = 16;
+const cache = new Map<string, ChiStarResult>();
+
+function chiStarFingerprint(
+  graph: CausalGraph,
+  topK: number | null | undefined,
+): string {
+  const { nodes, edges } = graph;
+  const nN = nodes.length;
+  const nE = edges.length;
+  const nFirst = nN > 0 ? nodes[0].id : "";
+  const nLast = nN > 0 ? nodes[nN - 1].id : "";
+  const eFirst = nE > 0 ? edges[0].id : "";
+  const eLast = nE > 0 ? edges[nE - 1].id : "";
+  const k = topK === undefined || topK === null ? "d" : String(topK);
+  return `${nN}:${nFirst}:${nLast}|${nE}:${eFirst}:${eLast}|${k}`;
+}
+
 /**
  * Compute the χ★ bridge set: strict bridges ∪ top-k BES edges.
  *
@@ -242,6 +287,15 @@ export function chiStar(
   graph: CausalGraph,
   options: ChiStarOptions = {},
 ): ChiStarResult {
+  const fp = chiStarFingerprint(graph, options.topK);
+  const cached = cache.get(fp);
+  if (cached) {
+    // Refresh insertion order so this entry survives the next eviction.
+    cache.delete(fp);
+    cache.set(fp, cached);
+    return cached;
+  }
+
   const bridges = findBridges(graph);
   const bes = bridgeEdgeStrength(graph);
 
@@ -276,13 +330,21 @@ export function chiStar(
   const chiStarSet = new Set<string>(bridges);
   for (const eid of topByBes) chiStarSet.add(eid);
 
-  return {
+  const result: ChiStarResult = {
     bridges,
     bes,
     chiStar: [...chiStarSet],
     besRanking,
     topK,
   };
+
+  if (cache.size >= MAX_ENTRIES) {
+    // FIFO eviction — drop the oldest entry.
+    const firstKey = cache.keys().next().value;
+    if (firstKey !== undefined) cache.delete(firstKey);
+  }
+  cache.set(fp, result);
+  return result;
 }
 
 /**


### PR DESCRIPTION
## What & why

Rounds 15+16 (PR #471) deferred `chiStar` off the launch frame and gated feed ticks via per-component `useMemo` + `useDeferredValue` on a topology fingerprint. That leaves one remaining hot path: **view-mode switches.**

When you toggle 3D → 2D → 3D (very common during analysis), the canvas component unmounts and remounts. Each `useMemo` dies with the unmount, so the remount runs a fresh O(V·E) Brandes pass (~120K ops on the default ~350-node graph) even though the topology is unchanged. Same applies to `NodeInspector`'s mount/unmount cycle as you select/deselect nodes.

## Fix

Intern `chiStar` results in a **module-level fingerprint cache** inside the `chiStar` function itself:

```
fingerprint = `${nodes.length}:${first id}:${last id}|${edges.length}:${first id}:${last id}|topK=${k ?? "default"}`
```

Cache is `Map<fingerprint, ChiStarResult>` with `MAX_ENTRIES = 16` and FIFO eviction (delete-and-re-set on hit gives an LRU-ish refresh).

## Why content-fingerprint vs `WeakMap<edges, result>`

Every canvas caller passes `graphData.edges.filter((e) => !e.isSevered)` — a fresh array reference per call. A WeakMap on that array would miss every time. The content fingerprint is array-reference-agnostic, so feed-tick `.map()` rebuilds of the nodes array produce an identical fingerprint and hit the cache.

## Hits cover

- **View-mode switches (main motivation)** — 3D ↔ 2D ↔ Map ↔ Relief remounts all return cached.
- **NodeInspector mount on node selection** — no chiStar re-run.
- **Feed-tick paths** in case round 16's per-canvas `useMemo` gating is ever bypassed (defense in depth).

## Sever invalidation stays correct

Severing monotonically shortens the filtered edges array, so `edges.length` (part of the fingerprint) shifts → cache miss → recompute → cache. The pre-existing "severed edges don't refresh chi-star tinting" behaviour (from rounds 15–16's `sig`-based memo keying in the components) is unchanged by this round, because the components still don't re-call `chiStar` on sever. Severs only matter here when *something else* triggers a chiStar call against the new edges array.

## Tests

- 26 chi-star + 4 omega-bridge-density + 20 bes-temporal — all passing
- **137 estimator tests + 20 discovery tests = 157 total green**
- `tsc` unchanged at 15 pre-existing test-file errors

## Test plan

- [ ] Switch view modes repeatedly (3D ↔ 2D ↔ Map ↔ Relief) on a loaded workspace — no input jank at the second-or-later visit to each view
- [ ] Open/close NodeInspector by clicking and deselecting a node — first-frame paint of the inspector lands without the ~120K-op Brandes hitch
- [ ] Load a different domain workspace — chi-star tinting is correct for the new topology (not the previous one served from cache)
- [ ] Sever an edge in 3D — pre-existing 3D behaviour preserved (chi-star tints don't refresh until a topology key change rederives)

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_