### PR TITLE
perf(pareto): decouple relevance bootstrap from replay-transient countdown

### DIFF
--- a/src/components/modules/ParetoPanel.tsx
+++ b/src/components/modules/ParetoPanel.tsx
@@ -128,18 +128,29 @@ function ParetoPanel({
     ? replayEpochs[currentEpoch] ?? null
     : null;
   // ── Derive three criticality countdowns ──
-  // CSD: Critical Slowing Down — based on spectral radius and cascade load
-  const csdEpochs = useMemo(() => {
+  // CSD: Critical Slowing Down — based on spectral radius and cascade load.
+  //
+  // Split into a replay-STABLE base and the replay-animated display value.
+  // `csdBaseEpochs` depends only on graph structure + shocks — NOT on
+  // `currentSnapshot` — so it is constant across a cascade replay. It seeds the
+  // LPPLS relevance fit (see `lpplsData`), which is what keeps the 200-sample
+  // relevance bootstrap in `relevanceMap` from re-running on every 150 ms epoch
+  // tick. `csdEpochs` layers the per-epoch countdown on top for DISPLAY only.
+  // When replay is inactive (currentSnapshot === null) the two are identical,
+  // so the settled-state relevance is byte-for-byte unchanged by this split.
+  const csdBaseEpochs = useMemo(() => {
     const lambdaMax = graphData.edges.reduce((max, e) => {
       const srcNode = graphData.nodes.find((n) => n.id === e.source);
       return Math.max(max, (srcNode?.omegaFragility.cascadeLoad ?? 0) * e.weight / 10);
     }, 0);
     const shockPressure = shocks.reduce((s, sh) => s + sh.severity, 0);
-    const baseEpochs = Math.max(3, Math.round(200 * (1 - lambdaMax) * (1 - shockPressure * 0.4)));
-    return currentSnapshot
-      ? Math.max(0, baseEpochs - Math.round(currentSnapshot.epoch * (1 + shockPressure)))
-      : baseEpochs;
-  }, [graphData, shocks, currentSnapshot]);
+    return Math.max(3, Math.round(200 * (1 - lambdaMax) * (1 - shockPressure * 0.4)));
+  }, [graphData, shocks]);
+  const csdEpochs = useMemo(() => {
+    if (!currentSnapshot) return csdBaseEpochs;
+    const shockPressure = shocks.reduce((s, sh) => s + sh.severity, 0);
+    return Math.max(0, csdBaseEpochs - Math.round(currentSnapshot.epoch * (1 + shockPressure)));
+  }, [csdBaseEpochs, shocks, currentSnapshot]);
 
   // PH: Persistent Homology — based on topological holes (high-fragility clusters)
   const phEpochs = useMemo(() => {
@@ -399,8 +410,13 @@ function ParetoPanel({
     const seedPhase = avgOmega * 0.3;
 
     // Template values that used to be used verbatim; now a seed into the grid.
+    // tc seeds from the replay-STABLE `csdBaseEpochs`, not the per-epoch
+    // `csdEpochs` — otherwise the seed (and therefore this whole memo, and the
+    // 200-sample relevance bootstrap downstream) would churn on every replay
+    // tick. The seed is only a grid-search starting point; the converged fit is
+    // seed-robust, and outside replay csdBaseEpochs === csdEpochs.
     const seed = {
-      tc: 1 + csdEpochs / Math.max(1, csdEpochs + 50),
+      tc: 1 + csdBaseEpochs / Math.max(1, csdBaseEpochs + 50),
       omega: 6.36 + shockPressure * 2.1,
       m: 0.33 + shockPressure * 0.1,
       phase: seedPhase,
@@ -447,7 +463,7 @@ function ParetoPanel({
       fitted: true as const,
       evaluations: fit.evaluations,
     };
-  }, [scopedOmegaSeries, graphData.nodes, shocks, csdEpochs]);
+  }, [scopedOmegaSeries, graphData.nodes, shocks, csdBaseEpochs]);
 
   // ── BOCPD: Bayesian online change-point detection on the same Ω trajectory ──
   // Runs the run-length posterior over `scopedOmegaSeries` and exposes the


### PR DESCRIPTION
## Summary

Resolves the long-standing **Pearl ↔ Pareto loop** question on the backlog: *should the relevance card recompute on every cascade-replay tick, or only on the settled state?*

The answer is neither a debounce nor "every tick" — relevance is a property of the scoped **historical Ω trajectory** and graph structure, **neither of which is a function of the replay epoch**, so it should be replay-*invariant*. This PR makes it so.

## The bug

The 200-sample relevance bootstrap (`bootstrapRelevanceBatch` inside `relevanceMap`) was re-running on **every replay epoch** — one run every 150 ms at 1x, faster at higher `replaySpeed` (`useReplayTick.ts`). Cause: `lpplsData` seeded its LPPLS critical-time parameter `tc` from `csdEpochs`, and `csdEpochs` subtracts a per-epoch term derived from `currentSnapshot`, which the replay advances frame by frame:

```
currentEpoch++ (every 150ms)
  → currentSnapshot changes
    → csdEpochs changes            (display countdown — SHOULD animate)
      → lpplsData.seed.tc drifts    (incidental coupling — should NOT)
        → lpplsData identity churns
          → relevanceMap busts → 200-sample bootstrap re-runs + EMA reseeds
```

Two symptoms: sustained main-thread churn during every replay, and the relevance percentages visibly **jittering** as the seed drifted.

## The fix

Split the CSD countdown into a replay-stable base and the animated display value:

- **`csdBaseEpochs`** — depends only on graph structure + shocks (no `currentSnapshot`). Seeds the LPPLS relevance fit.
- **`csdEpochs`** — `csdBaseEpochs` minus the per-epoch term, for **display only** (the CSD tab's `T-NNN` countdown still ticks during replay).

`lpplsData` now seeds `tc` from `csdBaseEpochs` and depends on it, which removes `currentSnapshot` from the **entire** relevance dependency chain. The bootstrap (and its EMA smoothing) no longer re-run during replay.

## Why this is perf, not correctness

When replay is inactive (`currentSnapshot === null`), `csdEpochs === csdBaseEpochs`, so the seed — and therefore the relevance composite — is **byte-for-byte unchanged** in the normal analysis state. The seed only sets the grid-search starting point; the converged LPPLS fit is seed-robust (per the existing code comment), so even at the final replay epoch the relevance value is materially the same, just stable instead of drifting.

Verified the split is the *only* replay-transient input to `relevanceMap`: its other deps (`csdData`, `phData`, `bocpdData`, `graphData.*`, `scopeLabel`, `activeProfile`, `scopedNodeIds`) are all replay-stable.

## Test plan

- [x] `npx tsc --noEmit` → zero new errors on the changed file (15 pre-existing in unrelated discovery/onboarding test files unchanged)
- [x] `npx next build` → clean
- [x] `npx vitest run` → 1581/1581 pass (no test changes; pure component-memo refactor)
- [ ] PR-validate workflow green
- [ ] Manual: run a cascade replay with the Pareto tab open → relevance percentages hold steady while the CSD `T-NNN` countdown still ticks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
