### PR TITLE
feat(omega): system-level ΩF (ΩSF + ΩSX)

### DIFF
--- a/src/components/CDOmegaMonitor.tsx
+++ b/src/components/CDOmegaMonitor.tsx
@@ -3,6 +3,7 @@
 import { useDeferredValue, useMemo, useState } from "react";
 import { OmegaState, DoomsdayState, AlertLevel, CausalGraph } from "@/lib/types";
 import { getStatusColor } from "@/lib/omega-engine";
+import { computeSystemFragility } from "@/lib/omega-system";
 import { useFilteredGraph } from "@/hooks/useFilteredGraph";
 import { useApexStore } from "@/stores/useApexStore";
 import type { TemporalDataset } from "@/lib/temporal-data";
@@ -11,14 +12,6 @@ interface CDOmegaMonitorProps {
   state: OmegaState;
   doomsday: DoomsdayState;
   alertLevel: AlertLevel;
-}
-
-/** Compute average ΩF composite across all nodes (0-10 scale) */
-function computeAvgOmega(graph: CausalGraph): number {
-  const nodes = graph.nodes;
-  if (nodes.length === 0) return 0;
-  const sum = nodes.reduce((acc, n) => acc + (n.omegaFragility?.composite ?? 0), 0);
-  return sum / nodes.length;
 }
 
 /** Compute max ΩF composite across all nodes (0-10 scale) */
