### PR TITLE
docs(risk-flow): correct stale comment about first-tick history length

### DIFF
--- a/src/components/RiskPropagationFlow.tsx
+++ b/src/components/RiskPropagationFlow.tsx
@@ -376,10 +376,13 @@ export default function RiskPropagationFlow() {
               <div ref={containerRef} className="flex-1 flex items-stretch gap-2 overflow-x-auto min-w-0">
               {displayNodes.map((card, i) => {
                 const omegaHistory = nodeHistories.get(card.nodeId) ?? [];
-                // Prefer live-data when ANY liveData entry is attached (even
-                // if history hasn't accumulated yet — first tick has only the
-                // current value, history.length === 0). On second tick the
-                // sparkline gets 2 points and renders a curve.
+                // Prefer live-data when ANY liveData entry is attached. On
+                // the first tick `liveSignal.history` is empty, but the
+                // current observation is appended below as a literal — so
+                // `allHistory.length` is 1, not 0, and OmegaSparkline draws
+                // a horizontal hold-forward line at that single value. On
+                // the second tick `allHistory.length` is 2 and the sparkline
+                // renders a real curve.
                 const node = nodeById.get(card.nodeId);
                 const liveSignal = node?.liveData?.[0];
                 const usingLiveHistory = !!liveSignal;


### PR DESCRIPTION
## Summary
Pure comment edit. The inline comment at `RiskPropagationFlow.tsx:379` claimed "first tick has only the current value, history.length === 0" — but the code path right below it appends the current observation to `allHistory` as a literal, so `allHistory.length` is **1** on first tick, not 0. `OmegaSparkline` draws a horizontal hold-forward line at that single point; on the second tick `allHistory` gains the prior tick's value and a real curve renders.

## Why
Flagged during the ΩF "LIVE — building" tile audit on 2026-05-21 (see session_log.md) but the cleanup itself sat in the queue. Closing it now while waiting on Vercel deploys for #405 + #434.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Pure comment change — no behaviour delta

🤖 Generated with [Claude Code](https://claude.com/claude-code)