### PR TITLE
refactor(edges): modular edge-TYPE registry — open union + centralize presentation

### DIFF
--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -41,6 +41,7 @@ import {
 import { type NodeMetrics } from "@/lib/graph-layout";
 import { requestLayout2D } from "@/lib/workers/layout3d-client";
 import { cascadeActivationOrder } from "@/lib/cascade-activation-order";
+import { getEdgeTypeMeta } from "@/lib/edge-type-registry";
 import {
   cascadeEdgeActivationOrder,
   edgeFireIntensity,
@@ -328,19 +329,9 @@ function EdgeInspector({
   onClose: () => void;
   chiStarInfo?: ChiStarEdgeInfo | null;
 }) {
-  const typeColor =
-    edge.type === "temporal"
-      ? "#ffab00"
-      : edge.type === "confounded"
-        ? "#ff6d00"
-        : "#00e5ff";
-
-  const typeLabel =
-    edge.type === "temporal"
-      ? "TEMPORAL"
-      : edge.type === "confounded"
-        ? "CONFOUNDED"
-        : "DIRECTED";
+  const typeMeta = getEdgeTypeMeta(edge.type);
+  const typeColor = typeMeta.color;
+  const typeLabel = typeMeta.label;
 
   return (
     <motion.div
@@ -1128,9 +1119,9 @@ function CausalDAG2DInner() {
         const isInconsistent = truthFilter === "verified" && !!e.isInconsistent;
         const propagationSignal = currentSnapshot?.edgeStates[e.id]?.propagationSignal ?? 0;
         const isSelected = selectedEdge?.id === e.id;
+        const typeMeta = getEdgeTypeMeta(e.type);
         const isTemporal = e.type === "temporal";
         const isConfounded = e.type === "confounded";
-        const isFlow = e.type === "flow";
         // FIRE pulse — peaks at the edge's activation epoch and decays
         // over a 3-epoch window. 0 when the edge never fired in the
         // visible cascade. Severed / ablated suppress separately in
@@ -1141,15 +1132,9 @@ function CausalDAG2DInner() {
             ? edgeFireIntensity(fireActivationEpoch, clampedEpoch)
             : 0;
 
-        const baseColor = isInconsistent
-          ? "#ff1744"
-          : isTemporal
-            ? "#ffab00"
-            : isConfounded
-              ? "#ff6d00"
-              : isFlow
-                ? "#1de9b6"
-                : "#00e5ff";
+        // Inconsistent edges flag red regardless of type; otherwise the
+        // edge-type registry is the single source of the canvas hue.
+        const baseColor = isInconsistent ? "#ff1744" : typeMeta.color;
         const baseOpacity = isSelected ? 1 : isInconsistent ? 0.6 : 0.7;
         // Power-scale weight to widen the visible width range. Real
         // edge weights cluster between 0.4 and 0.8, so a linear
@@ -1159,7 +1144,7 @@ function CausalDAG2DInner() {
         // as ~3× a thin one even at typical clustering.
         const w = Math.max(0, Math.min(1, e.weight));
         const baseWidth = 0.7 + Math.pow(w, 2.4) * 3.3;
-        const showArrow = e.type === "directed" || isTemporal || isFlow;
+        const showArrow = typeMeta.arrow;
 
         return {
           id: e.id,
@@ -1171,7 +1156,7 @@ function CausalDAG2DInner() {
           // reads at rest — same intent as the 3D particle whoosh for
           // type==="flow". Temporal animates for its lag cue; any edge
           // animates while a cascade signal is propagating through it.
-          animated: isTemporal || isFlow || propagationSignal > 0.3,
+          animated: typeMeta.animated || propagationSignal > 0.3,
           markerEnd: showArrow
             ? { type: MarkerType.ArrowClosed, width: 12, height: 12, color: baseColor }
             : undefined,

--- a/src/components/CausalDAGMap.tsx
+++ b/src/components/CausalDAGMap.tsx
@@ -8,6 +8,7 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import { AnimatePresence } from "framer-motion";
 import { useApexStore } from "@/stores/useApexStore";
 import { getDomainColor } from "@/lib/graph-color";
+import { getEdgeTypeMeta } from "@/lib/edge-type-registry";
 import { getDomainCardColor } from "@/lib/domains";
 import { getNodeCoordinates } from "@/lib/geo-coordinates";
 import { chiStar } from "@/lib/estimators/chi-star";
@@ -337,23 +338,20 @@ function CausalDAGMapInner() {
         }
       }
 
-      // Edge color — matches 3D exactly. Severed gets a distinct slate color
-      // so Pearl link-breaks don't look like Tarski-inconsistent edges.
+      // Edge color — matches 3D exactly via the shared edge-type registry.
+      // Severed gets a distinct slate color so Pearl link-breaks don't look
+      // like Tarski-inconsistent edges; inconsistent overrides to red.
       const isSevered = edge.isSevered ?? false;
+      const typeMeta = getEdgeTypeMeta(edge.type);
       const edgeColor = isSevered
         ? "#78909c"
         : edge.isInconsistent
           ? "#ff1744"
-          : edge.type === "temporal"
-            ? "#ffab00"
-            : edge.type === "confounded"
-              ? "#ff6d00"
-              : edge.type === "flow"
-                ? "#1de9b6"
-                : "#00e5ff";
+          : typeMeta.color;
 
-      // Dashed: confounded, inconsistent, or severed (matches 3D isDashed logic)
-      const isDashed = edge.type === "confounded" || edge.isInconsistent || isSevered;
+      // Dashed: registry-dashed type (confounded), inconsistent, or severed
+      // (matches 3D isDashed logic)
+      const isDashed = typeMeta.dashed || edge.isInconsistent || isSevered;
 
       const baseOpacity = isSevered ? 0.45 : 0.5;
       const opacity = edgeIsDimmed ? 0.08 : baseOpacity;
@@ -429,7 +427,7 @@ function CausalDAGMapInner() {
     return solidEdgeGeoJSON.features
       .filter(
         (f) =>
-          (f.properties?.type === "temporal" || f.properties?.type === "flow") &&
+          getEdgeTypeMeta(f.properties?.type ?? "").animated &&
           (f.properties?.opacity ?? 1) > 0.1,
       )
       .map((f) => {

--- a/src/components/EdgeInspector.tsx
+++ b/src/components/EdgeInspector.tsx
@@ -13,6 +13,7 @@ import {
   extractAutoBridgeScore,
   bridgeStatus,
 } from "@/lib/cross-domain-bridging";
+import { getEdgeTypeMeta } from "@/lib/edge-type-registry";
 import { useApexStore } from "@/stores/useApexStore";
 
 /**
@@ -51,19 +52,12 @@ export default function EdgeInspector({
 }) {
   const promoteAutoBridge = useApexStore((s) => s.promoteAutoBridge);
   const status = bridgeStatus(edge);
-  const typeColor =
-    edge.type === "temporal"
-      ? "#ffab00"
-      : edge.type === "confounded"
-        ? "#ff6d00"
-        : "#00e5ff";
-
-  const typeLabel =
-    edge.type === "temporal"
-      ? "TEMPORAL"
-      : edge.type === "confounded"
-        ? "CONFOUNDED"
-        : "DIRECTED";
+  // Color + label come from the shared edge-type registry, so FLOW (and
+  // any domain-registered type) renders its own hue/label instead of
+  // silently falling through to the cyan DIRECTED default.
+  const typeMeta = getEdgeTypeMeta(edge.type);
+  const typeColor = typeMeta.color;
+  const typeLabel = typeMeta.label;
 
   // Resolve provenance once. Missing fields fall back to author so the
   // analyst always sees *some* signal — silence would be a worse UX

--- a/src/components/dag3d/DAGEdge3D.tsx
+++ b/src/components/dag3d/DAGEdge3D.tsx
@@ -6,6 +6,7 @@ import { Line } from "@react-three/drei";
 import * as THREE from "three";
 import { CausalEdge, EdgeEpochState } from "@/lib/types";
 import { edgeFireIntensity } from "@/lib/cascade-edge-activation-order";
+import { getEdgeTypeMeta } from "@/lib/edge-type-registry";
 
 interface DAGEdge3DProps {
   edge: CausalEdge;
@@ -62,21 +63,13 @@ interface DAGEdge3DProps {
 }
 
 /**
- * Edge color — matches 2D ReactFlow edge styling:
- *   directed  → cyan (#00e5ff)  — solid line
- *   temporal  → amber (#ffab00) — solid line + animated particle
- *   confounded → orange (#ff6d00) — dashed line
- *   inconsistent → red (#ff1744) — overrides type color
+ * Edge color — the per-type hue comes from the edge-type registry
+ * (single source of truth across 3D / 2D / Map). Tarski-inconsistent
+ * edges override the type color with red.
  */
 function getEdgeColor(edge: CausalEdge, isVerifiedInconsistent: boolean): string {
   if (isVerifiedInconsistent) return "#ff1744";
-  switch (edge.type) {
-    case "directed": return "#00e5ff";
-    case "temporal": return "#ffab00";
-    case "confounded": return "#ff6d00";
-    case "flow": return "#1de9b6";
-    default: return "#42466a";
-  }
+  return getEdgeTypeMeta(edge.type).color;
 }
 
 function DAGEdge3DInner({
@@ -190,10 +183,13 @@ function DAGEdge3DInner({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [posKey, curveOffset]);
 
-  // Edge type determines rendering style
+  // Edge type determines rendering style. Color / dash come from the
+  // edge-type registry; the temporal-particle vs flow-whoosh motion
+  // distinction stays an explicit per-renderer treatment (the registry
+  // only declares THAT a type animates, not the 3D cadence).
   const isTemporalFlow = edge.type === "temporal";
   const isFlow = edge.type === "flow";
-  const isDashed = edge.type === "confounded" || isVerifiedInconsistent ||
+  const isDashed = getEdgeTypeMeta(edge.type).dashed || isVerifiedInconsistent ||
     isAblated || isSevered;
 
   // Selection-aware opacity
@@ -227,12 +223,15 @@ function DAGEdge3DInner({
     : isConnectedToSelected ? 1.0
     : Math.min(1, baseOpacity);
 
-  // Should the particle flow animate? Fire pulse counts as a reason
-  // to animate too — at very low propSignal the steady-flow path
+  // Should the particle flow animate? The registry's `animated` flag is
+  // the cross-surface gate for "this type carries a steady at-rest motion
+  // cue" (temporal + flow today, plus any domain type that opts in) — the
+  // 3D cadence below stays a local treatment. Fire pulse counts as a
+  // reason to animate too — at very low propSignal the steady-flow path
   // wouldn't kick in, but the fire moment still needs to render
   // a particle whoosh.
   const shouldAnimate = !isSevered && !isAblated && !selectionDim &&
-    (isTemporalFlow || isFlow || propSignal > 0.3 || fireIntensity > 0.05);
+    (getEdgeTypeMeta(edge.type).animated || propSignal > 0.3 || fireIntensity > 0.05);
   // Boost the animation speed during the fire pulse so the particle
   // visibly accelerates at firing time — matches the human read of
   // "signal arriving fast" vs "signal continuously flowing." Flow

--- a/src/components/dag3d/DAGOverlay.tsx
+++ b/src/components/dag3d/DAGOverlay.tsx
@@ -3,6 +3,12 @@
 import { startTransition, useEffect, useMemo, useRef, useState } from "react";
 import { useApexStore } from "@/stores/useApexStore";
 import { getDomainColor } from "@/lib/graph-color";
+import {
+  getAllEdgeTypeMeta,
+  getEdgeTypeMeta,
+  BUILTIN_EDGE_TYPE_IDS,
+  type EdgeTypeMeta,
+} from "@/lib/edge-type-registry";
 import { useTemporalGraph } from "@/hooks/useTemporalGraph";
 import { DOMAIN_CARDS } from "@/lib/domains";
 import { DOMAIN_MAP } from "@/hooks/useFilteredGraph";
@@ -68,6 +74,17 @@ function EncodingLegend({
       help: "Lies on shortest paths between others. Surfaces chokepoints.",
     },
   ];
+
+  // Built-in edge-type colors come from the shared registry so the legend
+  // swatches stay in lockstep with the canvas. The four built-in rows keep
+  // their bespoke swatch shapes (arrow / dot / dashed gradient) and prose;
+  // only the hue is registry-sourced. Any DOMAIN-registered (non-built-in)
+  // type appends a generic auto-row below, so a new type documents itself
+  // with no edits here.
+  const builtinColor = (id: string) => getEdgeTypeMeta(id).color;
+  const domainEdgeTypes = getAllEdgeTypeMeta().filter(
+    (m) => !(BUILTIN_EDGE_TYPE_IDS as readonly string[]).includes(m.id),
+  );
 
   return (
     <div
@@ -176,8 +193,8 @@ function EncodingLegend({
           help="Direct cause: A → B. Arrowed."
           swatch={
             <div className="flex items-center gap-0.5">
-              <span className="h-0.5 w-6" style={{ backgroundColor: "#00e5ff" }} />
-              <span className="text-[8px]" style={{ color: "#00e5ff" }}>▶</span>
+              <span className="h-0.5 w-6" style={{ backgroundColor: builtinColor("directed") }} />
+              <span className="text-[8px]" style={{ color: builtinColor("directed") }}>▶</span>
             </div>
           }
         />
@@ -186,8 +203,8 @@ function EncodingLegend({
           help="Lag-correlation: A leads B by some delay. Particles flow source → target."
           swatch={
             <div className="flex items-center gap-0.5">
-              <span className="h-0.5 w-6" style={{ backgroundColor: "#ffab00" }} />
-              <span className="h-1 w-1 rounded-full" style={{ backgroundColor: "#ffab00", boxShadow: "0 0 4px #ffab00" }} />
+              <span className="h-0.5 w-6" style={{ backgroundColor: builtinColor("temporal") }} />
+              <span className="h-1 w-1 rounded-full" style={{ backgroundColor: builtinColor("temporal"), boxShadow: `0 0 4px ${builtinColor("temporal")}` }} />
             </div>
           }
         />
@@ -199,8 +216,7 @@ function EncodingLegend({
               <span
                 className="h-0.5 w-7"
                 style={{
-                  backgroundImage:
-                    "linear-gradient(to right, #ff6d00 50%, transparent 50%)",
+                  backgroundImage: `linear-gradient(to right, ${builtinColor("confounded")} 50%, transparent 50%)`,
                   backgroundSize: "4px 100%",
                 }}
               />
@@ -212,12 +228,23 @@ function EncodingLegend({
           help="Directed transmission of material / capital / signal through the network. Distinct from CAUSAL (a claim of cause) and TEMPORAL (a lag correlation) — flow means stuff is actually moving along this edge."
           swatch={
             <div className="flex items-center gap-0.5">
-              <span className="h-0.5 w-6" style={{ backgroundColor: "#1de9b6" }} />
-              <span className="h-1 w-1 rounded-full" style={{ backgroundColor: "#1de9b6", boxShadow: "0 0 4px #1de9b6" }} />
-              <span className="text-[8px]" style={{ color: "#1de9b6" }}>▶</span>
+              <span className="h-0.5 w-6" style={{ backgroundColor: builtinColor("flow") }} />
+              <span className="h-1 w-1 rounded-full" style={{ backgroundColor: builtinColor("flow"), boxShadow: `0 0 4px ${builtinColor("flow")}` }} />
+              <span className="text-[8px]" style={{ color: builtinColor("flow") }}>▶</span>
             </div>
           }
         />
+        {/* Domain-registered edge types (none by default) document
+            themselves here with a generic swatch derived from the
+            registry flags — no edits needed when a domain adds a type. */}
+        {domainEdgeTypes.map((meta) => (
+          <LegendRow
+            key={meta.id}
+            label={meta.label}
+            help={meta.description}
+            swatch={<DomainEdgeSwatch meta={meta} />}
+          />
+        ))}
         <LegendRow
           label="INCONSISTENT (red)"
           help="Tarski filter: edge violates a domain-aware axiom. Only visible when the verified-truth filter is on."
@@ -308,6 +335,44 @@ function LegendRow({
         <div className="text-[8px] tracking-wider text-text-muted">{label}</div>
         <div className="text-[9px] text-foreground leading-snug">{help}</div>
       </div>
+    </div>
+  );
+}
+
+/**
+ * Generic legend swatch for a DOMAIN-registered edge type, derived
+ * entirely from its registry flags (color + dashed / animated / arrow).
+ * The four built-ins keep their hand-tuned swatches above; this renders
+ * any type a domain adds at runtime so it's documented without a UI edit.
+ */
+function DomainEdgeSwatch({ meta }: { meta: EdgeTypeMeta }) {
+  if (meta.dashed) {
+    return (
+      <div className="flex items-center">
+        <span
+          className="h-0.5 w-7"
+          style={{
+            backgroundImage: `linear-gradient(to right, ${meta.color} 50%, transparent 50%)`,
+            backgroundSize: "4px 100%",
+          }}
+        />
+      </div>
+    );
+  }
+  return (
+    <div className="flex items-center gap-0.5">
+      <span className="h-0.5 w-6" style={{ backgroundColor: meta.color }} />
+      {meta.animated && (
+        <span
+          className="h-1 w-1 rounded-full"
+          style={{ backgroundColor: meta.color, boxShadow: `0 0 4px ${meta.color}` }}
+        />
+      )}
+      {meta.arrow && (
+        <span className="text-[8px]" style={{ color: meta.color }}>
+          ▶
+        </span>
+      )}
     </div>
   );
 }
@@ -498,14 +563,11 @@ export default function DAGOverlay() {
             of them are on screen. */}
         {(viewMode === "3d" || viewMode === "2d" || viewMode === "map") && (
           <div className="flex items-center gap-0.5 rounded border border-border overflow-hidden">
-            {(
-              [
-                { type: "directed", label: "CAUSAL", color: "#00e5ff" },
-                { type: "temporal", label: "TEMP", color: "#ffab00" },
-                { type: "confounded", label: "CONF", color: "#ff6d00" },
-                { type: "flow", label: "FLOW", color: "#1de9b6" },
-              ] as const
-            ).map(({ type, label, color }) => {
+            {/* Data-driven from the edge-type registry: every registered
+                type (the four built-ins + any domain-registered type)
+                gets a chip with no edits here. id / chipLabel / color all
+                come from the shared registry. */}
+            {getAllEdgeTypeMeta().map(({ id: type, chipLabel: label, color }) => {
               // Empty Set === everything visible (back-compat).
               const isVisible =
                 visibleEdgeTypes.size === 0 || visibleEdgeTypes.has(type);

--- a/src/lib/__tests__/edge-type-registry.test.ts
+++ b/src/lib/__tests__/edge-type-registry.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BUILTIN_EDGE_TYPE_IDS,
+  getAllEdgeTypeMeta,
+  getEdgeTypeMeta,
+  isEdgeTypeRegistered,
+  registerEdgeType,
+  type EdgeTypeMeta,
+} from "@/lib/edge-type-registry";
+
+/**
+ * The edge-type registry is the single source of truth for how every
+ * canvas surface (3D / 2D / Map), the EdgeInspector, the per-type toggle
+ * strip, and the legend PRESENT an edge type. These tests lock:
+ *   - the four built-ins exist with their exact canonical canvas hues
+ *     (a color regression here would silently desync the surfaces), and
+ *   - the never-throw fallback + runtime-extension contract that lets a
+ *     domain register a brand-new type without renderer edits.
+ *
+ * Vitest gives each test file its own module instance, so the
+ * `registerEdgeType` mutations below don't leak into other suites.
+ */
+describe("edge-type-registry: built-ins", () => {
+  it("ships the four built-in types", () => {
+    expect([...BUILTIN_EDGE_TYPE_IDS].sort()).toEqual(
+      ["confounded", "directed", "flow", "temporal"].sort(),
+    );
+    for (const id of BUILTIN_EDGE_TYPE_IDS) {
+      expect(isEdgeTypeRegistered(id)).toBe(true);
+    }
+  });
+
+  // Canonical canvas hues — a regression test locks these exact values so
+  // a future edit can't silently shift a color on one surface.
+  it("locks the canonical canvas colors", () => {
+    expect(getEdgeTypeMeta("directed").color).toBe("#00e5ff");
+    expect(getEdgeTypeMeta("temporal").color).toBe("#ffab00");
+    expect(getEdgeTypeMeta("confounded").color).toBe("#ff6d00");
+    expect(getEdgeTypeMeta("flow").color).toBe("#1de9b6");
+  });
+
+  it("dashes only the confounded type", () => {
+    expect(getEdgeTypeMeta("confounded").dashed).toBe(true);
+    expect(getEdgeTypeMeta("directed").dashed).toBe(false);
+    expect(getEdgeTypeMeta("temporal").dashed).toBe(false);
+    expect(getEdgeTypeMeta("flow").dashed).toBe(false);
+  });
+
+  it("animates only the temporal + flow types at rest", () => {
+    expect(getEdgeTypeMeta("temporal").animated).toBe(true);
+    expect(getEdgeTypeMeta("flow").animated).toBe(true);
+    expect(getEdgeTypeMeta("directed").animated).toBe(false);
+    expect(getEdgeTypeMeta("confounded").animated).toBe(false);
+  });
+
+  it("arrows every directional type except confounded", () => {
+    expect(getEdgeTypeMeta("directed").arrow).toBe(true);
+    expect(getEdgeTypeMeta("temporal").arrow).toBe(true);
+    expect(getEdgeTypeMeta("flow").arrow).toBe(true);
+    expect(getEdgeTypeMeta("confounded").arrow).toBe(false);
+  });
+
+  it("uppercases the inspector label and ships a non-empty description", () => {
+    for (const id of BUILTIN_EDGE_TYPE_IDS) {
+      const meta = getEdgeTypeMeta(id);
+      expect(meta.label).toBe(meta.label.toUpperCase());
+      expect(meta.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("lists all built-ins via getAllEdgeTypeMeta in registration order", () => {
+    const ids = getAllEdgeTypeMeta().map((m) => m.id);
+    expect(ids.slice(0, 4)).toEqual([
+      "directed",
+      "temporal",
+      "confounded",
+      "flow",
+    ]);
+  });
+});
+
+describe("edge-type-registry: unknown-type fallback", () => {
+  it("never throws — returns a neutral slate fallback for an unknown id", () => {
+    const meta = getEdgeTypeMeta("nonexistent-domain-type");
+    expect(meta.color).toBe("#42466a");
+    expect(meta.id).toBe("nonexistent-domain-type");
+    expect(meta.label).toBe("NONEXISTENT-DOMAIN-TYPE");
+    expect(meta.arrow).toBe(true);
+    expect(meta.dashed).toBe(false);
+    expect(meta.animated).toBe(false);
+  });
+
+  it("reports an unknown id as not registered", () => {
+    expect(isEdgeTypeRegistered("nonexistent-domain-type")).toBe(false);
+  });
+
+  it("degrades an empty type id without crashing", () => {
+    const meta = getEdgeTypeMeta("");
+    expect(meta.label).toBe("UNKNOWN");
+    expect(meta.color).toBe("#42466a");
+  });
+});
+
+describe("edge-type-registry: runtime registration", () => {
+  const domainType: EdgeTypeMeta = {
+    id: "metabolic",
+    label: "METABOLIC",
+    chipLabel: "METAB",
+    color: "#7c4dff",
+    dashed: false,
+    animated: true,
+    arrow: true,
+    description: "T1D metabolic coupling between physiological signals.",
+  };
+
+  it("adds a domain type that then resolves + appears in the full list", () => {
+    expect(isEdgeTypeRegistered("metabolic")).toBe(false);
+    registerEdgeType(domainType);
+
+    expect(isEdgeTypeRegistered("metabolic")).toBe(true);
+    expect(getEdgeTypeMeta("metabolic")).toEqual(domainType);
+    expect(getAllEdgeTypeMeta().map((m) => m.id)).toContain("metabolic");
+    // Built-ins stay first; the domain type appends after them.
+    expect(getAllEdgeTypeMeta().length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("throws on a duplicate id so a domain can't clobber an existing type", () => {
+    // metabolic was registered by the previous test in this file.
+    expect(() => registerEdgeType(domainType)).toThrow(/already registered/);
+  });
+
+  it("throws when a domain tries to override a built-in", () => {
+    expect(() =>
+      registerEdgeType({ ...domainType, id: "directed" }),
+    ).toThrow(/already registered/);
+  });
+});

--- a/src/lib/edge-type-registry.ts
+++ b/src/lib/edge-type-registry.ts
@@ -1,0 +1,202 @@
+/**
+ * Edge-TYPE registry — the single source of truth for how each edge
+ * type is PRESENTED (color, label, dash, motion, arrow, prose) across
+ * every canvas surface (3D / 2D / Map), the EdgeInspector, the per-type
+ * visibility toggle strip, and the encoding legend.
+ *
+ * WHY a registry (vs the closed `EdgeType` union it replaces):
+ * before this, the four built-in types' color / label / dash were
+ * duplicated as hardcoded ternaries / switches in five files. Adding a
+ * domain type (T1D `metabolic`, finance `contagion`, …) was impossible
+ * without editing every one of them, and the literals had already
+ * drifted — `flow` fell through to the cyan "directed" default in both
+ * EdgeInspector and the 2D tooltip. This module centralizes the
+ * contract so:
+ *   - changing a type's color is a one-line edit here, and
+ *   - a domain can `registerEdgeType(...)` a brand-new type that
+ *     immediately renders + appears in the toggle strip, with no
+ *     renderer edits.
+ *
+ * Design decisions (the three open questions from the backlog):
+ *   1. `flow` does NOT get a dedicated `capacity` field on CausalEdge.
+ *      Capacity stays overloaded into `weight` until a flow-capacity
+ *      use case demands the split — YAGNI, consistent with deferring
+ *      the constants-tuning pass.
+ *   2. The registry IS runtime-discoverable: it ships seeded with the
+ *      four built-ins, but `registerEdgeType` lets an importer / domain
+ *      module add types at runtime. Lookups never throw on an unknown
+ *      type — they fall back to a neutral slate meta so a custom type
+ *      always renders rather than crashing a canvas.
+ *   3. Per-renderer GLYPH mapping lives HERE for the shared contract
+ *      (color / label / dashed / arrow / animates-at-rest). Fine-grained
+ *      per-renderer animation nuance that genuinely differs (3D's
+ *      temporal-particle vs flow-whoosh cadence) stays local to the
+ *      renderer — the `animated` flag only says "this type carries a
+ *      steady at-rest motion cue", not how each surface draws it.
+ *
+ * Distinct from `edge-provenance-registry.ts` (#465): that catalogs
+ * SOURCES (where an edge's weight / confidence came from); this catalogs
+ * the type TAXONOMY (what kind of relationship the edge encodes).
+ */
+
+import type { BuiltinEdgeType, EdgeType } from "@/lib/types";
+
+export interface EdgeTypeMeta {
+  /** The discriminator stored on `CausalEdge.type`. */
+  id: string;
+  /**
+   * Inspector / tooltip label, uppercase to match the existing
+   * aesthetic (TEMPORAL / CONFOUNDED / DIRECTED).
+   */
+  label: string;
+  /** Short label for the per-type visibility toggle strip in DAGOverlay. */
+  chipLabel: string;
+  /** Canvas color (hex). Kept in lockstep across 3D / 2D / Map. */
+  color: string;
+  /** Render dashed (latent / no-direct-link relationship). */
+  dashed: boolean;
+  /**
+   * Carries a steady at-rest motion cue — 3D particle / whoosh, 2D
+   * marching-ants, Map particles. This flag only declares THAT the
+   * type animates at rest; HOW each surface draws it stays local to
+   * the renderer.
+   */
+  animated: boolean;
+  /** Draw an arrowhead at the target (directional edge). */
+  arrow: boolean;
+  /** One-line plain-prose explainer for the legend / tooltip. */
+  description: string;
+}
+
+/**
+ * Neutral fallback color for an unregistered type — matches the slate
+ * `default` the 3D renderer used for unknown edge types before this
+ * registry existed.
+ */
+const UNKNOWN_EDGE_COLOR = "#42466a";
+
+/**
+ * The four built-in edge types. Colors are the canonical canvas hues —
+ * a regression test locks these exact values so a future edit can't
+ * silently shift a canvas color.
+ */
+const BUILTIN_EDGE_TYPES: Record<BuiltinEdgeType, EdgeTypeMeta> = {
+  directed: {
+    id: "directed",
+    label: "DIRECTED",
+    chipLabel: "CAUSAL",
+    color: "#00e5ff",
+    dashed: false,
+    animated: false,
+    arrow: true,
+    description: "Direct cause: A → B. Arrowed.",
+  },
+  temporal: {
+    id: "temporal",
+    label: "TEMPORAL",
+    chipLabel: "TEMP",
+    color: "#ffab00",
+    dashed: false,
+    animated: true,
+    arrow: true,
+    description:
+      "Lag-correlation: A leads B by some delay. Particles flow source → target.",
+  },
+  confounded: {
+    id: "confounded",
+    label: "CONFOUNDED",
+    chipLabel: "CONF",
+    color: "#ff6d00",
+    dashed: true,
+    animated: false,
+    arrow: false,
+    description:
+      "A and B share a hidden common cause, no direct link. Dashed to flag the latent variable.",
+  },
+  flow: {
+    id: "flow",
+    label: "FLOW",
+    chipLabel: "FLOW",
+    color: "#1de9b6",
+    dashed: false,
+    animated: true,
+    arrow: true,
+    description:
+      "Directed transmission of material / capital / signal through the network. Distinct from CAUSAL (a claim of cause) and TEMPORAL (a lag correlation) — flow means stuff is actually moving along this edge.",
+  },
+};
+
+/**
+ * Mutable registry, seeded with the built-ins. A `Map` (not a plain
+ * Record) so lookups are honestly typed `EdgeTypeMeta | undefined` and
+ * the unknown-key fallback is type-checked rather than relying on
+ * `noUncheckedIndexedAccess`.
+ */
+const REGISTRY = new Map<string, EdgeTypeMeta>(
+  Object.entries(BUILTIN_EDGE_TYPES),
+);
+
+/** The built-in type ids, frozen. The "closed core" every surface ships with. */
+export const BUILTIN_EDGE_TYPE_IDS: readonly BuiltinEdgeType[] = Object.freeze(
+  Object.keys(BUILTIN_EDGE_TYPES) as BuiltinEdgeType[],
+);
+
+/** True if `id` has a registered presentation (built-in or domain-added). */
+export function isEdgeTypeRegistered(id: string): boolean {
+  return REGISTRY.has(id);
+}
+
+/**
+ * Presentation meta for an unregistered type. Neutral slate, id-derived
+ * labels — enough to render a custom domain type that hasn't called
+ * `registerEdgeType`, instead of crashing.
+ */
+function fallbackMeta(type: string): EdgeTypeMeta {
+  const label = (type || "unknown").toUpperCase();
+  return {
+    id: type,
+    label,
+    chipLabel: label.slice(0, 4),
+    color: UNKNOWN_EDGE_COLOR,
+    dashed: false,
+    animated: false,
+    arrow: true,
+    description: `Custom edge type "${type}". No presentation registered — rendered with the neutral fallback.`,
+  };
+}
+
+/**
+ * Resolve a type id to its presentation meta. Never throws: an
+ * unregistered id returns a neutral fallback so a custom domain type
+ * always renders. This is the function every renderer / inspector
+ * calls instead of switching on `edge.type` literals.
+ */
+export function getEdgeTypeMeta(type: EdgeType | string): EdgeTypeMeta {
+  return REGISTRY.get(type) ?? fallbackMeta(type);
+}
+
+/**
+ * Every registered type's meta, in registration order (built-ins first).
+ * Drives the per-type visibility toggle strip + the encoding legend, so
+ * a newly-registered domain type appears in both with no UI edits.
+ */
+export function getAllEdgeTypeMeta(): EdgeTypeMeta[] {
+  return [...REGISTRY.values()];
+}
+
+/**
+ * Register a domain-specific edge type at runtime. Throws on a duplicate
+ * id (including the built-ins) so a domain can't silently clobber the
+ * shared core — mirrors `buildProvenanceIndex`'s dup-id guard. Check
+ * `isEdgeTypeRegistered` first if a re-register is legitimate (e.g. HMR).
+ */
+export function registerEdgeType(meta: EdgeTypeMeta): void {
+  if (REGISTRY.has(meta.id)) {
+    throw new Error(
+      `registerEdgeType: edge type "${meta.id}" is already registered. ` +
+        `Built-ins (${BUILTIN_EDGE_TYPE_IDS.join(", ")}) cannot be overridden; ` +
+        `check isEdgeTypeRegistered() before re-registering a custom type.`,
+    );
+  }
+  REGISTRY.set(meta.id, meta);
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -109,9 +109,10 @@ export type NodeCategory =
   | "science";
 
 /**
- * Edge-type discriminator. Visual encoding (kept in lockstep across
- * the four canvas surfaces — see `CausalDAG2D` / `DAGEdge3D` /
- * `CausalDAGMap` / `CausalDAGRelief`):
+ * The four built-in edge-type discriminators. Visual encoding (kept in
+ * lockstep across the canvas surfaces — see `CausalDAG2D` / `DAGEdge3D`
+ * / `CausalDAGMap`) is now owned centrally by `edge-type-registry.ts`,
+ * not duplicated per renderer:
  *
  *   - `directed`   → cyan, solid, arrow on target. "A → B" causal claim.
  *   - `temporal`   → amber, solid, arrow on target, animated particle.
@@ -124,7 +125,19 @@ export type NodeCategory =
  *                    and `temporal` (lag correlation) — `flow` is
  *                    "stuff is actually moving here".
  */
-export type EdgeType = "directed" | "confounded" | "temporal" | "flow";
+export type BuiltinEdgeType = "directed" | "confounded" | "temporal" | "flow";
+
+/**
+ * Edge-type discriminator stored on `CausalEdge.type`. OPEN string enum:
+ * the four built-ins above get editor autocomplete, but a domain may
+ * declare its own type (e.g. T1D `metabolic` / `immunological`, finance
+ * `contagion`) by calling `registerEdgeType(...)` in
+ * `edge-type-registry.ts`. The registry owns presentation; an
+ * unregistered string still renders with a neutral fallback rather than
+ * crashing a canvas. (Was a closed union before the edge-types-registry
+ * PR — opened so the type taxonomy is extensible per domain.)
+ */
+export type EdgeType = BuiltinEdgeType | (string & {});
 
 /**
  * Where an edge attribute (weight, confidence) came from. Surfaces in


### PR DESCRIPTION
## Summary
Replaces the closed `EdgeType` union with an **open string enum** backed by a runtime-extensible **edge-TYPE registry** — the single source of truth for how each edge type is *presented* (color / label / dashed / animated / arrow / prose) across every surface.

- **Opens the taxonomy:** `EdgeType = BuiltinEdgeType | (string & {})`. The four built-ins keep editor autocomplete; a domain can `registerEdgeType(...)` a new type (T1D `metabolic`, finance `contagion`, …) that renders everywhere with **zero renderer edits**. Unknown ids never throw — they resolve to a neutral slate fallback.
- **Centralizes presentation:** color/label/dash/animation were duplicated as hardcoded ternaries/switches in 5 files and had already drifted — `flow` fell through to the cyan **DIRECTED** default in both the EdgeInspector and the 2D tooltip. Both bugs are fixed by routing through `getEdgeTypeMeta`.

## Migrated presentation sites
- **DAGEdge3D** — color + dashed + at-rest animation gate (the 3D particle-vs-whoosh *cadence* stays a deliberate local treatment).
- **CausalDAG2D** — tooltip + local `EdgeInspector` + edge-build `baseColor` / `showArrow` / `animated`.
- **CausalDAGMap** — edge color + dashed + animated-particle filter.
- **EdgeInspector** (shared) — type color + label.
- **DAGOverlay** — per-type toggle chip strip + `EncodingLegend` swatches are now data-driven from the registry; domain-registered types append a generic auto-row.

## Out of scope (intentionally untouched)
Behavioral / algorithm sites that branch on `edge.type` for **semantics** — FCI, DCD, Tarski, cascade, import/validation. This PR centralizes *presentation* and *opens the type system* only.

## Stacking
Stacked on `claude/flow-edge-material` (#483). **Merge #483 first**, then this retargets to `main` automatically.

## Test plan
- [x] `tsc --noEmit` — clean in all changed files (15 unrelated, pre-existing errors live in 3 untouched test files: onboarding-metrics / fci / notears).
- [x] `vitest run` — **1609/1609 pass**, incl. 13 new registry tests (canonical-color regression lock, never-throw fallback, runtime register + dup-guard).
- [x] `next build` — exit 0.
- [ ] Visual spot-check 3D / 2D / Map after #483 merges (colors, dashed confounded, temporal+flow motion, toggle chips, legend swatches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
