### PR TITLE
perf(instrument): User Timing marks on launch / feed-tick / view-switch

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,13 @@ import dynamic from "next/dynamic";
 import { useApexStore } from "@/stores/useApexStore";
 import { protectGraphData } from "@/lib/data-protection";
 import { useFeedRegistry } from "@/hooks/useFeedRegistry";
+import { mark, measureBetween } from "@/lib/perf/instrument";
+
+// Earliest mark on the launch path — fires when this module is
+// evaluated (before any React render). Paired with "launch:firstFrame"
+// emitted from the first canvas's onCreated to give a real
+// page-load-to-pixels number in __manifoldPerf.
+mark("launch:moduleLoad");
 import HeaderBar from "@/components/HeaderBar";
 import StructuralMetrics from "@/components/StructuralMetrics";
 import FeedbackWidget from "@/components/FeedbackWidget";
@@ -200,6 +207,27 @@ export default function Home() {
     severedHydratedRef.current = true;
     hydrateSeveredEdges();
   }, [hasGraph, hydrateSeveredEdges]);
+
+  // View-switch instrumentation. setViewMode in the store stamps a
+  // "view-switch:start:{mode}" mark; this effect closes the loop on
+  // the next paint after the new view commits. rAF gives a real
+  // "switch felt complete" number — measuring just the React commit
+  // skips browser layout / paint cost which is where the user-felt
+  // latency actually lives. Skips the initial mount: no setViewMode
+  // call was made, so there's no matching start mark to measure from.
+  const viewMountedRef = useRef(false);
+  useEffect(() => {
+    if (!viewMountedRef.current) {
+      viewMountedRef.current = true;
+      return;
+    }
+    const startMark = `view-switch:start:${viewMode}`;
+    requestAnimationFrame(() => {
+      const endMark = `view-switch:end:${viewMode}:${performance.now()}`;
+      mark(endMark);
+      measureBetween("view-switch", startMark, endMark);
+    });
+  }, [viewMode]);
 
   // Live-data feed registry — single hook that polls every registered
   // provider on its declared cadence. Add a new provider in

--- a/src/components/CausalDAG3D.tsx
+++ b/src/components/CausalDAG3D.tsx
@@ -26,6 +26,7 @@ import CanvasWatermark from "./CanvasWatermark";
 import { useReplayTick } from "@/lib/useReplayTick";
 import { AnimatePresence } from "framer-motion";
 import { EpochSnapshot, CausalEdge } from "@/lib/types";
+import { mark, measureBetween } from "@/lib/perf/instrument";
 
 // Error boundary to catch WebGL context loss and recover
 class DAGErrorBoundary extends React.Component<
