### PR TITLE
feat(copilot): expose timeline/temporal navigation tools

### DIFF
--- a/src/lib/__tests__/copilot-temporal-tools.test.ts
+++ b/src/lib/__tests__/copilot-temporal-tools.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from "vitest";
+import { executeTag } from "@/lib/copilot/tool-registry";
+import "@/lib/copilot/tools";
+import type { ApexState } from "@/stores/useApexStore";
+
+// ─── Spy store for the temporal/timeline tools ──────────────────
+
+interface TemporalSpy {
+  position: number | null;
+  range: { start: number; end: number } | null;
+  granularity: string | null;
+  live: boolean | null;
+  activeTimeline: string | null;
+  epochSteps: number[];
+  currentEpoch: number;
+}
+
+function makeCtx(initialRange?: { start: number; end: number }) {
+  const spy: TemporalSpy = {
+    position: null,
+    range: null,
+    granularity: null,
+    live: null,
+    activeTimeline: null,
+    epochSteps: [],
+    currentEpoch: 3,
+  };
+  const fakeStore = {
+    timelineRange: initialRange,
+    currentEpoch: spy.currentEpoch,
+    setTimelinePosition: (ts: number) => {
+      spy.position = ts;
+    },
+    setTimelineRange: (r: { start: number; end: number }) => {
+      spy.range = r;
+    },
+    setTimelineGranularity: (g: string) => {
+      spy.granularity = g;
+    },
+    setIsLive: (b: boolean) => {
+      spy.live = b;
+    },
+    setActiveTimeline: (id: string) => {
+      spy.activeTimeline = id;
+    },
+    stepEpoch: (delta: number) => {
+      spy.epochSteps.push(delta);
+      spy.currentEpoch += delta;
+      fakeStore.currentEpoch = spy.currentEpoch;
+    },
+  } as unknown as ApexState & { currentEpoch: number };
+
+  return { ctx: { getStore: () => fakeStore }, spy };
+}
+
+const ISO = (s: string) => Date.parse(s);
+
+describe("set_time", () => {
+  it("moves the scrubber to an in-range ISO date", async () => {
+    const { ctx, spy } = makeCtx({ start: ISO("2024-01-01"), end: ISO("2024-12-31") });
+    const result = await executeTag({ name: "set_time", payload: "date=2024-07-01", raw: "" }, ctx);
+    expect(spy.position).toBe(ISO("2024-07-01"));
+    expect(result).toContain("2024-07-01");
+  });
+
+  it("clamps an out-of-range date to the window end", async () => {
+    const { ctx, spy } = makeCtx({ start: ISO("2024-01-01"), end: ISO("2024-12-31") });
+    const result = await executeTag({ name: "set_time", payload: "date=2030-06-01", raw: "" }, ctx);
+    expect(spy.position).toBe(ISO("2024-12-31"));
+    expect(result).toContain("2024-12-31");
+  });
+
+  it("rejects an unparseable date without calling the setter", async () => {
+    const { ctx, spy } = makeCtx();
+    const result = await executeTag({ name: "set_time", payload: "date=not-a-date", raw: "" }, ctx);
+    expect(spy.position).toBeNull();
+    expect(result).toMatch(/Could not parse date/);
+  });
+});
+
+describe("set_time_range", () => {
+  it("sets the visible window from ISO start/end", async () => {
+    const { ctx, spy } = makeCtx();
+    const result = await executeTag(
+      { name: "set_time_range", payload: "start=2024-02-01,end=2024-05-01", raw: "" },
+      ctx,
+    );
+    expect(spy.range).toEqual({ start: ISO("2024-02-01"), end: ISO("2024-05-01") });
+    expect(result).toContain("2024-02-01");
+    expect(result).toContain("2024-05-01");
+  });
+
+  it("rejects a backwards range", async () => {
+    const { ctx, spy } = makeCtx();
+    const result = await executeTag(
+      { name: "set_time_range", payload: "start=2024-05-01,end=2024-02-01", raw: "" },
+      ctx,
+    );
+    expect(spy.range).toBeNull();
+    expect(result).toMatch(/must be before/);
+  });
+});
+
+describe("set_time_granularity", () => {
+  it("sets a valid granularity", async () => {
+    const { ctx, spy } = makeCtx();
+    const result = await executeTag(
+      { name: "set_time_granularity", payload: "granularity=month", raw: "" },
+      ctx,
+    );
+    expect(spy.granularity).toBe("month");
+    expect(result).toContain("month");
+  });
+
+  it("rejects an out-of-enum granularity at coercion", async () => {
+    const { ctx, spy } = makeCtx();
+    const result = await executeTag(
+      { name: "set_time_granularity", payload: "granularity=fortnight", raw: "" },
+      ctx,
+    );
+    expect(spy.granularity).toBeNull();
+    expect(result).toMatch(/not in \[/);
+  });
+});
+
+describe("set_live", () => {
+  it("turns live on (on=true)", async () => {
+    const { ctx, spy } = makeCtx();
+    const result = await executeTag({ name: "set_live", payload: "on=true", raw: "" }, ctx);
+    expect(spy.live).toBe(true);
+    expect(result).toMatch(/following real-time/i);
+  });
+
+  it("turns live off (on=false)", async () => {
+    const { ctx, spy } = makeCtx();
+    const result = await executeTag({ name: "set_live", payload: "on=false", raw: "" }, ctx);
+    expect(spy.live).toBe(false);
+    expect(result).toMatch(/frozen/i);
+  });
+
+  it("accepts a bare legacy payload", async () => {
+    const { ctx, spy } = makeCtx();
+    await executeTag({ name: "set_live", payload: "true", raw: "" }, ctx);
+    expect(spy.live).toBe(true);
+  });
+});
+
+describe("set_active_timeline", () => {
+  it("switches to the intervention timeline", async () => {
+    const { ctx, spy } = makeCtx();
+    const result = await executeTag(
+      { name: "set_active_timeline", payload: "intervention", raw: "" },
+      ctx,
+    );
+    expect(spy.activeTimeline).toBe("intervention");
+    expect(result).toContain("intervention");
+  });
+});
+
+describe("step_epoch", () => {
+  it("steps forward and reports the new epoch", async () => {
+    const { ctx, spy } = makeCtx();
+    const result = await executeTag({ name: "step_epoch", payload: "delta=2", raw: "" }, ctx);
+    expect(spy.epochSteps).toEqual([2]);
+    expect(result).toContain("epoch 5"); // started at 3, +2
+  });
+
+  it("steps backward with a negative delta", async () => {
+    const { ctx, spy } = makeCtx();
+    await executeTag({ name: "step_epoch", payload: "delta=-1", raw: "" }, ctx);
+    expect(spy.epochSteps).toEqual([-1]);
+  });
+});

--- a/src/lib/copilot/eval/cases/seed.ts
+++ b/src/lib/copilot/eval/cases/seed.ts
@@ -336,4 +336,65 @@ export const SEED_CASES: TestCase[] = [
     forbidden_in_response: [/\d+\s*°|sunny|cloudy|rain(\s|y|ing)|temperature/i],
     tags: ["refusal", "no-tool", "off-topic"],
   },
+
+  // ─── Temporal / timeline navigation ────────────────────────────
+
+  {
+    id: "set_time_specific_date",
+    description: "User names a specific moment — set_time with an ISO date the model derives.",
+    user_message: "jump the timeline to the start of July 2024",
+    graph_fixture: "geopolitical_main",
+    accepted_tool_calls: [{ name: "set_time", params_match: { date: /2024-0?7/ } }],
+    tags: ["tool-selection", "temporal"],
+  },
+  {
+    id: "set_time_range_zoom",
+    description: "User zooms the timeline to a window — set_time_range with ISO start/end.",
+    user_message: "zoom the timeline into 2024",
+    graph_fixture: "geopolitical_main",
+    accepted_tool_calls: [{ name: "set_time_range", params_match: { start: /2024/ } }],
+    tags: ["tool-selection", "temporal"],
+  },
+  {
+    id: "set_time_granularity_month",
+    description: "User asks for a monthly resolution — set_time_granularity:month.",
+    user_message: "show the timeline by month",
+    graph_fixture: "geopolitical_main",
+    accepted_tool_calls: [{ name: "set_time_granularity", params_match: { granularity: "month" } }],
+    tags: ["tool-selection", "temporal"],
+  },
+  {
+    id: "set_live_off",
+    description: "User freezes the live feed — set_live:on=false.",
+    user_message: "stop following live and freeze the timeline where it is",
+    graph_fixture: "geopolitical_main",
+    accepted_tool_calls: [{ name: "set_live", params_match: { on: /false/ } }],
+    tags: ["tool-selection", "temporal"],
+  },
+  {
+    id: "set_live_on",
+    description: "User resumes real-time — set_live:on=true.",
+    user_message: "go live",
+    graph_fixture: "geopolitical_main",
+    accepted_tool_calls: [{ name: "set_live", params_match: { on: /true/ } }],
+    tags: ["tool-selection", "temporal"],
+  },
+  {
+    id: "set_active_timeline_intervention",
+    description: "User switches the cascade view to the intervention timeline.",
+    user_message: "show me the intervention timeline instead of the baseline",
+    graph_fixture: "geopolitical_main",
+    accepted_tool_calls: [
+      { name: "set_active_timeline", params_match: { timeline: "intervention" } },
+    ],
+    tags: ["tool-selection", "temporal"],
+  },
+  {
+    id: "step_epoch_forward",
+    description: "User steps the cascade replay forward one frame — step_epoch:delta=1.",
+    user_message: "step the cascade forward one frame",
+    graph_fixture: "geopolitical_main",
+    accepted_tool_calls: [{ name: "step_epoch", params_match: { delta: /^1$/ } }],
+    tags: ["tool-selection", "temporal", "replay"],
+  },
 ];

