### PR TITLE
feat(dock): persist bottom-dock collapse state across reloads

### DIFF
--- a/src/components/TimeSeriesOverlay.tsx
+++ b/src/components/TimeSeriesOverlay.tsx
@@ -139,8 +139,16 @@ export default function TimeSeriesOverlay() {
   // the retired RiskPropagationFlow strip: a clickable header bar that hides
   // both the watchlist rail and the chart, giving the canvas above more
   // vertical room when the user wants to focus on the primary module.
-  // Local state (non-persisted) for parity with the previous behaviour.
-  const [collapsed, setCollapsed] = useState(false);
+  // Persisted via the store (localStorage-backed) so the choice survives a
+  // reload; hydrated post-mount to keep SSR and first client render in sync.
+  const collapsed = useApexStore((s) => s.bottomDockCollapsed);
+  const setBottomDockCollapsed = useApexStore((s) => s.setBottomDockCollapsed);
+  const hydrateBottomDockCollapsed = useApexStore(
+    (s) => s.hydrateBottomDockCollapsed,
+  );
+  useEffect(() => {
+    hydrateBottomDockCollapsed();
+  }, [hydrateBottomDockCollapsed]);
   // X-axis zoom mode.
   //  - "dial": chart x-axis mirrors the TimeDial's 60-day window so the
   //    chart cursor lines up with the scrubber below. Default, matches the
@@ -666,7 +674,7 @@ export default function TimeSeriesOverlay() {
           above more vertical room. Mirrors the affordance the retired
           RiskPropagationFlow strip used to expose. */}
       <button
-        onClick={() => setCollapsed((c) => !c)}
+        onClick={() => setBottomDockCollapsed(!collapsed)}
         className="flex items-center gap-3 w-full px-4 py-1 hover:bg-surface transition-colors"
         title={collapsed ? "Expand ΩF time series" : "Collapse ΩF time series"}
       >

--- a/src/lib/ui-prefs-persistence.ts
+++ b/src/lib/ui-prefs-persistence.ts
@@ -1,0 +1,43 @@
+// ─── UI preferences — localStorage persistence ──────────────────────
+//
+// Small, deliberate UI choices the user makes that should outlive a
+// page reload — distinct from session state (graph, selection, timeline
+// position) which intentionally resets. Kept separate from
+// calc-history-persistence so each file owns exactly one concern.
+//
+// First (and currently only) member: the bottom time-series dock's
+// collapsed/expanded state. Collapsing reclaims canvas room for the
+// primary module; if the user does that, having it spring back open on
+// every refresh is annoying, so we remember it.
+
+const BOTTOM_DOCK_COLLAPSED_KEY = "manifold:bottom-dock-collapsed";
+
+/**
+ * Load the persisted bottom-dock collapsed preference. SSR-safe.
+ * Returns `null` when nothing is stored (or storage is unavailable) so
+ * the caller can keep its own default rather than being forced to false.
+ */
+export function loadBottomDockCollapsed(): boolean | null {
+  if (typeof window === "undefined" || !window.localStorage) return null;
+  try {
+    const raw = window.localStorage.getItem(BOTTOM_DOCK_COLLAPSED_KEY);
+    if (raw === null) return null;
+    return raw === "1";
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist the bottom-dock collapsed preference. SSR-safe + swallows
+ * quota / private-mode errors (best-effort; must never break the toggle
+ * that triggered it).
+ */
+export function saveBottomDockCollapsed(collapsed: boolean): void {
+  if (typeof window === "undefined" || !window.localStorage) return;
+  try {
+    window.localStorage.setItem(BOTTOM_DOCK_COLLAPSED_KEY, collapsed ? "1" : "0");
+  } catch {
+    // ignore — quota exceeded, private-mode, etc.
+  }
+}

--- a/src/stores/useApexStore.ts
+++ b/src/stores/useApexStore.ts
@@ -24,6 +24,10 @@ import {
   loadGraphCalcHistory,
   saveGraphCalcHistory,
 } from "@/lib/calc-history-persistence";
+import {
+  loadBottomDockCollapsed,
+  saveBottomDockCollapsed,
+} from "@/lib/ui-prefs-persistence";
 // `applyTarskiFlags`, `clearTarskiFlags`, and the `TarskiValidationReport`
 // type live in the lightweight `tarski-flags.ts`. `runTarskiValidation`
 // stays in `tarski-data.ts` next to the 891-LOC AXIOM_LIBRARY +
@@ -250,6 +254,14 @@ export interface ApexState {
   // is per-node, not per-app.
   expandedPillar: PillarKey | null;
   setExpandedPillar: (key: PillarKey | null) => void;
+
+  /** Bottom time-series dock collapsed state. Persisted to localStorage
+   *  (see ui-prefs-persistence) so the user's choice to reclaim canvas
+   *  room survives reloads. Defaults to expanded; hydrated post-mount via
+   *  hydrateBottomDockCollapsed to avoid an SSR hydration mismatch. */
+  bottomDockCollapsed: boolean;
+  setBottomDockCollapsed: (collapsed: boolean) => void;
+  hydrateBottomDockCollapsed: () => void;
 
   // Selected edge (for edge inspector popup)
   selectedEdgeId: string | null;
@@ -750,6 +762,19 @@ export const useApexStore = create<ApexState>((set, get) => ({
 
   expandedPillar: null,
   setExpandedPillar: (key) => set({ expandedPillar: key }),
+
+  // Bottom-dock collapse. Default expanded; the persisted preference is
+  // applied post-mount by hydrateBottomDockCollapsed so server and first
+  // client render agree (both see `false`) before the stored value lands.
+  bottomDockCollapsed: false,
+  setBottomDockCollapsed: (collapsed) => {
+    saveBottomDockCollapsed(collapsed);
+    set({ bottomDockCollapsed: collapsed });
+  },
+  hydrateBottomDockCollapsed: () => {
+    const persisted = loadBottomDockCollapsed();
+    if (persisted !== null) set({ bottomDockCollapsed: persisted });
+  },
 
   // Selected edge
   selectedEdgeId: null,


### PR DESCRIPTION
Follow-up to #490 (which restored the collapse toggle on the consolidated bottom dock).

**Problem:** #490 used local component `useState`, so the dock sprang back **open** on every page reload. If you collapse it to reclaim canvas room for the primary module, that choice should stick.

**Fix:** move the collapsed flag into `useApexStore`, backed by `localStorage`:
- New focused helper `src/lib/ui-prefs-persistence.ts` (`load/saveBottomDockCollapsed`) — mirrors the existing `calc-history-persistence` pattern, SSR-safe, swallows quota/private-mode errors. Kept separate so each persistence file owns one concern.
- Store gains `bottomDockCollapsed` + `setBottomDockCollapsed` (writes through to localStorage) + `hydrateBottomDockCollapsed`.
- `TimeSeriesOverlay` reads the flag from the store and calls `hydrateBottomDockCollapsed()` once on mount. Default is **expanded**; the persisted value is applied post-mount so server and first client render agree (no SSR hydration mismatch).

**Verification:**
- `tsc --noEmit`: clean for all three changed files (pre-existing test-file errors unrelated).
- `eslint`: clean for changed files (the line-168 `setXAxisMode` warning and the scissors/ablation `no-unused-vars` warnings are all pre-existing).
- Local `next build` fails only on Google Fonts fetch (sandbox has no network) — unrelated to this change; Vercel will build fine.

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_