### PR TITLE
feat(edges): VX-880 provenance audit — 4 entries, 5 edges, cross-domain reuse

### DIFF
--- a/src/lib/__tests__/edge-provenance-registry.test.ts
+++ b/src/lib/__tests__/edge-provenance-registry.test.ts
@@ -158,9 +158,54 @@ describe("live registry — t1d audit", () => {
 
   it("only the audited domains populate the live index", () => {
     // allEdgeProvenanceEntries flattens every populated domain. Today that's
-    // t1d only; un-audited domains resolve to an empty catalog.
-    expect(allEdgeProvenanceEntries().length).toBe(6);
+    // t1d (6) + vx880 (4) = 10; un-audited domains resolve to an empty catalog.
+    expect(allEdgeProvenanceEntries().length).toBe(10);
     expect(getEdgeProvenanceCatalog("geopolitical")).toEqual([]);
+  });
+});
+
+describe("live registry — vx880 audit", () => {
+  // The four vx880-OWNED entries. The vx880 graph additionally reuses two
+  // t1d-domain ids cross-domain (reichman-nejm-2025, vigersky-2019) — those
+  // are asserted by the cross-domain reuse test below, not counted here.
+  const VX880_IDS = [
+    "shapiro-edmonton-2000",
+    "hering-cit07-2016",
+    "ryan-2005",
+    "hla-dr-islet-2023",
+  ];
+
+  it("exposes the audited vx880 catalog as 4 cited literature entries", () => {
+    const catalog = getEdgeProvenanceCatalog("vx880");
+    expect(catalog.length).toBe(4);
+    expect(catalog.map((e) => e.id).sort()).toEqual([...VX880_IDS].sort());
+    for (const entry of catalog) {
+      expect(entry.domain).toBe("vx880");
+      expect(entry.kind).toBe("literature");
+      expect(entry.citation).toBeTruthy();
+    }
+  });
+
+  it("resolves each audited vx880 id to its entry", () => {
+    for (const id of VX880_IDS) {
+      expect(getEdgeProvenanceEntry(id)?.id).toBe(id);
+    }
+  });
+
+  it("the vx880 graph reuses t1d-domain entries cross-domain by global id", () => {
+    // The registry's headline feature: an edge in one domain references a
+    // citation authored in another. These two ids live under domain "t1d" yet
+    // are tagged on vx880 edges (e6 → reichman, e19 → vigersky).
+    for (const id of ["reichman-nejm-2025", "vigersky-2019"]) {
+      expect(getEdgeProvenanceEntry(id)?.domain).toBe("t1d");
+    }
+    const vx880Refs = new Set(
+      VX880_GRAPH.edges
+        .flatMap((e) => [e.weightSourceRef, e.confidenceSourceRef])
+        .filter((r): r is string => Boolean(r)),
+    );
+    expect(vx880Refs.has("reichman-nejm-2025")).toBe(true);
+    expect(vx880Refs.has("vigersky-2019")).toBe(true);
   });
 });
 
@@ -191,5 +236,16 @@ describe("real graph data ref integrity", () => {
       .filter((r): r is string => Boolean(r));
     expect(t1dRefs.length).toBe(16);
     expect(validateEdgeProvenanceRefs(t1dRefs)).toEqual([]);
+  });
+
+  it("the vx880 audit tagged real edges (guard is non-vacuous)", () => {
+    // The vx880 audit tagged 5 edges, each carrying both a weight + confidence
+    // ref → 10 ref slots. Note e11 deliberately splits the two across separate
+    // sources (weight ← shapiro-edmonton-2000, confidence ← hering-cit07-2016).
+    const vx880Refs = VX880_GRAPH.edges
+      .flatMap((e) => [e.weightSourceRef, e.confidenceSourceRef])
+      .filter((r): r is string => Boolean(r));
+    expect(vx880Refs.length).toBe(10);
+    expect(validateEdgeProvenanceRefs(vx880Refs)).toEqual([]);
   });
 });

--- a/src/lib/edge-provenance-registry.ts
+++ b/src/lib/edge-provenance-registry.ts
@@ -24,8 +24,11 @@
  * domain is the first audited (DCCT/EDIC, TrialNet TN-10, FORWARD-101,
  * TIR↔HbA1c consensus); every entry is a real, verifiable publication, all
  * DOIs cross-checked against the repo's own vetted source-of-truth in
