### PR TITLE
fix(3d): canvas frameloop always so orbs animate at idle

### DIFF
--- a/src/components/CausalDAG3D.tsx
+++ b/src/components/CausalDAG3D.tsx
@@ -1146,11 +1146,16 @@ export default function CausalDAG3D() {
         />
       )}
       <DAGErrorBoundary>
-      {/* frameloop="demand" stops the render loop when idle — invalidate() is called
-          on every interaction event so nothing visible is lost (item #1). */}
+      {/* frameloop="always" so the orb idle-breath in DAGNode3D's useFrame
+          renders continuously, matching 2D/map view behaviour. Was
+          "demand" — a battery-saving optimization that froze the orbs
+          between mouse moves and read as a dead canvas. The
+          invalidate()-based StoreInvalidator / ReplayInvalidator below
+          remain harmless no-ops in always mode and stay for low-cost
+          safety against any future flip back to demand. */}
       <Canvas
         key={canvasKey}
-        frameloop="demand"
+        frameloop="always"
         camera={{ position: [40, 30, 80], fov: 60 }}
         style={{ background: "#050508", position: "absolute", inset: 0, touchAction: "none" }}
         gl={{ antialias: true, powerPreference: "high-performance", preserveDrawingBuffer: true }}


### PR DESCRIPTION
**Reverts a perf decision per user request.**

The 3D Canvas was running `frameloop="demand"` — a battery-saving optimization that paused the render loop between events. With the idle-breath in `DAGNode3D`'s `useFrame` (the gentle ~1.5% scale pulse at one cycle per ~4–6 s), this read as a dead canvas: orbs visibly froze whenever the mouse stopped moving and only twitched back to life on the next pointermove / selection / replay tick.

User explicitly wants the orbs perpetually animating, matching 2D / map / relief behaviour. Flip to `frameloop="always"`.

## Decisions

- **Kept the existing invalidate() machinery** (`StoreInvalidator`, `ReplayInvalidator`, `FrameMonitor`, the hover-event invalidate, the `dag3d-invalidate` window listener). They become harmless no-ops in always mode but stay in place so we don't regress the demand-mode path if we ever flip back. Cost is negligible.
- **Per-frame cost on a laptop:** 192-orb scene running `useFrame` at 60 Hz. The orb hot path already skips greyed-out, ablated, and orbiting nodes, so visible work is bounded by what's on screen. The explicit UX preference takes precedence here.

## Files
- `src/components/CausalDAG3D.tsx` — one-word change + updated comment.

## Verification
- `tsc --noEmit`: clean.
- `eslint`: clean for changed file (one pre-existing `chiStarSet` warning unrelated).

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_