### PR TITLE
docs(workflow): adopt AI Adviser Council as standing approach

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# Working agreements for AI sessions on this repo
+
+## AI Adviser Council (standing approach)
+
+For substantive decisions — architecture, product direction, spend, go/no-go calls — run the question through the **five-adviser council** described in `docs/AI_ADVISER_COUNCIL.md` and synthesize a recommendation. Convene proactively; do not wait to be asked.
+
+The five lenses:
+
+1. **The Contrarian** — what fails?
+2. **The First-Principles adviser** — what assumptions break?
+3. **The Expansionist** — what upside am I missing?
+4. **The Outsider** — what would an outsider notice?
+5. **The Executor** — what do you do Monday morning?
+
+Each lens must earn its place (no boilerplate). End every council session with a named decision and a Monday-morning move. Scale depth to stakes — one sharp line per lens for small calls, a paragraph each for big ones.
+
+**Skip the ritual for trivial mechanical tasks.** A typo fix, a rename, an obvious bug with one root cause does not need a council session — performing it dilutes the signal when the council does fire.
+
+See `docs/AI_ADVISER_COUNCIL.md` for the full spec.
+
+## Documentation surface
+
+In-app reference docs are surfaced via the Settings → Documentation drawer (`src/components/DocumentationDrawer.tsx`). When adding a user-facing doc:
+
+1. Add the source path + slug to the `DOCS` array in `scripts/sync-public-docs.mjs`.
+2. Add a matching entry (title + blurb) to `DOC_INDEX` in `src/lib/docs/index.ts`.
+
+The `prebuild` step copies the curated source files to `public/docs/` so they're served as static assets.

--- a/docs/AI_ADVISER_COUNCIL.md
+++ b/docs/AI_ADVISER_COUNCIL.md
@@ -1,0 +1,38 @@
+# AI Adviser Council
+
+A standing working approach for substantive decisions on this codebase. Not a process for trivial mechanical tasks — for those, just do the obvious thing.
+
+## What it is
+
+For architecture, product direction, spend, go/no-go calls — don't answer in a single voice. Run the question through a council of five advisers, each a distinct lens, then synthesize. Karpathy-style "LLM console": multiple perspectives deliberating before a recommendation, not one flattened opinion.
+
+**Convene proactively when a decision is substantive.** Don't wait to be asked.
+
+## The five advisers
+
+1. **The Contrarian — "What fails?"** Stress-test the plan. Where does it break, what's the failure mode, what are we glossing over, what's the strongest case against? Assume the rosy version is wrong and find why.
+
+2. **The First-Principles adviser — "What assumptions break?"** Strip to fundamentals. Which premises are we taking for granted that might be false or arbitrary? Re-derive the goal — is the thing we're building actually the thing the goal needs?
+
+3. **The Expansionist — "What upside am I missing?"** Look for the bigger opportunity. The 10× version, the reusable asset, the second-order use, the under-reach. Where are we thinking too small?
+
+4. **The Outsider — "What would an outsider notice?"** Fresh eyes / naive question. What's obvious to someone outside the company or the field that we've gone blind to — the "why are you even doing this?" question. Blind spots insiders skip.
+
+5. **The Executor — "What do you do Monday morning?"** Cut to the concrete. The pragmatic first action, what ships, the cheap experiment that resolves the debate. No theory — the next move.
+
+## How to use it
+
+- Apply for strategic / uncertain calls in any lane; convene on your own initiative.
+- **Skip mechanical tasks** — don't perform the ritual when there's one obvious answer.
+- **Each lens must earn its place:** a real, specific point, not boilerplate. If a lens has nothing to add, say so briefly rather than pad.
+- **End with a SYNTHESIS** — the council informs the recommendation, doesn't replace it. Name the decision and the Monday-morning move.
+- **Scale depth to stakes:** one sharp line per lens for small calls, a paragraph each for a big one.
+
+## When NOT to convene
+
+- A bug fix with one root cause.
+- A rename, a typo, a missing import.
+- A user explicitly asking for one specific action.
+- Anything where the trade-off space is essentially one-dimensional.
+
+Running the ritual on these wastes everyone's time and dilutes the council's signal when it does fire.


### PR DESCRIPTION
Adopts the **AI Adviser Council** as a standing working approach for substantive decisions on this codebase. Karpathy-style "LLM console" — multiple perspectives deliberating before a recommendation, not one flattened opinion.

## What's in this PR

**New `docs/AI_ADVISER_COUNCIL.md`** — the spec verbatim. Five lenses, when to apply, when to skip.

**New `CLAUDE.md` at repo root** — working-agreements file that auto-loads in every future AI session here, pointing at the spec. Previously the council convention lived only in your local `~/.claude/projects/...` directory (per-machine, doesn't follow across devices). Committing it to the repo makes it durable.

## The five lenses

1. **Contrarian** — what fails?
2. **First-Principles** — what assumptions break?
3. **Expansionist** — what upside am I missing?
4. **Outsider** — what would an outsider notice?
5. **Executor** — what do you do Monday morning?

## Behavioural commitment

Going forward I'll:
- Convene **proactively** on architecture / product / spend / go-no-go calls — not waiting to be asked.
- Skip the ritual on trivial mechanical tasks (typos, renames, one-root-cause bugs) — performing it dilutes the signal.
- End every council session with a named decision + Monday-morning move.
- Scale depth to stakes — one sharp line per lens for small calls, paragraph each for big ones.

Pure docs PR — no code, no tests, no build impact.

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_