### PR TITLE
perf: top-N partial select / nodeById map / rAF resize [3/3]

### DIFF
--- a/src/components/TimeSeriesOverlay.tsx
+++ b/src/components/TimeSeriesOverlay.tsx
@@ -7,6 +7,7 @@ import { getDomainColor } from "@/lib/graph-color";
 import { getNodeDataDescription } from "@/lib/real-timeseries";
 import type { NodeTemporalState } from "@/lib/temporal-data";
 import { CALCULATION_REGISTRY } from "@/lib/calculations/registry";
+import { topByKey } from "@/lib/perf/top-n";
 
 const CHART_HEIGHT = 120;
 // left/right are overridden at runtime to match the TimeDial track's actual
@@ -230,20 +231,44 @@ export default function TimeSeriesOverlay() {
           : { width, left, right },
       );
     };
+    // Coalesce resize storms (window-resize drag, container reflow
+    // chains) into a single per-frame update. ResizeObserver + the
+    // window listener can fire many times within one frame; without
+    // this the geom state was being set 3–5×/frame during interactive
+    // resizes, each triggering a full chart re-render.
+    let rafId: number | null = null;
+    const schedule = () => {
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        update();
+      });
+    };
     update();
-    const ro = new ResizeObserver(update);
+    const ro = new ResizeObserver(schedule);
     if (svgRef.current) ro.observe(svgRef.current);
     const track = document.querySelector<HTMLElement>("[data-timedial-track]");
     if (track) ro.observe(track);
-    window.addEventListener("resize", update);
+    window.addEventListener("resize", schedule);
     return () => {
+      if (rafId !== null) cancelAnimationFrame(rafId);
       ro.disconnect();
-      window.removeEventListener("resize", update);
+      window.removeEventListener("resize", schedule);
     };
   }, [pinnedNodes.length]);
 
   const plotInset = geom;
   const chartW = geom.width;
+
+  // O(1) id → node lookup. Replaces an O(N) Array.find() that ran
+  // once per pinned series inside curves and once per suggestion
+  // candidate — both rebuilt on every feed tick (graphData ref
+  // changes). On a 200-node graph with 6 pinned series that was
+  // ~1200 linear scans per tick.
+  const nodeById = useMemo(
+    () => new Map(graphData.nodes.map((n) => [n.id, n] as const)),
+    [graphData.nodes],
+  );
 
   // Gather histories for pinned nodes. Prefer live-data history when a node
   // has any liveData[] attached (consistent with the per-card sparkline
@@ -253,7 +278,7 @@ export default function TimeSeriesOverlay() {
     if (pinnedNodes.length === 0) return [];
     return pinnedNodes
       .map((nodeId) => {
-        const node = graphData.nodes.find((n) => n.id === nodeId);
+        const node = nodeById.get(nodeId);
         if (!node) return null;
         const dataDesc = getNodeDataDescription(nodeId);
 
@@ -317,7 +342,7 @@ export default function TimeSeriesOverlay() {
       sourceLabel: string | null;
       sourceUnit: string | null;
     }[];
-  }, [pinnedNodes, temporalData, graphData]);
+  }, [pinnedNodes, temporalData, nodeById]);
 
   // (Pinned nodes with no plottable history are surfaced directly in the
   // watchlist rail below via each row's `hasData: false` branch, so the
@@ -445,8 +470,8 @@ export default function TimeSeriesOverlay() {
     const seen = new Set(pinnedNodes);
     const out: { nodeId: string; label: string; color: string; omega: number }[] = [];
     const push = (id: string) => {
-      if (seen.has(id)) return;
-      const n = graphData.nodes.find((x) => x.id === id);
+      if (seen.has(id) || out.length >= 6) return;
+      const n = nodeById.get(id);
       if (!n) return;
       seen.add(id);
       out.push({
@@ -457,12 +482,25 @@ export default function TimeSeriesOverlay() {
       });
     };
     for (const id of [selectedNode, ...selectedNodes]) if (id) push(id);
-    for (const n of graphData.nodes) if (n.liveData && n.liveData.length > 0) push(n.id);
-    [...graphData.nodes]
-      .sort((a, b) => b.omegaFragility.composite - a.omegaFragility.composite)
-      .forEach((n) => push(n.id));
-    return out.slice(0, 6);
-  }, [graphData, pinnedNodes, selectedNode, selectedNodes]);
+    for (const n of graphData.nodes) {
+      if (out.length >= 6) break;
+      if (n.liveData && n.liveData.length > 0) push(n.id);
+    }
+    // Partial-select top-Ω instead of full sort. We may push past the
+    // 6-cap from this list since `push` itself respects the cap.
+    if (out.length < 6) {
+      const topRanked = topByKey(
+        graphData.nodes,
+        (n) => n.omegaFragility.composite,
+        6 + seen.size,
+      );
+      for (const n of topRanked) {
+        if (out.length >= 6) break;
+        push(n.id);
+      }
+    }
+    return out;
+  }, [graphData, pinnedNodes, selectedNode, selectedNodes, nodeById]);
 
   // Per-curve scale: each pinned curve normalizes to its OWN min/max so
   // curves with mismatched units (Ω 0-10, %, mb/d, USD/ton, programs)

