### PR TITLE
feat(feeds): EIA Qatar dry-gas production provider → North Field nodes

### DIFF
--- a/docs/sessions/geopolitical-macro.md
+++ b/docs/sessions/geopolitical-macro.md
@@ -381,6 +381,80 @@ Apply shared-infrastructure decomposition when:
 - **Tarski session** — A-04 chokepoint axiom currently reads the single conflated node's `value` and `capacity` fields. After Phase 16 cleanup these now refer to nothing (legacy nodes deleted). A coordinated Tarski-session PR is needed to update A-04 to read `si_<concept>_throughput.value > si_<concept>_capacity.value` directly.
 - **UX / Onboarding session** — domain-profiles.ts may eventually want an explicit "Shared Infrastructure" profile entry (for sidebar grouping, persona mapping, etc.). For now, untyped string domains render correctly with default behavior; no UX coordination required for the pilot.
 
+## Phase 17 — Aggregate-proxy lift into the physical-asset moat
+
+The pipeline audit (above) classed 52 nodes as "physical-asset moat —
+unlikely to wire live" because per-asset APIs don't exist for individual
+refineries, fields, ports, or pipelines. But it flagged one escape hatch:
+
+> Aggregate proxies could lift some of these via the `derivations`
+> provider (e.g. EIA aggregate KSA production driving multiple Aramco
+> nodes).
+
+Phase 17 starts working that hatch. The key realisation is that a
+**national production aggregate is a direct observed proxy for the
+deliverability of the single dominant asset** when one asset accounts for
+~all of a country's output. You don't need per-asset data; the national
+number *is* the asset number.
+
+### Applied: EIA Qatar dry-gas → North Field (#479)
+
+- **Source**: EIA v2 `international/data`, productId=26 (Dry natural
+  gas), activityId=1 (Production), country=QAT. Annual cadence (no
+  monthly partition exists for this series). Returns two rows per period
+  — BCM + BCF; the parser prefers BCM.
+- **Drives** `qe_north_field_gas_field` + `qf_north_field_gas` (the QAFCO
+  duplicate). North Field is the source of ~all Qatari dry gas, so
+  national production proxies its deliverability — the variable that
+  bounds every downstream LNG train / GTL plant / Barzan / ammonia node.
+- **Negative exclusion**: `qe_north_field_expansion_nfe_nfs` ("North
+  Field Expansion (NFE + NFS)") shares the "north field" substring but
+  represents *future added capacity*, not current realized production.
+  Excluded in the matcher — same throughput-vs-capacity discipline as the
+  Phase 16 facets.
+- **Live value**: 169.95 BCM/yr (2024), capacity 220 BCM/yr (disclosed
+  post-NFE/NFS medium-term estimate, not an official nameplate — see the
+  feed module header), severity 0.773.
+- **Files**: `src/lib/feeds/eia-qatar-gas.ts` (fetch/parse/mock),
+  `src/lib/feeds/providers/eia-qatar-gas.ts` (matcher + dispatch),
+  `src/app/api/feeds/eia/qatar-gas/route.ts` (cached proxy),
+  registered in `registry.ts`. 12 tests.
+- **+2 nodes** to live coverage.
+
+### The recipe (repeatable for the rest of the moat)
+
+When a physical-asset node is the dominant component of a national
+aggregate that EIA International publishes:
+
+1. Find the EIA International `(productId, activityId, countryRegionId)`
+   tuple — probe `https://api.eia.gov/v2/international/facet/productId`
+   for the product, then query `international/data` to confirm cadence +
+   unit rows.
+2. Clone `eia-saudi-crude.ts` / `eia-qatar-gas.ts` — change the three
+   facet IDs, the capacity constant (disclose the basis), and the unit
+   handling.
+3. Provider matcher: positive substring on the asset/concept, negative
+   exclusion on any sibling capacity/expansion/war-risk node that shares
+   the substring.
+4. API route is boilerplate (copy saudi-crude/route.ts).
+5. Register, test, live-validate the fetch+parse with the prod key.
+
+### Next aggregate-proxy candidates
+
+- **Iran / Iraq / UAE / Kuwait crude** (EIA International, productId=53,
+  activity=1) — each is the dominant national producer behind several
+  domain nodes; same shape as Saudi crude. Watch for sanction-data
+  caveats on Iran (the published figure may understate actual flow).
+- **US / Qatar LNG exports** (EIA natural-gas trade series) — would drive
+  the export-train + Ras Laffan port nodes with a *flow* signal distinct
+  from the upstream production signal this PR adds.
+- **Algeria / Nigeria gas** (productId=26) — drive their respective
+  feedstock/export nodes if/when those domains gain graph presence.
+
+The hard limit remains: this only works where one asset ≈ the national
+aggregate. Multi-asset countries (e.g. US refineries) need per-asset
+data that doesn't exist publicly, so they stay in the moat.
+
 ## Likely upcoming themes
 
 - New domain cards as customer pilots demand them.

--- a/src/app/api/feeds/eia/qatar-gas/route.ts
+++ b/src/app/api/feeds/eia/qatar-gas/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import {
+  buildEiaQatarGasUrl,
+  mockEiaQatarGasFeed,
+  parseEiaQatarGasResponse,
+  type EiaQatarGasFeed,
+} from "@/lib/feeds/eia-qatar-gas";
+
+const CACHE_TTL_MS = 6 * 60 * 60 * 1000; // EIA annual cadence
+
+let cache: { feed: EiaQatarGasFeed; expiresAt: number } | null = null;
+
+export async function GET() {
+  const now = Date.now();
+  if (cache && cache.expiresAt > now) {
+    return NextResponse.json(cache.feed, {
+      headers: { "x-feed-cache": "hit" },
+    });
+  }
+
+  const apiKey = process.env.EIA_API_KEY;
+  if (!apiKey) {
+    const feed = mockEiaQatarGasFeed();
+    cache = { feed, expiresAt: now + CACHE_TTL_MS };
+    return NextResponse.json(feed, {
+      headers: { "x-feed-cache": "miss", "x-feed-mode": "mock" },
+    });
+  }
+
+  try {
+    const upstreamRes = await fetch(buildEiaQatarGasUrl(apiKey), {
+      cache: "no-store",
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!upstreamRes.ok) {
+      // Mock-fallback on upstream error so the engine path still
+      // exercises rather than going stale.
+      const feed = mockEiaQatarGasFeed();
+      cache = { feed, expiresAt: now + CACHE_TTL_MS };
+      return NextResponse.json(feed, {
+        headers: {
+          "x-feed-cache": "miss",
+          "x-feed-mode": "mock-fallback",
+          "x-upstream-status": String(upstreamRes.status),
+        },
+      });
+    }
+    const json = await upstreamRes.json();
+    const feed = parseEiaQatarGasResponse(json);
+    cache = { feed, expiresAt: now + CACHE_TTL_MS };
+    return NextResponse.json(feed, {
+      headers: { "x-feed-cache": "miss", "x-feed-mode": "live" },
+    });
+  } catch {
+    const feed = mockEiaQatarGasFeed();
+    cache = { feed, expiresAt: now + CACHE_TTL_MS };
+    return NextResponse.json(feed, {
+      headers: { "x-feed-cache": "miss", "x-feed-mode": "mock-fallback" },
+    });
+  }
+}

--- a/src/lib/__tests__/feeds/eia-qatar-gas.test.ts
+++ b/src/lib/__tests__/feeds/eia-qatar-gas.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildEiaQatarGasUrl,
+  parseEiaQatarGasResponse,
+  mockEiaQatarGasFeed,
+  QATAR_GAS_CAPACITY_BCM,
+} from "@/lib/feeds/eia-qatar-gas";
+import { eiaQatarGasProvider } from "@/lib/feeds/providers/eia-qatar-gas";
+import { makeNode } from "../fixtures/graph-fixtures";
+
+describe("buildEiaQatarGasUrl", () => {
+  it("builds the EIA v2 international/data URL with QAT + dry-gas + production + annual filters", () => {
+    const url = buildEiaQatarGasUrl("test-key");
+    expect(url).toContain("api.eia.gov/v2/international/data");
+    expect(url).toContain("api_key=test-key");
+    expect(url).toContain("frequency=annual");
+    expect(url).toContain("facets%5BcountryRegionId%5D%5B%5D=QAT");
+    expect(url).toContain("facets%5BproductId%5D%5B%5D=26"); // dry natural gas
+    expect(url).toContain("facets%5BactivityId%5D%5B%5D=1"); // production
+    expect(url).toContain("sort%5B0%5D%5Bdirection%5D=desc"); // newest first
+  });
+});
+
+describe("parseEiaQatarGasResponse", () => {
+  it("prefers the BCM row and picks the latest finite period", () => {
+    const raw = {
+      response: {
+        data: [
+          { period: "2024", value: "6001.9", unit: "BCF" },
+          { period: "2024", value: "169.95", unit: "BCM" },
+          { period: "2023", value: "6032.3", unit: "BCF" },
+          { period: "2023", value: "170.8", unit: "BCM" },
+        ],
+      },
+    };
+    const feed = parseEiaQatarGasResponse(raw);
+    expect(feed.value).toBeCloseTo(169.95, 2);
+    expect(feed.unit).toBe("BCM/yr");
+    expect(feed.capacity).toBe(QATAR_GAS_CAPACITY_BCM);
+    expect(feed.period).toBe("2024");
+    expect(feed.observedAt.startsWith("2024-01-01")).toBe(true);
+    expect(feed.source).toContain("period 2024");
+  });
+
+  it("falls back to a BCF row scaled to BCM when no BCM row is present", () => {
+    const raw = {
+      response: {
+        data: [{ period: "2024", value: "6001.9", unit: "BCF" }],
+      },
+    };
+    const feed = parseEiaQatarGasResponse(raw);
+    // 6001.9 BCF * 0.0283168 ≈ 169.95 BCM
+    expect(feed.value).toBeCloseTo(169.95, 1);
+    expect(feed.unit).toBe("BCM/yr");
+  });
+
+  it("skips a null latest period and falls back to the next valid one", () => {
+    const raw = {
+      response: {
+        data: [
+          { period: "2025", value: null, unit: "BCM" },
+          { period: "2024", value: "169.95", unit: "BCM" },
+        ],
+      },
+    };
+    const feed = parseEiaQatarGasResponse(raw);
+    expect(feed.period).toBe("2024");
+    expect(feed.value).toBeCloseTo(169.95, 2);
+  });
+
+  it("accepts numeric (non-string) values defensively", () => {
+    const raw = {
+      response: { data: [{ period: "2024", value: 169.95, unit: "BCM" }] },
+    };
+    const feed = parseEiaQatarGasResponse(raw);
+    expect(feed.value).toBeCloseTo(169.95, 2);
+  });
+
+  it("throws on empty data array", () => {
+    expect(() => parseEiaQatarGasResponse({ response: { data: [] } })).toThrow();
+  });
+
+  it("throws when no finite BCM/BCF value found in the window", () => {
+    expect(() =>
+      parseEiaQatarGasResponse({
+        response: {
+          data: [
+            { period: "2024", value: null, unit: "BCM" },
+            { period: "2024", value: "NA", unit: "BCF" },
+          ],
+        },
+      }),
+    ).toThrow();
+  });
+});
+
+describe("mockEiaQatarGasFeed", () => {
+  it("emits a plausible mock tagged (mock — EIA_API_KEY unset)", () => {
+    const feed = mockEiaQatarGasFeed();
+    expect(feed.source).toContain("(mock");
+    expect(feed.unit).toBe("BCM/yr");
+    expect(feed.value).toBeGreaterThan(0);
+    expect(feed.value).toBeLessThanOrEqual(QATAR_GAS_CAPACITY_BCM);
+    expect(feed.capacity).toBe(QATAR_GAS_CAPACITY_BCM);
+  });
+});
+
+describe("eiaQatarGasProvider.matchPayload", () => {
+  it("attaches a production signal to both North Field source nodes", () => {
+    const nodes = [
+      makeNode({ id: "qe_nf", label: "North Field (gas field)" }),
+      makeNode({ id: "qf_nf", label: "Qatar North Field natural gas resource" }),
+      makeNode({ id: "neutral", label: "Generic LNG Train" }),
+    ];
+    const feed = mockEiaQatarGasFeed();
+    const batch = eiaQatarGasProvider.matchPayload(feed, nodes);
+
+    expect(batch.providerId).toBe("eia-qatar-gas");
+    expect(batch.signalKinds).toEqual(["production"]);
+    const matched = batch.updates.map((u) => u.nodeId).sort();
+    expect(matched).toContain("qe_nf");
+    expect(matched).toContain("qf_nf");
+    expect(matched).not.toContain("neutral");
+  });
+
+  it("excludes the North Field Expansion (NFE + NFS) project node", () => {
+    // The expansion node shares "north field" in its label but
+    // represents added future capacity, not current realized production.
+    const nodes = [
+      makeNode({ id: "source", label: "North Field (gas field)" }),
+      makeNode({ id: "expansion", label: "North Field Expansion (NFE + NFS)" }),
+    ];
+    const feed = mockEiaQatarGasFeed();
+    const batch = eiaQatarGasProvider.matchPayload(feed, nodes);
+    const matched = batch.updates.map((u) => u.nodeId).sort();
+    expect(matched).toContain("source");
+    expect(matched).not.toContain("expansion");
+  });
+
+  it("emits no event when no nodes match", () => {
+    const feed = mockEiaQatarGasFeed();
+    const batch = eiaQatarGasProvider.matchPayload(feed, [
+      makeNode({ id: "x", label: "Unrelated Asset" }),
+    ]);
+    expect(batch.updates).toHaveLength(0);
+    expect(batch.event).toBeUndefined();
+  });
+
+  it("severity scales with production-vs-capacity ratio (capped at 1.0)", () => {
+    const nodes = [makeNode({ id: "qe_nf", label: "North Field (gas field)" })];
+    const feed = { ...mockEiaQatarGasFeed(), value: 200 };
+    const batch = eiaQatarGasProvider.matchPayload(feed, nodes);
+    expect(batch.event).toBeDefined();
+    expect(batch.event!.severity).toBeCloseTo(200 / QATAR_GAS_CAPACITY_BCM, 5);
+  });
+});

--- a/src/lib/feeds/eia-qatar-gas.ts
+++ b/src/lib/feeds/eia-qatar-gas.ts
@@ -1,0 +1,158 @@
+/**
+ * EIA Qatar dry-natural-gas production feed — drives the upstream
+ * North Field gas-source nodes with annual production data.
+ *
+ * Source: EIA v2 international/data with productId=26 (Dry natural
+ * gas), activityId=1 (Production), country=QAT. EIA publishes this
+ * series annually only (no monthly partition), and returns two rows
+ * per period — one in BCM (billion cubic metres) and one in BCF
+ * (billion cubic feet). We prefer the BCM row for a cleaner
+ * international-standard magnitude and fall back to BCF→BCM if only
+ * BCF is present.
+ *
+ * Why this is the right proxy: the North Field is the source of
+ * essentially all Qatari dry-gas output, so national dry-gas
+ * production is a direct observed proxy for North Field deliverability
+ * — the variable that bounds every downstream QatarEnergy / QAFCO node
+ * (LNG trains, GTL plants, Barzan, ammonia/urea feedstock). This is the
+ * same "aggregate national production drives the physical-asset cluster"
+ * shape as `eia-saudi-crude.ts`; the moat is per-asset data, not
+ * national aggregates, and the aggregate is the strongest free signal.
+ *
+ * Capacity = 220 BCM/yr — post-North-Field-Expansion (NFE + NFS)
+ * medium-term ceiling. Current production (~170 BCM/yr) sits on the
+ * pre-expansion plateau that held 2022-2024; NFE (first LNG ~2026,
+ * 77→126 MTPA) and NFS (~2030, →142 MTPA) lift the gas envelope. The
+ * 220 figure is a disclosed engineering estimate (≈ +29% over the
+ * current plateau, scaled to the incremental gas behind the LNG ramp),
+ * not an official nameplate — it exists so the severity ratio
+ * (value/capacity) reads "high utilisation, approaching expansion
+ * ceiling" (~0.77) rather than a meaningless absolute.
+ */
+import type { LiveDataPoint } from "@/lib/types";
+
+const PRODUCT_ID = "26"; // Dry natural gas
+const ACTIVITY_ID = "1"; // Production
+const COUNTRY_ID = "QAT";
+
+/** BCF → BCM conversion factor (1 cubic foot = 0.0283168 m³). */
+const BCF_TO_BCM = 0.0283168;
+
+/** Qatar post-NFE/NFS medium-term production ceiling (BCM/yr). See
+ *  module header for the basis — disclosed estimate, not a nameplate. */
+export const QATAR_GAS_CAPACITY_BCM = 220;
+
+export interface EiaQatarGasFeed extends LiveDataPoint {
+  /** Period (YYYY) of the latest observation — annual cadence. */
+  period: string;
+}
+
+/** Build the EIA v2 international/data URL for Qatar dry-gas
+ *  production, annual, sorted period descending so the latest year is
+ *  first. We don't filter by unit server-side (the unitId facet value
+ *  isn't the display string), so both BCM + BCF rows come back and the
+ *  parser picks. */
+export function buildEiaQatarGasUrl(apiKey: string): string {
+  const base = "https://api.eia.gov/v2/international/data/";
+  const params = new URLSearchParams();
+  params.set("api_key", apiKey);
+  params.set("frequency", "annual");
+  params.append("data[0]", "value");
+  params.append("facets[productId][]", PRODUCT_ID);
+  params.append("facets[activityId][]", ACTIVITY_ID);
+  params.append("facets[countryRegionId][]", COUNTRY_ID);
+  params.append("sort[0][column]", "period");
+  params.append("sort[0][direction]", "desc");
+  params.set("offset", "0");
+  // 6 = a couple of years of headroom; each year has BCM + BCF rows so
+  // this is ~3 distinct periods.
+  params.set("length", "6");
+  return `${base}?${params.toString()}`;
+}
+
+interface EiaResponseRow {
+  period?: string;
+  value?: number | string | null;
+  unit?: string;
+}
+
+interface EiaResponseEnvelope {
+  response?: { data?: EiaResponseRow[] };
+}
+
+function finiteValue(v: number | string | null | undefined): number | null {
+  const n = typeof v === "string" ? parseFloat(v) : v;
+  return typeof n === "number" && Number.isFinite(n) ? n : null;
+}
+
+/** Parse the EIA response → latest finite period → BCM LiveDataPoint.
+ *  Rows are period-desc; we prefer the BCM unit row, falling back to a
+ *  BCF row scaled to BCM when BCM is absent for the latest period. */
+export function parseEiaQatarGasResponse(raw: unknown): EiaQatarGasFeed {
+  const envelope = raw as EiaResponseEnvelope;
+  const rows = envelope?.response?.data ?? [];
+  if (rows.length === 0) throw new Error("EIA Qatar gas response had no data rows");
+
+  // First pass: latest period with a finite BCM value (rows are desc).
+  let chosen: { period: string; valueBcm: number } | null = null;
+  for (const row of rows) {
+    if (!row.period || row.unit !== "BCM") continue;
+    const v = finiteValue(row.value);
+    if (v === null) continue;
+    chosen = { period: row.period, valueBcm: v };
+    break;
+  }
+
+  // Fallback: latest period with a finite BCF value, scaled to BCM.
+  if (!chosen) {
+    for (const row of rows) {
+      if (!row.period || row.unit !== "BCF") continue;
+      const v = finiteValue(row.value);
+      if (v === null) continue;
+      chosen = { period: row.period, valueBcm: +(v * BCF_TO_BCM).toFixed(3) };
+      break;
+    }
+  }
+
+  if (!chosen) throw new Error("EIA Qatar gas response: no finite BCM/BCF value in window");
+
+  return {
+    kind: "production",
+    value: +chosen.valueBcm.toFixed(3),
+    capacity: QATAR_GAS_CAPACITY_BCM,
+    unit: "BCM/yr",
+    observedAt: periodToIso(chosen.period),
+    source: `EIA v2 / Qatar dry natural gas production (period ${chosen.period})`,
+    period: chosen.period,
+  };
+}
+
+/** Mock feed — used when EIA_API_KEY is unset or upstream errors.
+ *  ~170 BCM/yr is the 2022-2024 plateau; ratio ~77% of the disclosed
+ *  expansion ceiling. */
+export function mockEiaQatarGasFeed(): EiaQatarGasFeed {
+  const observedAt = new Date().toISOString();
+  return {
+    kind: "production",
+    value: 170,
+    capacity: QATAR_GAS_CAPACITY_BCM,
+    unit: "BCM/yr",
+    observedAt,
+    source: "EIA v2 / Qatar dry natural gas production (mock — EIA_API_KEY unset)",
+    period: "mock",
+  };
+}
+
+/** EIA annual periods are bare years ("2024"); monthly would be
+ *  "YYYY-MM". Handle both defensively. */
+function periodToIso(period: string): string {
+  const monthly = /^(\d{4})-(\d{2})$/.exec(period);
+  if (monthly) {
+    return new Date(`${monthly[1]}-${monthly[2]}-01T00:00:00Z`).toISOString();
+  }
+  const annual = /^(\d{4})$/.exec(period);
+  if (annual) {
+    return new Date(`${annual[1]}-01-01T00:00:00Z`).toISOString();
+  }
+  return new Date().toISOString();
+}

--- a/src/lib/feeds/providers/eia-qatar-gas.ts
+++ b/src/lib/feeds/providers/eia-qatar-gas.ts
@@ -1,0 +1,81 @@
+/**
+ * EIA Qatar dry-gas production provider — drives the upstream North
+ * Field gas-source nodes (`qe_north_field_gas_field` and the QAFCO-domain
+ * duplicate `qf_north_field_gas`) with annual dry-gas production data.
+ *
+ * Matching: `labelPatterns` substring-match against `node.label`. Both
+ * North Field source nodes contain "north field"; the expansion *project*
+ * node ("North Field Expansion (NFE + NFS)") also contains the substring
+ * but represents future capacity addition, not current realized
+ * production — so it is explicitly excluded, mirroring the Phase 16
+ * throughput-vs-capacity facet discipline.
+ */
+import type { CausalNode, LiveDataPoint } from "@/lib/types";
+import { type EiaQatarGasFeed } from "@/lib/feeds/eia-qatar-gas";
+import type { FeedDispatchBatch, FeedProvider } from "./types";
+
+/** Substring (case-insensitive) marking a node as receiving Qatar
+ *  dry-gas production updates. North Field is the source of ~all Qatari
+ *  dry gas, so national production is a direct proxy for its
+ *  deliverability. */
+const NORTH_FIELD_PATTERN = "north field";
+
+function matchesNorthFieldProduction(node: CausalNode): boolean {
+  const label = node.label.toLowerCase();
+  // Exclude the expansion *project* node — it shares "north field" in
+  // its label but represents added future capacity (NFE/NFS), not the
+  // current realized production this provider emits. Without this guard
+  // the production value would land on the expansion node and read as
+  // "the expansion is already producing", which is wrong.
+  if (label.includes("expansion")) return false;
+  return label.includes(NORTH_FIELD_PATTERN);
+}
+
+export const eiaQatarGasProvider: FeedProvider<EiaQatarGasFeed> = {
+  id: "eia-qatar-gas",
+  label: "EIA · Qatar dry-gas production",
+  endpoint: "/api/feeds/eia/qatar-gas",
+  // EIA publishes this series annually; 6h client poll keeps the store
+  // fresh well within one upstream cycle (the proxy caches 6h upstream).
+  pollIntervalMs: 6 * 60 * 60 * 1000,
+  matchPayload(payload, nodes): FeedDispatchBatch {
+    const matches = nodes.filter(matchesNorthFieldProduction);
+    const isLive = !payload.source.toLowerCase().includes("(mock");
+    const updates: Array<{ nodeId: string; point: LiveDataPoint }> = matches.map(
+      (n) => ({
+        nodeId: n.id,
+        point: {
+          kind: "production",
+          value: payload.value,
+          capacity: payload.capacity,
+          unit: payload.unit,
+          observedAt: payload.observedAt,
+          source: payload.source,
+        },
+      }),
+    );
+
+    return {
+      providerId: this.id,
+      signalKinds: ["production"],
+      updates,
+      event:
+        updates.length > 0
+          ? {
+              id: `eia-qatar-gas-${payload.observedAt}`,
+              label: "EIA · Qatar dry-gas production refresh",
+              description: `${updates.length} node${updates.length === 1 ? "" : "s"} touched · ${payload.value.toFixed(1)} ${payload.unit} (${isLive ? "live" : "mock"})`,
+              observedAt: payload.observedAt,
+              severity: Math.min(1, payload.value / payload.capacity),
+              affectedNodeIds: matches.map((n) => n.id),
+            }
+          : undefined,
+    };
+  },
+};
+
+export type { EiaQatarGasFeed };
+
+/** Exported for unit testing the matcher in isolation. */
+export const eiaQatarGasMatchesNode = (n: Pick<CausalNode, "label">) =>
+  matchesNorthFieldProduction(n as CausalNode);

--- a/src/lib/feeds/registry.ts
+++ b/src/lib/feeds/registry.ts
@@ -13,6 +13,7 @@
 import { clinicalTrialsProvider } from "./providers/clinical-trials";
 import { derivationsProvider } from "./providers/derivations";
 import { eiaHormuzProvider } from "./providers/eia-hormuz";
+import { eiaQatarGasProvider } from "./providers/eia-qatar-gas";
 import { eiaSaudiCrudeProvider } from "./providers/eia-saudi-crude";
 import { fredProvider } from "./providers/fred";
 import { noaaStormsProvider } from "./providers/noaa-storms";
@@ -30,6 +31,7 @@ import type { FeedProvider } from "./providers/types";
 export const FEED_PROVIDERS: ReadonlyArray<FeedProvider> = [
   eiaHormuzProvider,
   eiaSaudiCrudeProvider,
+  eiaQatarGasProvider,
   ofacSdnProvider,
   fredProvider,
   worldBankProvider,


### PR DESCRIPTION
## Summary

Adds an **EIA Qatar dry-natural-gas production** feed as a live aggregate proxy for the upstream North Field gas-source nodes — the documented path for lifting the physical-asset moat under free-source constraints, and a direct parallel to the existing `eia-saudi-crude` provider.

- **Source**: EIA v2 `international/data` — productId=26 (Dry natural gas), activityId=1 (Production), country=QAT, annual cadence.
- **Drives** `qe_north_field_gas_field` + the QAFCO-domain duplicate `qf_north_field_gas`. National dry-gas production is a direct observed proxy for North Field deliverability, which bounds every downstream QatarEnergy / QAFCO node (LNG trains, GTL plants, Barzan, ammonia/urea feedstock).
- **Negative exclusion**: the `North Field Expansion (NFE + NFS)` project node shares the "north field" substring but represents added *future* capacity, not current realized production — excluded, mirroring the Phase 16 throughput-vs-capacity facet discipline.
- **Unit handling**: EIA returns BCM + BCF rows per period; parser prefers BCM, falls back to BCF→BCM.
- **Live-validated end to end**: HTTP 200 → 169.95 BCM/yr (2024), capacity 220 BCM/yr (disclosed post-NFE/NFS estimate), severity 0.773.

**+2 nodes** promoted to live coverage.

## Test plan

- [x] 12 new unit tests (`eia-qatar-gas.test.ts`): URL builder, BCM-preferred parse, BCF fallback, null-skip, empty/no-finite throw, mock shape, matcher matches both North Field nodes + excludes expansion + excludes unrelated, severity ratio.
- [x] Full feed suite (117) + full repo suite (1574) green.
- [x] Live fetch+parse against EIA with prod key returns 169.95 BCM/yr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
