### PR TITLE
feat(copilot): surface system-level ΩF (ΩSF/ΩSX) in copilot context

### DIFF
--- a/src/lib/copilot-context.ts
+++ b/src/lib/copilot-context.ts
@@ -1,4 +1,5 @@
 import { CausalGraph, CausalNode, CausalEdge } from "./types";
+import { computeSystemFragility } from "./omega-system";
 import type { SystemStateSnapshot } from "./snapshots/types";
 import { diffSnapshots } from "./snapshots/diff";
 import { TarskiValidationReport, AXIOM_LIBRARY } from "./tarski-data";
@@ -97,6 +98,19 @@ export function serializeGraphContext(
   lines.push(
     `Inconsistent edges: ${graph.metadata.inconsistentEdges} | ` +
       `Restricted nodes: ${graph.metadata.restrictedNodes}`
+  );
+
+  // System-level Ω-Fragility — the network-wide aggregations so the copilot
+  // can answer "how fragile is the whole system?" rather than only quoting
+  // per-node Ω. Mirrors the CD-Ω monitor header (computeSystemFragility).
+  const sys = computeSystemFragility(graph);
+  lines.push("");
+  lines.push("=== SYSTEM FRAGILITY (ΩSF / ΩSX) ===");
+  lines.push(
+    `ΩSF (throughput-weighted): ${sys.omegaSF.toFixed(1)} | ` +
+      `ΩSX (exposure-weighted by concentration): ${sys.omegaSX.toFixed(1)} | ` +
+      `Contagion radius (nodes Ω≥7): ${sys.contagionRadius} | ` +
+      `Buffer horizon: ${sys.bufferHorizon} epochs`
   );
 
   // Selected node detail


### PR DESCRIPTION
## Surface system-level ΩF (ΩSF/ΩSX) in the copilot context

Completes the system-fragility work from #522 by making the network-wide metrics visible to the copilot. It already cites per-node Ω; now it can answer "how fragile is the *whole system*?".

Adds a `=== SYSTEM FRAGILITY (ΩSF / ΩSX) ===` section to `serializeGraphContext` (the LIVE GRAPH CONTEXT block), computed via `computeSystemFragility`:
`ΩSF (throughput-weighted) | ΩSX (exposure-weighted by concentration) | contagion radius (Ω≥7) | buffer horizon`.

**Purely additive** — no restructuring of the existing context, so tool-selection behaviour is unchanged.

### Verification
- `tsc --noEmit` clean.
- 12 existing copilot-context tests green (format assertions still hold).
- Renders on the real graph: `ΩSF 6.8 | ΩSX 6.5 | Contagion radius 81 | Buffer horizon 16 epochs` (energy-systems), matching the CD-Ω monitor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
