### PR TITLE
feat(persist): snapshots / severed edges / enabled axioms [1/3]

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import dynamic from "next/dynamic";
 import { useApexStore } from "@/stores/useApexStore";
 import { protectGraphData } from "@/lib/data-protection";
@@ -177,6 +177,27 @@ export default function Home() {
   // Gate to defer the ΩF Time Series dock chunk until a graph is loaded.
   // An empty workspace has nothing to watch, suggest, or chart.
   const hasGraph = useApexStore((s) => s.graphData.nodes.length > 0);
+
+  // App-wide hydration of persisted user state. Non-graph-dependent
+  // entries (axioms, snapshot history) run once on mount; severed
+  // edges wait for the graph so the prune-to-valid-ids step has
+  // something to match against. The ref-guard prevents a re-hydration
+  // if hasGraph ever flips false→true again (e.g. workspace reset).
+  const hydrateEnabledAxioms = useApexStore((s) => s.hydrateEnabledAxioms);
+  const hydrateSnapshotHistory = useApexStore(
+    (s) => s.hydrateSnapshotHistory,
+  );
+  const hydrateSeveredEdges = useApexStore((s) => s.hydrateSeveredEdges);
+  useEffect(() => {
+    hydrateEnabledAxioms();
+    hydrateSnapshotHistory();
+  }, [hydrateEnabledAxioms, hydrateSnapshotHistory]);
+  const severedHydratedRef = useRef(false);
+  useEffect(() => {
+    if (!hasGraph || severedHydratedRef.current) return;
+    severedHydratedRef.current = true;
+    hydrateSeveredEdges();
+  }, [hasGraph, hydrateSeveredEdges]);
 
   // Live-data feed registry — single hook that polls every registered
   // provider on its declared cadence. Add a new provider in

--- a/src/lib/ui-prefs-persistence.ts
+++ b/src/lib/ui-prefs-persistence.ts
@@ -5,9 +5,14 @@
 // position) which intentionally resets. Kept separate from
 // calc-history-persistence so each file owns exactly one concern.
 
+import type { SystemStateSnapshot } from "@/lib/snapshots/types";
+
 const BOTTOM_DOCK_COLLAPSED_KEY = "manifold:bottom-dock-collapsed";
 const WATCHLIST_COLLAPSED_KEY = "manifold:watchlist-collapsed";
 const PINNED_SERIES_KEY = "manifold:pinned-series";
+const SEVERED_EDGES_KEY = "manifold:severed-edges";
+const ENABLED_AXIOMS_KEY = "manifold:enabled-axioms";
+const SNAPSHOT_HISTORY_KEY = "manifold:snapshot-history";
 
 /**
  * Load the persisted bottom-dock collapsed preference. SSR-safe.
@@ -77,6 +82,70 @@ export function savePinnedSeries(pins: PersistedPinnedSeries): void {
   }
 }
 
+// ─── Pearl scissors mode: severed edges ─────────────────────────────
+//
+// User-curated edge severs are real interdiction work, not session
+// state. Pruning to the current graph happens on hydration (caller's
+// job) so stale ids drop silently.
+
+export function loadSeveredEdges(): string[] | null {
+  return loadStringArray(SEVERED_EDGES_KEY);
+}
+export function saveSeveredEdges(edges: string[]): void {
+  saveStringArray(SEVERED_EDGES_KEY, edges);
+}
+
+// ─── Tarski axioms: user's enabled subset ───────────────────────────
+//
+// Serialized as a sorted array; the store keeps it as a Set. An empty
+// stored array means "explicit empty subset" (user disabled all); a
+// missing key means "never customized" → fall back to default.
+
+export function loadEnabledAxioms(): string[] | null {
+  return loadStringArray(ENABLED_AXIOMS_KEY);
+}
+export function saveEnabledAxioms(axioms: Set<string>): void {
+  saveStringArray(ENABLED_AXIOMS_KEY, Array.from(axioms).sort());
+}
+
+// ─── Snapshot history (Pareto panel captures) ───────────────────────
+//
+// `SystemStateSnapshot` is a slim summary (~50 nodes + a few floats
+// each), so even the 50-entry cap stays well under localStorage's
+// ~5MB quota. Persisted as a JSON array; defensive on parse so a
+// corrupted entry returns null and the store keeps its empty default.
+
+export function loadSnapshotHistory(): SystemStateSnapshot[] | null {
+  if (typeof window === "undefined" || !window.localStorage) return null;
+  try {
+    const raw = window.localStorage.getItem(SNAPSHOT_HISTORY_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return null;
+    // Cheap shape check — version + timestamp + graph + tarskiValidation
+    // are the minimum we render against; anything missing those drops.
+    return parsed.filter(
+      (s): s is SystemStateSnapshot =>
+        !!s &&
+        typeof s === "object" &&
+        (s as { version?: unknown }).version === 1 &&
+        typeof (s as { timestamp?: unknown }).timestamp === "string" &&
+        !!(s as { graph?: unknown }).graph &&
+        !!(s as { tarskiValidation?: unknown }).tarskiValidation,
+    );
+  } catch {
+    return null;
+  }
+}
+export function saveSnapshotHistory(history: SystemStateSnapshot[]): void {
+  if (typeof window === "undefined" || !window.localStorage) return;
+  try {
+    window.localStorage.setItem(SNAPSHOT_HISTORY_KEY, JSON.stringify(history));
+  } catch {
+    // ignore — quota exceeded, private-mode, etc.
+  }
+}
+
 // ─── shared helpers ─────────────────────────────────────────────────
 
 function loadBoolFlag(key: string): boolean | null {
@@ -94,6 +163,28 @@ function saveBoolFlag(key: string, value: boolean): void {
   if (typeof window === "undefined" || !window.localStorage) return;
   try {
     window.localStorage.setItem(key, value ? "1" : "0");
+  } catch {
+    // ignore — quota exceeded, private-mode, etc.
+  }
+}
+
+function loadStringArray(key: string): string[] | null {
+  if (typeof window === "undefined" || !window.localStorage) return null;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (raw === null) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return null;
+    return parsed.filter((x): x is string => typeof x === "string");
+  } catch {
+    return null;
+  }
+}
+
+function saveStringArray(key: string, value: string[]): void {
+  if (typeof window === "undefined" || !window.localStorage) return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
   } catch {
     // ignore — quota exceeded, private-mode, etc.
   }

--- a/src/stores/useApexStore.ts
+++ b/src/stores/useApexStore.ts
@@ -34,6 +34,12 @@ import {
   saveWatchlistCollapsed,
   loadPinnedSeries,
   savePinnedSeries,
+  loadSeveredEdges,
+  saveSeveredEdges,
+  loadEnabledAxioms,
+  saveEnabledAxioms,
+  loadSnapshotHistory,
+  saveSnapshotHistory,
 } from "@/lib/ui-prefs-persistence";
 // `applyTarskiFlags`, `clearTarskiFlags`, and the `TarskiValidationReport`
 // type live in the lightweight `tarski-flags.ts`. `runTarskiValidation`
@@ -299,6 +305,15 @@ export interface ApexState {
    *  series mutations are persisted automatically by a store-level
    *  subscription (see end of file) — callers only need to hydrate. */
   hydratePinnedSeries: () => void;
+
+  /** Hydrate persisted Pearl-scissors severed edges, enabled Tarski
+   *  axioms, and Pareto snapshot history. Each is persisted on change
+   *  via the store-level subscription at the end of the file; callers
+   *  only need to trigger hydration once on mount. Severed edges are
+   *  pruned against the current graph so stale ids drop. */
+  hydrateSeveredEdges: () => void;
+  hydrateEnabledAxioms: () => void;
+  hydrateSnapshotHistory: () => void;
 
   // Selected edge (for edge inspector popup)
   selectedEdgeId: string | null;
@@ -935,6 +950,38 @@ export const useApexStore = create<ApexState>((set, get) => ({
         out.pinnedCalcSeries = nextCalcs;
       }
       return out;
+    });
+  },
+
+  hydrateSeveredEdges: () => {
+    const persisted = loadSeveredEdges();
+    if (!persisted || persisted.length === 0) return;
+    set((s) => {
+      // Prune to edge ids that still exist in the current graph; stale
+      // ids (graph was reloaded with a different schema) silently drop.
+      const valid = new Set(s.graphData.edges.map((e) => e.id));
+      const next = persisted.filter((id) => valid.has(id));
+      if (next.length === 0) return {};
+      return { severedEdges: next };
+    });
+  },
+  hydrateEnabledAxioms: () => {
+    const persisted = loadEnabledAxioms();
+    if (!persisted) return;
+    // Empty stored array is a deliberate "no axioms enabled" — preserved
+    // as such. Set reference always changes here so the persistence
+    // subscription will run once on hydration (harmless idempotent write).
+    set({ enabledAxioms: new Set(persisted) });
+  },
+  hydrateSnapshotHistory: () => {
+    const persisted = loadSnapshotHistory();
+    if (!persisted || persisted.length === 0) return;
+    set({
+      snapshotHistory: persisted,
+      // Surface the most recent persisted snapshot as the "current" so
+      // panels that read currentSnapshot have something to render
+      // immediately on mount.
+      currentSnapshot: persisted[persisted.length - 1],
     });
   },
 
