### PR TITLE
feat(feeds): extend EIA Saudi-crude proxy to Ras Tanura export terminal

### DIFF
--- a/src/lib/__tests__/feeds/eia-saudi-crude.test.ts
+++ b/src/lib/__tests__/feeds/eia-saudi-crude.test.ts
@@ -93,10 +93,11 @@ describe("mockEiaSaudiCrudeFeed", () => {
 });
 
 describe("eiaSaudiCrudeProvider.matchPayload", () => {
-  it("attaches a production signal to Abqaiq / Juaymah / 'Saudi crude production' nodes", () => {
+  it("attaches a production signal to Abqaiq / Juaymah / Ras Tanura terminal / 'Saudi crude production' nodes", () => {
     const nodes = [
       makeNode({ id: "abqaiq", label: "Abqaiq Plants" }),
       makeNode({ id: "juaymah", label: "Juaymah Crude Terminal" }),
+      makeNode({ id: "ras_tanura", label: "Ras Tanura Terminal" }),
       makeNode({ id: "future", label: "Saudi Crude Production (raw upstream)" }),
       makeNode({ id: "neutral", label: "Generic Refinery" }),
     ];
@@ -108,8 +109,24 @@ describe("eiaSaudiCrudeProvider.matchPayload", () => {
     const matched = batch.updates.map((u) => u.nodeId).sort();
     expect(matched).toContain("abqaiq");
     expect(matched).toContain("juaymah");
+    expect(matched).toContain("ras_tanura");
     expect(matched).toContain("future");
     expect(matched).not.toContain("neutral");
+  });
+
+  it("matches the Ras Tanura crude export terminal but NOT the co-located refinery", () => {
+    // "ras tanura terminal" is a specific substring: the export terminal
+    // is a crude-throughput proxy (paired with Juaymah), the refinery is
+    // a downstream consumer and must not receive the production signal.
+    const nodes = [
+      makeNode({ id: "terminal", label: "Ras Tanura Terminal" }),
+      makeNode({ id: "refinery", label: "Ras Tanura Refinery" }),
+    ];
+    const feed = mockEiaSaudiCrudeFeed();
+    const batch = eiaSaudiCrudeProvider.matchPayload(feed, nodes);
+    const matched = batch.updates.map((u) => u.nodeId).sort();
+    expect(matched).toContain("terminal");
+    expect(matched).not.toContain("refinery");
   });
 
   it("emits no event when no nodes match", () => {

--- a/src/lib/feeds/providers/eia-saudi-crude.ts
+++ b/src/lib/feeds/providers/eia-saudi-crude.ts
@@ -15,14 +15,22 @@ import type { FeedDispatchBatch, FeedProvider } from "./types";
 
 /** Substrings (case-insensitive) that mark a node as receiving Saudi
  *  crude-production updates. Conservative — Abqaiq is the main
- *  processing facility for ~half of Saudi production; Juaymah is the
- *  export terminal. Both are reasonable proxies for "Saudi crude
- *  throughput" today and any future "Saudi Crude Production"
- *  dedicated node will match. */
+ *  processing facility for ~half of Saudi production; Juaymah and Ras
+ *  Tanura form the integrated eastern crude-export complex (the graph's
+ *  own `sa_ras_tanura_terminal → sa_juaymah_crude_terminal` edge calls
+ *  them exactly that). All three are reasonable proxies for "Saudi
+ *  crude throughput" today and any future "Saudi Crude Production"
+ *  dedicated node will match.
+ *
+ *  Note the pattern is "ras tanura TERMINAL", not bare "ras tanura":
+ *  the co-located "Ras Tanura Refinery" is a downstream crude *consumer*,
+ *  not an export-throughput node, so the specific substring keeps the
+ *  production signal off it without needing a negative exclusion. */
 const SAUDI_PRODUCTION_PATTERNS = [
   "saudi crude production",
   "abqaiq",
   "juaymah crude",
+  "ras tanura terminal",
 ];
 
 function matchesSaudiProduction(node: CausalNode): boolean {


### PR DESCRIPTION
## Summary

Extends the existing **EIA Saudi-crude production** proxy to also drive `sa_ras_tanura_terminal` — the world's largest crude export terminal. This is consistent with the provider already driving the Juaymah crude terminal: the graph's own `sa_ras_tanura_terminal → sa_juaymah_crude_terminal` edge describes the two as *"an integrated eastern export complex sharing pipeline feed and port logistics"*, so the same upstream throughput proxy applies to both.

- Adds the **specific** substring `"ras tanura terminal"` to the matcher (not bare `"ras tanura"`).
- The co-located **Ras Tanura Refinery** is a downstream crude *consumer*, not an export-throughput node — the specific substring keeps the production signal off it with no negative exclusion needed.
- **+1 node** to live coverage.

## Test plan

- [x] Regression test asserts terminal-yes / refinery-no.
- [x] Updated the primary match test to include Ras Tanura terminal.
- [x] Feed suite 117 → 118 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
