### PR TITLE
refactor(edges): centralize edge-type encoding in a shared registry

### DIFF
--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -45,6 +45,7 @@ import {
   cascadeEdgeActivationOrder,
   edgeFireIntensity,
 } from "@/lib/cascade-edge-activation-order";
+import { getEdgeTypeMeta } from "@/lib/edge-type-registry";
 import { AnimatePresence } from "framer-motion";
 
 type NodeEmphasis = "focus" | "neighbor" | "dim" | "none";
@@ -328,19 +329,13 @@ function EdgeInspector({
   onClose: () => void;
   chiStarInfo?: ChiStarEdgeInfo | null;
 }) {
-  const typeColor =
-    edge.type === "temporal"
-      ? "#ffab00"
-      : edge.type === "confounded"
-        ? "#ff6d00"
-        : "#00e5ff";
-
-  const typeLabel =
-    edge.type === "temporal"
-      ? "TEMPORAL"
-      : edge.type === "confounded"
-        ? "CONFOUNDED"
-        : "DIRECTED";
+  // Color + label resolved from the edge-type registry — the single source
+  // of truth shared with the other surfaces. Before this, the local ternary
+  // only knew temporal/confounded and fell through to DIRECTED/cyan, so a
+  // `flow` edge was mislabelled here (same bug class the registry kills).
+  const typeMeta = getEdgeTypeMeta(edge.type);
+  const typeColor = typeMeta.color;
+  const typeLabel = typeMeta.label;
 
   return (
     <motion.div
@@ -1138,7 +1133,6 @@ function CausalDAG2DInner() {
         const isSelected = selectedEdge?.id === e.id;
         const isTemporal = e.type === "temporal";
         const isConfounded = e.type === "confounded";
-        const isFlow = e.type === "flow";
         // FIRE pulse — peaks at the edge's activation epoch and decays
         // over a 3-epoch window. 0 when the edge never fired in the
         // visible cascade. Severed / ablated suppress separately in
@@ -1149,15 +1143,11 @@ function CausalDAG2DInner() {
             ? edgeFireIntensity(fireActivationEpoch, clampedEpoch)
             : 0;
 
+        // Type color from the shared registry; the verified-inconsistent
+        // override still wins (it's a truth-filter signal, not a type).
         const baseColor = isInconsistent
           ? "#ff1744"
-          : isTemporal
-            ? "#ffab00"
-            : isConfounded
-              ? "#ff6d00"
-              : isFlow
-                ? "#1de9b6"
-                : "#00e5ff";
+          : getEdgeTypeMeta(e.type).color;
         const baseOpacity = isSelected ? 1 : isInconsistent ? 0.6 : 0.7;
         // Power-scale weight to widen the visible width range. Real
         // edge weights cluster between 0.4 and 0.8, so a linear
@@ -1167,7 +1157,7 @@ function CausalDAG2DInner() {
         // as ~3× a thin one even at typical clustering.
         const w = Math.max(0, Math.min(1, e.weight));
         const baseWidth = 0.7 + Math.pow(w, 2.4) * 3.3;
-        const showArrow = e.type === "directed" || isTemporal || isFlow;
+        const showArrow = getEdgeTypeMeta(e.type).arrow;
 
         return {
           id: e.id,

--- a/src/components/CausalDAGMap.tsx
+++ b/src/components/CausalDAGMap.tsx
@@ -8,6 +8,7 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import { AnimatePresence } from "framer-motion";
 import { useApexStore } from "@/stores/useApexStore";
 import { getDomainColor } from "@/lib/graph-color";
+import { getEdgeTypeMeta } from "@/lib/edge-type-registry";
 import { getDomainCardColor } from "@/lib/domains";
 import { getNodeCoordinates } from "@/lib/geo-coordinates";
 import { chiStar } from "@/lib/estimators/chi-star";
@@ -351,20 +352,16 @@ function CausalDAGMapInner() {
       // Edge color — matches 3D exactly. Severed gets a distinct slate color
       // so Pearl link-breaks don't look like Tarski-inconsistent edges.
       const isSevered = edge.isSevered ?? false;
+      // Type color via the central edge-type registry; severed (slate) and
+      // inconsistent (red) override it, matching 3D.
       const edgeColor = isSevered
         ? "#78909c"
         : edge.isInconsistent
           ? "#ff1744"
-          : edge.type === "temporal"
-            ? "#ffab00"
-            : edge.type === "confounded"
-              ? "#ff6d00"
-              : edge.type === "flow"
-                ? "#1de9b6"
-                : "#00e5ff";
+          : getEdgeTypeMeta(edge.type).color;
 
-      // Dashed: confounded, inconsistent, or severed (matches 3D isDashed logic)
-      const isDashed = edge.type === "confounded" || edge.isInconsistent || isSevered;
+      // Dashed: confounded (per registry), inconsistent, or severed (matches 3D isDashed logic)
+      const isDashed = getEdgeTypeMeta(edge.type).dashed || edge.isInconsistent || isSevered;
 
       const baseOpacity = isSevered ? 0.45 : 0.5;
       const opacity = edgeIsDimmed ? 0.08 : baseOpacity;

--- a/src/components/EdgeInspector.tsx
+++ b/src/components/EdgeInspector.tsx
@@ -13,6 +13,7 @@ import {
   extractAutoBridgeScore,
   bridgeStatus,
 } from "@/lib/cross-domain-bridging";
+import { getEdgeTypeMeta } from "@/lib/edge-type-registry";
 import { useApexStore } from "@/stores/useApexStore";
 
 /**
@@ -51,19 +52,13 @@ export default function EdgeInspector({
 }) {
   const promoteAutoBridge = useApexStore((s) => s.promoteAutoBridge);
   const status = bridgeStatus(edge);
-  const typeColor =
-    edge.type === "temporal"
-      ? "#ffab00"
-      : edge.type === "confounded"
-        ? "#ff6d00"
-        : "#00e5ff";
-
-  const typeLabel =
-    edge.type === "temporal"
-      ? "TEMPORAL"
-      : edge.type === "confounded"
-        ? "CONFOUNDED"
-        : "DIRECTED";
+  // Type → color/label via the central registry (src/lib/edge-type-registry).
+  // Previously a hardcoded ternary that only knew temporal/confounded and fell
+  // through to DIRECTED/cyan — so a `flow` edge showed as DIRECTED here while
+  // rendering teal on every canvas. The registry fixes that drift.
+  const typeMeta = getEdgeTypeMeta(edge.type);
+  const typeColor = typeMeta.color;
+  const typeLabel = typeMeta.label;
 
   // Resolve provenance once. Missing fields fall back to author so the
   // analyst always sees *some* signal — silence would be a worse UX

--- a/src/components/dag3d/DAGEdge3D.tsx
+++ b/src/components/dag3d/DAGEdge3D.tsx
@@ -6,6 +6,7 @@ import { Line } from "@react-three/drei";
 import * as THREE from "three";
 import { CausalEdge, EdgeEpochState } from "@/lib/types";
 import { edgeFireIntensity } from "@/lib/cascade-edge-activation-order";
+import { getEdgeTypeMeta } from "@/lib/edge-type-registry";
 
 interface DAGEdge3DProps {
   edge: CausalEdge;
@@ -62,21 +63,13 @@ interface DAGEdge3DProps {
 }
 
 /**
- * Edge color — matches 2D ReactFlow edge styling:
- *   directed  → cyan (#00e5ff)  — solid line
- *   temporal  → amber (#ffab00) — solid line + animated particle
- *   confounded → orange (#ff6d00) — dashed line
- *   inconsistent → red (#ff1744) — overrides type color
+ * Edge color — sourced from the central edge-type registry
+ * (src/lib/edge-type-registry), kept in lockstep with 2D / Map / inspector.
+ * `inconsistent` (red) overrides the type color.
  */
 function getEdgeColor(edge: CausalEdge, isVerifiedInconsistent: boolean): string {
   if (isVerifiedInconsistent) return "#ff1744";
-  switch (edge.type) {
-    case "directed": return "#00e5ff";
-    case "temporal": return "#ffab00";
-    case "confounded": return "#ff6d00";
-    case "flow": return "#1de9b6";
-    default: return "#42466a";
-  }
+  return getEdgeTypeMeta(edge.type).color;
 }
 
 function DAGEdge3DInner({
@@ -193,7 +186,7 @@ function DAGEdge3DInner({
   // Edge type determines rendering style
   const isTemporalFlow = edge.type === "temporal";
   const isFlow = edge.type === "flow";
-  const isDashed = edge.type === "confounded" || isVerifiedInconsistent ||
+  const isDashed = getEdgeTypeMeta(edge.type).dashed || isVerifiedInconsistent ||
     isAblated || isSevered;
 
   // Selection-aware opacity

--- a/src/components/dag3d/DAGOverlay.tsx
+++ b/src/components/dag3d/DAGOverlay.tsx
@@ -3,6 +3,12 @@
 import { startTransition, useEffect, useMemo, useRef, useState } from "react";
 import { useApexStore } from "@/stores/useApexStore";
 import { getDomainColor } from "@/lib/graph-color";
+import {
+  getEdgeTypeMeta,
+  getAllEdgeTypeMeta,
+  getBuiltinEdgeTypeMeta,
+  type EdgeTypeMeta,
+} from "@/lib/edge-type-registry";
 import { useTemporalGraph } from "@/hooks/useTemporalGraph";
 import { DOMAIN_CARDS } from "@/lib/domains";
 import { DOMAIN_MAP } from "@/hooks/useFilteredGraph";
@@ -68,6 +74,17 @@ function EncodingLegend({
       help: "Lies on shortest paths between others. Surfaces chokepoints.",
     },
   ];
+
+  // The four built-in edge-type rows below keep their bespoke swatch shapes
+  // (arrow / dot / dashed gradient) + prose, but pull their HUE from the
+  // shared registry so the legend stays in lockstep with the canvas. Any
+  // DOMAIN-registered (non-built-in) type appends a generic auto-row, so a
+  // new type documents itself with no edit here. Empty by default — nothing
+  // registers a custom type through the closed union yet.
+  const builtinTypeIds = new Set(getBuiltinEdgeTypeMeta().map((m) => m.type));
+  const domainEdgeTypes = getAllEdgeTypeMeta().filter(
+    (m) => !builtinTypeIds.has(m.type)
+  );
 
   return (
     <div
@@ -176,8 +193,8 @@ function EncodingLegend({
           help="Direct cause: A → B. Arrowed."
           swatch={
             <div className="flex items-center gap-0.5">
-              <span className="h-0.5 w-6" style={{ backgroundColor: "#00e5ff" }} />
-              <span className="text-[8px]" style={{ color: "#00e5ff" }}>▶</span>
+              <span className="h-0.5 w-6" style={{ backgroundColor: getEdgeTypeMeta("directed").color }} />
+              <span className="text-[8px]" style={{ color: getEdgeTypeMeta("directed").color }}>▶</span>
             </div>
           }
         />
@@ -186,8 +203,8 @@ function EncodingLegend({
           help="Lag-correlation: A leads B by some delay. Particles flow source → target."
           swatch={
             <div className="flex items-center gap-0.5">
-              <span className="h-0.5 w-6" style={{ backgroundColor: "#ffab00" }} />
-              <span className="h-1 w-1 rounded-full" style={{ backgroundColor: "#ffab00", boxShadow: "0 0 4px #ffab00" }} />
+              <span className="h-0.5 w-6" style={{ backgroundColor: getEdgeTypeMeta("temporal").color }} />
+              <span className="h-1 w-1 rounded-full" style={{ backgroundColor: getEdgeTypeMeta("temporal").color, boxShadow: `0 0 4px ${getEdgeTypeMeta("temporal").color}` }} />
             </div>
           }
         />
@@ -199,8 +216,7 @@ function EncodingLegend({
               <span
                 className="h-0.5 w-7"
                 style={{
-                  backgroundImage:
-                    "linear-gradient(to right, #ff6d00 50%, transparent 50%)",
+                  backgroundImage: `linear-gradient(to right, ${getEdgeTypeMeta("confounded").color} 50%, transparent 50%)`,
                   backgroundSize: "4px 100%",
                 }}
               />
@@ -212,12 +228,24 @@ function EncodingLegend({
           help="Directed transmission of material / capital / signal through the network. Distinct from CAUSAL (a claim of cause) and TEMPORAL (a lag correlation) — flow means stuff is actually moving along this edge."
           swatch={
             <div className="flex items-center gap-0.5">
-              <span className="h-0.5 w-6" style={{ backgroundColor: "#1de9b6" }} />
-              <span className="h-1 w-1 rounded-full" style={{ backgroundColor: "#1de9b6", boxShadow: "0 0 4px #1de9b6" }} />
-              <span className="text-[8px]" style={{ color: "#1de9b6" }}>▶</span>
+              <span className="h-0.5 w-6" style={{ backgroundColor: getEdgeTypeMeta("flow").color }} />
+              <span className="h-1 w-1 rounded-full" style={{ backgroundColor: getEdgeTypeMeta("flow").color, boxShadow: `0 0 4px ${getEdgeTypeMeta("flow").color}` }} />
+              <span className="text-[8px]" style={{ color: getEdgeTypeMeta("flow").color }}>▶</span>
             </div>
           }
         />
+        {/* Domain-registered edge types (none by default — the EdgeType union
+            is closed in this PR) document themselves here with a generic
+            swatch derived from the registry flags. No edit needed when a
+            domain registers a type via `registerEdgeType`. */}
+        {domainEdgeTypes.map((meta) => (
+          <LegendRow
+            key={meta.type}
+            label={meta.label}
+            help={meta.description}
+            swatch={<DomainEdgeSwatch meta={meta} />}
+          />
+        ))}
         <LegendRow
           label="INCONSISTENT (red)"
           help="Tarski filter: edge violates a domain-aware axiom. Only visible when the verified-truth filter is on."
@@ -308,6 +336,39 @@ function LegendRow({
         <div className="text-[8px] tracking-wider text-text-muted">{label}</div>
         <div className="text-[9px] text-foreground leading-snug">{help}</div>
       </div>
+    </div>
+  );
+}
+
+/**
+ * Generic legend swatch for a DOMAIN-registered edge type, derived entirely
+ * from its registry flags (color + dashed). The four built-ins keep their
+ * hand-tuned swatches above; this renders any type a domain adds at runtime
+ * via `registerEdgeType` so it's documented without a UI edit. Mirrors the
+ * dashed-vs-solid distinction the built-in confounded/causal rows draw.
+ */
+function DomainEdgeSwatch({ meta }: { meta: EdgeTypeMeta }) {
+  if (meta.dashed) {
+    return (
+      <div className="flex items-center">
+        <span
+          className="h-0.5 w-7"
+          style={{
+            backgroundImage: `linear-gradient(to right, ${meta.color} 50%, transparent 50%)`,
+            backgroundSize: "4px 100%",
+          }}
+        />
+      </div>
+    );
+  }
+  return (
+    <div className="flex items-center gap-0.5">
+      <span className="h-0.5 w-6" style={{ backgroundColor: meta.color }} />
+      {meta.arrow && (
+        <span className="text-[8px]" style={{ color: meta.color }}>
+          ▶
+        </span>
+      )}
     </div>
   );
 }
@@ -500,10 +561,13 @@ export default function DAGOverlay() {
           <div className="flex items-center gap-0.5 rounded border border-border overflow-hidden">
             {(
               [
-                { type: "directed", label: "CAUSAL", color: "#00e5ff" },
-                { type: "temporal", label: "TEMP", color: "#ffab00" },
-                { type: "confounded", label: "CONF", color: "#ff6d00" },
-                { type: "flow", label: "FLOW", color: "#1de9b6" },
+                // Short chip labels stay bespoke (CAUSAL/TEMP/CONF/FLOW —
+                // tighter than the registry's full labels); only the hue is
+                // registry-sourced so the strip tracks the canvas.
+                { type: "directed", label: "CAUSAL", color: getEdgeTypeMeta("directed").color },
+                { type: "temporal", label: "TEMP", color: getEdgeTypeMeta("temporal").color },
+                { type: "confounded", label: "CONF", color: getEdgeTypeMeta("confounded").color },
+                { type: "flow", label: "FLOW", color: getEdgeTypeMeta("flow").color },
               ] as const
             ).map(({ type, label, color }) => {
               // Empty Set === everything visible (back-compat).

--- a/src/lib/__tests__/edge-type-registry.test.ts
+++ b/src/lib/__tests__/edge-type-registry.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, afterEach } from "vitest";
+import type { EdgeType } from "@/lib/types";
+import {
+  getEdgeTypeMeta,
+  resolveEdgeTypeMeta,
+  registerEdgeType,
+  getAllEdgeTypeMeta,
+  getBuiltinEdgeTypeMeta,
+  __clearCustomEdgeTypes,
+  type EdgeTypeMeta,
+} from "@/lib/edge-type-registry";
+
+// The four built-in types and their canonical encoding. These values are the
+// single source of truth the four canvas surfaces (2D / 3D / Map) and the
+// EdgeInspector all read from — locking them here is what prevents the drift
+// that previously let a `flow` edge render teal on canvas yet show DIRECTED in
+// the inspector. If a value changes intentionally, this table changes with it.
+const EXPECTED: Record<EdgeType, Omit<EdgeTypeMeta, "type" | "description">> = {
+  directed: {
+    color: "#00e5ff",
+    label: "DIRECTED",
+    dashed: false,
+    arrow: true,
+    animated: false,
+    animationCadence: "none",
+  },
+  temporal: {
+    color: "#ffab00",
+    label: "TEMPORAL",
+    dashed: false,
+    arrow: true,
+    animated: true,
+    animationCadence: "standard",
+  },
+  confounded: {
+    color: "#ff6d00",
+    label: "CONFOUNDED",
+    dashed: true,
+    arrow: false,
+    animated: false,
+    animationCadence: "none",
+  },
+  flow: {
+    color: "#1de9b6",
+    label: "FLOW",
+    dashed: false,
+    arrow: true,
+    animated: true,
+    animationCadence: "fast",
+  },
+};
+
+describe("edge-type-registry — built-ins", () => {
+  afterEach(() => __clearCustomEdgeTypes());
+
+  it("exposes exactly the four built-in types, keyed by the EdgeType union", () => {
+    const builtins = getBuiltinEdgeTypeMeta();
+    expect(builtins).toHaveLength(4);
+    expect(builtins.map((m) => m.type)).toEqual([
+      "directed",
+      "temporal",
+      "confounded",
+      "flow",
+    ]);
+  });
+
+  it.each(Object.keys(EXPECTED) as EdgeType[])(
+    "encodes %s with its canonical color/label/dashed/arrow/animation",
+    (type) => {
+      const meta = getEdgeTypeMeta(type);
+      expect(meta.type).toBe(type);
+      expect(meta.color).toBe(EXPECTED[type].color);
+      expect(meta.label).toBe(EXPECTED[type].label);
+      expect(meta.dashed).toBe(EXPECTED[type].dashed);
+      expect(meta.arrow).toBe(EXPECTED[type].arrow);
+      expect(meta.animated).toBe(EXPECTED[type].animated);
+      expect(meta.animationCadence).toBe(EXPECTED[type].animationCadence);
+      // Every type carries a one-line semantic description.
+      expect(meta.description.length).toBeGreaterThan(0);
+    }
+  );
+
+  it("flow is teal and confounded is the only dash-without-arrow type", () => {
+    // Pin the two encodings that previously drifted / are semantically load-
+    // bearing: flow's teal (the bug that motivated this registry) and the
+    // confounder's no-direction dashed look (latent common cause).
+    expect(getEdgeTypeMeta("flow").color).toBe("#1de9b6");
+    const dashed = getBuiltinEdgeTypeMeta().filter((m) => m.dashed);
+    expect(dashed.map((m) => m.type)).toEqual(["confounded"]);
+    const noArrow = getBuiltinEdgeTypeMeta().filter((m) => !m.arrow);
+    expect(noArrow.map((m) => m.type)).toEqual(["confounded"]);
+  });
+});
+
+describe("edge-type-registry — resolveEdgeTypeMeta (loose accessor)", () => {
+  afterEach(() => __clearCustomEdgeTypes());
+
+  it("resolves a built-in type string to its built-in meta", () => {
+    expect(resolveEdgeTypeMeta("flow")).toBe(getEdgeTypeMeta("flow"));
+  });
+
+  it("degrades an unrecognised type to the neutral UNKNOWN default (never throws)", () => {
+    const meta = resolveEdgeTypeMeta("metabolic-not-yet-registered");
+    expect(meta.type).toBe("unknown");
+    expect(meta.label).toBe("UNKNOWN");
+    expect(meta.color).toBe("#5a5e72");
+  });
+});
+
+describe("edge-type-registry — registerEdgeType (forward-compat hook)", () => {
+  afterEach(() => __clearCustomEdgeTypes());
+
+  const metabolic: EdgeTypeMeta = {
+    type: "metabolic",
+    color: "#c51162",
+    label: "METABOLIC",
+    description: "Domain-declared T1D metabolic coupling.",
+    dashed: false,
+    arrow: true,
+    animated: false,
+    animationCadence: "none",
+  };
+
+  it("round-trips a runtime-registered custom type through resolveEdgeTypeMeta", () => {
+    expect(resolveEdgeTypeMeta("metabolic").type).toBe("unknown"); // before
+    registerEdgeType(metabolic);
+    expect(resolveEdgeTypeMeta("metabolic")).toEqual(metabolic); // after
+  });
+
+  it("includes customs in getAllEdgeTypeMeta but not in getBuiltinEdgeTypeMeta", () => {
+    registerEdgeType(metabolic);
+    expect(getAllEdgeTypeMeta().map((m) => m.type)).toContain("metabolic");
+    expect(getBuiltinEdgeTypeMeta().map((m) => m.type)).not.toContain(
+      "metabolic"
+    );
+    // Built-ins stay exactly four regardless of custom registrations.
+    expect(getBuiltinEdgeTypeMeta()).toHaveLength(4);
+  });
+
+  it("throws when a custom key collides with a built-in (no silent shadowing)", () => {
+    expect(() =>
+      registerEdgeType({ ...metabolic, type: "flow" })
+    ).toThrowError(/collides with a built-in/);
+    // The built-in flow is untouched by the rejected registration.
+    expect(getEdgeTypeMeta("flow").color).toBe("#1de9b6");
+  });
+
+  it("__clearCustomEdgeTypes drops all runtime registrations", () => {
+    registerEdgeType(metabolic);
+    expect(resolveEdgeTypeMeta("metabolic").type).toBe("metabolic");
+    __clearCustomEdgeTypes();
+    expect(resolveEdgeTypeMeta("metabolic").type).toBe("unknown");
+  });
+});

--- a/src/lib/edge-type-registry.ts
+++ b/src/lib/edge-type-registry.ts
@@ -1,0 +1,177 @@
+// Single source of truth for how each edge TYPE is encoded — visually and
+// semantically — across the four canvas surfaces (CausalDAG2D / DAGEdge3D /
+// CausalDAGMap / CausalDAGRelief) and the shared EdgeInspector.
+//
+// Before this registry every surface hardcoded its own `edge.type → color`
+// switch. They drifted: the actual edge-draw paths learned `flow` (teal,
+// shipped #439) but several *secondary* sites — EdgeInspector and the 2D
+// in-canvas edge tooltip — never got the case and silently fell through to
+// "directed"/cyan. So a flow edge rendered teal on the canvas yet showed up
+// as DIRECTED in the inspector. Centralising the type→encoding map here kills
+// that drift class: a new type is described once and every surface reads it.
+//
+// Convention mirrors `criticality-registry.ts`: a closed `Record<EdgeType,…>`
+// keyed by the union (so internal call sites stay compile-time exhaustive),
+// plus accessors. See `resolveEdgeTypeMeta` / `registerEdgeType` at the bottom
+// for the forward-compatible path to runtime-declared domain types — the union
+// itself stays CLOSED in this PR (see NOTE).
+
+import type { EdgeType } from "./types";
+
+export type EdgeAnimationCadence = "none" | "standard" | "fast";
+
+export interface EdgeTypeMeta {
+  /** The type key. `string` (not `EdgeType`) so runtime-registered custom
+   *  types from importers fit the same shape — see `registerEdgeType`. */
+  type: string;
+  /** Hex stroke / particle color. Kept in lockstep across all surfaces. */
+  color: string;
+  /** UPPERCASE label shown in EdgeInspector + legends. */
+  label: string;
+  /** One-line semantic description — what the edge asserts. */
+  description: string;
+  /** Dashed line = latent / no direct link (confounded). Solid otherwise. */
+  dashed: boolean;
+  /** Arrowhead on the target node. Causal claims + transmission carry one;
+   *  a confounder (common cause, no direction) does not. */
+  arrow: boolean;
+  /**
+   * Canonical motion cue: does this type animate a travelling particle?
+   * `temporal` = lag, `flow` = material transport.
+   *
+   * DESCRIPTIVE in this PR. Renderers read `.color/.label/.dashed/.arrow`
+   * today; `.animated` + `.animationCadence` document the *intended* motion
+   * encoding so it lives with the rest of the type's spec. 3D already
+   * animates flow; the 2D marching-ants + Map teal-particle wiring lands
+   * with #483 — at which point those renderers read `.animated` here rather
+   * than re-deriving it. Kept now so the registry is the whole truth.
+   */
+  animated: boolean;
+  /** Relative particle cadence when animated. `flow` runs faster than
+   *  `temporal` (material moving vs. a lagged correlation). */
+  animationCadence: EdgeAnimationCadence;
+}
+
+// ─── Built-in types (closed, exhaustive over the EdgeType union) ─────────
+// Values transcribed verbatim from the pre-registry switches so the
+// migration is byte-for-byte behavior-preserving on every surface.
+const REGISTRY: Record<EdgeType, EdgeTypeMeta> = {
+  directed: {
+    type: "directed",
+    color: "#00e5ff", // cyan
+    label: "DIRECTED",
+    description: "Direct causal claim: A → B.",
+    dashed: false,
+    arrow: true,
+    animated: false,
+    animationCadence: "none",
+  },
+  temporal: {
+    type: "temporal",
+    color: "#ffab00", // amber
+    label: "TEMPORAL",
+    description: "Lag-correlation — A leads B with a delay.",
+    dashed: false,
+    arrow: true,
+    animated: true,
+    animationCadence: "standard",
+  },
+  confounded: {
+    type: "confounded",
+    color: "#ff6d00", // orange
+    label: "CONFOUNDED",
+    description: "Latent common cause — no direct link.",
+    dashed: true,
+    arrow: false,
+    animated: false,
+    animationCadence: "none",
+  },
+  flow: {
+    type: "flow",
+    color: "#1de9b6", // teal-green
+    label: "FLOW",
+    description:
+      "Directed transmission of material / capital / signal — stuff is actually moving here.",
+    dashed: false,
+    arrow: true,
+    animated: true,
+    animationCadence: "fast",
+  },
+};
+
+// Runtime-registered custom types (importer-declared). Empty until a dataset
+// declares one via `registerEdgeType`. Kept separate from REGISTRY so the
+// built-ins remain a closed, exhaustive Record for compile-time safety.
+const CUSTOM_REGISTRY = new Map<string, EdgeTypeMeta>();
+
+// Neutral fallback for an unrecognised type string. Mirrors graph-color.ts's
+// default grey so an unknown edge degrades gracefully instead of throwing or
+// masquerading as a real type.
+const DEFAULT_EDGE_TYPE_META: EdgeTypeMeta = {
+  type: "unknown",
+  color: "#5a5e72",
+  label: "UNKNOWN",
+  description: "Unrecognised edge type — rendered with neutral defaults.",
+  dashed: false,
+  arrow: true,
+  animated: false,
+  animationCadence: "none",
+};
+
+/**
+ * Type-safe accessor for the built-in types. `edge.type` is `EdgeType`, so
+ * every current call site uses this — exhaustive, never undefined.
+ */
+export function getEdgeTypeMeta(type: EdgeType): EdgeTypeMeta {
+  return REGISTRY[type];
+}
+
+/**
+ * Loose accessor for a raw type string (e.g. an importer reading a CSV/JSON
+ * column). Precedence: built-in > custom-registered > neutral default. Never
+ * throws — unknown strings degrade to `DEFAULT_EDGE_TYPE_META`.
+ */
+export function resolveEdgeTypeMeta(type: string): EdgeTypeMeta {
+  return (
+    REGISTRY[type as EdgeType] ??
+    CUSTOM_REGISTRY.get(type) ??
+    DEFAULT_EDGE_TYPE_META
+  );
+}
+
+/**
+ * Forward-compat hook: register a runtime/importer-declared edge type so the
+ * surfaces can render it without the type being part of the closed `EdgeType`
+ * union. Throws on a key that collides with a built-in (you can't silently
+ * shadow `flow`), mirroring `buildProvenanceIndex`'s dup-id guard.
+ *
+ * NOTE: opening the `EdgeType` union itself to `string` is the *documented
+ * next step* (backlog 1b.3) — it's deferred so this PR keeps compile-time
+ * exhaustiveness on the four built-ins and so new type *semantics* clear
+ * Dr. Pita sign-off first. Until then importers route through this hook +
+ * `resolveEdgeTypeMeta`.
+ */
+export function registerEdgeType(meta: EdgeTypeMeta): void {
+  if (meta.type in REGISTRY) {
+    throw new Error(
+      `registerEdgeType: "${meta.type}" collides with a built-in edge type — pick a distinct key.`
+    );
+  }
+  CUSTOM_REGISTRY.set(meta.type, meta);
+}
+
+/** All built-in types, plus any runtime-registered custom types. */
+export function getAllEdgeTypeMeta(): EdgeTypeMeta[] {
+  return [...Object.values(REGISTRY), ...CUSTOM_REGISTRY.values()];
+}
+
+/** The built-in four only — stable, ordered, excludes custom registrations.
+ *  Handy for legends that should show the canonical taxonomy. */
+export function getBuiltinEdgeTypeMeta(): EdgeTypeMeta[] {
+  return Object.values(REGISTRY);
+}
+
+/** Test/teardown helper — drop all runtime-registered custom types. */
+export function __clearCustomEdgeTypes(): void {
+  CUSTOM_REGISTRY.clear();
+}


### PR DESCRIPTION
## Summary

Centralizes how each edge **type** is encoded — color / label / dashed / arrow — into a single registry, `src/lib/edge-type-registry.ts`, and points all five consumer surfaces at it.

> **Supersedes #492** (closed). That PR implemented the same backlog item (1b.3) with the *opened-union* design and was stacked on #483; this PR uses the in-session-approved conservative design (closed union, off `main`) and ports #492's DAGOverlay legend coverage.

- **Kills a drift-class bug.** Every surface (CausalDAG2D / DAGEdge3D / CausalDAGMap) and the shared EdgeInspector each hardcoded its own `edge.type → color` switch. When `flow` shipped (#483 / #439), the edge-draw paths learned it (teal `#1de9b6`) but two *secondary* sites — the EdgeInspector and the 2D in-canvas edge tooltip — never got the case and silently fell through to `directed`/cyan. So a flow edge rendered teal on the canvas yet showed up as **DIRECTED** in the inspector. This PR fixes both sites by reading from the registry.
- **One source of truth.** Convention mirrors `criticality-registry.ts`: a closed `Record<EdgeType, EdgeTypeMeta>` (compile-time exhaustive over the four built-ins) with `getEdgeTypeMeta()` for current call sites.
- **Forward-compat hook for domain types.** `resolveEdgeTypeMeta()` + `registerEdgeType()` give importers a resolve-with-fallback + dup-id-throw path (the #465 precedent) to declare runtime types (e.g. T1D `metabolic`, finance `contagion`) without being in the union yet. The DAGOverlay legend auto-documents any such registered type via a generic swatch — no UI edit needed.
- **The `EdgeType` union itself stays CLOSED in this PR.** Opening it is the documented next step (backlog **1b.3**) and gates on edge-semantics sign-off — mis-tagging an edge misrepresents the graph, so new type *semantics* clear review first.

## Surfaces migrated (5)

`CausalDAG2D` (edge memo + in-canvas tooltip), `DAGEdge3D`, `CausalDAGMap`, the shared `EdgeInspector`, and `DAGOverlay` (EncodingLegend swatches + the interactive chip strip). `CausalDAGRelief` has no edge-type color glyphs, so nothing to migrate there.

## Behavior-preservation

This is behavior-preserving on every surface **except** the two bug sites above. Specifically:

- Consumers read `color` / `label` / `dashed` / `arrow` from the registry; values transcribed byte-for-byte from the pre-existing switches (legend swatches and chips render the exact same hues).
- **Per-renderer animation logic is left local and untouched.** The registry's `.animated` / `.animationCadence` fields are *descriptive only* in this PR — renderers do not read them yet. This deliberately avoids importing #483's 2D/Map flow-animation behavior, which is not on `main` and belongs to that PR.

## Heads-up: parallel-PR conflict risk

This PR and **#483** (flow-edge animation, open) both touch `CausalDAG2D.tsx` and `CausalDAGMap.tsx`. There's no file overlap with the commits that have landed on `main` since this branched, so it merges cleanly against `main` today — but whichever of this / #483 merges second will need a trivial rebase on those two files.

## Test plan

- [x] `npx tsc --noEmit` — the changed files are clean (the 25 remaining errors are pre-existing, in unrelated files: optional-dep module resolution + two pre-existing test files).
- [x] Full `vitest` suite green — **134 files / 1645 tests**, including the new `edge-type-registry.test.ts` (12 cases: built-in lock-in, `resolveEdgeTypeMeta` fallback, `registerEdgeType` round-trip + collision-throw, custom-type teardown).
- [ ] Visual confirm the bug fix: open a `flow` edge's inspector + 2D tooltip and confirm both now read **FLOW** / teal (previously DIRECTED / cyan); spot-check the 3D legend popover renders the four swatches in their usual hues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
