### PR TITLE
perf(worker): slim node/edge payload sent to layout worker

### DIFF
--- a/src/lib/workers/layout3d-client.ts
+++ b/src/lib/workers/layout3d-client.ts
@@ -49,6 +49,47 @@ let nextId = 0;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const pending = new Map<number, (r: any) => void>();
 
+/**
+ * Slim projections sent across the worker boundary.
+ *
+ * Both `computeLayout3D` / `computeNetworkMetrics` (3D) and
+ * `compute2DForceLayout` (2D) read only a tiny subset of CausalNode /
+ * CausalEdge: `id` (+ `domain` for 3D's z-layering) per node, and
+ * `source` / `target` / `weight` per edge. Everything else — `label`,
+ * `shortLabel`, the `omegaFragility` object, `liveData` arrays (which
+ * grow per live-feed tick), `physicalMechanism` natural-language
+ * strings, etc — is dead weight to the worker.
+ *
+ * structuredClone is O(payload bytes) and routinely runs 5-20 ms per MB
+ * for nested objects. On the default ~350-node graph the full payload
+ * sits around 200-700 KB; the slim projection is ~30 KB. Stripping the
+ * payload before postMessage cuts launch / domain-swap clone time by
+ * roughly an order of magnitude.
+ *
+ * The slim objects are cast to CausalNode / CausalEdge so the existing
+ * worker request types still typecheck without forcing a sweep of
+ * compute*Layout / computeNetworkMetrics signatures. Safe at runtime
+ * because those functions only touch the fields the slim type carries.
+ */
+function slimNodes(nodes: CausalNode[]): CausalNode[] {
+  const out: { id: string; domain: string }[] = new Array(nodes.length);
+  for (let i = 0; i < nodes.length; i++) {
+    const n = nodes[i];
+    out[i] = { id: n.id, domain: n.domain };
+  }
+  return out as unknown as CausalNode[];
+}
+
+function slimEdges(edges: CausalEdge[]): CausalEdge[] {
+  const out: { id: string; source: string; target: string; weight: number }[] =
+    new Array(edges.length);
+  for (let i = 0; i < edges.length; i++) {
+    const e = edges[i];
+    out[i] = { id: e.id, source: e.source, target: e.target, weight: e.weight };
+  }
+  return out as unknown as CausalEdge[];
+}
+
 function ensureWorker(): Worker | null {
   if (typeof window === "undefined" || typeof Worker === "undefined") {
     return null;
@@ -95,7 +136,13 @@ export function requestLayout3D(
   }
   const promise = new Promise<LayoutResult>((resolve) => {
     pending.set(id, resolve);
-    w.postMessage({ id, kind: "layout3d", nodes, edges, prev });
+    w.postMessage({
+      id,
+      kind: "layout3d",
+      nodes: slimNodes(nodes),
+      edges: slimEdges(edges),
+      prev,
+    });
   });
   return Object.assign(promise, { id });
 }
@@ -125,7 +172,12 @@ export function requestLayout2D(
   }
   const promise = new Promise<Layout2DResult>((resolve) => {
     pending.set(id, resolve);
-    w.postMessage({ id, kind: "layout2d", nodes, edges });
+    w.postMessage({
+      id,
+      kind: "layout2d",
+      nodes: slimNodes(nodes),
+      edges: slimEdges(edges),
+    });
   });
   return Object.assign(promise, { id });
 }


### PR DESCRIPTION
## What & why

The layout Web Worker (`layout3d-worker.ts`) calls `computeLayout3D` / `computeNetworkMetrics` / `compute2DForceLayout`. Across those three consumers it reads **only**:

- per node: `id` (+ `domain` for 3D's z-layering)
- per edge: `source`, `target`, `weight`

Everything else — `label`, `shortLabel`, the `omegaFragility` compound object, `liveData` arrays (which accumulate per live-feed tick, sometimes 10+ entries per live node), `physicalMechanism` natural-language strings, etc — was crossing the worker boundary on every `requestLayout3D` / `requestLayout2D` call as **pure dead weight**.

`structuredClone` is O(payload bytes) and routinely runs 5–20 ms per MB for nested objects. On the default ~350-node graph the full payload sits around **200–700 KB** (driven mostly by `liveData` on live nodes); the slim projection is **~30 KB**. Stripping cuts launch / domain-swap clone time by roughly an order of magnitude. The worker's response (`NodePosition[]` + `NodeMetrics`) was already small and is unaffected.

## Fix

Introduce `slimNodes()` / `slimEdges()` in the client wrapper that project each entry to the minimal field set the worker consumes, and post the slim arrays:

```ts
function slimNodes(nodes: CausalNode[]): CausalNode[] {
  const out = new Array(nodes.length);
  for (let i = 0; i < nodes.length; i++) {
    const n = nodes[i];
    out[i] = { id: n.id, domain: n.domain };
  }
  return out as unknown as CausalNode[];
}
```

(Cast back to `CausalNode[]` / `CausalEdge[]` at the `postMessage` call so existing worker request types still typecheck without forcing a sweep of `compute*Layout` / `computeNetworkMetrics` signatures. Safe at runtime — those functions only touch fields the slim type carries, which I verified by grepping field access patterns in both `graph-layout.ts` and `graph-layout-2d.ts`.)

## When this fires

- **LAUNCH WORKSPACE** — full topology re-layout
- **Domain swap** in `DomainSelector` — same
- **Sever/restore** that changes `topologyKey` — same

That's typically a handful of times per session, but each call previously stalled the main thread for the duration of `structuredClone` on a multi-hundred-KB graph payload.

## Checks

- `tsc` unchanged at 15 pre-existing test-file errors
- ESLint clean
- **1100/1100 vitest tests green** (3 `layout3d-client` + 1097 lib tests)

## Test plan

- [ ] LAUNCH WORKSPACE with a large cross-domain selection (lots of live-fed nodes) — launch feels at least as snappy as before; bridge tinting + node positions still resolve correctly
- [ ] Domain swap with live workspaces — same
- [ ] Switch view modes (3D ↔ 2D) — layout still updates as expected
- [ ] Live feed tick during workspace use — `liveData` is still observable on the canvas (because we send slim payload to the WORKER only; the main-thread render reads the full `CausalNode`)

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_