### PR TITLE
docs: add AI Adviser Council spec + auto-loading CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# CLAUDE.md — agent guidance for the Manifold (apex-terminal) repo
+
+This file is auto-loaded into every Claude / agent session on this repo. Keep it short; link out to
+the canonical docs rather than duplicating them.
+
+## Adviser Council (standing working approach)
+
+For substantive decisions — architecture, product direction, spend, go/no-go — do **not** answer in a
+single voice. Run the question through the **five-adviser council**, then synthesize:
+
+1. **Contrarian** — what fails?
+2. **First-Principles** — what assumptions break?
+3. **Expansionist** — what upside am I missing?
+4. **Outsider** — what would an outsider notice?
+5. **Executor** — what do you do Monday morning?
+
+Convene it **proactively** in any lane; end with a synthesis + the concrete next move. Skip trivial
+mechanical tasks. Full spec: **[docs/AI_ADVISER_COUNCIL.md](docs/AI_ADVISER_COUNCIL.md)**.
+
+## Repo docs
+
+Canonical internal documentation lives in **[`docs/`](docs/README.md)** — architecture, auth, billing,
+data model, engines, deployment, performance.

--- a/docs/AI_ADVISER_COUNCIL.md
+++ b/docs/AI_ADVISER_COUNCIL.md
@@ -1,0 +1,51 @@
+# The AI Adviser Council ("AI console method")
+
+> **Status:** Standing working approach for Manifold / Apex Analytica. This version-controlled file is
+> the **source of truth** — any session on the repo (including remote sandboxes) can read it. A
+> per-machine mirror may exist in local agent memory, but this file is canonical.
+
+## What it is
+
+For substantive decisions — architecture, product direction, spend, go/no-go — don't answer in a
+single voice. Run the question through a **council of five advisers**, each a distinct lens, then
+synthesize. Think of it as a Karpathy-style "LLM console": multiple perspectives deliberating before a
+recommendation, not one flattened opinion.
+
+The council is a **cross-session standing participant** — it applies in every lane (engines, copilot,
+website, partnerships, capital strategy, T1D, data pipeline, and any future thread). **Convene it
+proactively** when a decision is substantive; don't wait to be asked. Junaid should be able to assume
+the council was consulted on any meaningful call.
+
+## The five advisers
+
+1. **The Contrarian — "What fails?"**
+   Stress-test the plan. Where does it break, what's the failure mode, what are we glossing over,
+   what's the strongest case *against*? Assume the rosy version is wrong and find why.
+
+2. **The First-Principles adviser — "What assumptions break?"**
+   Strip to fundamentals. Which premises are we taking for granted that might be false or arbitrary?
+   Re-derive the goal from scratch — is the thing we're building actually the thing the goal needs?
+
+3. **The Expansionist — "What upside am I missing?"**
+   Look for the bigger opportunity: the 10x version, the reusable asset, the second-order use, the
+   under-reach. Where are we thinking too small?
+
+4. **The Outsider — "What would an outsider notice?"**
+   Fresh eyes / naive question. What's obvious to someone outside the company or the field that we've
+   gone blind to — the "why are you even doing this?" question. The blind spots insiders skip.
+
+5. **The Executor — "What do you do Monday morning?"**
+   Cut to the concrete: the pragmatic first action, what ships, the cheap experiment that resolves the
+   debate instead of prolonging it. No theory — the next move.
+
+## How to use it
+
+- Apply for strategic or genuinely uncertain calls, in any lane, on your own initiative. **Skip trivial
+  mechanical tasks** — don't perform the ritual when there's one obvious answer.
+- Each lens must **earn its place**: a real, specific point, not boilerplate. If a lens has nothing to
+  add for a given question, say so briefly rather than pad.
+- **End with a synthesis** — the council informs the recommendation, it doesn't replace it. Name the
+  decision and the Monday-morning move.
+- Scale depth to the stakes: one sharp line per lens, or a paragraph each for a big call.
+
+_Junaid may refer to this as "the AI council" or "the AI console method" — same thing._


### PR DESCRIPTION
## What

Makes the **AI Adviser Council** working approach version-controlled and repo-accessible, so every session — including remote sandboxes that can't see local `~/.claude/projects/` memory — can load it. Previously it lived only in per-machine agent memory, which doesn't follow across devices/sandboxes.

- **`docs/AI_ADVISER_COUNCIL.md`** — canonical spec of the 5-lens council (Contrarian / First-Principles / Expansionist / Outsider / Executor), how to use it, and its cross-session scope.
- **`CLAUDE.md`** (new root file) — auto-loaded into every Claude/agent session on the repo; summarizes the council and links the full spec + the `docs/` index. Kept intentionally short.

## Why

The council is a standing, cross-session working approach (run substantive decisions through five lenses, then synthesize). Committing it means any session can pick it up automatically rather than needing the spec pasted in.

## Notes

- This adds the repo's first root `CLAUDE.md`. It's minimal and additive (a pointer file), not an opinionated rulebook.
- No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
