### PR TITLE
feat(dock): watchlist left-collapse + persist pinned series

### DIFF
--- a/src/components/TimeSeriesOverlay.tsx
+++ b/src/components/TimeSeriesOverlay.tsx
@@ -146,9 +146,23 @@ export default function TimeSeriesOverlay() {
   const hydrateBottomDockCollapsed = useApexStore(
     (s) => s.hydrateBottomDockCollapsed,
   );
+  // Watchlist column collapse (independent of the whole-dock collapse).
+  // Lets the chart take the freed width without hiding the chart too.
+  const watchlistCollapsed = useApexStore((s) => s.watchlistCollapsed);
+  const setWatchlistCollapsed = useApexStore((s) => s.setWatchlistCollapsed);
+  const hydrateWatchlistCollapsed = useApexStore(
+    (s) => s.hydrateWatchlistCollapsed,
+  );
+  const hydratePinnedSeries = useApexStore((s) => s.hydratePinnedSeries);
   useEffect(() => {
     hydrateBottomDockCollapsed();
-  }, [hydrateBottomDockCollapsed]);
+    hydrateWatchlistCollapsed();
+    hydratePinnedSeries();
+  }, [
+    hydrateBottomDockCollapsed,
+    hydrateWatchlistCollapsed,
+    hydratePinnedSeries,
+  ]);
   // X-axis zoom mode.
   //  - "dial": chart x-axis mirrors the TimeDial's 60-day window so the
   //    chart cursor lines up with the scrubber below. Default, matches the
