### PR TITLE
feat(omega): per-domain ΩF composite weighting

### DIFF
--- a/src/components/NodeInspector.tsx
+++ b/src/components/NodeInspector.tsx
@@ -7,7 +7,7 @@ import { getCategoryColor, getDomainColor, getCategoryLabel } from "@/lib/graph-
 import { useTemporalGraph } from "@/hooks/useTemporalGraph";
 import type { NodeTemporalState } from "@/lib/temporal-data";
 import { getNodeDataDescription } from "@/lib/real-timeseries";
-import { resolveDomainProfile, type PillarKey } from "@/lib/domain-profiles";
+import { resolveDomainProfile, formatWeights, type PillarKey } from "@/lib/domain-profiles";
 import { chiStar } from "@/lib/estimators/chi-star";
 import { graphSignature } from "@/lib/graph-layout-2d";
 import { buildContextualReview } from "@/lib/contextual-review";
@@ -521,6 +521,21 @@ export default function NodeInspector() {
                 selectedKey={expandedPillar}
                 onSelect={(k) => setExpandedPillar(expandedPillar === k ? null : k)}
               />
+              {/* Audit trail when the active profile re-weighted this node's
+                  composite (compositeMode: "recomputed", e.g. AI-Safety on the
+                  borrowed `main` graph) — surfaces the original authored score
+                  so the reweighting isn't silent. */}
+              {node.omegaFragility.baselineComposite != null &&
+                node.omegaFragility.baselineComposite !== node.omegaFragility.composite && (
+                  <div className="flex justify-center mt-1">
+                    <span
+                      className="text-[7px] font-mono text-accent-amber/80 tracking-wider cursor-help"
+                      title={`Re-weighted under the ${profile.displayName} profile (${formatWeights(profile.weights)}). Authored / default-weighted score was ${node.omegaFragility.baselineComposite.toFixed(1)}.`}
+                    >
+                      ↻ REWEIGHTED FROM {node.omegaFragility.baselineComposite.toFixed(1)} · {profile.displayName.toUpperCase()}
+                    </span>
+                  </div>
+                )}
               <div className="flex justify-center mt-1">
                 <button
                   onClick={() => setShowMethodology((v) => !v)}

--- a/src/components/import/ImportModal.tsx
+++ b/src/components/import/ImportModal.tsx
@@ -6,6 +6,7 @@ import { useApexStore } from "@/stores/useApexStore";
 import { parseFile } from "@/lib/import/parsers";
 import { parseCSV } from "@/lib/import/parsers/csv-parser";
 import { validateParsedGraph } from "@/lib/import/validation";
+import { resolveDomainProfile } from "@/lib/domain-profiles";
 import { mergeGraphs } from "@/lib/import/merge";
 import {
   ImportStep,
@@ -206,7 +207,12 @@ export default function ImportModal() {
       // Run the same cross-file resolution and stub creation
       resolveEdgeReferences(combined.nodes, combined.edges, combined.warnings, breakdown);
 
-      const result = validateParsedGraph(combined, graphData);
+      // Score imported nodes against the active profile's pillar weighting
+      // (defaults to the platform default for the geopolitical/empty selection).
+      const importWeights = resolveDomainProfile(
+        useApexStore.getState().selectedDomains,
+      ).weights;
+      const result = validateParsedGraph(combined, graphData, importWeights);
       setValidationResult(result);
       setFileBreakdown(breakdown);
       setStep("preview");
@@ -267,7 +273,12 @@ export default function ImportModal() {
         warnings: allWarnings,
       };
 
-      const result = validateParsedGraph(combined, graphData);
+      // Score imported nodes against the active profile's pillar weighting
+      // (defaults to the platform default for the geopolitical/empty selection).
+      const importWeights = resolveDomainProfile(
+        useApexStore.getState().selectedDomains,
+      ).weights;
+      const result = validateParsedGraph(combined, graphData, importWeights);
       setValidationResult(result);
       setFileBreakdown(breakdown);
       setStep("preview");

--- a/src/lib/__tests__/omega-weighting-integration.test.ts
+++ b/src/lib/__tests__/omega-weighting-integration.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { buildGraphFromDomains } from "@/lib/build-domain-graph";
+import { weightedComposite } from "@/lib/omega-weighting";
+import { AI_SAFETY_PROFILE } from "@/lib/domain-profiles";
+
+// End-to-end through the REAL function the store calls when a domain is
+// selected (useApexStore → buildGraphFromDomains(domainIds)). Both cards
+// below resolve to the same `main` dataset (domains.ts), so they load the
+// identical node set — the ONLY difference is the active profile's weighting.
+// This is the integration point where the AI-Safety skew has to become
+// visible (the card has no nodes of its own; it overlays `main`).
+
+function meanComposite(nodes: { omegaFragility: { composite: number } }[]): number {
+  return nodes.reduce((s, n) => s + n.omegaFragility.composite, 0) / Math.max(1, nodes.length);
+}
+
+describe("buildGraphFromDomains × profile weighting (integration)", () => {
+  const geo = buildGraphFromDomains(["energy-systems"]); // GEOPOLITICAL, authored
+  const ai = buildGraphFromDomains(["ai-safety-ids"]); // AI_SAFETY, recomputed (same `main` nodes)
+
+  it("loads the same node set for both (ai-safety overlays the main graph)", () => {
+    expect(ai.nodes.length).toBe(geo.nodes.length);
+    expect(ai.nodes.length).toBeGreaterThan(0);
+    expect(new Set(ai.nodes.map((n) => n.id))).toEqual(new Set(geo.nodes.map((n) => n.id)));
+  });
+
+  it("geopolitical (authored) leaves composites untouched — no baseline stamped", () => {
+    for (const n of geo.nodes) {
+      expect(n.omegaFragility.baselineComposite).toBeUndefined();
+    }
+  });
+
+  it("ai-safety recomputes every composite from pillars × AI weights, preserving the authored baseline", () => {
+    const geoById = new Map(geo.nodes.map((n) => [n.id, n.omegaFragility.composite]));
+    for (const n of ai.nodes) {
+      const o = n.omegaFragility;
+      expect(o.composite).toBe(weightedComposite(o, AI_SAFETY_PROFILE.weights));
+      // baseline === the authored (geopolitical-weighted) score for the same node
+      expect(o.baselineComposite).toBe(geoById.get(n.id));
+    }
+  });
+
+  it("the skew is actually visible — many node scores shift and the CDΩ mean moves", () => {
+    const geoById = new Map(geo.nodes.map((n) => [n.id, n.omegaFragility.composite]));
+    const shifted = ai.nodes.filter(
+      (n) => n.omegaFragility.composite !== geoById.get(n.id),
+    ).length;
+    // The cascade+tail skew should move a substantial fraction of nodes.
+    expect(shifted).toBeGreaterThan(ai.nodes.length * 0.25);
+    // CDΩ header proxy (mean composite) should differ between the two profiles.
+    expect(meanComposite(ai.nodes)).not.toBe(meanComposite(geo.nodes));
+  });
+});

--- a/src/lib/__tests__/omega-weighting.test.ts
+++ b/src/lib/__tests__/omega-weighting.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from "vitest";
+import { weightedComposite, recomputeComposite } from "@/lib/omega-weighting";
+import {
+  GEOPOLITICAL_PROFILE,
+  T1D_PROFILE,
+  AI_SAFETY_PROFILE,
+  formatWeights,
+} from "@/lib/domain-profiles";
+import { DEFAULT_OMEGA_WEIGHTS } from "@/lib/types";
+import type {
+  CausalGraph,
+  CausalNode,
+  OmegaFragilityProfile,
+  OmegaPillarWeights,
+} from "@/lib/types";
+
+// The pre-refactor inline formula from enrich.ts, kept verbatim here so the
+// extracted helper is pinned to the exact behaviour it replaced.
+function legacyComposite(p: OmegaFragilityProfile, w: OmegaPillarWeights): number {
+  return (
+    Math.round(
+      (w.irreplaceability * p.irreplaceability +
+        w.restorationLatency * p.restorationLatency +
+        w.jurisdictionalHazard * p.jurisdictionalHazard +
+        w.cascadeLoad * p.cascadeLoad +
+        w.tailDepth * p.tailDepth) *
+        10,
+    ) / 10
+  );
+}
+
+function omega(
+  composite: number,
+  i: number,
+  r: number,
+  j: number,
+  c: number,
+  t: number,
+): OmegaFragilityProfile {
+  return {
+    composite,
+    irreplaceability: i,
+    restorationLatency: r,
+    jurisdictionalHazard: j,
+    cascadeLoad: c,
+    tailDepth: t,
+  };
+}
+
+function node(id: string, o: OmegaFragilityProfile): CausalNode {
+  // Only omegaFragility matters to the weighting transform; cast keeps the
+  // fixture small (the transform spreads the rest of the node untouched).
+  return { id, omegaFragility: o } as unknown as CausalNode;
+}
+
+function graph(nodes: CausalNode[]): CausalGraph {
+  return { nodes, edges: [], metadata: {} } as unknown as CausalGraph;
+}
+
+describe("weightedComposite", () => {
+  it("matches the legacy inline enrich.ts formula across varied pillar sets", () => {
+    const samples: OmegaFragilityProfile[] = [
+      omega(0, 7.0, 7.5, 7.5, 10, 5.0),
+      omega(0, 8.5, 6.0, 5.5, 8.5, 7.0),
+      omega(0, 1, 1, 1, 1, 1),
+      omega(0, 10, 10, 10, 10, 10),
+      omega(0, 3.3, 9.1, 4.7, 6.2, 2.8),
+    ];
+    const weightSets = [
+      DEFAULT_OMEGA_WEIGHTS,
+      AI_SAFETY_PROFILE.weights,
+      { irreplaceability: 0.2, restorationLatency: 0.2, jurisdictionalHazard: 0.2, cascadeLoad: 0.2, tailDepth: 0.2 },
+    ];
+    for (const p of samples) {
+      for (const w of weightSets) {
+        expect(weightedComposite(p, w)).toBe(legacyComposite(p, w));
+      }
+    }
+  });
+
+  it("reproduces the hand-authored East-West Pipeline composite (7.6) under default weights", () => {
+    // graph-data.ts: omega(7.6, 7.0, 7.5, 7.5, 10, 5.0) — evidence the authored
+    // literals were tuned against DEFAULT_OMEGA_WEIGHTS (J 0.15 / C 0.25).
+    expect(weightedComposite(omega(0, 7.0, 7.5, 7.5, 10, 5.0), DEFAULT_OMEGA_WEIGHTS)).toBe(7.6);
+  });
+});
+
+describe("profile weight integrity", () => {
+  it("every profile's weights sum to 1.0", () => {
+    for (const profile of [GEOPOLITICAL_PROFILE, T1D_PROFILE, AI_SAFETY_PROFILE]) {
+      const w = profile.weights;
+      const sum =
+        w.irreplaceability +
+        w.restorationLatency +
+        w.jurisdictionalHazard +
+        w.cascadeLoad +
+        w.tailDepth;
+      expect(sum).toBeCloseTo(1.0, 10);
+    }
+  });
+
+  it("geopolitical and T1D keep the platform default; AI-Safety skews to C+T", () => {
+    expect(GEOPOLITICAL_PROFILE.weights).toEqual(DEFAULT_OMEGA_WEIGHTS);
+    expect(T1D_PROFILE.weights).toEqual(DEFAULT_OMEGA_WEIGHTS);
+    expect(GEOPOLITICAL_PROFILE.compositeMode).toBe("authored");
+    expect(T1D_PROFILE.compositeMode).toBe("authored");
+    expect(AI_SAFETY_PROFILE.compositeMode).toBe("recomputed");
+    expect(AI_SAFETY_PROFILE.weights.cascadeLoad).toBe(0.3);
+    expect(AI_SAFETY_PROFILE.weights.tailDepth).toBe(0.3);
+    // cascade + tail dominate
+    expect(AI_SAFETY_PROFILE.weights.cascadeLoad + AI_SAFETY_PROFILE.weights.tailDepth).toBeCloseTo(0.6, 10);
+  });
+});
+
+describe("recomputeComposite", () => {
+  const pipeline = omega(7.6, 7.0, 7.5, 7.5, 10, 5.0);
+
+  it("is a no-op for authored profiles (geopolitical) — composite untouched, no baseline stamped", () => {
+    const g = graph([node("n1", { ...pipeline })]);
+    const out = recomputeComposite(g, GEOPOLITICAL_PROFILE);
+    expect(out.nodes[0].omegaFragility.composite).toBe(7.6);
+    expect(out.nodes[0].omegaFragility.baselineComposite).toBeUndefined();
+  });
+
+  it("reweights under a recomputed profile (AI-Safety) and preserves the authored baseline", () => {
+    const g = graph([node("n1", { ...pipeline })]);
+    const out = recomputeComposite(g, AI_SAFETY_PROFILE);
+    const o = out.nodes[0].omegaFragility;
+    expect(o.composite).toBe(weightedComposite(pipeline, AI_SAFETY_PROFILE.weights));
+    expect(o.baselineComposite).toBe(7.6);
+    // pipeline is already high-cascade, so the C+T skew nudges it down slightly
+    expect(o.composite).toBeLessThan(7.6);
+  });
+
+  it("moves a high-tail / low-cascade node UP under the AI-Safety skew", () => {
+    // authored-ish node with modest cascade but severe tail
+    const tailHeavy = omega(5.0, 4, 4, 4, 3, 10);
+    const g = graph([node("n1", { ...tailHeavy })]);
+    const out = recomputeComposite(g, AI_SAFETY_PROFILE);
+    expect(out.nodes[0].omegaFragility.composite).toBeGreaterThan(
+      weightedComposite(tailHeavy, DEFAULT_OMEGA_WEIGHTS),
+    );
+  });
+
+  it("is idempotent — re-applying keeps the FIRST-seen authored baseline", () => {
+    const g = graph([node("n1", { ...pipeline })]);
+    const once = recomputeComposite(g, AI_SAFETY_PROFILE);
+    const twice = recomputeComposite(once, AI_SAFETY_PROFILE);
+    expect(twice.nodes[0].omegaFragility.composite).toBe(once.nodes[0].omegaFragility.composite);
+    expect(twice.nodes[0].omegaFragility.baselineComposite).toBe(7.6);
+  });
+
+  it("does not mutate the input graph", () => {
+    const original = omega(7.6, 7.0, 7.5, 7.5, 10, 5.0);
+    const g = graph([node("n1", original)]);
+    recomputeComposite(g, AI_SAFETY_PROFILE);
+    expect(g.nodes[0].omegaFragility.composite).toBe(7.6);
+    expect(g.nodes[0].omegaFragility.baselineComposite).toBeUndefined();
+  });
+});
+
+describe("formatWeights (methodology prose derivation)", () => {
+  it("renders the canonical default tuple", () => {
+    expect(formatWeights(DEFAULT_OMEGA_WEIGHTS)).toBe(
+      "I(0.25) + R(0.20) + J(0.15) + C(0.25) + T(0.15)",
+    );
+  });
+
+  it("renders the AI-Safety skew", () => {
+    expect(formatWeights(AI_SAFETY_PROFILE.weights)).toBe(
+      "I(0.10) + R(0.20) + J(0.10) + C(0.30) + T(0.30)",
+    );
+  });
+
+  it("the methodology prose contains the formatted weights (no drift)", () => {
+    expect(GEOPOLITICAL_PROFILE.compositeMethodology).toContain(
+      formatWeights(GEOPOLITICAL_PROFILE.weights),
+    );
+    expect(T1D_PROFILE.compositeMethodology).toContain(formatWeights(T1D_PROFILE.weights));
+    expect(AI_SAFETY_PROFILE.compositeMethodology).toContain(
+      formatWeights(AI_SAFETY_PROFILE.weights),
+    );
+  });
+});

--- a/src/lib/build-domain-graph.ts
+++ b/src/lib/build-domain-graph.ts
@@ -15,6 +15,8 @@ import { VX880_GRAPH } from "@/lib/t1d-vx880-graph-data";
 import { mergeGraphs } from "@/lib/import/merge";
 import type { CausalGraph } from "@/lib/types";
 import { DOMAIN_CARDS, type DomainCard } from "@/lib/domains";
+import { resolveDomainProfile } from "@/lib/domain-profiles";
+import { recomputeComposite } from "@/lib/omega-weighting";
 
 // Static node counts per dataset — exposed so the picker can render
 // "X nodes will load" previews without forcing the data through
@@ -63,6 +65,16 @@ export function buildGraphFromDomains(domainIds: string[]): CausalGraph {
     const { graph: merged } = mergeGraphs(graph, { nodes: [], edges: BRIDGE_EDGES });
     graph = merged;
   }
+
+  // Apply the active domain profile's pillar weighting. No-op for
+  // "authored" profiles (Geopolitical, T1D keep their hand-tuned
+  // composites); for "recomputed" profiles (AI-Safety) every node's
+  // composite is re-derived from its pillars under the profile's weights,
+  // so the skew reaches every downstream consumer via `graphData`.
+  // resolveDomainProfile falls back to Geopolitical (authored) for the
+  // empty / default selection, so the default load path is unchanged.
+  const profile = resolveDomainProfile(domainIds);
+  graph = recomputeComposite(graph, profile);
 
   return graph;
 }

--- a/src/lib/domain-profiles.ts
+++ b/src/lib/domain-profiles.ts
@@ -7,7 +7,8 @@
 // terminal on one dataset and a medical-research terminal on another
 // without forking the codebase.
 
-import type { ManifoldModule } from "./types";
+import type { ManifoldModule, OmegaPillarWeights } from "./types";
+import { DEFAULT_OMEGA_WEIGHTS } from "./types";
 // GEOPOLITICAL_MODULES used to be defined inline here; HeaderBar (on the
 // critical-path bundle) was pulling all 480 LOC of profile data just to
 // render the four tab labels. The constant now lives in `module-tabs.ts`
@@ -65,6 +66,31 @@ export interface DomainProfile {
   pillarLabels: PillarLabels;
   pillarDetails: Record<PillarKey, PillarDetail>;
   compositeMethodology: string;
+  /**
+   * Per-domain ΩF pillar weighting (must sum to 1.0). The canonical
+   * source of truth for this domain's composite aggregation — both the
+   * runtime recompute (`recomputeComposite`) and the methodology prose
+   * (`formatWeights`) read from here, so the displayed numbers can never
+   * drift from the math again. Default domains carry
+   * `DEFAULT_OMEGA_WEIGHTS`; domains with a deliberate skew (AI-Safety
+   * → cascade + tail, per Ghauri 2025) override it.
+   */
+  weights: OmegaPillarWeights;
+  /**
+   * How this profile's `omegaFragility.composite` is sourced for display:
+   *   - "authored"   → trust the hand-authored composite literals in the
+   *                    graph-data modules (and the import-path scorer).
+   *                    Used by domains whose nodes were tuned against the
+   *                    default weighting (Geopolitical, T1D). No recompute.
+   *   - "recomputed" → derive composite = Σ(weightᵢ × pillarᵢ) at
+   *                    graph-build time, stashing the prior value in
+   *                    `baselineComposite`. Required for overlay profiles
+   *                    that borrow another domain's authored pillars under
+   *                    a different lens (AI-Safety rides the `main` graph),
+   *                    where the authored composite reflects the WRONG
+   *                    weighting for this domain.
+   */
+  compositeMode: "authored" | "recomputed";
   criticalityEstimators: EstimatorId[];
   /**
    * Optional id of a pre-built relevance-reference JSON
@@ -80,6 +106,19 @@ export interface DomainProfile {
    * calibrated yet.
    */
   relevanceReferenceId?: string;
+}
+
+/**
+ * Render a weight set as methodology prose ("I(0.25) + R(0.20) + J(0.15)
+ * + C(0.25) + T(0.15)"). The `compositeMethodology` strings interpolate
+ * this so the numbers an analyst reads are derived from the same
+ * `weights` object the engine aggregates with — they can never drift
+ * apart again (they had: the old geopolitical prose claimed J/C = 0.20
+ * while the constant used J 0.15 / C 0.25).
+ */
+export function formatWeights(w: OmegaPillarWeights): string {
+  const f = (n: number) => n.toFixed(2);
+  return `I(${f(w.irreplaceability)}) + R(${f(w.restorationLatency)}) + J(${f(w.jurisdictionalHazard)}) + C(${f(w.cascadeLoad)}) + T(${f(w.tailDepth)})`;
 }
 
 // ─── Geopolitical / financial (current default) ─────────────────────
@@ -132,8 +171,15 @@ const GEOPOLITICAL_PILLAR_DETAILS: Record<PillarKey, PillarDetail> = {
   },
 };
 
+// Canonical geopolitical/financial weighting = the platform default.
+// The hand-authored composites in graph-data.ts were tuned against these
+// (e.g. East-West Pipeline omega(7.6, 7.0, 7.5, 7.5, 10, 5.0) reproduces
+// 7.6 exactly under this set), so this profile trusts the literals
+// (`compositeMode: "authored"`).
+const GEOPOLITICAL_WEIGHTS: OmegaPillarWeights = DEFAULT_OMEGA_WEIGHTS;
+
 const GEOPOLITICAL_METHODOLOGY =
-  "The \u03A9F (Omega Fragility) composite score is a weighted aggregation of five orthogonal risk pillars, each scored 0\u201310. The composite weights are: I(0.25) + R(0.20) + J(0.20) + C(0.20) + T(0.15). Scores above 7.0 indicate elevated systemic fragility; above 9.0 indicates critical nodes where disruption would cascade across multiple domains.";
+  `The \u03A9F (Omega Fragility) composite score is a weighted aggregation of five orthogonal risk pillars, each scored 0\u201310. The composite weights are: ${formatWeights(GEOPOLITICAL_WEIGHTS)}. Scores above 7.0 indicate elevated systemic fragility; above 9.0 indicates critical nodes where disruption would cascade across multiple domains.`;
 
 export const GEOPOLITICAL_PROFILE: DomainProfile = {
   id: "geopolitical",
@@ -142,6 +188,8 @@ export const GEOPOLITICAL_PROFILE: DomainProfile = {
   pillarLabels: GEOPOLITICAL_PILLARS,
   pillarDetails: GEOPOLITICAL_PILLAR_DETAILS,
   compositeMethodology: GEOPOLITICAL_METHODOLOGY,
+  weights: GEOPOLITICAL_WEIGHTS,
+  compositeMode: "authored",
   // BOCPD is now live as a fourth criticality estimator (PR #234) — it
   // runs on the same scoped Ω trajectory CSD/LPPLS already use and produces
   // a regular F·E·G·S·M breakdown. Including it here makes the analyst
@@ -257,8 +305,13 @@ const T1D_PILLAR_DETAILS: Record<PillarKey, PillarDetail> = {
   },
 };
 
+// T1D "stays at default" \u2014 the medical pillars were authored against the
+// same weighting as geopolitical, so cross-domain comparison stays
+// apples-to-apples and the literals are trusted (`compositeMode: "authored"`).
+const T1D_WEIGHTS: OmegaPillarWeights = DEFAULT_OMEGA_WEIGHTS;
+
 const T1D_METHODOLOGY =
-  "The CRITICALITY composite score aggregates five orthogonal biological risk pillars, each scored 0\u201310: mechanism rarity, restoration latency, regulatory exposure, complication load, and outcome tail. Weights match the geopolitical composite (0.25 / 0.20 / 0.20 / 0.20 / 0.15) so cross-domain comparison stays apples-to-apples. Scores above 7.0 flag mechanisms worth prioritising for intervention; above 9.0 indicates nodes whose failure cascades across metabolic, vascular, and neurological subsystems.";
+  `The CRITICALITY composite score aggregates five orthogonal biological risk pillars, each scored 0\u201310: mechanism rarity, restoration latency, regulatory exposure, complication load, and outcome tail. Weights match the geopolitical composite (${formatWeights(T1D_WEIGHTS)}) so cross-domain comparison stays apples-to-apples. Scores above 7.0 flag mechanisms worth prioritising for intervention; above 9.0 indicates nodes whose failure cascades across metabolic, vascular, and neurological subsystems.`;
 
 export const T1D_PROFILE: DomainProfile = {
   id: "t1d",
@@ -267,6 +320,8 @@ export const T1D_PROFILE: DomainProfile = {
   pillarLabels: T1D_PILLARS,
   pillarDetails: T1D_PILLAR_DETAILS,
   compositeMethodology: T1D_METHODOLOGY,
+  weights: T1D_WEIGHTS,
+  compositeMode: "authored",
   criticalityEstimators: [
     "bocpd",
     "transfer-entropy",
@@ -384,8 +439,22 @@ const AI_SAFETY_PILLAR_DETAILS: Record<PillarKey, PillarDetail> = {
   },
 };
 
+// AI-Safety skews toward Cascade + Tail — endogenous failure (catastrophic
+// forgetting, χ⋆-bridge cascade, adversarial drift) is dominated by those
+// two pillars per Ghauri (2025). It has no nodes of its own (the
+// `ai-safety-ids` card overlays the `main` graph), so the borrowed authored
+// composites reflect the GEOPOLITICAL weighting; `compositeMode:
+// "recomputed"` re-derives them under this skew at graph-build time.
+const AI_SAFETY_WEIGHTS: OmegaPillarWeights = {
+  irreplaceability: 0.10,
+  restorationLatency: 0.20,
+  jurisdictionalHazard: 0.10,
+  cascadeLoad: 0.30,
+  tailDepth: 0.30,
+};
+
 const AI_SAFETY_METHODOLOGY =
-  "The ENDOGENOUS FRAGILITY composite aggregates five orthogonal AI-system risk pillars, each scored 0–10: mechanism rarity, forgetting latency, threat-model exposure, cascade susceptibility, adversarial tail depth. AI-domain weights skew toward C(0.30) and T(0.30) — cascade and tail are the dominant failure modes per Ghauri (2025) — with I(0.10) + R(0.20) + J(0.10) summing the remainder. Scores above 7.0 flag mechanisms worth structural hardening (χ⋆-edge intervention, topology-aware replay); above 9.0 indicates architectural Achilles' heels where compromise cascades across reasoning, memory, and decision subsystems.";
+  `The ENDOGENOUS FRAGILITY composite aggregates five orthogonal AI-system risk pillars, each scored 0–10: mechanism rarity, forgetting latency, threat-model exposure, cascade susceptibility, adversarial tail depth. AI-domain weights skew toward cascade and tail — the dominant endogenous failure modes per Ghauri (2025): ${formatWeights(AI_SAFETY_WEIGHTS)}. Scores above 7.0 flag mechanisms worth structural hardening (χ⋆-edge intervention, topology-aware replay); above 9.0 indicates architectural Achilles' heels where compromise cascades across reasoning, memory, and decision subsystems.`;
 
 export const AI_SAFETY_PROFILE: DomainProfile = {
   id: "ai-safety",
@@ -394,6 +463,8 @@ export const AI_SAFETY_PROFILE: DomainProfile = {
   pillarLabels: AI_SAFETY_PILLARS,
   pillarDetails: AI_SAFETY_PILLAR_DETAILS,
   compositeMethodology: AI_SAFETY_METHODOLOGY,
+  weights: AI_SAFETY_WEIGHTS,
+  compositeMode: "recomputed",
   // Pareto criticality strip = four time-series estimators that share
   // a common shape (observed-vs-model fit on a Ω-trajectory, with an
   // "epochs to critical" reading). cvar-w1 and chi-star are SNAPSHOT

--- a/src/lib/import/enrich.ts
+++ b/src/lib/import/enrich.ts
@@ -1,4 +1,5 @@
-import { CausalNode, CausalEdge, DEFAULT_OMEGA_WEIGHTS } from "@/lib/types";
+import { CausalNode, CausalEdge, DEFAULT_OMEGA_WEIGHTS, OmegaPillarWeights } from "@/lib/types";
+import { weightedComposite } from "@/lib/omega-weighting";
 
 interface EnrichResult {
   nodes: CausalNode[];
@@ -109,7 +110,11 @@ function isDefault(v: number): boolean {
  *   C (Cascade Load)         → Spirtes topology + Pareto simulation depth
  *   T (Tail Depth)           → Pareto: tail statistics from cascade simulation
  */
-function computeOmegaScores(nodes: CausalNode[], edges: CausalEdge[]): CausalNode[] {
+function computeOmegaScores(
+  nodes: CausalNode[],
+  edges: CausalEdge[],
+  weights: OmegaPillarWeights = DEFAULT_OMEGA_WEIGHTS,
+): CausalNode[] {
   // Build degree maps
   const inDegree = new Map<string, number>();
   const outDegree = new Map<string, number>();
@@ -191,8 +196,6 @@ function computeOmegaScores(nodes: CausalNode[], edges: CausalEdge[]): CausalNod
     return clamp(j, 1, 10);
   }
 
-  const w = DEFAULT_OMEGA_WEIGHTS;
-
   return nodes.map((node) => {
     const omega = { ...node.omegaFragility };
     const inDeg = inDegree.get(node.id) ?? 0;
@@ -243,15 +246,11 @@ function computeOmegaScores(nodes: CausalNode[], edges: CausalEdge[]): CausalNod
       omega.tailDepth = clamp(t, 1, 10);
     }
 
-    // ΩF composite: configurable weighted average
+    // ΩF composite: configurable weighted average (shared formula —
+    // see weightedComposite in omega-weighting.ts, also used by the
+    // runtime profile recompute so the two can't diverge).
     if (isDefault(omega.composite)) {
-      omega.composite = Math.round(
-        (w.irreplaceability * omega.irreplaceability +
-          w.restorationLatency * omega.restorationLatency +
-          w.jurisdictionalHazard * omega.jurisdictionalHazard +
-          w.cascadeLoad * omega.cascadeLoad +
-          w.tailDepth * omega.tailDepth) * 10
-      ) / 10;
+      omega.composite = weightedComposite(omega, weights);
     }
 
     return { ...node, omegaFragility: omega };
@@ -280,7 +279,11 @@ function normalizeConcentration(nodes: CausalNode[]): CausalNode[] {
   });
 }
 
-export function enrichGraph(nodes: CausalNode[], edges: CausalEdge[]): EnrichResult {
+export function enrichGraph(
+  nodes: CausalNode[],
+  edges: CausalEdge[],
+  weights: OmegaPillarWeights = DEFAULT_OMEGA_WEIGHTS,
+): EnrichResult {
   // Normalize concentration values before scoring
   const normalizedNodes = normalizeConcentration(nodes);
 
@@ -288,8 +291,11 @@ export function enrichGraph(nodes: CausalNode[], edges: CausalEdge[]): EnrichRes
   const { edges: inferredEdges, warnings } = inferEdges(normalizedNodes, edges);
   const allEdges = [...edges, ...inferredEdges];
 
-  // Compute omega scores using full topology (original + inferred edges)
-  const enrichedNodes = computeOmegaScores(normalizedNodes, allEdges);
+  // Compute omega scores using full topology (original + inferred edges).
+  // `weights` lets an import under a non-default profile score against that
+  // profile's pillar weighting; defaults to the platform default so the
+  // common import path is unchanged.
+  const enrichedNodes = computeOmegaScores(normalizedNodes, allEdges, weights);
 
   return {
     nodes: enrichedNodes,

--- a/src/lib/import/validation.ts
+++ b/src/lib/import/validation.ts
@@ -1,4 +1,4 @@
-import { CausalGraph, NodeCategory, EdgeType } from "@/lib/types";
+import { CausalGraph, NodeCategory, EdgeType, DEFAULT_OMEGA_WEIGHTS, OmegaPillarWeights } from "@/lib/types";
 import { ParsedGraph, ValidationIssue, ValidationResult } from "./types";
 import { applyNodeDefaults, applyEdgeDefaults } from "./defaults";
 import { enrichGraph } from "./enrich";
@@ -22,7 +22,8 @@ const VALID_EDGE_TYPES: Set<string> = new Set<EdgeType>([
 
 export function validateParsedGraph(
   parsed: ParsedGraph,
-  existingGraph: CausalGraph
+  existingGraph: CausalGraph,
+  weights: OmegaPillarWeights = DEFAULT_OMEGA_WEIGHTS,
 ): ValidationResult {
   const issues: ValidationIssue[] = [];
 
@@ -202,7 +203,7 @@ export function validateParsedGraph(
 
   // ─── Post-import enrichment: auto-edges & omega scoring ─────
   const { nodes: resolvedNodes, edges: resolvedEdges, warnings: enrichWarnings } =
-    enrichGraph(defaultedNodes, defaultedEdges);
+    enrichGraph(defaultedNodes, defaultedEdges, weights);
 
   for (const warning of enrichWarnings) {
     issues.push({

--- a/src/lib/omega-weighting.ts
+++ b/src/lib/omega-weighting.ts
@@ -1,0 +1,90 @@
+// ΩF composite weighting — the single place that turns the five pillar
+// scores into the headline composite, and the only place that applies a
+// domain profile's per-pillar weighting to a graph at display time.
+//
+// Why this module exists:
+//   - Built-in graphs hand-author `omegaFragility.composite` as a literal
+//     (graph-data.ts etc.). Those literals were tuned against the DEFAULT
+//     weighting, so Geopolitical/T1D (`compositeMode: "authored"`) keep
+//     them untouched.
+//   - AI-Safety has no nodes of its own — the `ai-safety-ids` card overlays
+//     the `main` graph (domains.ts). The only way its cascade+tail skew can
+//     reach the score is to RE-DERIVE composite from the borrowed pillars
+//     under AI-Safety's weights. That's `compositeMode: "recomputed"`.
+//
+// Recompute happens ONCE, at graph-build time (see build-domain-graph.ts),
+// so every downstream consumer of `omegaFragility.composite` (CDΩ header,
+// inspector, 2D/3D/Map/Relief geometry, interdiction, Pareto, copilot) picks
+// up the reweighted value with no per-consumer changes.
+
+import type { CausalGraph, OmegaFragilityProfile, OmegaPillarWeights } from "./types";
+import type { DomainProfile } from "./domain-profiles";
+
+/** Just the five pillar scores — the inputs to a composite. */
+type Pillars = Pick<
+  OmegaFragilityProfile,
+  | "irreplaceability"
+  | "restorationLatency"
+  | "jurisdictionalHazard"
+  | "cascadeLoad"
+  | "tailDepth"
+>;
+
+/**
+ * Weighted aggregation of the five pillars, rounded to one decimal.
+ *
+ * This is the canonical composite formula — extracted verbatim from the
+ * import-path scorer (enrich.ts) so the import path and the runtime
+ * recompute can never disagree on the math. `weights` is assumed to sum to
+ * 1.0 (enforced by the profile definitions + a unit test); no
+ * re-normalisation is applied, matching the original behaviour.
+ */
+export function weightedComposite(p: Pillars, w: OmegaPillarWeights): number {
+  return (
+    Math.round(
+      (w.irreplaceability * p.irreplaceability +
+        w.restorationLatency * p.restorationLatency +
+        w.jurisdictionalHazard * p.jurisdictionalHazard +
+        w.cascadeLoad * p.cascadeLoad +
+        w.tailDepth * p.tailDepth) *
+        10,
+    ) / 10
+  );
+}
+
+/**
+ * Apply a domain profile's pillar weighting to every node's composite.
+ *
+ *   - `compositeMode === "authored"` → returns the graph UNCHANGED. The
+ *     hand-authored / default-weighted composites stay the source of truth.
+ *   - `compositeMode === "recomputed"` → returns a new graph whose nodes'
+ *     `composite` is re-derived from their pillars under `profile.weights`,
+ *     with the prior value preserved in `baselineComposite` for audit
+ *     (so the inspector can show "reweighted from X.X").
+ *
+ * Idempotent: re-running preserves the FIRST-seen baseline (via
+ * `baselineComposite ?? composite`), so a double apply on the same graph
+ * doesn't lose the original authored value.
+ */
+export function recomputeComposite(
+  graph: CausalGraph,
+  profile: DomainProfile,
+): CausalGraph {
+  if (profile.compositeMode !== "recomputed") return graph;
+
+  const nodes = graph.nodes.map((node) => {
+    const omega = node.omegaFragility;
+    const baseline = omega.baselineComposite ?? omega.composite;
+    const composite = weightedComposite(omega, profile.weights);
+    return {
+      ...node,
+      omegaFragility: {
+        ...omega,
+        composite,
+        baselineComposite: baseline,
+      },
+    };
+  });
+
+  return { ...graph, nodes };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -63,6 +63,17 @@ export interface TerminalLine {
 // ─── Omega-Fragility Profile ────────────────────────────────────
 export interface OmegaFragilityProfile {
   composite: number;              // ΩF 0-10 headline fragility score
+  /**
+   * The hand-authored / default-weighted composite this node carried
+   * before an active domain profile re-weighted it (see
+   * `recomputeComposite` in src/lib/omega-weighting.ts). Set ONLY when a
+   * profile with `compositeMode: "recomputed"` (e.g. AI-Safety) has
+   * overwritten `composite` with its own pillar weighting. Lets the
+   * inspector surface "reweighted from X.X" so the change stays auditable
+   * and the original tuned score isn't silently lost. Undefined means the
+   * displayed `composite` is the authored/default value itself.
+   */
+  baselineComposite?: number;
   irreplaceability: number;       // I  0-10 how impossible to substitute (capacity share, tech exclusivity)
   restorationLatency: number;     // R  0-10 time to restore equivalent capacity after catastrophic failure
   jurisdictionalHazard: number;   // J  0-10 sanctions, conflict, export controls, regulatory exposure


### PR DESCRIPTION
## Per-domain ΩF composite weighting

Makes the ΩF composite weighting **per-domain** instead of one hardcoded uniform set.

### What changed
- **`DomainProfile` gains `weights` + `compositeMode`.** Geopolitical & T1D = platform default (`compositeMode: "authored"`); **AI-Safety skews to cascade + tail** — `I.10 / R.20 / J.10 / C.30 / T.30` per Ghauri 2025 (`compositeMode: "recomputed"`).
- **New `omega-weighting.ts`** — `weightedComposite()` (the canonical formula, extracted verbatim from `enrich.ts` so import and runtime can't diverge) + `recomputeComposite(graph, profile)`.
- **Single write point** in `buildGraphFromDomains`: no-op for authored profiles; for recomputed profiles (AI-Safety, which overlays the `main` graph) every composite is re-derived under the profile weights, preserving the authored value in `baselineComposite`. All ~40 `composite` consumers pick up the skew with zero per-consumer edits.
- **Methodology prose derived** via `formatWeights()` — fixes the existing drift (geopolitical prose said J/C = 0.20 while the engine used J .15 / C .25).
- Import path threaded with the active profile's weights; `NodeInspector` shows a "↻ reweighted from X.X" audit note.

### Verification
- `tsc --noEmit` clean.
- **16 new tests** (`omega-weighting` unit + real-data integration) + **182 existing** profile/omega/import tests green.
- Real data: AI-Safety shifts **87% of nodes** vs geopolitical, CDΩ mean 6.62 → 6.33; geopolitical/T1D byte-identical (no recompute).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