- * research/scripts/build_t1d_timeseries.py. Other domains (geopolitical
- * energy, AI-safety, the VX-880 companion graph) land in later passes.
+ * research/scripts/build_t1d_timeseries.py. The `vx880` companion graph is the
+ * second audited domain (Edmonton/Shapiro, CIT-07, Ryan 5-yr, HLA-DR matching),
+ * and it also showcases cross-domain reuse — its dose→engraftment and TIR→HbA1c
+ * edges reference `t1d`-domain entries by global id rather than re-citing them.
+ * Other domains (geopolitical energy, AI-safety) land in later passes.
  *
  * Honesty note: a `literature` entry asserts that the *relationship* (sign +
  * approximate magnitude) of an edge is grounded in the cited source. The
@@ -128,9 +131,10 @@ const CATALOGS: Record<string, EdgeProvenanceEntry[]> = {
       citation:
         "Reichman et al. N Engl J Med 2025. doi:10.1056/NEJMoa2506549",
       note:
-        "Vertex FORWARD-101 (zimislecel, full-dose cohort n=12): stem-cell-derived islet " +
-        "engraftment restored endogenous insulin, with 83% insulin-independent at 1 year. " +
-        "Early-phase, small n — hence the edge's deliberately low confidence.",
+        "Vertex FORWARD-101 (zimislecel): single intraportal infusion of stem-cell-derived " +
+        "islets; full-dose cohort (n=12) reached 83% insulin-independence at 1 year, half-dose " +
+        "(part A) markedly less. The dose-response + engraftment evidence base. Early-phase, " +
+        "small n. (Shared by the t1d SC-β edge and the vx880 dose→engraftment edge.)",
     },
     {
       // TIR↔HbA1c published relationship + international consensus. Grounds the
@@ -144,7 +148,70 @@ const CATALOGS: Record<string, EdgeProvenanceEntry[]> = {
         "consensus: Battelino T et al. Diabetes Care 2019;42(8):1593-1603. doi:10.2337/dci19-0028",
       note:
         "Published TIR↔HbA1c relationship — a near-mathematical coupling via time-averaged " +
-        "glucose. Grounds the high confidence on the real-world-TIR → population-HbA1c edge.",
+        "glucose (r²≈0.80). Grounds the high confidence on real-world TIR → HbA1c edges " +
+        "(shared by the t1d and vx880 graphs).",
+    },
+  ],
+  vx880: [
+    {
+      // Edmonton Protocol — the steroid-free immunosuppression regimen that
+      // made clinical islet transplantation reproducible. Grounds the
+      // immunosuppression → alloimmune-rejection (graft-protection) weight.
+      id: "shapiro-edmonton-2000",
+      domain: "vx880",
+      kind: "literature",
+      citation:
+        "Shapiro AMJ et al. N Engl J Med 2000;343(4):230-238. doi:10.1056/NEJM200007273430401",
+      note:
+        "The Edmonton Protocol: 7/7 recipients achieved insulin independence under a " +
+        "glucocorticoid-free sirolimus/tacrolimus/daclizumab regimen. Grounds the SIGN and " +
+        "approximate strength of the immunosuppression → alloimmune-rejection edge (more " +
+        "effective IS ⇒ less graft loss); the edge weight is an author calibration to [-1,1].",
+    },
+    {
+      // CIT-07 — the phase-3 multicentre trial that confirmed the Edmonton
+      // approach at scale. Grounds CONFIDENCE on the immunosuppression edge
+      // (intentionally a different source from the weight, to show the
+      // registry's weight-vs-confidence separation across two citations).
+      id: "hering-cit07-2016",
+      domain: "vx880",
+      kind: "literature",
+      citation:
+        "Hering BJ et al. Diabetes Care 2016;39(7):1230-1240. PMID:27208344 (CIT-07)",
+      note:
+        "CIT-07 phase-3 (n=48): 87.5% reached HbA1c <7.0% with no severe hypoglycemia at 1 " +
+        "year, establishing reproducibility of the regimen across centres. Used to ground the " +
+        "CONFIDENCE of the immunosuppression edge (the weight is grounded by Edmonton/Shapiro " +
+        "— two sources deliberately split across the weight/confidence axes).",
+    },
+    {
+      // Ryan 5-year follow-up — established the durability picture and the
+      // stimulated-C-peptide ('Ryan criteria') link to lasting independence.
+      // Grounds the MMTT-AUC C-peptide → insulin-independence edge.
+      id: "ryan-2005",
+      domain: "vx880",
+      kind: "literature",
+      citation:
+        "Ryan EA et al. Diabetes 2005;54(7):2060-2069. doi:10.2337/diabetes.54.7.2060",
+      note:
+        "Five-year follow-up of the Edmonton cohort: graft function (stimulated C-peptide) " +
+        "tracked durable insulin independence — the basis for using MMTT-stimulated C-peptide " +
+        "AUC as the functional-mass readout. Grounds the sign/approximate magnitude of the " +
+        "C-peptide → insulin-independence edge; weight is calibrated.",
+    },
+    {
+      // HLA-DR matching and islet-transplant outcomes. Replaces a vague prior
+      // attribution with a specific, verifiable source. Grounds the HLA-risk →
+      // autoimmune-recurrence edge.
+      id: "hla-dr-islet-2023",
+      domain: "vx880",
+      kind: "literature",
+      citation:
+        "Front Immunol 2023;14:1110544. doi:10.3389/fimmu.2023.1110544",
+      note:
+        "HLA-DR matching (notably excluding DR3/DR4 mismatch) associated with better islet-" +
+        "graft survival and insulin independence — the basis for the recipient HLA-risk → " +
+        "autoimmune-recurrence edge. Grounds direction/approximate strength; weight is calibrated.",
     },
   ],
 };

