### PR TITLE
perf(graph-signature): fingerprint cache around graphSignature()

### DIFF
--- a/src/lib/graph-layout-2d.ts
+++ b/src/lib/graph-layout-2d.ts
@@ -180,12 +180,53 @@ export function create2DLiveSimulation(
 /**
  * Stable signature over the node and edge id sets. Layout is recomputed only
  * when this changes — filter/isolation/replay don't trigger a re-layout.
+ *
+ * Memoised on a cheap content fingerprint (length + first/last id of each
+ * input array). On live workspaces, `graphData.nodes` is rebuilt via `.map`
+ * on every feed tick to overlay liveData, so each canvas component's
+ * `useMemo(() => graphSignature(...), [nodes, edges])` re-fires per tick.
+ * The full O((N+E) log (N+E)) sort+join + ~10KB string allocation can
+ * stack to a few ms across the 4 canvas-class callers (2D, Map, Relief,
+ * NodeInspector) — and the output is invariant when topology is stable.
+ * The internal cache returns the prior signature in O(1) on a quick-key
+ * hit, so feed ticks become free across all consumers.
+ *
+ * Cache shape mirrors the round 17 fingerprint cache in chi-star.ts:
+ * bounded Map with FIFO eviction, delete-and-re-set on hit for an
+ * LRU-ish refresh.
  */
+const SIG_MAX_ENTRIES = 16;
+const sigCache = new Map<string, string>();
+
+function quickSigKey(nodes: CausalNode[], edges: CausalEdge[]): string {
+  const nN = nodes.length;
+  const nE = edges.length;
+  const nFirst = nN > 0 ? nodes[0].id : "";
+  const nLast = nN > 0 ? nodes[nN - 1].id : "";
+  const eFirst = nE > 0 ? edges[0].id : "";
+  const eLast = nE > 0 ? edges[nE - 1].id : "";
+  return `${nN}:${nFirst}:${nLast}|${nE}:${eFirst}:${eLast}`;
+}
+
 export function graphSignature(
   nodes: CausalNode[],
   edges: CausalEdge[],
 ): string {
+  const qk = quickSigKey(nodes, edges);
+  const cached = sigCache.get(qk);
+  if (cached !== undefined) {
+    // Refresh insertion order so this entry survives the next eviction.
+    sigCache.delete(qk);
+    sigCache.set(qk, cached);
+    return cached;
+  }
   const ns = nodes.map((n) => n.id).sort().join("|");
   const es = edges.map((e) => e.id).sort().join("|");
-  return `${ns}#${es}`;
+  const sig = `${ns}#${es}`;
+  if (sigCache.size >= SIG_MAX_ENTRIES) {
+    const firstKey = sigCache.keys().next().value;
+    if (firstKey !== undefined) sigCache.delete(firstKey);
+  }
+  sigCache.set(qk, sig);
+  return sig;
 }


### PR DESCRIPTION
## What & why

Rounds 15–17 deferred + topology-gated + cached the `chiStar` Brandes pass. The remaining sustained background work on a live workspace landed on `graphSignature()` itself — the helper rounds 16–17 lean on as the topology key:

| Caller | Calls `graphSignature` inside |
|---|---|
| `CausalDAG2D` | `useMemo(..., [nodes, edges])` |
| `CausalDAGMap` | `useMemo(..., [nodes, edges])` |
| `CausalDAGRelief` | `useMemo(..., [nodes, edges])` |
| `NodeInspector` | `useMemo(..., [nodes, edges])` |

On every feed tick, `applyFeedBatch` rebuilds `graphData.nodes` via `.map()` to overlay `liveData` (edges array reference stays). The `useMemo` deps include `nodes`, so each one re-fires per tick — even though the resulting signature string is identical because IDs and topology haven't moved.

Per call: O(N log N) + O(E log E) sort, two `.map()`, two `.join()`, ~10 KB string allocation. Across 4 consumers on a ~350-node graph that's a few ms of synchronous main-thread work per tick. With multiple feed providers polling on 30s–5min cadences, it's compounding background CPU for nothing.

## Fix

Mirror PR #474's chi-star pattern — intern signatures in a module-level `Map<quickKey, signature>` keyed on a cheap O(1) content fingerprint:

```
quickKey = `(nodes.length, first id, last id, edges.length, first id, last id)`
```

Hit returns the cached signature directly. Cache bounded to `MAX_ENTRIES = 16` with FIFO eviction and delete-and-re-set on hit (LRU-ish refresh). Same shape as round 17.

## Sever invalidation stays correct

Callers that filter on `isSevered` before calling `graphSignature` produce a shorter edges array on a sever, so `edges.length` in `quickKey` shifts → cache miss → recompute.

## Checks

- **1097/1097 vitest tests green**
- `tsc` unchanged at 15 pre-existing test-file errors
- Cache is internal — no API surface change. All existing callers work without modification.

## Test plan

- [ ] LAUNCH WORKSPACE — first paint snappier than before (multiple canvases no longer block on graphSignature recompute)
- [ ] Live feed tick on a loaded workspace — no per-tick main-thread allocation traceable to `graphSignature` (verify with React DevTools profiler if curious)
- [ ] Domain swap via DomainSelector — chi-star tinting + 2D/Relief layout still derived from the new topology (not the previous one served from cache)
- [ ] Sever an edge in any canvas — downstream behaviour unchanged (this PR doesn't change sever semantics; round 16's `sig`-based memo keying is the active gate)

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_