@@ -1160,6 +1161,15 @@ export default function CausalDAG3D() {
         style={{ background: "#050508", position: "absolute", inset: 0, touchAction: "none" }}
         gl={{ antialias: true, powerPreference: "high-performance", preserveDrawingBuffer: true }}
         onCreated={({ gl }) => {
+          // Launch instrumentation: r3f calls onCreated once the Canvas
+          // is mounted and the GL context is live but before the first
+          // frame paints. Pair with the "launch:moduleLoad" mark in
+          // page.tsx to give a full module-load → canvas-ready number.
+          // Subsequent canvas remounts (key change) re-fire; the
+          // aggregator rolls them into the same bucket which is fine —
+          // remount cost is itself worth tracking.
+          mark("launch:firstFrame");
+          measureBetween("launch", "launch:moduleLoad", "launch:firstFrame");
           const canvas = gl.domElement;
           canvas.addEventListener("webglcontextlost", (e) => {
             e.preventDefault();

--- a/src/lib/perf/instrument.ts
+++ b/src/lib/perf/instrument.ts
@@ -1,0 +1,180 @@
+// ─── Performance instrumentation ────────────────────────────────────
+//
+// Lightweight wrapper around `performance.mark` / `performance.measure`
+// for the three paths that historically dominate Manifold's frame
+// budget: app launch, per-feed-tick processing, view-mode switch.
+//
+// Each call site uses `mark(start)` / `mark(end)` and the aggregator
+// computes mean / p50 / p95 over a rolling window so the inspector
+// shows useful numbers instead of one-shot noise. Snapshot via
+// `window.__manifoldPerf` in DevTools.
+//
+// Goals:
+//  - Zero overhead in production builds (helpers compile to no-ops via
+//    a single env check; the User Timing API entries don't accumulate
+//    because mark/measure aren't called at all).
+//  - No third-party deps and no React tree integration — the call
+//    sites just import a function and call it.
+//  - Bounded memory: each measurement keeps the last 100 samples.
+
+const ENABLED =
+  typeof window !== "undefined" &&
+  typeof performance !== "undefined" &&
+  process.env.NODE_ENV !== "production";
+
+const ROLLING_WINDOW = 100;
+
+interface Aggregate {
+  samples: number[]; // ring of last N durations, ms
+  total: number; // monotonic count since session start
+}
+
+const aggregates = new Map<string, Aggregate>();
+
+/**
+ * Mark a named instant in the User Timing timeline. No-op in prod.
+ * Pair start/end marks with the same suffix convention
+ * (`"launch:start"` / `"launch:end"`) so `measureBetween` can join
+ * them automatically.
+ */
+export function mark(name: string): void {
+  if (!ENABLED) return;
+  try {
+    performance.mark(name);
+  } catch {
+    // mark() throws on invalid name characters — swallow rather than
+    // breaking the call site, which is by definition non-critical.
+  }
+}
+
+/**
+ * Measure between two previously-marked instants and record the
+ * duration in the rolling aggregate keyed on `measureName`. Returns
+ * the duration in ms (or 0 in prod / on failure).
+ */
+export function measureBetween(
+  measureName: string,
+  startMark: string,
+  endMark: string,
+): number {
+  if (!ENABLED) return 0;
+  try {
+    const entry = performance.measure(measureName, startMark, endMark);
+    record(measureName, entry.duration);
+    return entry.duration;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * One-shot helper: marks an end, measures from a start mark created
+ * elsewhere, and records the result. Use when the start mark is known
+ * but you don't want a manual `mark + measure` pair.
+ */
+export function endMeasure(
+  measureName: string,
+  startMark: string,
+): number {
+  if (!ENABLED) return 0;
+  const endMark = `${measureName}:__end_${Date.now()}_${Math.random()}`;
+  mark(endMark);
+  return measureBetween(measureName, startMark, endMark);
+}
+
+/**
+ * Record a raw duration without using marks. Useful when you measure
+ * with `performance.now()` directly (e.g. inside a tight loop where
+ * the User Timing buffer would itself add overhead).
+ */
+export function record(measureName: string, durationMs: number): void {
+  if (!ENABLED) return;
+  let agg = aggregates.get(measureName);
+  if (!agg) {
+    agg = { samples: [], total: 0 };
+    aggregates.set(measureName, agg);
+  }
+  agg.samples.push(durationMs);
+  if (agg.samples.length > ROLLING_WINDOW) agg.samples.shift();
+  agg.total += 1;
+}
+
+interface MeasurementSummary {
+  count: number;
+  mean: number;
+  p50: number;
+  p95: number;
+  min: number;
+  max: number;
+  last: number;
+}
+
+/**
+ * Snapshot the current aggregates as a plain object — call from
+ * DevTools via `window.__manifoldPerf.snapshot()` for a quick read.
+ */
+export function snapshot(): Record<string, MeasurementSummary> {
+  const out: Record<string, MeasurementSummary> = {};
+  for (const [name, agg] of aggregates) {
+    if (agg.samples.length === 0) continue;
+    const sorted = [...agg.samples].sort((a, b) => a - b);
+    const sum = sorted.reduce((s, v) => s + v, 0);
+    out[name] = {
+      count: agg.total,
+      mean: sum / sorted.length,
+      p50: sorted[Math.floor(sorted.length * 0.5)],
+      p95: sorted[Math.floor(sorted.length * 0.95)],
+      min: sorted[0],
+      max: sorted[sorted.length - 1],
+      last: agg.samples[agg.samples.length - 1],
+    };
+  }
+  return out;
+}
+
+/** Reset all aggregates. Useful when starting a fresh measurement run. */
+export function reset(): void {
+  aggregates.clear();
+  if (ENABLED) {
+    try {
+      performance.clearMarks();
+      performance.clearMeasures();
+    } catch {
+      // ignore — older browsers without selective clear support
+    }
+  }
+}
+
+/**
+ * Pretty-print the current snapshot to the console as a single table.
+ * Easier to scan than the raw object — durations rounded to 2dp.
+ */
+export function logSnapshot(): void {
+  if (!ENABLED) return;
+  const snap = snapshot();
+  const rows = Object.entries(snap).map(([name, s]) => ({
+    name,
+    count: s.count,
+    mean_ms: +s.mean.toFixed(2),
+    p50_ms: +s.p50.toFixed(2),
+    p95_ms: +s.p95.toFixed(2),
+    last_ms: +s.last.toFixed(2),
+    min_ms: +s.min.toFixed(2),
+    max_ms: +s.max.toFixed(2),
+  }));
+  console.table(rows);
+}
+
+// Expose to DevTools. The check matches ENABLED so production never
+// has the global at all; dev sessions can `__manifoldPerf.logSnapshot()`
+// directly from the console.
+if (ENABLED) {
+  (window as unknown as { __manifoldPerf: unknown }).__manifoldPerf = {
+    snapshot,
+    logSnapshot,
+    reset,
+    mark,
+    measureBetween,
+    record,
+  };
+}

--- a/src/stores/useApexStore.ts
+++ b/src/stores/useApexStore.ts
@@ -32,6 +32,16 @@ import {
   saveAxiomInteractionHistory,
   type AxiomInteractionHistory,
 } from "@/lib/axiom-interaction-persistence";
+import { record as recordPerf } from "@/lib/perf/instrument";
+
+// Mirrors instrument.ts's internal ENABLED gate so hot-path call sites
+// can skip even the cheap performance.now() in production. Keeping the
+// constant local avoids exporting an internal from the perf module.
+const ENABLED_PERF =
+  typeof window !== "undefined" &&
+  typeof performance !== "undefined" &&
+  process.env.NODE_ENV !== "production";
+
 import {
   loadBottomDockCollapsed,
   saveBottomDockCollapsed,
@@ -647,7 +657,18 @@ export const useApexStore = create<ApexState>((set, get) => ({
 
   // View
   viewMode: "3d",
-  setViewMode: (mode) => set({ viewMode: mode }),
+  setViewMode: (mode) => {
+    // View-switch instrumentation: start mark fires the instant the
+    // user picks a new view. The end mark is emitted from the new
+    // view component's first mount effect; measureBetween joins them
+    // into a "view-switch" rolling aggregate. We tag the mark per
+    // target mode so consecutive switches don't overwrite each other
+    // mid-render.
+    if (ENABLED_PERF) {
+      performance.mark(`view-switch:start:${mode}`);
+    }
+    set({ viewMode: mode });
+  },
 
   // Default to eigenvector — that's what the 3D view shipped with before
   // the toggle. Surfacing the choice as a visible UI control is the
@@ -677,6 +698,12 @@ export const useApexStore = create<ApexState>((set, get) => ({
     });
   },
   applyFeedBatch: (batch) => {
+    // Perf instrumentation: synchronous phase only — the post-set
+    // Tarski revalidation (phase 2) runs async and gets its own
+    // microtask budget. The "feed-tick" bucket therefore measures
+    // exactly the work that blocks the next paint, which is what we
+    // care about for laptop-felt smoothness.
+    const tickStart = ENABLED_PERF ? performance.now() : 0;
     // Phase 1: apply feed mutation + omega adjustments synchronously. The
     // non-verified path is complete here. Verified mode trails phase 2.
     let needsTarskiRevalidation = false;
@@ -752,6 +779,7 @@ export const useApexStore = create<ApexState>((set, get) => ({
       needsTarskiRevalidation = s.truthFilter === "verified";
       return { ...base, graphData: adjusted };
     });
+    if (ENABLED_PERF) recordPerf("feed-tick", performance.now() - tickStart);
 
     if (!needsTarskiRevalidation) return;
     void loadTarskiHelpers().then(({ runTarskiValidation, resolveDomainProfile }) => {


### PR DESCRIPTION
Stands up the instrumentation the perf audit (this session) called out as the highest-leverage next move — converting vibes into numbers so the next round of optimization work has baselines instead of guesses.

## What you get

New `src/lib/perf/instrument.ts` exports a minimal wrapper around the User Timing API: `mark` / `measureBetween` / `record` / `snapshot` / `logSnapshot` / `reset`.

**Production builds compile the helpers to no-ops via a single `NODE_ENV` check** — zero runtime cost shipped. Dev sessions expose `window.__manifoldPerf` for inspection from DevTools:

```
> __manifoldPerf.logSnapshot()
┌────────────────┬───────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┐
│ name           │ count │ mean_ms │ p50_ms  │ p95_ms  │ last_ms │ min_ms  │ max_ms  │
├────────────────┼───────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ launch         │   1   │   ??    │   ??    │   ??    │   ??    │   ??    │   ??    │
│ feed-tick      │  142  │   ??    │   ??    │   ??    │   ??    │   ??    │   ??    │
│ view-switch    │   3   │   ??    │   ??    │   ??    │   ??    │   ??    │   ??    │
└────────────────┴───────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
```

Rolling window of 100 samples per measurement. `__manifoldPerf.reset()` to start a fresh measurement run.

## Three call sites cover the three audit-flagged paths

| Bucket | Start mark | End mark / record |
|---|---|---|
| `launch` | `page.tsx` top-level on module load | `CausalDAG3D.onCreated` (canvas ready) |
| `feed-tick` | store `applyFeedBatch` — performance.now() | Same function exit, sync phase only. Phase-2 Tarski revalidation is async and **excluded** so the bucket measures exactly what blocks paint. |
| `view-switch` | store `setViewMode` — tagged per target mode so concurrent switches don't collide | `page.tsx` `useEffect([viewMode])` inside `requestAnimationFrame` — reflects user-felt latency (commit + browser layout + paint), not just React commit |

## Decisions worth flagging

- **Why a local `ENABLED_PERF` constant in the store** (not imported from instrument.ts): hot-path call sites skip the `performance.now()` overhead entirely in production. Keeping the constant local avoids exporting an internal from the perf module.
- **Why rAF for view-switch end**: measuring just the React commit consistently undershoots the user-felt cost on the heavier views (map / relief). rAF fires after the next paint, so the number actually reflects what the user perceives.
- **No behavioural change** in any of the three instrumented paths.

## Verification
- `tsc --noEmit`: clean.
- `eslint`: clean for new code; 3 pre-existing warnings (chiStarSet, scissors/ablation s-unused) unchanged.

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_