--- a/src/components/dag3d/DAGOverlay.tsx
+++ b/src/components/dag3d/DAGOverlay.tsx
@@ -7,6 +7,21 @@ import { useTemporalGraph } from "@/hooks/useTemporalGraph";
 import { DOMAIN_CARDS } from "@/lib/domains";
 import { DOMAIN_MAP } from "@/hooks/useFilteredGraph";
 import type { NodeSizeMetric } from "@/lib/types";
+import { topByKey } from "@/lib/perf/top-n";
+
+// Static lookups derived from module-level constants — hoisted out of
+// the domainPanelRows memo so every memo invalidation (which fires on
+// any activeGraph.nodes / selectedDomainCardIds change) doesn't
+// rebuild them from scratch. DOMAIN_CARDS and DOMAIN_MAP are imports;
+// these maps are pure functions of them and never change at runtime.
+const DOMAIN_CARD_BY_ID = new Map(DOMAIN_CARDS.map((c) => [c.id, c]));
+const RAW_DOMAIN_TO_CARD_ID = (() => {
+  const m = new Map<string, string>();
+  for (const [cardId, rawDomains] of Object.entries(DOMAIN_MAP)) {
+    for (const raw of rawDomains) m.set(raw, cardId);
+  }
+  return m;
+})();
 
 /**
  * Documents every visual encoding the network views use, in one
@@ -384,11 +399,6 @@ export default function DAGOverlay() {
   // chose, displayed with the same label they recognised on the way in.
   const selectedDomainCardIds = useApexStore((s) => s.selectedDomains);
   const domainPanelRows = useMemo(() => {
-    const cardById = new Map(DOMAIN_CARDS.map((c) => [c.id, c]));
-    const rawDomainToCardId = new Map<string, string>();
-    for (const [cardId, rawDomains] of Object.entries(DOMAIN_MAP)) {
-      for (const raw of rawDomains) rawDomainToCardId.set(raw, cardId);
-    }
     type Row = {
       key: string;
       label: string;
@@ -399,9 +409,9 @@ export default function DAGOverlay() {
     };
     const byKey = new Map<string, Row>();
     for (const n of activeGraph.nodes) {
-      const cardId = rawDomainToCardId.get(n.domain);
+      const cardId = RAW_DOMAIN_TO_CARD_ID.get(n.domain);
       if (cardId) {
-        const card = cardById.get(cardId);
+        const card = DOMAIN_CARD_BY_ID.get(cardId);
         if (!card) continue;
         const existing = byKey.get(cardId);
         if (existing) {
@@ -448,12 +458,15 @@ export default function DAGOverlay() {
     return rows;
   }, [activeGraph.nodes, selectedDomainCardIds]);
 
-  // Top-Ω nodes
-  const topOmega = useMemo(() => {
-    return [...activeGraph.nodes]
-      .sort((a, b) => b.omegaFragility.composite - a.omegaFragility.composite)
-      .slice(0, 5);
-  }, [activeGraph.nodes]);
+  // Top-Ω nodes. O(N · 5) partial-select via topByKey; was
+  // [...nodes].sort().slice(0, 5) — O(N log N) plus a wasted full-array
+  // allocation. The legend only renders 5 entries, so paying for a
+  // total sort was strictly wasted work.
+  const topOmega = useMemo(
+    () =>
+      topByKey(activeGraph.nodes, (n) => n.omegaFragility.composite, 5),
+    [activeGraph.nodes],
+  );
 
   return (
     <div className="absolute inset-0 pointer-events-none z-10">

--- a/src/lib/perf/top-n.ts
+++ b/src/lib/perf/top-n.ts
@@ -1,0 +1,42 @@
+// ─── Partial top-N selection ────────────────────────────────────────
+//
+// Returns the n items with the highest `key(item)` in O(N · k) for
+// small k — strictly cheaper than [...arr].sort().slice(0, n) which
+// is O(N log N) and (worse) allocates a fresh array of length N just
+// to discard most of it. Used for top-Ω rankings (k=5..6) on graphs
+// with hundreds of nodes.
+//
+// Result is returned in descending key order. Ties keep insertion
+// (first-seen) order — matches what stable sort would produce for the
+// same data, so swapping `sort().slice` callsites is behaviour-preserving.
+
+export function topByKey<T>(
+  items: readonly T[],
+  key: (item: T) => number,
+  n: number,
+): T[] {
+  if (n <= 0 || items.length === 0) return [];
+  if (items.length <= n) {
+    // Tiny inputs: sort directly — at this size the overhead of a
+    // bounded-buffer scan isn't worth it.
+    return [...items].sort((a, b) => key(b) - key(a));
+  }
+
+  // Bounded-buffer scan: keep `top` sorted descending, length ≤ n.
+  // For each item, drop it if it can't beat the current floor; else
+  // insert at the right position and pop the floor if we exceed n.
+  const top: { item: T; k: number }[] = [];
+  let floor = -Infinity;
+  for (const item of items) {
+    const k = key(item);
+    if (top.length === n && k <= floor) continue;
+    // Linear insert is fine for small n (n ≤ ~10); for larger n a
+    // proper binary-heap would beat this, but our callsites are k≤6.
+    let i = top.length;
+    while (i > 0 && top[i - 1].k < k) i--;
+    top.splice(i, 0, { item, k });
+    if (top.length > n) top.pop();
+    floor = top[top.length - 1].k;
+  }
+  return top.map((t) => t.item);
+}


### PR DESCRIPTION
**Part 3 of 3** from the platform audit. Ships the four perf wins the laptop audit ranked top of the actionable list. All scoped, no behavioural change.

## What changed (ranked by expected user-felt impact)

### 1. New `topByKey()` partial-select helper (`src/lib/perf/top-n.ts`)
O(N · k) bounded-buffer scan instead of `[...arr].sort().slice(0, n)` (O(N log N) plus a wasted N-length allocation). Used by:
- `DAGOverlay.topOmega` legend (k=5)
- `TimeSeriesOverlay.suggestions` (k=6)

On 200-node graphs the legend/suggestion rebuild drops from ~1500 comparisons to ~1000 and skips the throwaway allocation. Behaviour-preserving (descending key order, stable on ties).

### 2. `TimeSeriesOverlay` `nodeById` O(1) lookup
Replaces an O(N) `Array.find()` that ran once per pinned series in the `curves` memo and once per suggestion candidate — **both rebuilt on every feed tick** (graphData ref changes). On a 200-node graph with 6 pinned series that was ~1200 linear scans per tick.

### 3. `DAGOverlay.domainPanelRows`: hoist static Maps
`DOMAIN_CARD_BY_ID` and `RAW_DOMAIN_TO_CARD_ID` are pure functions of the `DOMAIN_CARDS`/`DOMAIN_MAP` imports and never change at runtime. Lifting them to module scope removes rebuild cost on every `activeGraph.nodes` / `selectedDomainCardIds` change.

### 4. `TimeSeriesOverlay` rAF-coalesced resize
ResizeObserver + window-resize listener both can fire many times within one frame. Without coalescing, `geom` was being set 3–5×/frame during interactive resizes — each triggering a full chart re-render. Now a single per-frame `schedule()`; cleaned up via `cancelAnimationFrame` on unmount.

## What's NOT touched
The sub-ms leftovers documented in `docs/sessions/rendering-perf.md` stay parked per the audit's "intentionally not done" call.

## Verification
- `tsc --noEmit`: clean for changed files.
- `eslint`: clean for new code; the `tooltipValues` / `setXAxisMode` errors and the two `s`-unused warnings are pre-existing and untouched here.

## Sequencing
This is Part 3 of the 3-PR audit batch. #503 (HIGH persistence) and #505 (MEDIUM prefs) already in. This PR's branch was reset to `main` then re-applied so its diff is clean against the merged Part 1.

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_