@@ -706,12 +720,49 @@ export default function TimeSeriesOverlay() {
       {/* LEFT: watchlist rail — pinned series + suggestions. Doubles as the
           chart legend (each pinned row is a curve) and the discovery surface
           (suggested rows pin with one click). Replaces the old standalone
-          risk-card strip and the chart's bottom legend chips. */}
-      <div className="w-56 flex-shrink-0 border-r border-border flex flex-col">
-        <div className="flex items-center justify-between px-3 py-1 border-b border-border">
-          <span className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-accent-cyan">
+          risk-card strip and the chart's bottom legend chips.
+          When `watchlistCollapsed`, the rail shrinks to a narrow vertical
+          strip with a single expand chevron + pin count, letting the chart
+          fill the freed width. */}
+      <motion.div
+        animate={{ width: watchlistCollapsed ? 24 : 224 }}
+        transition={{ duration: 0.18, ease: "easeOut" }}
+        className="flex-shrink-0 border-r border-border flex flex-col overflow-hidden"
+      >
+      {watchlistCollapsed ? (
+        // Collapsed rail: vertical expand affordance + pinned count.
+        // Whole column is clickable to reduce target-acquisition cost.
+        <button
+          onClick={() => setWatchlistCollapsed(false)}
+          className="flex-1 flex flex-col items-center justify-start gap-2 pt-2 pb-1 hover:bg-surface transition-colors"
+          title="Expand watchlist"
+        >
+          <span className="text-[9px] font-mono text-text-muted leading-none">▶</span>
+          <span
+            className="text-[7px] font-[family-name:var(--font-michroma)] tracking-wider text-accent-cyan"
+            style={{ writingMode: "vertical-rl", transform: "rotate(180deg)" }}
+          >
             WATCHLIST
           </span>
+          {(pinnedRows.length + pinnedCalcRows.length) > 0 && (
+            <span className="text-[7px] font-mono text-accent-cyan tabular-nums">
+              {pinnedRows.length + pinnedCalcRows.length}
+            </span>
+          )}
+        </button>
+      ) : (
+        <>
+        <div className="flex items-center justify-between px-3 py-1 border-b border-border">
+          <button
+            onClick={() => setWatchlistCollapsed(true)}
+            className="flex items-center gap-1.5 hover:text-foreground transition-colors"
+            title="Collapse watchlist to the left"
+          >
+            <span className="text-[9px] font-mono text-text-muted leading-none">◀</span>
+            <span className="text-[8px] font-[family-name:var(--font-michroma)] tracking-wider text-accent-cyan">
+              WATCHLIST
+            </span>
+          </button>
           <div className="flex items-center gap-2">
             {liveCount > 0 && (
               <span className="flex items-center gap-1 text-[7px] font-mono text-accent-green">
@@ -837,7 +888,9 @@ export default function TimeSeriesOverlay() {
             </div>
           )}
         </div>
-      </div>
+        </>
+      )}
+      </motion.div>
 
       {/* RIGHT: header + comparison chart */}
       <div className="flex-1 min-w-0 flex flex-col">

--- a/src/lib/ui-prefs-persistence.ts
+++ b/src/lib/ui-prefs-persistence.ts
@@ -4,13 +4,10 @@
 // page reload — distinct from session state (graph, selection, timeline
 // position) which intentionally resets. Kept separate from
 // calc-history-persistence so each file owns exactly one concern.
-//
-// First (and currently only) member: the bottom time-series dock's
-// collapsed/expanded state. Collapsing reclaims canvas room for the
-// primary module; if the user does that, having it spring back open on
-// every refresh is annoying, so we remember it.
 
 const BOTTOM_DOCK_COLLAPSED_KEY = "manifold:bottom-dock-collapsed";
+const WATCHLIST_COLLAPSED_KEY = "manifold:watchlist-collapsed";
+const PINNED_SERIES_KEY = "manifold:pinned-series";
 
 /**
  * Load the persisted bottom-dock collapsed preference. SSR-safe.
@@ -18,14 +15,7 @@ const BOTTOM_DOCK_COLLAPSED_KEY = "manifold:bottom-dock-collapsed";
  * the caller can keep its own default rather than being forced to false.
  */
 export function loadBottomDockCollapsed(): boolean | null {
-  if (typeof window === "undefined" || !window.localStorage) return null;
-  try {
-    const raw = window.localStorage.getItem(BOTTOM_DOCK_COLLAPSED_KEY);
-    if (raw === null) return null;
-    return raw === "1";
-  } catch {
-    return null;
-  }
+  return loadBoolFlag(BOTTOM_DOCK_COLLAPSED_KEY);
 }
 
 /**
@@ -34,10 +24,78 @@ export function loadBottomDockCollapsed(): boolean | null {
  * that triggered it).
  */
 export function saveBottomDockCollapsed(collapsed: boolean): void {
+  saveBoolFlag(BOTTOM_DOCK_COLLAPSED_KEY, collapsed);
+}
+
+/** Watchlist column (inside the dock) collapsed-to-left preference. */
+export function loadWatchlistCollapsed(): boolean | null {
+  return loadBoolFlag(WATCHLIST_COLLAPSED_KEY);
+}
+export function saveWatchlistCollapsed(collapsed: boolean): void {
+  saveBoolFlag(WATCHLIST_COLLAPSED_KEY, collapsed);
+}
+
+export interface PersistedPinnedSeries {
+  nodes: string[];
+  calcs: string[];
+}
+
+/**
+ * Load persisted pinned series (both node curves and graph-calc
+ * trajectories). Pruning to the current graph is the caller's job — we
+ * just hand back whatever was stored. Defensively validates the shape;
+ * a corrupted entry returns null so the caller keeps its in-memory
+ * default rather than wiping pins.
+ */
+export function loadPinnedSeries(): PersistedPinnedSeries | null {
+  if (typeof window === "undefined" || !window.localStorage) return null;
+  try {
+    const raw = window.localStorage.getItem(PINNED_SERIES_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return null;
+    const obj = parsed as { nodes?: unknown; calcs?: unknown };
+    const nodes = Array.isArray(obj.nodes)
+      ? obj.nodes.filter((x): x is string => typeof x === "string")
+      : [];
+    const calcs = Array.isArray(obj.calcs)
+      ? obj.calcs.filter((x): x is string => typeof x === "string")
+      : [];
+    return { nodes, calcs };
+  } catch {
+    return null;
+  }
+}
+
+/** Persist pinned series. Best-effort. */
+export function savePinnedSeries(pins: PersistedPinnedSeries): void {
   if (typeof window === "undefined" || !window.localStorage) return;
   try {
-    window.localStorage.setItem(BOTTOM_DOCK_COLLAPSED_KEY, collapsed ? "1" : "0");
+    window.localStorage.setItem(PINNED_SERIES_KEY, JSON.stringify(pins));
   } catch {
     // ignore — quota exceeded, private-mode, etc.
   }
 }
+
+// ─── shared helpers ─────────────────────────────────────────────────
+
+function loadBoolFlag(key: string): boolean | null {
+  if (typeof window === "undefined" || !window.localStorage) return null;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (raw === null) return null;
+    return raw === "1";
+  } catch {
+    return null;
+  }
+}
+
+function saveBoolFlag(key: string, value: boolean): void {
+  if (typeof window === "undefined" || !window.localStorage) return;
+  try {
+    window.localStorage.setItem(key, value ? "1" : "0");
+  } catch {
+    // ignore — quota exceeded, private-mode, etc.
+  }
+}
+

--- a/src/stores/useApexStore.ts
+++ b/src/stores/useApexStore.ts
@@ -27,6 +27,10 @@ import {
 import {
   loadBottomDockCollapsed,
   saveBottomDockCollapsed,
+  loadWatchlistCollapsed,
+  saveWatchlistCollapsed,
+  loadPinnedSeries,
+  savePinnedSeries,
 } from "@/lib/ui-prefs-persistence";
 // `applyTarskiFlags`, `clearTarskiFlags`, and the `TarskiValidationReport`
 // type live in the lightweight `tarski-flags.ts`. `runTarskiValidation`
@@ -262,6 +266,20 @@ export interface ApexState {
   bottomDockCollapsed: boolean;
   setBottomDockCollapsed: (collapsed: boolean) => void;
   hydrateBottomDockCollapsed: () => void;
+
+  /** Watchlist column (inside the dock) collapsed-to-left state.
+   *  Independent of the whole-dock collapse: the user can shrink just
+   *  the watchlist rail to a narrow strip and let the chart fill the
+   *  freed width while keeping both surfaces visible. */
+  watchlistCollapsed: boolean;
+  setWatchlistCollapsed: (collapsed: boolean) => void;
+  hydrateWatchlistCollapsed: () => void;
+
+  /** Hydrate persisted pinned series (node + calc) from localStorage,
+   *  pruned against the current graph so stale node ids drop. Pinned
+   *  series mutations are persisted automatically by a store-level
+   *  subscription (see end of file) — callers only need to hydrate. */
+  hydratePinnedSeries: () => void;
 
   // Selected edge (for edge inspector popup)
   selectedEdgeId: string | null;
@@ -774,6 +792,47 @@ export const useApexStore = create<ApexState>((set, get) => ({
   hydrateBottomDockCollapsed: () => {
     const persisted = loadBottomDockCollapsed();
     if (persisted !== null) set({ bottomDockCollapsed: persisted });
+  },
+
+  // Watchlist column collapse. Same post-mount hydration pattern.
+  watchlistCollapsed: false,
+  setWatchlistCollapsed: (collapsed) => {
+    saveWatchlistCollapsed(collapsed);
+    set({ watchlistCollapsed: collapsed });
+  },
+  hydrateWatchlistCollapsed: () => {
+    const persisted = loadWatchlistCollapsed();
+    if (persisted !== null) set({ watchlistCollapsed: persisted });
+  },
+
+  // Pinned series hydration. Node ids are pruned against the current
+  // graph so a persisted pin for a node that no longer exists silently
+  // drops rather than rendering a phantom row. Calc ids are kept as-is
+  // — graphCalcHistory hydrates separately and the chart's hasData
+  // branch handles the empty case.
+  hydratePinnedSeries: () => {
+    const persisted = loadPinnedSeries();
+    if (!persisted) return;
+    set((s) => {
+      const nextNodes = prunePinsToGraph(s.graphData, persisted.nodes);
+      const nextCalcs = persisted.calcs;
+      // Only update keys that actually change so we don't kick off a
+      // re-render or trip the persistence subscription for a no-op.
+      const out: Partial<ApexState> = {};
+      if (
+        nextNodes.length !== s.pinnedTimeSeriesNodes.length ||
+        nextNodes.some((id, i) => id !== s.pinnedTimeSeriesNodes[i])
+      ) {
+        out.pinnedTimeSeriesNodes = nextNodes;
+      }
+      if (
+        nextCalcs.length !== s.pinnedCalcSeries.length ||
+        nextCalcs.some((id, i) => id !== s.pinnedCalcSeries[i])
+      ) {
+        out.pinnedCalcSeries = nextCalcs;
+      }
+      return out;
+    });
   },
 
   // Selected edge
@@ -1535,3 +1594,29 @@ export const useApexStore = create<ApexState>((set, get) => ({
     })),
   clearPinnedCalcSeries: () => set({ pinnedCalcSeries: [] }),
 }));
+
+// ─── Pinned-series persistence (store-level subscription) ──────────
+//
+// Rather than wire savePinnedSeries() into every mutator + every
+// graph-change path that calls prunePinsToGraph(), subscribe once and
+// write whenever either array's reference changes. Reference equality
+// is correct here — all mutators (toggle/clear) and the prune paths
+// produce new arrays via spread/filter, so a referential delta tracks
+// the semantic delta exactly.
+//
+// SSR-safe via the localStorage guard inside savePinnedSeries itself.
+// The subscription fires once on initial subscribe with `prev` ===
+// current state, so the first invocation is a no-op; subsequent
+// invocations only persist on actual change.
+useApexStore.subscribe((state, prev) => {
+  if (
+    state.pinnedTimeSeriesNodes === prev.pinnedTimeSeriesNodes &&
+    state.pinnedCalcSeries === prev.pinnedCalcSeries
+  ) {
+    return;
+  }
+  savePinnedSeries({
+    nodes: state.pinnedTimeSeriesNodes,
+    calcs: state.pinnedCalcSeries,
+  });
+});


### PR DESCRIPTION
Two related dock improvements on top of #491.

## 1. Watchlist column collapses independently to the left

Click `◀ WATCHLIST` in the column header → the rail shrinks to a 24px vertical strip with an expand chevron + pinned-count badge, and the chart fills the freed width. Distinct from the whole-dock collapse: you can keep the chart visible while hiding the rail.

Persisted across reloads via `useApexStore.watchlistCollapsed` + `ui-prefs-persistence`.

## 2. Pinned series now persist across reloads

Previously every refresh wiped `pinnedTimeSeriesNodes` and `pinnedCalcSeries` — the user had to re-pin every curve, undercutting the watchlist's whole purpose.

Implementation choice worth flagging: instead of wiring `savePinnedSeries()` into every mutator + every `prunePinsToGraph` site (~8 places), I added a single store-level `useApexStore.subscribe()` that writes whenever either array's reference changes. All mutators produce new arrays via spread/filter, so reference-equality tracks the semantic delta exactly. Trade-off: one extra write per real change is fine; the alternative was scattered and easy to miss on a future code path.

Hydration prunes persisted node ids against the current graph so a phantom pin for a deleted node silently drops.

## Verification
- `tsc --noEmit`: clean for the three changed files (`ui-prefs-persistence.ts`, `useApexStore.ts`, `TimeSeriesOverlay.tsx`); other test-file errors are pre-existing.
- `eslint`: clean for new code; the two `s`-unused warnings and the `tooltipValues` / `setXAxisMode` errors are all pre-existing in code I didn't touch.

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_