### PR TITLE
fix(pearl): manual ablation, budget overflow, VX-880 gate, auto-solve clarity (council r2)

### DIFF
--- a/src/components/AblationPanel.tsx
+++ b/src/components/AblationPanel.tsx
@@ -78,7 +78,24 @@ export default function AblationPanel({
         </>
       )}
 
+      {/* Embedded in the redesigned PEARL Manual tab: that tab auto-enters
+          ablation mode (PearlWorkspace effect), so the explicit ENTER/EXIT
+          button is redundant here — replace it with a live status hint. */}
+      {embedded && (
+        <div
+          className="text-[8px] font-mono leading-snug"
+          style={{
+            color: ablationMode ? "var(--accent-cyan)" : "var(--text-muted)",
+          }}
+        >
+          {ablationMode
+            ? "Canvas is live — click any node or edge to cut it, then Run cascade below."
+            : "Switch to this tab to start selecting nodes / edges on the canvas."}
+        </div>
+      )}
+
       <div className="flex items-center gap-2 flex-wrap">
+        {!embedded && (
         <button
           type="button"
           onClick={() => setAblationMode(!ablationMode)}
@@ -95,6 +112,7 @@ export default function AblationPanel({
         >
           {ablationMode ? "EXIT ABLATION MODE" : "ENTER ABLATION MODE"}
         </button>
+        )}
 
         <button
           type="button"

--- a/src/components/InterdictionPanel.tsx
+++ b/src/components/InterdictionPanel.tsx
@@ -107,10 +107,17 @@ export default function InterdictionPanel({
         </>
       )}
 
-      {/* Controls */}
-      <div className="flex items-center gap-2">
+      {/* Controls — wrap so the BUDGET + MODE pills never overflow the
+          fixed 320px PEARL panel (founder live-test: "budget buttons
+          extend out beyond the actual window"). */}
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
         <div className="flex items-center gap-1">
-          <span className="text-[8px] font-mono text-text-muted">BUDGET:</span>
+          <span
+            className="text-[8px] font-mono text-text-muted"
+            title="Maximum number of cuts the solver may apply (1–5; it skips 4 by design)"
+          >
+            BUDGET:
+          </span>
           {[1, 2, 3, 5].map((b) => (
             <button
               key={b}

--- a/src/components/pearl/PearlWorkspace.tsx
+++ b/src/components/pearl/PearlWorkspace.tsx
@@ -28,10 +28,11 @@
 // disclosure), not in always-on paragraphs. The forecast and the active
 // cut set are never hidden behind a click — only the *explanation* is.
 //
-// VX880 stays as a collapsible secondary section (domain-specific trial
-// presets; off the critical path for most sessions).
+// VX880 is a domain-gated secondary section — it renders ONLY when a
+// t1d-* domain is active (T1D-specific trial presets; an out-of-place
+// artifact in any other session, per founder live-test).
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useApexStore } from "@/stores/useApexStore";
 import SectionHeader from "./SectionHeader";
 import ScenarioInput from "../ScenarioInput";
@@ -84,6 +85,26 @@ export default function PearlWorkspace({
   const resetAblation = useApexStore((s) => s.resetAblation);
   const startAblationReplay = useApexStore((s) => s.startAblationReplay);
   const lastInterdictionResult = useApexStore((s) => s.lastInterdictionResult);
+  const setAblationActive = useApexStore((s) => s.setAblationActive);
+  const selectedDomains = useApexStore((s) => s.selectedDomains);
+
+  // VX-880 trial presets are T1D-specific — only surface them when a
+  // t1d-* domain is active (mirrors ModulePanel's TissueCohortView gate).
+  // The `t1d-` prefix check avoids pulling domain-profiles into the bundle.
+  const isT1DDomain = useMemo(
+    () => selectedDomains.some((id) => id.startsWith("t1d-")),
+    [selectedDomains],
+  );
+
+  // The Manual tab IS canvas ablation: selecting it puts the canvas into
+  // click-to-cut mode so the analyst just clicks nodes/edges — no hidden
+  // "ENTER ABLATION MODE" step. Leaving the tab (or unmounting PEARL)
+  // turns the click-mode off NON-destructively via `setAblationActive`
+  // (NOT `setAblationMode`, which would wipe the cuts already made).
+  useEffect(() => {
+    setAblationActive(method === "manual");
+  }, [method, setAblationActive]);
+  useEffect(() => () => setAblationActive(false), [setAblationActive]);
 
   // Resolve the raw id lists into human labels. Edge labels read
   // "Source → Target" off the node table; if an id has gone stale
@@ -127,14 +148,9 @@ export default function PearlWorkspace({
 
   return (
     <div data-tour="pearl-workspace" className="space-y-3">
-      {/* One-line orientation. The adviser council pushed back hard on
-          removing ALL guidance: "operationalize" is a workflow-legibility
-          gap, not only a word-count one. This single plain-language line
-          names the loop and stays visible; concept-level detail still
-          lives behind the `?` popovers per the original brief. */}
-      <p className="text-[10px] font-mono text-text-muted leading-snug">
-        Pick connections to cut, run the cascade, then read the forecast.
-      </p>
+      {/* Per founder live-test ("more buttons than words; explanations all
+          collapsible"), the always-visible orientation line was folded into
+          the DEFINE CUTS `?` below. Zero prose before the first control. */}
 
       {/* ── Zone 1 — DEFINE CUTS ─────────────────────────────── */}
       <section className="border border-accent-amber/25 rounded bg-accent-amber/5 p-3 space-y-2">
@@ -156,6 +172,10 @@ export default function PearlWorkspace({
               <br />
               <b>Manual</b> — click nodes or edges on the canvas to cut
               them yourself.
+              <br />
+              <br />
+              Then <b>Run cascade</b> in ACTIVE CUTS and read the{" "}
+              <b>Forecast</b> below.
             </>
           }
         />
@@ -219,7 +239,16 @@ export default function PearlWorkspace({
             id="cut-panel-solve"
             aria-labelledby="cut-tab-solve"
             hidden={method !== "solve"}
+            className="space-y-2"
           >
+            {/* Founder: "auto-solve — I have no idea what that does."
+                One visible plain-language line (Auto-solve can't be an icon —
+                its concept has no real-world analogue). */}
+            <p className="text-[8px] font-mono text-text-muted leading-snug">
+              Finds the fewest cuts that blunt the worst-case cascade.
+              {" "}<b>Budget</b> = how many cuts it may use; <b>mode</b> = what
+              it may cut (edges, nodes, or both).
+            </p>
             <InterdictionPanel embedded />
           </div>
           <div
@@ -313,7 +342,11 @@ export default function PearlWorkspace({
         <MonteCarloForecast expanded={expanded} embedded />
       </section>
 
-      {/* ── VX880 — collapsible secondary ────────────────────── */}
+      {/* ── VX880 — domain-gated secondary (T1D sessions only) ──
+          Founder: "VX-880 at the bottom seems to be an artifact from the
+          T1D details." It is — it now renders only when a t1d-* domain is
+          active, so non-T1D sessions never see it. */}
+      {isT1DDomain && (
       <section className="border border-border/60 rounded bg-surface/20 p-3 space-y-2">
         <SectionHeader
           title="VX-880 TRIAL"
@@ -331,6 +364,7 @@ export default function PearlWorkspace({
         />
         {vx880Open && <VX880TrialPanel />}
       </section>
+      )}
     </div>
   );
 }

--- a/src/stores/useApexStore.ts
+++ b/src/stores/useApexStore.ts
@@ -411,6 +411,15 @@ export interface ApexState {
   ablatedNodeIds: string[];
   ablatedEdgeIds: string[];
   setAblationMode: (on: boolean) => void;
+  /**
+   * Toggle the canvas ablation CLICK-MODE without clearing the existing
+   * cut set. `setAblationMode(false)` wipes `ablatedNodeIds`/`ablatedEdgeIds`
+   * (intended for the classic "exit & discard" flow); the redesigned PEARL
+   * workspace binds the Manual tab to this NON-destructive variant so
+   * leaving the tab stops the canvas hijacking clicks WITHOUT losing the
+   * cuts the analyst already made.
+   */
+  setAblationActive: (on: boolean) => void;
   toggleAblatedNode: (nodeId: string) => void;
   toggleAblatedEdge: (edgeId: string) => void;
   resetAblation: () => void;
@@ -1232,6 +1241,14 @@ export const useApexStore = create<ApexState>((set, get) => ({
     ablationMode: on,
     ...(on ? { scissorsMode: false } : {}),
     ...(!on ? { ablatedNodeIds: [], ablatedEdgeIds: [] } : {}),
+  })),
+  // Non-destructive: flips the canvas click-mode only; never clears the
+  // cut set. Used by the redesigned PEARL Manual tab so switching tabs
+  // (or leaving PEARL) can safely stop canvas-hijacking without deleting
+  // the analyst's ablations.
+  setAblationActive: (on) => set((s) => ({
+    ablationMode: on,
+    ...(on ? { scissorsMode: false } : {}),
   })),
   toggleAblatedNode: (nodeId) =>
     set((s) => {


### PR DESCRIPTION
## PEARL fixes — founder live-test + adviser-council round 2

Follow-up to #526. Acted on the founder's live-test of the shipped redesign plus a full 5-lens adviser-council pass.

### Bug fixes (P0)
- **Manual tab now works.** Selecting it auto-enters canvas ablation click-mode, so you just click nodes/edges — no hidden "ENTER ABLATION MODE" step. Implemented with a **new non-destructive store action `setAblationActive`**: the existing `setAblationMode(false)` *clears* the cut set (intended for the classic exit-and-discard flow), so binding the tab to it would silently delete the analyst's cuts on tab-switch — the council Contrarian flagged this as a silent data-corruption path. Leaving the tab (or unmounting PEARL) now stops the canvas hijack without losing cuts. The redundant ENTER/EXIT button is hidden in embedded mode, replaced by a live status hint.
- **Budget/mode controls no longer overflow** the fixed 320px panel — `flex-wrap` on the InterdictionPanel control row.
- **VX-880 is domain-gated.** It rendered unconditionally; now only shows in `t1d-*` sessions (reuses the ModulePanel `isT1DDomain` pattern), so it stops leaking into geopolitical/other sessions as a stray artifact.

### Clarity — "more buttons than words, explanations collapsible" (P1)
- **Auto-solve** gained one visible plain-language line ("Finds the fewest cuts that blunt the worst-case cascade. Budget = how many cuts; mode = what it may cut."). The founder said "I have no idea what that does," and the concept has no icon-able analogue.
- The always-visible top **orientation line was folded into the DEFINE CUTS `?`** (zero prose before the first control), with the run→forecast loop appended there.
- BUDGET label tooltip clarifies budget = max cuts (and that it skips 4 by design).

### Notes
- Pure IA + one additive store action; real data only. Still behind the NEW⇄CLASSIC toggle.
- `tsc` clean on touched files; full build green locally.
- **Deferred for a product decision** (council's headline structural recommendation): collapse Describe + Auto-solve into a single "you pick vs. the system picks" two-mode picker — Describe is really the natural-language front-end to Auto-solve, not a peer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
