### PR TITLE
feat(copilot): expose Tarski axiom configuration to the copilot

### DIFF
--- a/src/lib/__tests__/copilot-axiom-tools.test.ts
+++ b/src/lib/__tests__/copilot-axiom-tools.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { executeTag } from "@/lib/copilot/tool-registry";
+import "@/lib/copilot/tools";
+import type { ApexState } from "@/stores/useApexStore";
+
+// ─── Spy store for the axiom-config tools ───────────────────────
+
+interface AxiomSpy {
+  enabled: Set<string> | null;
+  level: "all" | 0 | 1 | 2 | null;
+  validations: number;
+}
+
+function makeCtx() {
+  const spy: AxiomSpy = { enabled: null, level: null, validations: 0 };
+  const fakeStore = {
+    tarskiReport: {
+      inconsistentEdgeIds: new Set<string>(["e1"]),
+      restrictedNodeIds: new Set<string>(),
+      proofTraces: [],
+    },
+    setEnabledAxioms: (s: Set<string>) => {
+      spy.enabled = s;
+    },
+    setAxiomLevelFilter: (f: "all" | 0 | 1 | 2) => {
+      spy.level = f;
+    },
+    runTarskiWithAxioms: () => {
+      spy.validations++;
+    },
+  } as unknown as ApexState;
+  return { ctx: { getStore: () => fakeStore }, spy };
+}
+
+describe("enable_axioms", () => {
+  it("resolves axiom ids, sets the active set, and re-runs validation", async () => {
+    const { ctx, spy } = makeCtx();
+    const result = await executeTag(
+      { name: "enable_axioms", payload: "axioms=A-01|R-01", raw: "" },
+      ctx,
+    );
+    expect(spy.enabled).not.toBeNull();
+    expect([...(spy.enabled ?? [])].sort()).toEqual(["A-01", "R-01"]);
+    expect(spy.validations).toBe(1);
+    expect(result).toMatch(/Enabled 2 axiom/);
+    expect(result).toContain("A-01");
+  });
+
+  it("resolves by name fragment (case-insensitive)", async () => {
+    const { ctx, spy } = makeCtx();
+    await executeTag(
+      { name: "enable_axioms", payload: "axioms=temporal priority", raw: "" },
+      ctx,
+    );
+    expect([...(spy.enabled ?? [])]).toContain("A-01");
+  });
+
+  it("reports unmatched tokens but still enables the valid ones", async () => {
+    const { ctx, spy } = makeCtx();
+    const result = await executeTag(
+      { name: "enable_axioms", payload: "axioms=A-01|NOPE", raw: "" },
+      ctx,
+    );
+    expect([...(spy.enabled ?? [])]).toEqual(["A-01"]);
+    expect(result).toMatch(/no match: NOPE/);
+  });
+
+  it("returns an error and skips mutation when nothing matches", async () => {
+    const { ctx, spy } = makeCtx();
+    const result = await executeTag(
+      { name: "enable_axioms", payload: "axioms=ZZZ|QQQ", raw: "" },
+      ctx,
+    );
+    expect(spy.enabled).toBeNull();
+    expect(spy.validations).toBe(0);
+    expect(result).toMatch(/No axioms matched/);
+  });
+});
+
+describe("set_axiom_level", () => {
+  it("maps numeric levels and re-runs validation", async () => {
+    const { ctx, spy } = makeCtx();
+    const result = await executeTag(
+      { name: "set_axiom_level", payload: "level=0", raw: "" },
+      ctx,
+    );
+    expect(spy.level).toBe(0);
+    expect(spy.validations).toBe(1);
+    expect(result).toContain("0");
+  });
+
+  it("maps the 'all' level", async () => {
+    const { ctx, spy } = makeCtx();
+    await executeTag({ name: "set_axiom_level", payload: "all", raw: "" }, ctx);
+    expect(spy.level).toBe("all");
+  });
+
+  it("rejects an out-of-enum level at coercion", async () => {
+    const { ctx, spy } = makeCtx();
+    const result = await executeTag(
+      { name: "set_axiom_level", payload: "level=9", raw: "" },
+      ctx,
+    );
+    expect(spy.level).toBeNull();
+    expect(result).toMatch(/not in \[/);
+  });
+});

--- a/src/lib/copilot-context.ts
+++ b/src/lib/copilot-context.ts
@@ -100,6 +100,15 @@ export function serializeGraphContext(
       `Restricted nodes: ${graph.metadata.restrictedNodes}`
   );
 
+  // Tarski axiom catalog — the full set of selectable axiom ids so the
+  // copilot can drive enable_axioms / set_axiom_level. Without this the
+  // model only ever sees axioms that already appear in a violation.
+  lines.push("");
+  lines.push("=== TARSKI AXIOMS (catalog — ids for enable_axioms) ===");
+  for (const ax of AXIOM_LIBRARY) {
+    lines.push(`  ${ax.id} (L${ax.level}) ${ax.name}`);
+  }
+
   // System-level Ω-Fragility — the network-wide aggregations so the copilot
   // can answer "how fragile is the whole system?" rather than only quoting
   // per-node Ω. Mirrors the CD-Ω monitor header (computeSystemFragility).

--- a/src/lib/copilot/eval/cases/seed.ts
+++ b/src/lib/copilot/eval/cases/seed.ts
@@ -336,4 +336,34 @@ export const SEED_CASES: TestCase[] = [
     forbidden_in_response: [/\d+\s*°|sunny|cloudy|rain(\s|y|ing)|temperature/i],
     tags: ["refusal", "no-tool", "off-topic"],
   },
+
+  // ─── Tarski axiom configuration ────────────────────────────────
+
+  {
+    id: "enable_axioms_subset",
+    description:
+      "User wants the Tarski lens focused on specific axioms — enable_axioms with those ids/names.",
+    user_message: "turn on just the temporal priority and chokepoint axioms and re-validate",
+    graph_fixture: "geopolitical_main",
+    // The exact id set is model-chosen from the catalog — assert the tool fires.
+    accepted_tool_calls: [{ name: "enable_axioms" }],
+    tags: ["tool-selection", "tarski", "axioms"],
+  },
+  {
+    id: "enable_axioms_arbitrary_three",
+    description:
+      "User asks to arbitrarily pick three axioms and show how they render (the live-demo case).",
+    user_message: "arbitrarily select three axioms and show me how they render on the graph",
+    graph_fixture: "geopolitical_main",
+    accepted_tool_calls: [{ name: "enable_axioms" }],
+    tags: ["tool-selection", "tarski", "axioms"],
+  },
+  {
+    id: "set_axiom_level_core",
+    description: "User asks to restrict to core (level-0) axioms — set_axiom_level:0.",
+    user_message: "only apply the core level-0 axioms",
+    graph_fixture: "geopolitical_main",
+    accepted_tool_calls: [{ name: "set_axiom_level", params_match: { level: "0" } }],
+    tags: ["tool-selection", "tarski", "axioms"],
+  },
 ];