@@ -1698,19 +1745,19 @@ export const useApexStore = create<ApexState>((set, get) => ({
   clearPinnedCalcSeries: () => set({ pinnedCalcSeries: [] }),
 }));
 
-// ─── Pinned-series persistence (store-level subscription) ──────────
+// ─── Auto-persistence (store-level subscriptions) ──────────────────
 //
-// Rather than wire savePinnedSeries() into every mutator + every
-// graph-change path that calls prunePinsToGraph(), subscribe once and
-// write whenever either array's reference changes. Reference equality
-// is correct here — all mutators (toggle/clear) and the prune paths
-// produce new arrays via spread/filter, so a referential delta tracks
-// the semantic delta exactly.
+// Rather than wire save*() into every mutator + every graph-change
+// path, subscribe once per concern and write whenever the watched
+// reference changes. Reference equality is correct here — all
+// mutators (toggle/clear/prune) produce new arrays/sets via
+// spread/filter/new Set(...), so a referential delta tracks the
+// semantic delta exactly.
 //
-// SSR-safe via the localStorage guard inside savePinnedSeries itself.
-// The subscription fires once on initial subscribe with `prev` ===
-// current state, so the first invocation is a no-op; subsequent
-// invocations only persist on actual change.
+// SSR-safe via the localStorage guard inside each save* helper. The
+// subscription does not fire on initial subscribe, so the first
+// invocation is always on a real state change.
+
 useApexStore.subscribe((state, prev) => {
   if (
     state.pinnedTimeSeriesNodes === prev.pinnedTimeSeriesNodes &&
@@ -1722,4 +1769,16 @@ useApexStore.subscribe((state, prev) => {
     nodes: state.pinnedTimeSeriesNodes,
     calcs: state.pinnedCalcSeries,
   });
+});
+
+useApexStore.subscribe((state, prev) => {
+  if (state.severedEdges !== prev.severedEdges) {
+    saveSeveredEdges(state.severedEdges);
+  }
+  if (state.enabledAxioms !== prev.enabledAxioms) {
+    saveEnabledAxioms(state.enabledAxioms);
+  }
+  if (state.snapshotHistory !== prev.snapshotHistory) {
+    saveSnapshotHistory(state.snapshotHistory);
+  }
 });


### PR DESCRIPTION
**Part 1 of 3** from the platform-wide persistence + perf audit.

Closes the HIGH-severity persistence gaps the audit surfaced — pieces of real user work that get wiped on every page reload today.

## What's now persisted

| Field | Why HIGH | localStorage key |
|---|---|---|
| `snapshotHistory` / `currentSnapshot` | Pareto-panel captures the user deliberately took (≤50). | `manifold:snapshot-history` |
| `severedEdges` | Pearl scissors cuts — careful interdiction work. | `manifold:severed-edges` |
| `enabledAxioms` | Tarski axiom subset the user tuned. | `manifold:enabled-axioms` |

## Implementation notes

- **Same subscribe() pattern as PR #497** — one store-level subscription block watches all three references and persists on change. No mutator wiring required.
- **Snapshot hydration also surfaces `currentSnapshot`** as the most recent persisted entry so panels reading `currentSnapshot` have content immediately on mount.
- **Severed edges hydration is gated on `hasGraph`** (in `page.tsx`) so the prune-to-valid-ids step has edges to match against. A ref-guard prevents re-hydration if `hasGraph` flips false→true again.
- **`enabledAxioms` empty array distinction**: missing key = "never customized" (keep default); empty stored array = "deliberate empty subset" (preserved).

## Out of scope (intentionally)
- MEDIUM preference fields (viewMode / activeModule / nodeSizeMetric / visibleEdgeTypes / truthFilter / activePersona / selectedDataSources) → next PR (Part 2).
- Perf wins #1–#4 → Part 3.
- `loadedTrainingTrace` IndexedDB persistence → user opted out.

## Verification
- `tsc --noEmit`: clean for changed files.
- `eslint`: clean for new code; the two `s` warnings in store are pre-existing in scissors/ablation setters.

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_