@@ -111,7 +104,11 @@ export default function CDOmegaMonitor({
 
   const hasNodes = filteredGraph.nodes.length > 0;
 
-  const avgOmega = useMemo(() => computeAvgOmega(filteredGraph), [filteredGraph]);
+  // System-level ΩF (ΩSF/ΩSX/contagion/buffer). The status badge, buffer bar
+  // and regime now derive from the throughput-weighted ΩSF rather than an
+  // unweighted mean of composites — the principled system metric.
+  const sys = useMemo(() => computeSystemFragility(filteredGraph), [filteredGraph]);
+  const avgOmega = sys.omegaSF;
   const maxOmega = useMemo(() => computeMaxOmega(filteredGraph), [filteredGraph]);
   // computeAvgPathLength does BFS from every node (APSP) — O(N·(N+E)),
   // ~121K ops on the default ~350-node graph. It used to run
@@ -149,6 +146,10 @@ export default function CDOmegaMonitor({
 
   // Secondary metrics for overflow menu on small screens
   const secondaryMetrics = [
+    { label: "ΩSF", value: hasNodes ? sys.omegaSF.toFixed(1) : "—" },
+    { label: "ΩSX", value: hasNodes ? sys.omegaSX.toFixed(1) : "—" },
+    { label: "CONTAGION", value: hasNodes ? String(sys.contagionRadius) : "—" },
+    { label: "BUFFER", value: hasNodes ? `${sys.bufferHorizon}e` : "—" },
     { label: "AVG PATH", value: avgPathLen.toFixed(2) },
     { label: "MAX ΩF", value: maxOmega.toFixed(1) },
     { label: "DENSITY", value: (filteredGraph.metadata.density * 100).toFixed(1) + "%" },
@@ -282,6 +283,23 @@ export default function CDOmegaMonitor({
             {edgeCount}
           </span>
           <span className="text-[8px] text-text-muted tracking-wider">EDGES</span>
+        </div>
+      </div>
+
+      {/* System-level ΩF — ΩSF (throughput-weighted) + ΩSX (exposure-weighted).
+          The principled aggregations of node ΩF; hidden below lg. */}
+      <div className="hidden lg:flex items-center gap-3 shrink-0" title="ΩSF: throughput-weighted system fragility · ΩSX: exposure-weighted (concentration) system fragility">
+        <div className="flex flex-col items-center">
+          <span className="font-mono text-sm font-bold tabular-nums" style={{ color: displayColor }}>
+            {hasNodes ? sys.omegaSF.toFixed(1) : "—"}
+          </span>
+          <span className="text-[8px] text-text-muted tracking-wider">ΩSF</span>
+        </div>
+        <div className="flex flex-col items-center">
+          <span className="font-mono text-sm font-bold tabular-nums" style={{ color: "var(--text-muted)" }}>
+            {hasNodes ? sys.omegaSX.toFixed(1) : "—"}
+          </span>
+          <span className="text-[8px] text-text-muted tracking-wider">ΩSX</span>
         </div>
       </div>
 

--- a/src/lib/__tests__/omega-system.test.ts
+++ b/src/lib/__tests__/omega-system.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeSystemFragility,
+  throughputWeight,
+  exposureWeight,
+  LOSS_THRESHOLD,
+  MAX_BUFFER_EPOCHS,
+} from "@/lib/omega-system";
+import { buildGraphFromDomains } from "@/lib/build-domain-graph";
+import type { CausalGraph, CausalNode, LiveDataPoint } from "@/lib/types";
+
+function mkNode(
+  id: string,
+  composite: number,
+  cascadeLoad: number,
+  globalConcentration: string,
+  liveData?: LiveDataPoint[],
+): CausalNode {
+  return {
+    id,
+    globalConcentration,
+    liveData,
+    omegaFragility: {
+      composite,
+      irreplaceability: 5,
+      restorationLatency: 5,
+      jurisdictionalHazard: 5,
+      cascadeLoad,
+      tailDepth: 5,
+    },
+  } as unknown as CausalNode;
+}
+
+function graph(nodes: CausalNode[]): CausalGraph {
+  return { nodes, edges: [], metadata: {} } as unknown as CausalGraph;
+}
+
+const throughput = (value: number, capacity: number): LiveDataPoint[] => [
+  { kind: "throughput", value, capacity, unit: "mb/d", observedAt: "", source: "" } as LiveDataPoint,
+];
+
+describe("exposureWeight (eᵢ = concentration share)", () => {
+  it("parses a concentration percentage", () => {
+    expect(exposureWeight(mkNode("a", 5, 5, "100% Saudi Arabia"))).toBe(1.0);
+    expect(exposureWeight(mkNode("b", 5, 5, "93% China"))).toBeCloseTo(0.93, 10);
+  });
+  it("treats explicit single-source phrasing as full exposure", () => {
+    expect(exposureWeight(mkNode("c", 5, 5, "single-source supplier"))).toBe(1.0);
+  });
+  it("falls back to neutral 0.5 when no concentration is stated", () => {
+    expect(exposureWeight(mkNode("d", 5, 5, "diversified global market"))).toBe(0.5);
+    expect(exposureWeight(mkNode("e", 5, 5, ""))).toBe(0.5);
+  });
+});
+
+describe("throughputWeight (αᵢ = live utilization, else cascadeLoad)", () => {
+  it("uses live throughput utilization when a feed is attached", () => {
+    expect(throughputWeight(mkNode("a", 5, 2, "x", throughput(5, 10)))).toBe(0.5);
+    expect(throughputWeight(mkNode("b", 5, 2, "x", throughput(9, 10)))).toBeCloseTo(0.9, 10);
+  });
+  it("falls back to the cascadeLoad pillar (normalised) when no feed", () => {
+    expect(throughputWeight(mkNode("c", 5, 8, "x"))).toBeCloseTo(0.8, 10);
+  });
+  it("floors at a sliver so a zero-cascade node never drops out", () => {
+    expect(throughputWeight(mkNode("d", 5, 0, "x"))).toBe(0.05);
+  });
+});
+
+describe("computeSystemFragility", () => {
+  it("returns zeros + full buffer for an empty graph", () => {
+    expect(computeSystemFragility(graph([]))).toEqual({
+      omegaSF: 0,
+      omegaSX: 0,
+      contagionRadius: 0,
+      bufferHorizon: MAX_BUFFER_EPOCHS,
+    });
+  });
+
+  it("computes the throughput- and exposure-weighted means", () => {
+    // A: composite 8, cascadeLoad 10 (α=1.0), concentration 100% (e=1.0)
+    // B: composite 4, cascadeLoad 0  (α=0.05 floor), concentration 10% (e=0.1)
+    const g = graph([
+      mkNode("A", 8, 10, "100% one country"),
+      mkNode("B", 4, 0, "10% diversified"),
+    ]);
+    const sys = computeSystemFragility(g);
+    // ΩSF = (1.0*8 + 0.05*4)/1.05 = 7.81 → 7.8
+    expect(sys.omegaSF).toBe(7.8);
+    // ΩSX = (1.0*8 + 0.1*4)/1.1 = 7.64 → 7.6
+    expect(sys.omegaSX).toBe(7.6);
+  });
+
+  it("ΩSF and ΩSX diverge when throughput and exposure rank nodes differently", () => {
+    // A: low composite but high throughput; B: high composite + high exposure.
+    const g = graph([
+      mkNode("A", 2, 10, "10% diversified"), // α=1.0, e=0.1
+      mkNode("B", 9, 0, "100% sole source"), // α=0.05, e=1.0
+    ]);
+    const sys = computeSystemFragility(g);
+    // throughput pulls toward the low-composite node; exposure toward the high one
+    expect(sys.omegaSF).toBeLessThan(4);
+    expect(sys.omegaSX).toBeGreaterThan(8);
+    expect(sys.omegaSX).toBeGreaterThan(sys.omegaSF);
+  });
+
+  it("contagionRadius counts nodes in the loss zone (composite ≥ threshold)", () => {
+    const g = graph([
+      mkNode("A", LOSS_THRESHOLD, 5, "x"),
+      mkNode("B", LOSS_THRESHOLD + 1, 5, "x"),
+      mkNode("C", LOSS_THRESHOLD - 0.1, 5, "x"),
+    ]);
+    expect(computeSystemFragility(g).contagionRadius).toBe(2);
+  });
+
+  it("bufferHorizon shrinks as system fragility rises", () => {
+    const calm = computeSystemFragility(graph([mkNode("A", 2, 5, "50% x")]));
+    const dire = computeSystemFragility(graph([mkNode("A", 9, 5, "50% x")]));
+    expect(dire.bufferHorizon).toBeLessThan(calm.bufferHorizon);
+    expect(dire.bufferHorizon).toBeGreaterThanOrEqual(1);
+    expect(calm.bufferHorizon).toBeLessThanOrEqual(MAX_BUFFER_EPOCHS);
+  });
+});
+
+describe("computeSystemFragility on the real graph (integration)", () => {
+  it("produces sane, populated system metrics for the default geopolitical graph", () => {
+    const g = buildGraphFromDomains(["energy-systems"]);
+    const sys = computeSystemFragility(g);
+    expect(g.nodes.length).toBeGreaterThan(0);
+    expect(sys.omegaSF).toBeGreaterThan(0);
+    expect(sys.omegaSF).toBeLessThanOrEqual(10);
+    expect(sys.omegaSX).toBeGreaterThan(0);
+    expect(sys.omegaSX).toBeLessThanOrEqual(10);
+    expect(sys.contagionRadius).toBeGreaterThan(0);
+    expect(sys.contagionRadius).toBeLessThanOrEqual(g.nodes.length);
+    expect(sys.bufferHorizon).toBeGreaterThanOrEqual(1);
+    expect(sys.bufferHorizon).toBeLessThanOrEqual(MAX_BUFFER_EPOCHS);
+    // throughput- and exposure-weighting are different lenses on real data
+    expect(sys.omegaSF).not.toBe(sys.omegaSX);
+  });
+});

--- a/src/lib/omega-system.ts
+++ b/src/lib/omega-system.ts
@@ -1,0 +1,113 @@
+// System-level Ω-Fragility — the aggregation layer above per-node ΩF.
+//
+// Node ΩF (omegaFragility.composite) answers "how fragile is THIS node?".
+// The system layer answers "how fragile is the NETWORK?" via two weighted
+// aggregations the platform's `/framework` page advertises but that, until
+// now, had no implementation (the `OmegaSystemFragility` interface in
+// types.ts was declared and never constructed/read):
+//
+//   ΩSF — throughput-weighted fragility: Σ(αᵢ·ΩFᵢ)/Σαᵢ. "Where the load
+//         actually flows, how fragile is it?" αᵢ is live throughput
+//         utilization where a feed is attached, else the cascadeLoad pillar
+//         (the topological throughput proxy) so every node contributes.
+//
+//   ΩSX — exposure-weighted fragility: Σ(eᵢ·ΩFᵢ)/Σeᵢ. "Weighted by how
+//         exposed/concentrated each node is, how fragile is the system?"
+//         eᵢ is geographic/market concentration (globalConcentration share),
+//         chosen because it has full node coverage AND is orthogonal to αᵢ —
+//         so ΩSX measures something ΩSF doesn't, rather than re-weighting the
+//         same signal.
+//
+// Both are weighted means on the same 0–10 scale as node composites, so they
+// sit naturally beside avg/max ΩF in the CD-Ω monitor.
+
+import type { CausalGraph, CausalNode, OmegaSystemFragility } from "./types";
+import { getLiveSignal } from "./types";
+
+/** Composite at/above this is "in the loss zone" — counted by contagionRadius. */
+export const LOSS_THRESHOLD = 7.0;
+/** Headroom scale for bufferHorizon (epochs). Matches the geopolitical
+ *  relevance-reference horizon ("node-critical event within next 50 epochs"). */
+export const MAX_BUFFER_EPOCHS = 50;
+/** Floor so a node with zero throughput/exposure still contributes a sliver
+ *  rather than dropping out of the weighted mean entirely. */
+const MIN_WEIGHT = 0.05;
+
+/**
+ * αᵢ — throughput weight. Live throughput utilization (value/capacity, e.g.
+ * EIA Hormuz) where a feed is attached; otherwise the cascadeLoad pillar
+ * (downstream-impact depth — the topological throughput proxy) normalised to
+ * 0–1, so coverage is total even though live throughput is sparse.
+ */
+export function throughputWeight(node: CausalNode): number {
+  const sig = getLiveSignal(node, "throughput");
+  if (sig && sig.capacity > 0) {
+    return Math.max(MIN_WEIGHT, Math.min(1, sig.value / sig.capacity));
+  }
+  return Math.max(MIN_WEIGHT, Math.min(1, node.omegaFragility.cascadeLoad / 10));
+}
+
+/**
+ * eᵢ — exposure weight = geographic/market concentration share parsed from
+ * `globalConcentration` ("100% Saudi Arabia" → 1.0, "93% China" → 0.93).
+ * Unparseable strings fall back to a neutral 0.5 (unknown exposure), except
+ * explicit single-source phrasing → 1.0. Floored so every node contributes.
+ */
+export function exposureWeight(node: CausalNode): number {
+  const gc = node.globalConcentration?.toLowerCase() ?? "";
+  const pct = gc.match(/(\d+)%/);
+  let e: number;
+  if (pct) {
+    e = parseInt(pct[1], 10) / 100;
+  } else if (gc.includes("single-source") || gc.includes("single source")) {
+    e = 1;
+  } else {
+    e = 0.5;
+  }
+  return Math.max(MIN_WEIGHT, Math.min(1, e));
+}
+
+/** Weighted mean of node composites under a per-node weight fn, rounded to
+ *  one decimal (matching the composite scale). Returns 0 for no weight. */
+function weightedMeanComposite(
+  nodes: CausalNode[],
+  weightFn: (n: CausalNode) => number,
+): number {
+  let num = 0;
+  let den = 0;
+  for (const n of nodes) {
+    const w = weightFn(n);
+    num += w * n.omegaFragility.composite;
+    den += w;
+  }
+  return den > 0 ? Math.round((num / den) * 10) / 10 : 0;
+}
+
+/**
+ * Compute the system-level ΩF object for a graph. Pure + side-effect free —
+ * the CD-Ω monitor calls this per graph reference (memoised).
+ */
+export function computeSystemFragility(graph: CausalGraph): OmegaSystemFragility {
+  const nodes = graph.nodes;
+  if (nodes.length === 0) {
+    return { omegaSF: 0, omegaSX: 0, contagionRadius: 0, bufferHorizon: MAX_BUFFER_EPOCHS };
+  }
+
+  const omegaSF = weightedMeanComposite(nodes, throughputWeight);
+  const omegaSX = weightedMeanComposite(nodes, exposureWeight);
+
+  // contagionRadius: how many nodes sit in the loss zone (composite ≥ threshold)
+  // — the count of "critical" nodes a system-wide shock would light up.
+  const contagionRadius = nodes.filter(
+    (n) => n.omegaFragility.composite >= LOSS_THRESHOLD,
+  ).length;
+
+  // bufferHorizon: epochs of headroom before systemic failure, scaled by how
+  // far ΩSF sits below the 0–10 ceiling. Higher system fragility → fewer epochs.
+  const bufferHorizon = Math.max(
+    1,
+    Math.round((MAX_BUFFER_EPOCHS * (10 - omegaSF)) / 10),
+  );
+
+  return { omegaSF, omegaSX, contagionRadius, bufferHorizon };
+}


### PR DESCRIPTION
## System-level ΩF — ΩSF (throughput-weighted) + ΩSX (exposure-weighted)

Implements the previously **dead** `OmegaSystemFragility` layer (backlog **1h.1 + 1h.2**). The interface was declared in `types.ts` but never constructed or read; the "system" numbers were either an unweighted mean (CD-Ω header) or shock-driven (`omega-engine`).

### What changed
- **New `omega-system.ts`** — pure `computeSystemFragility(graph)`:
  - **ΩSF** = Σ(αᵢ·ΩFᵢ)/Σαᵢ, αᵢ = live throughput utilization where a feed exists, else the `cascadeLoad` pillar (topological throughput proxy → full coverage).
  - **ΩSX** = Σ(eᵢ·ΩFᵢ)/Σeᵢ, eᵢ = geographic/market concentration from `globalConcentration` — the "System Exposure" metric the `/framework` page advertises but that had **no implementation**. Orthogonal to αᵢ by design.
  - **contagionRadius** = nodes in the loss zone (composite ≥ 7).
  - **bufferHorizon** = epochs of headroom scaled by ΩSF.
- **`CDOmegaMonitor`** now drives status / regime / buffer off the principled **ΩSF** (was an unweighted mean), and surfaces ΩSF / ΩSX / CONTAGION / BUFFER. Removes the now-dead `computeAvgOmega`.

### Verification
- `tsc --noEmit` clean.
- **12 new tests** (weighting math, concentration parse, αᵢ fallback, ΩSF≠ΩSX orthogonality, contagion, buffer monotonicity, empty graph, real-data integration) + **45 existing** omega-engine tests green.
- Real data: energy-systems unweighted mean 6.62 → **ΩSF 6.8 / ΩSX 6.5**, contagion 81, buffer 16e — the three lenses genuinely diverge.

Independent of #521 (no overlapping files); both can land cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