--- a/src/lib/copilot/tools.ts
+++ b/src/lib/copilot/tools.ts
@@ -632,6 +632,71 @@ defineTool({
   },
 });
 
+defineTool({
+  name: "enable_axioms",
+  description:
+    "Choose which Tarski axioms are ACTIVE, then re-run validation so the graph re-renders the resulting inconsistent edges / restricted nodes. Pass axiom ids (A-01|R-01|H-02) or name fragments. This REPLACES the active set (not additive).",
+  guidance:
+    "Use when the user wants to focus the Tarski lens on a specific axiom set: 'check only temporal priority and the chokepoint axioms', 'turn on the T1D axioms', 'arbitrarily pick three axioms and show how they render'. The full catalog (ids + names) is in === TARSKI AXIOMS === in the live context — pick ids from there. Don't pre-state the resulting counts; the SYS result line confirms what was enabled and how it rendered.",
+  params: {
+    axioms: {
+      type: "string[]",
+      required: true,
+      description: "Axiom ids or name fragments separated by | (e.g. A-01|R-01|H-02)",
+    },
+  },
+  legacyParam: "axioms",
+  handler: async ({ axioms }, ctx) => {
+    const store = ctx.getStore();
+    const { AXIOM_LIBRARY } = await import("../tarski-data");
+    const resolved = new Set<string>();
+    const unmatched: string[] = [];
+    for (const a of axioms) {
+      const q = a.trim().toLowerCase();
+      if (!q) continue;
+      const hit = AXIOM_LIBRARY.find(
+        (ax) => ax.id.toLowerCase() === q || ax.name.toLowerCase().includes(q),
+      );
+      if (hit) resolved.add(hit.id);
+      else unmatched.push(a);
+    }
+    if (resolved.size === 0) {
+      return `No axioms matched ${axioms.join(", ")}. Use ids like A-01, R-01, H-02 (see === TARSKI AXIOMS ===).`;
+    }
+    store.setEnabledAxioms(resolved);
+    store.runTarskiWithAxioms();
+    const names = [...resolved]
+      .map((id) => {
+        const ax = AXIOM_LIBRARY.find((a) => a.id === id);
+        return ax ? `${ax.id} ${ax.name}` : id;
+      })
+      .join(", ");
+    const note = unmatched.length > 0 ? ` (no match: ${unmatched.join(", ")})` : "";
+    const report = ctx.getStore().tarskiReport;
+    const rendered = report
+      ? ` → ${report.inconsistentEdgeIds.size} inconsistent edge(s), ${report.restrictedNodeIds.size} restricted node(s)`
+      : "";
+    return `Enabled ${resolved.size} axiom(s): ${names}${note}${rendered}`;
+  },
+});
+
+defineTool({
+  name: "set_axiom_level",
+  description:
+    "Filter active Tarski axioms by level, then re-run validation. all = every level; 0 = core; 1 = regional; 2 = higher-order.",
+  params: {
+    level: { type: "enum", values: ["all", "0", "1", "2"] as const, required: true },
+  },
+  legacyParam: "level",
+  handler: ({ level }, ctx) => {
+    const store = ctx.getStore();
+    const f: "all" | 0 | 1 | 2 = level === "all" ? "all" : (Number(level) as 0 | 1 | 2);
+    store.setAxiomLevelFilter(f);
+    store.runTarskiWithAxioms();
+    return `Axiom level filter set to: ${level}`;
+  },
+});
+
 // ─── Visualization controls ─────────────────────────────────────
 
 defineTool({


### PR DESCRIPTION
## What

Closes the **axiom-config** slice of the tool-exposure audit (#13). Surfaced live during a demo: asking the copilot to *"arbitrarily select three axioms and show how they render"* did nothing — the copilot had **no tool to choose axioms** (`run_tarski` only re-runs with whatever is already enabled).

- **`enable_axioms(axioms=A-01|R-01|…)`** — resolves axiom ids *or* name fragments against `AXIOM_LIBRARY`, sets the active set, and re-runs validation so the graph re-renders inconsistent edges / restricted nodes. Replaces the active set (not additive).
- **`set_axiom_level(level=all|0|1|2)`** — filter active axioms by level.
- **Context catalog** — `copilot-context.ts` now emits a `=== TARSKI AXIOMS ===` section (id / level / name) so the copilot knows which axiom ids exist. Previously it only ever saw axioms that already appeared in a violation, so it couldn't reliably pick any.

## Tests

- **+7 unit tests** (`copilot-axiom-tools.test.ts`): id + name-fragment resolution, partial-match reporting, no-match guard, level mapping, enum rejection.
- **+3 eval cases** (incl. the exact live-demo phrasing).
- Full copilot suite: **167/167 pass**; typecheck clean for touched files.

## Behavior note (follow-up, not in this PR)

When the copilot is asked for something it has no tool for, it currently no-ops silently (that's how this gap showed up). Worth a separate change to make it say *"I can't do that yet"* instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