--- a/src/lib/t1d-vx880-graph-data.ts
+++ b/src/lib/t1d-vx880-graph-data.ts
@@ -352,6 +352,8 @@ const EDGES: CausalEdge[] = [
     confidence: 0.75,
     isInconsistent: false,
     physicalMechanism: "DR3/DR4 alleles present islet autoantigens (preproinsulin, GAD65) — HR ~2-3 per risk allele (Nepom/Pugliese)",
+    weightSourceRef: "hla-dr-islet-2023",
+    confidenceSourceRef: "hla-dr-islet-2023",
   },
   {
     id: "vx880_e2",
@@ -412,7 +414,9 @@ const EDGES: CausalEdge[] = [
     type: "directed",
     confidence: 0.85,
     isInconsistent: false,
-    physicalMechanism: "Dose-dependent engraftment: full-dose cohort >> half-dose in Reichman NEJM 2023",
+    physicalMechanism: "Dose-dependent engraftment: full-dose cohort >> half-dose in Reichman NEJM 2025",
+    weightSourceRef: "reichman-nejm-2025",
+    confidenceSourceRef: "reichman-nejm-2025",
   },
   {
     id: "vx880_e7",
@@ -470,6 +474,8 @@ const EDGES: CausalEdge[] = [
     confidence: 0.85,
     isInconsistent: false,
     physicalMechanism: "Primary IS role — prevents HLA-mismatch-driven rejection (Edmonton protocol; CIT-07)",
+    weightSourceRef: "shapiro-edmonton-2000",
+    confidenceSourceRef: "hering-cit07-2016",
   },
   {
     id: "vx880_e12",
@@ -564,6 +570,8 @@ const EDGES: CausalEdge[] = [
     confidence: 0.95,
     isInconsistent: false,
     physicalMechanism: "TIR ↔ HbA1c mathematically coupled via time-averaged glucose (Vigersky/Battelino 2019, r²≈0.80)",
+    weightSourceRef: "vigersky-2019",
+    confidenceSourceRef: "vigersky-2019",
   },
   {
     id: "vx880_e20",
@@ -586,6 +594,8 @@ const EDGES: CausalEdge[] = [
     confidence: 0.8,
     isInconsistent: false,
     physicalMechanism: "Stimulated C-peptide AUC is the stronger determinant of sustained insulin independence (Ryan criteria)",
+    weightSourceRef: "ryan-2005",
+    confidenceSourceRef: "ryan-2005",
   },
 ];
 


### PR DESCRIPTION
## Summary

Second **per-domain provenance audit** on the edge-provenance registry (#465), following the T1D leg (#472). Fills the **vx880** companion-graph domain with real, verifiable citations and tags the edges those sources ground. Crucially, it exercises the registry's headline feature — **cross-domain "cite once, reference many"**: two vx880 edges reference `t1d`-domain entries by global id rather than re-citing the same paper.

> **Stacked on #472** (which is itself stacked on #465). Base is `feat/t1d-provenance-audit` because the vx880 edges reference `reichman-nejm-2025` / `vigersky-2019` — entries authored in the t1d catalog by #472 — and the shared-note generalization + test scaffolding live there. Retargets onto `main` as the stack merges down.

## Catalog — 4 new `CATALOGS.vx880` entries

Every citation web-verified before tagging:

| id | source | grounds |
|---|---|---|
| `shapiro-edmonton-2000` | Shapiro AMJ et al., NEJM 2000;343(4):230-238 | Edmonton Protocol → IS protective weight |
| `hering-cit07-2016` | Hering BJ et al., Diabetes Care 2016;39(7):1230-1240 (CIT-07) | phase-3 reproducibility → IS confidence |
| `ryan-2005` | Ryan EA et al., Diabetes 2005;54(7):2060-2069 | Ryan criteria → C-peptide AUC → independence |
| `hla-dr-islet-2023` | HLA-DR matching, Front Immunol 2023;14:1110544 | HLA-risk → autoimmune recurrence |

## Edges tagged — `t1d-vx880-graph-data.ts` (5 of 21)

| edge | relationship | weightRef | confidenceRef |
|---|---|---|---|
| `vx880_e1` | HLA-risk → autoimmune recurrence | `hla-dr-islet-2023` | `hla-dr-islet-2023` |
| `vx880_e6` | dose → engraftment | `reichman-nejm-2025` ⟂ | `reichman-nejm-2025` ⟂ |
| `vx880_e11` | immunosuppression → alloimmune rejection | `shapiro-edmonton-2000` | `hering-cit07-2016` |
| `vx880_e19` | real-world TIR → HbA1c | `vigersky-2019` ⟂ | `vigersky-2019` ⟂ |
| `vx880_e21` | MMTT-AUC C-peptide → insulin independence | `ryan-2005` | `ryan-2005` |

⟂ = **cross-domain reuse** of a `t1d`-domain entry by global id (the registry's whole point).

**`vx880_e11` splits weight vs confidence across two different sources** — Edmonton grounds the protective magnitude; CIT-07 grounds our confidence via phase-3 reproducibility — demonstrating per-attribute resolution.

## Real-only discipline (the "nothing synthetic" rule)

- The two **Bottino**-attributed edges (`vx880_e2`, `vx880_e10`) are left **author-backfilled**: the cited "Bottino 2018, Transplantation" could not be verified, so they are NOT tagged.
- Corrected `vx880_e6` prose that mislabeled the Reichman trial as **NEJM 2023** — the verified publication is **NEJM 2025** (doi:10.1056/NEJMoa2506549).
- A `literature` entry asserts the edge's **relationship** (sign + approximate magnitude); the exact scalar stays an **author calibration**, stated in each `note`. No fabricated effect sizes.

## Tests — `edge-provenance-registry.test.ts` (15 → 19)

- New **vx880-audit** block: catalog exposes 4 cited literature entries, each id resolves, and a dedicated **cross-domain-reuse** test asserts `reichman-nejm-2025` / `vigersky-2019` resolve to domain `t1d` yet appear on vx880 edges.
- Live-index total assertion moves **6 → 10**.
- New **non-vacuous vx880 guard**: the graph carries exactly **10 ref slots**, all resolving — the integrity guard now scans real refs across **two** domains.

## Test plan

- [x] `npx tsc --noEmit` → zero new errors on changed files (15 pre-existing in unrelated discovery/onboarding test files unchanged)
- [x] `npx next build` → clean
- [x] `npx vitest run` → 1581/1581 pass (+4 net)
- [ ] PR-validate workflow green

## What's next

Subsequent per-domain audits (separate PRs, same data-only pattern): **geopolitical-energy**, then **AI-safety** (migrate #391's inline citations into the registry + the Ghauri-2025 edges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
