### PR TITLE
feat(3d): omega-driven spatial response on live + historical scrub

### DIFF
--- a/src/components/CausalDAG3D.tsx
+++ b/src/components/CausalDAG3D.tsx
@@ -530,6 +530,12 @@ export default function CausalDAG3D() {
   const interventionEpochs = useApexStore((s) => s.interventionEpochs);
   const activeTimeline = useApexStore((s) => s.activeTimeline);
   const isLive = useApexStore((s) => s.isLive);
+  // Timeline scrub state + per-node temporal history. Both feed the
+  // posMap memo below so historical scrubbing reads omega-at-the-
+  // scrubbed-time instead of always-current omega (the bug the user
+  // reported as "scrubbing doesn't do the migration thing anymore").
+  const timelinePosition = useApexStore((s) => s.timelinePosition);
+  const temporalData = useApexStore((s) => s.temporalData);
 
   const selectionBoxRef = useRef<{ x1: number; y1: number; x2: number; y2: number } | null>(null);
   const [selectionRect, setSelectionRect] = useState<{ x1: number; y1: number; x2: number; y2: number } | null>(null);
@@ -758,30 +764,53 @@ export default function CausalDAG3D() {
   //   Movement is driven by absolute omega level (not delta), ensuring visible change.
   // During LIVE: return base positions (no movement).
   const posMap = useMemo(() => {
-    // Live mode — no animation
-    if (isLive && !currentSnapshot) return basePosMap;
-
     const map: Record<string, [number, number, number]> = {};
 
-    // Get stress for each node (0 to 1 scale)
+    // Get stress for each node (0 to 1 scale).
+    //
+    // Three sources, in priority order:
+    //  1. Active cascade replay → currentSnapshot.shockIntensity. Sharp,
+    //     intervention-driven motion.
+    //  2. Historical scrub (timeline dragged off "now") → omega-at-the-
+    //     scrubbed-time from temporalData.nodes[id].history. Live feed
+    //     data writes into this history every tick, so scrubbing back
+     //     reads the real past, not the current-adjusted omega.
+    //  3. Live mode → node.omegaFragility.composite, which is the
+    //     feed-adjusted live value (applyOmegaLiveAdjustments). Slow
+    //     drift as real-world data ticks in.
+    //
+    // All three paths funnel through the same omega → stress curve so
+    // the displacement code below doesn't have to branch.
     const getStress = (nodeId: string): number => {
       if (currentSnapshot) {
         const state = currentSnapshot.nodeStates[nodeId];
         return state ? state.shockIntensity : 0;
       }
-      // Historical mode: use the temporal omega value directly
-      // High omega (>4) = stressed, pulls inward
-      // Low omega (<4) = relaxed, pushes outward
-      // Use O(1) nodeById lookup (item #10) instead of O(N) find
       const node = nodeById.get(nodeId);
       if (!node) return 0;
-      const omega = node.omegaFragility.composite;
+      let omega = node.omegaFragility.composite;
+      if (!isLive) {
+        // Historical scrub: look up the closest temporal sample at or
+        // before the scrubbed timestamp. Fall through to current omega
+        // if the node has no history (newly-added domains, etc.).
+        const history = temporalData?.nodes.get(nodeId)?.history;
+        if (history && history.length > 0) {
+          let lo = 0;
+          let hi = history.length - 1;
+          // Binary search for the rightmost timestamp ≤ target.
+          while (lo < hi) {
+            const mid = (lo + hi + 1) >> 1;
+            if (history[mid].timestamp <= timelinePosition) lo = mid;
+            else hi = mid - 1;
+          }
+          omega = history[lo].omegaComposite;
+        }
+      }
       // Map omega → [-1, +1] stress with a steeper curve around the
-      // mid-band so synthetic temporal data's typical ±0.5 drift
-      // around omega 5-7 actually moves the orb. Old `(omega-5)/4`
-      // produced stress 0.25-0.5 at typical levels; new ramp puts
-      // it at 0.5-0.75 — paired with the 2D CONTRACTION push, the
-      // dial scrub finally reads as "the cluster is breathing."
+      // mid-band so typical ±0.5 drift around omega 5-7 actually
+      // moves the orb. The displacement magnitudes (PULL_MAX / PUSH_MAX
+      // below) are deliberately small in live mode — the breath should
+      // be subtle so the user notices it as motion, not jitter.
       return Math.max(-1, Math.min(1, (omega - 4) / 3));
     };
 
@@ -884,7 +913,16 @@ export default function CausalDAG3D() {
 
     return map;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [basePosMap, currentSnapshot, neighbors, omegaKey, isLive, nodeById]);
+  }, [
+    basePosMap,
+    currentSnapshot,
+    neighbors,
+    omegaKey,
+    isLive,
+    nodeById,
+    timelinePosition,
+    temporalData,
+  ]);
 
   const domainMap = useMemo(() => getNodeDomainMap(), []);
 

--- a/src/components/dag3d/DAGNode3D.tsx
+++ b/src/components/dag3d/DAGNode3D.tsx
@@ -86,6 +86,14 @@ function DAGNode3DInner({
   const nodeSizeMetric = useApexStore((s) => s.nodeSizeMetric);
   const meshRef = useRef<THREE.Mesh>(null);
   const selectionRingRef = useRef<THREE.Mesh>(null);
+  const groupRef = useRef<THREE.Group>(null);
+  // Smoothed position. Parent posMap recomputes whenever omega values
+  // change (live feed tick / historical scrub), producing a new target
+  // position. Without lerping, every feed tick would snap the orb to
+  // the new position — visually jarring and erases the "system slowly
+  // breathing" insight. Each frame we ease the group's actual position
+  // toward the prop with a fixed time constant.
+  const currentPos = useRef<[number, number, number]>(position);
   const birthProgress = useRef(isConsequence ? 0 : 1);
   const displayOmega = useRef(node.omegaFragility.composite);
   const [hovered, setHovered] = useState(false);
@@ -133,6 +141,21 @@ function DAGNode3DInner({
   })());
 
   useFrame(({ clock }, delta) => {
+    // Smooth position toward target. Runs even when the cosmetic-pulse
+    // gates below skip — a greyed-out orb still needs to migrate when
+    // its omega changes, otherwise the network "shape" reads as a lie
+    // (the orb is at its old position despite the underlying state
+    // having moved on). Fixed-rate exponential ease: ~85% of the
+    // distance closed per 100ms feels smooth without being mushy.
+    if (groupRef.current) {
+      const k = 1 - Math.exp(-delta * 12);
+      const cur = currentPos.current;
+      cur[0] += (position[0] - cur[0]) * k;
+      cur[1] += (position[1] - cur[1]) * k;
+      cur[2] += (position[2] - cur[2]) * k;
+      groupRef.current.position.set(cur[0], cur[1], cur[2]);
+    }
+
     // Per-frame work is now baseline-idle by default — every visible
     // orb gets a slow breathing pulse so the canvas reads as alive
     // when nothing's happening. Reasons to skip outright:
@@ -189,7 +212,7 @@ function DAGNode3DInner({
   });
 
   return (
-    <group position={position} onClick={onClick} onDoubleClick={onDoubleClick}>
+    <group ref={groupRef} position={position} onClick={onClick} onDoubleClick={onDoubleClick}>
       {/* Selection ring (bright cyan pulsing) */}
       {isSelected && (
         <mesh ref={selectionRingRef} rotation={[Math.PI / 2, 0, 0]}>


### PR DESCRIPTION
**Restores the omega-driven node migration the user originally implemented and recently reported was no longer working.**

The "system pulsates / nodes migrate apart as omega diverges" insight is the whole point of the time dial — not aesthetics, real spatial encoding of systemic stress. It was broken in three specific ways, all in `CausalDAG3D` / `DAGNode3D`.

## What was broken

### 1. Live mode was hard-disabled
`CausalDAG3D.tsx` opened `posMap` with:
```ts
if (isLive && !currentSnapshot) return basePosMap;  // no movement
```
So the displacement code only ran during cascade replay and historical scrub — never during normal live operation. Feed providers were happily updating `node.omegaFragility.composite` every tick, but positions never reacted to it.

**Fix:** removed the guard. Live mode now flows through the same displacement code, driven by `omegaFragility.composite` (the feed-adjusted live value).

### 2. Historical scrub used current omega, not historical
`getStress()` read `node.omegaFragility.composite` — the **present** live-adjusted value — regardless of where the timeline was scrubbed. So scrubbing back to 2024 showed orbs positioned using today's omega values. Migration insight lost.

**Fix:** when scrubbing (not live), binary-search `temporalData.nodes[id].history` for the rightmost timestamp ≤ `timelinePosition`. That's the omega value as recorded at the scrubbed moment. Falls through to current omega for nodes with no history (newly-added domains).

### 3. No smoothing
Positions snapped to whatever `posMap` returned, so every feed tick teleported the orb. Added per-frame exponential ease (`k = 12`, ~50% gap closed in 58 ms) on the group ref in `DAGNode3D`. Slow enough to read as motion rather than jitter, fast enough that the orb tracks intent.

## Memo deps
Extended `posMap`'s memo deps to include `timelinePosition` and `temporalData` — previously `omegaKey` was the only invalidation signal and it didn't change during scrub, so dragging the dial did nothing.

## The architecture you wanted

Omega is now the single shared driver of position:

```
Feed providers → applyOmegaLiveAdjustments → node.omegaFragility       ┐
Cascade replay → currentSnapshot.shockIntensity                        ├→ getStress() → displacement
Historical scrub → temporalData.nodes[id].history[t ≤ scrub]           ┘
```

All three paths funnel into the same stress curve and displacement code, so the visualization always encodes systemic stress as **shape**, not just color.

## Files
- `src/components/CausalDAG3D.tsx` — removed live skip; historical-omega lookup; extended memo deps
- `src/components/dag3d/DAGNode3D.tsx` — group ref + per-frame position lerp

## Verification
- `tsc --noEmit`: clean.
- `eslint`: clean for new code; the two pre-existing `chiStarSet` / `ablationMode` unused-var warnings are untouched.
- No behavioural change to cascade replay or to orb size / color / glow — only adds spatial response.

## Tuning to expect
The displacement constants (`PULL_MAX = 0.45`, `PUSH_MAX = 0.25`) were tuned for historical scrub where omega values swing wider. In live mode the per-tick omega drift is typically small (Δ < 0.5), so the motion will be subtle by design. If you want it more pronounced or less, two knobs:
- Drop / raise `PULL_MAX` / `PUSH_MAX`
- Steepen / flatten the `(omega - 4) / 3` stress curve

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_