### PR TITLE
fix(domains): rename cards to apples-to-apples 'X Systems' taxonomy

### DIFF
--- a/src/lib/domains.ts
+++ b/src/lib/domains.ts
@@ -92,7 +92,7 @@ export const DOMAIN_GROUPS: DomainGroup[] = [
       },
       {
         id: "manufacturing",
-        label: "Fertilizer & Agrochemical",
+        label: "Agrochemical Systems",
         icon: "factory",
         color: "#448aff",
         colorVar: "var(--accent-blue)",
@@ -102,7 +102,7 @@ export const DOMAIN_GROUPS: DomainGroup[] = [
       },
       {
         id: "supply-chain",
-        label: "Supply Chain Shock Risk",
+        label: "Supply Chain Systems",
         icon: "chain",
         color: "#00e5ff",
         colorVar: "var(--accent-cyan)",
@@ -118,7 +118,7 @@ export const DOMAIN_GROUPS: DomainGroup[] = [
     domains: [
       {
         id: "financial-contagion",
-        label: "Financial Contagion Risk",
+        label: "Financial Contagion Systems",
         icon: "bank",
         color: "#ff6d00",
         colorVar: "var(--accent-orange)",
@@ -128,7 +128,7 @@ export const DOMAIN_GROUPS: DomainGroup[] = [
       },
       {
         id: "sovereign-risk",
-        label: "Emerging Market Sovereign Risk",
+        label: "Sovereign Risk Systems",
         icon: "globe",
         color: "#ffab00",
         colorVar: "var(--accent-amber)",
@@ -144,7 +144,7 @@ export const DOMAIN_GROUPS: DomainGroup[] = [
     domains: [
       {
         id: "infrastructure",
-        label: "Infrastructure Resilience",
+        label: "Infrastructure Systems",
         icon: "cable",
         color: "#7c4dff",
         colorVar: "var(--accent-purple)",
@@ -154,7 +154,7 @@ export const DOMAIN_GROUPS: DomainGroup[] = [
       },
       {
         id: "defense-isr",
-        label: "Defense & ISR",
+        label: "Defense Systems",
         icon: "shield",
         color: "#00e676",
         colorVar: "var(--accent-green)",
@@ -170,7 +170,7 @@ export const DOMAIN_GROUPS: DomainGroup[] = [
     domains: [
       {
         id: "macro-labor",
-        label: "Labor, Growth & Housing",
+        label: "Labor & Growth Systems",
         icon: "chart-bar",
         color: "#40c4ff",
         colorVar: "var(--accent-cyan)",
@@ -180,7 +180,7 @@ export const DOMAIN_GROUPS: DomainGroup[] = [
       },
       {
         id: "macro-inflation",
-        label: "Inflation & Policy",
+        label: "Monetary Policy Systems",
         icon: "trending",
         color: "#ff80ab",
         colorVar: "var(--accent-pink)",
@@ -196,7 +196,7 @@ export const DOMAIN_GROUPS: DomainGroup[] = [
     domains: [
       {
         id: "t1d-beta-cell",
-        label: "T1D β-Cell Restoration",
+        label: "β-Cell Regeneration Systems",
         icon: "dna",
         color: "#40c4ff",
         colorVar: "var(--accent-blue)",
@@ -206,7 +206,7 @@ export const DOMAIN_GROUPS: DomainGroup[] = [
       },
       {
         id: "t1d-vx880",
-        label: "T1D Stem-Cell Transplant (VX-880)",
+        label: "Stem-Cell Therapy Systems (VX-880)",
         icon: "syringe",
         color: "#40c4ff",
         colorVar: "var(--accent-blue)",
@@ -222,7 +222,7 @@ export const DOMAIN_GROUPS: DomainGroup[] = [
     domains: [
       {
         id: "ai-safety-ids",
-        label: "AI Safety / Endogenous Catastrophe",
+        label: "AI Safety Systems",
         icon: "brain",
         color: "#7B68EE",
         colorVar: "var(--accent-violet)",
@@ -238,7 +238,7 @@ export const DOMAIN_GROUPS: DomainGroup[] = [
     domains: [
       {
         id: "frontier-science",
-        label: "Frontier Science",
+        label: "Frontier Research Systems",
         icon: "atom",
         color: "#e040fb",
         colorVar: "var(--accent-magenta)",


### PR DESCRIPTION
**AI Adviser Council on the landing-page taxonomy.**

User flagged that the domain workspace cards are apples-to-oranges: "Energy Systems" reads as a system, "Supply Chain Shock Risk" reads as a risk, "Infrastructure Resilience" as a posture. The grid feels like a hodgepodge.

## Council synthesis

**First-Principles:** Every `DomainCard` is a curated bundle of nodes + edges — a *causal subsystem* of the world. Through that lens every card IS a system. The current labels just describe them at different ontological tiers (substrate / mechanism / outcome), which is what breaks the visual reading.

**Contrarian:** Renaming everything "X Systems" risks papering over real differences. Verified by walking each card — all of them are accurately characterized as systems, just framed inconsistently today. Rename is principled, not cosmetic.

**Executor:** ~20 min mechanical pass, label-only, no architectural change.

## Renames

| Before | After |
|---|---|
| Fertilizer & Agrochemical | **Agrochemical Systems** |
| Supply Chain Shock Risk | **Supply Chain Systems** |
| Financial Contagion Risk | **Financial Contagion Systems** |
| Emerging Market Sovereign Risk | **Sovereign Risk Systems** |
| Infrastructure Resilience | **Infrastructure Systems** |
| Defense & ISR | **Defense Systems** |
| Labor, Growth & Housing | **Labor & Growth Systems** |
| Inflation & Policy | **Monetary Policy Systems** |
| T1D β-Cell Restoration | **β-Cell Regeneration Systems** |
| T1D Stem-Cell Transplant (VX-880) | **Stem-Cell Therapy Systems (VX-880)** |
| AI Safety / Endogenous Catastrophe | **AI Safety Systems** |
| Frontier Science | **Frontier Research Systems** |

Energy Systems was already correctly named — left unchanged.

## Scope intentionally narrow

Only the user-visible `label` field in `src/lib/domains.ts`. **The following are intentionally unchanged:**

- `node.domain` strings (`"Macro Impact: Labor, Growth & Housing"` etc.) — stable data-layer keys that drive color mappings, geo-coordinates, node lookups. Renaming would cascade through ~20 files.
- `displayName` in `domain-profiles.ts` — a separate UI surface for the omega-pillar profile shown in NodeInspector's "REWEIGHTED FROM" tag.

## Tests
The two test files that match these strings (`geo-coordinates.test.ts`, `ai-safety-domain-render.test.ts`) reference node-domain strings and `profile.displayName`, not card labels. No tests broken.

## What's NOT in this PR

Per the council pecking order: the bigger Thread A change — adding a natural-language search bar in `DomainSelector` so users can type their concern and have copilot recommend cards — was preview-only. Wants user sign-off before I build it.

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_