--- a/src/lib/copilot/tools.ts
+++ b/src/lib/copilot/tools.ts
@@ -253,6 +253,127 @@ defineTool({
   },
 });
 
+// ─── Temporal / timeline ────────────────────────────────────────
+
+defineTool({
+  name: "set_time",
+  description:
+    "Move the timeline scrubber to a point in time. Pass an ISO-8601 date (e.g. 2024-07-01); out-of-range dates clamp to the available window.",
+  guidance:
+    "Use when the user names a specific moment ('go to January 2024', 'jump to Q3 2024', 'show me last March'). Convert their phrasing to an ISO date yourself and pass date=YYYY-MM-DD. If the view is currently live and they want to inspect the past, also emit set_live:on=false. Do NOT state the landing position in prose — the SYS result line confirms where the scrubber actually settled after clamping.",
+  params: {
+    date: { type: "string", required: true, description: "ISO-8601 date, e.g. 2024-07-01" },
+  },
+  legacyParam: "date",
+  handler: ({ date }, ctx) => {
+    const store = ctx.getStore();
+    const ts = Date.parse(date);
+    if (Number.isNaN(ts)) {
+      return `Could not parse date "${date}". Use an ISO date like 2024-07-01.`;
+    }
+    const range = store.timelineRange;
+    const target =
+      range && typeof range.start === "number" && typeof range.end === "number"
+        ? Math.max(range.start, Math.min(range.end, ts))
+        : ts;
+    store.setTimelinePosition(target);
+    return `Timeline moved to ${new Date(target).toISOString().slice(0, 10)}`;
+  },
+});
+
+defineTool({
+  name: "set_time_range",
+  description:
+    "Set the visible timeline window. Pass ISO-8601 start and end dates (start must precede end).",
+  guidance:
+    "Use for 'zoom into 2024', 'show me Jan through March', 'widen to the full history'. Convert to ISO dates and pass start=YYYY-MM-DD,end=YYYY-MM-DD.",
+  params: {
+    start: { type: "string", required: true, description: "ISO-8601 start date" },
+    end: { type: "string", required: true, description: "ISO-8601 end date" },
+  },
+  handler: ({ start, end }, ctx) => {
+    const s = Date.parse(start);
+    const e = Date.parse(end);
+    if (Number.isNaN(s) || Number.isNaN(e)) {
+      return `Could not parse range "${start}".."${end}". Use ISO dates like 2024-01-01.`;
+    }
+    if (s >= e) {
+      return `Invalid range: start (${start}) must be before end (${end}).`;
+    }
+    ctx.getStore().setTimelineRange({ start: s, end: e });
+    return `Timeline window set to ${new Date(s).toISOString().slice(0, 10)} → ${new Date(e).toISOString().slice(0, 10)}`;
+  },
+});
+
+defineTool({
+  name: "set_time_granularity",
+  description: "Set the timeline resolution (zoom level of the time axis).",
+  params: {
+    granularity: {
+      type: "enum",
+      values: ["hour", "day", "week", "month", "year", "5year", "all"] as const,
+      required: true,
+    },
+  },
+  legacyParam: "granularity",
+  handler: ({ granularity }, ctx) => {
+    ctx.getStore().setTimelineGranularity(granularity);
+    return `Timeline granularity set to: ${granularity}`;
+  },
+});
+
+defineTool({
+  name: "set_live",
+  description:
+    "Follow real-time (on) or freeze the timeline at the current point (off).",
+  guidance:
+    "'go live' / 'resume live updates' → on=true. 'freeze' / 'pause the feed' / 'stop following live' → on=false.",
+  params: {
+    on: { type: "boolean", required: true, description: "true = follow real-time; false = freeze" },
+  },
+  legacyParam: "on",
+  handler: ({ on }, ctx) => {
+    ctx.getStore().setIsLive(on);
+    return on ? "Now following real-time" : "Timeline frozen (live off)";
+  },
+});
+
+defineTool({
+  name: "set_active_timeline",
+  description:
+    "Switch the active cascade timeline between baseline and intervention. Resets the replay to epoch 0.",
+  guidance:
+    "'show the baseline' → baseline. 'show the intervention timeline' / 'with my interdiction applied' → intervention.",
+  params: {
+    timeline: { type: "enum", values: ["baseline", "intervention"] as const, required: true },
+  },
+  legacyParam: "timeline",
+  handler: ({ timeline }, ctx) => {
+    ctx.getStore().setActiveTimeline(timeline);
+    return `Active timeline: ${timeline} (epoch reset to 0)`;
+  },
+});
+
+defineTool({
+  name: "step_epoch",
+  description:
+    "Step the cascade replay by N epochs (frames). Negative steps backward. Pauses playback.",
+  guidance:
+    "'step forward' → delta=1. 'go back two frames' → delta=-2. 'advance the cascade' → delta=1. For continuous playback use start_replay instead.",
+  params: {
+    delta: { type: "number", required: true, description: "Epochs to step; negative = backward" },
+  },
+  legacyParam: "delta",
+  handler: ({ delta }, ctx) => {
+    const store = ctx.getStore();
+    store.stepEpoch(delta);
+    const epoch = ctx.getStore().currentEpoch;
+    return typeof epoch === "number"
+      ? `Stepped to epoch ${epoch}`
+      : `Stepped ${delta >= 0 ? "+" : ""}${delta} epoch(s)`;
+  },
+});
+
 // ─── Truth filter ───────────────────────────────────────────────
 
 defineTool({


### PR DESCRIPTION
## What

Closes the **timeline/temporal** gap from the copilot tool-exposure audit (task #8). Recent features shipped timeline controls with no way for the copilot to drive them — this adds 6 tools wrapping the existing store actions:

| Tool | Store action | Example utterance |
|---|---|---|
| `set_time` | `setTimelinePosition` | "jump to July 2024" |
| `set_time_range` | `setTimelineRange` | "zoom into 2024" |
| `set_time_granularity` | `setTimelineGranularity` | "show the timeline by month" |
| `set_live` | `setIsLive` | "go live" / "freeze the feed" |
| `set_active_timeline` | `setActiveTimeline` | "show the intervention timeline" |
| `step_epoch` | `stepEpoch` | "step the cascade forward one frame" |

Handlers parse ISO dates, clamp `set_time` to the available `timelineRange`, coerce enums/booleans/numbers, and narrate **intent-not-result** (the SYS result line confirms where the scrubber actually landed). Tools auto-surface in `=== COPILOT ACTIONS ===` via `renderToolsForPrompt()`, so no system-prompt edit is needed.

## Tests

- **+13 unit tests** in `copilot-temporal-tools.test.ts` (parse / clamp / coerce / legacy-payload / error paths).
- **+7 eval cases** in `seed.ts` (30 to 37).
- Full copilot suite: **173/173 pass**; typecheck clean for touched files.

## Known limitation (follow-up)

`serializeGraphContext` does not yet expose the *current* temporal state, so **absolute** requests ("go to July 2024") work well but **relative** ones ("go back 3 months") are weak. Wiring a `=== TEMPORAL STATE ===` section has a wider blast radius (route + eval + teacher + system-prompt hash/size) and is deferred to its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
