### PR TITLE
fix(timeseries): restore collapse toggle on the consolidated bottom dock

### DIFF
--- a/src/components/TimeSeriesOverlay.tsx
+++ b/src/components/TimeSeriesOverlay.tsx
@@ -121,6 +121,12 @@ export default function TimeSeriesOverlay() {
   const selectedNodes = useApexStore((s) => s.selectedNodes);
 
   const [hoverX, setHoverX] = useState<number | null>(null);
+  // Collapse state for the whole dock. Mirrors the affordance that lived on
+  // the retired RiskPropagationFlow strip: a clickable header bar that hides
+  // both the watchlist rail and the chart, giving the canvas above more
+  // vertical room when the user wants to focus on the primary module.
+  // Local state (non-persisted) for parity with the previous behaviour.
+  const [collapsed, setCollapsed] = useState(false);
   // X-axis zoom mode.
   //  - "dial": chart x-axis mirrors the TimeDial's 60-day window so the
   //    chart cursor lines up with the scrubber below. Default, matches the
@@ -559,9 +565,43 @@ export default function TimeSeriesOverlay() {
   return (
     <div
       ref={containerRef}
-      className="border-t border-border bg-surface-elevated flex items-stretch"
+      className="border-t border-border bg-surface-elevated"
       data-tour="risk-flow"
     >
+      {/* Collapse toggle bar. When collapsed, only this strip is visible —
+          the watchlist + chart body below are hidden, giving the canvas
+          above more vertical room. Mirrors the affordance the retired
+          RiskPropagationFlow strip used to expose. */}
+      <button
+        onClick={() => setCollapsed((c) => !c)}
+        className="flex items-center gap-3 w-full px-4 py-1 hover:bg-surface transition-colors"
+        title={collapsed ? "Expand ΩF time series" : "Collapse ΩF time series"}
+      >
+        <span className="text-[9px] font-mono text-text-muted w-3 flex-shrink-0 text-center">
+          {collapsed ? "▶" : "▼"}
+        </span>
+        <span className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted">
+          {"Ω"}F TIME SERIES
+        </span>
+        {collapsed && (
+          <span className="text-[7px] font-mono text-text-muted/60 tabular-nums">
+            {pinnedRows.length > 0 ? `${pinnedRows.length} pinned` : "none pinned"}
+            {liveCount > 0 ? ` · ${liveCount} live` : ""}
+          </span>
+        )}
+      </button>
+
+      <AnimatePresence initial={false}>
+        {!collapsed && (
+          <motion.div
+            key="ts-body"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            className="overflow-hidden"
+          >
+            <div className="flex items-stretch border-t border-border/40">
       {/* LEFT: watchlist rail — pinned series + suggestions. Doubles as the
           chart legend (each pinned row is a curve) and the discovery surface
           (suggested rows pin with one click). Replaces the old standalone
@@ -673,11 +713,12 @@ export default function TimeSeriesOverlay() {
             {"\u2261"}
           </span>
         </div>
-        <span className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-text-muted flex-1">
-          {"\u03A9"}F TIME SERIES
+        {/* Title moved to the outer collapse toggle bar. Only the zoom
+            indicator stays here, when applicable. */}
+        <span className="text-[8px] font-mono text-text-muted flex-1">
           {xAxisMode === "data" && (
-            <span className="ml-2 text-accent-cyan/80">
-              {"·"} ZOOMED {new Date(xStart).getFullYear()}{"–"}{new Date(xEnd).getFullYear()}
+            <span className="text-accent-cyan/80">
+              ZOOMED {new Date(xStart).getFullYear()}{"–"}{new Date(xEnd).getFullYear()}
             </span>
           )}
         </span>
@@ -1014,6 +1055,10 @@ export default function TimeSeriesOverlay() {
       </AnimatePresence>
       )}
       </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }


### PR DESCRIPTION
Restore the collapse toggle that lived on the retired `RiskPropagationFlow` strip. #464 folded that strip into the consolidated `WATCHLIST + ΩF TIME SERIES` panel but dropped the affordance — the dock now sits permanently on the bottom of the workspace, eating canvas room.

## What changes

- Clickable header bar with chevron (`▼`/`▶`) + title. Click to collapse/expand.
- Collapsed: panel shrinks to a ~24px strip showing `▶ ΩF TIME SERIES — N pinned · M live` so the user knows it's still alive without it taking real estate.
- Expanded: the existing two-column watchlist + chart body, animated open via the `framer-motion` `AnimatePresence` already imported in this file (no new bundle cost).
- Title moved out of the right column's sub-header (was duplicated next to the new toggle); inner sub-header now only carries the `ZOOMED yyyy–yyyy` indicator and the `FIT TO DATA / SYNC TO TIMELINE` button, and drops out entirely when neither applies.

## State

Local `useState`, non-persisted, defaults to expanded. Parity with how the old `RiskPropagationFlow` strip behaved. If we want it to remember collapsed/expanded across reloads, wire through `useApexStore` as a follow-up.

## Files

- `src/components/TimeSeriesOverlay.tsx` — +50 / -5

## Verification

- `tsc --noEmit` clean for this file (pre-existing test-file errors elsewhere unrelated)
- No new lint warnings on the file
- Not browser-verified in this session — please eyeball after merge. Standard collapse pattern lifted from the same component family that previously shipped this UX, so confidence is high but a 30-second look is the proof.

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_