### PR TITLE
feat(copilot): honest "I can't do that yet" instead of silent no-op

### DIFF
--- a/src/lib/copilot/eval/cases/seed.ts
+++ b/src/lib/copilot/eval/cases/seed.ts
@@ -366,4 +366,19 @@ export const SEED_CASES: TestCase[] = [
     accepted_tool_calls: [{ name: "set_axiom_level", params_match: { level: "0" } }],
     tags: ["tool-selection", "tarski", "axioms"],
   },
+
+  // ─── Capability-gap honesty (no silent no-op) ──────────────────
+
+  {
+    id: "unsupported_action_honest_refusal",
+    description:
+      "User asks for an action with NO matching tool — the copilot should plainly say it can't, not silently no-op, fake success, or flail with an unrelated tool.",
+    user_message: "export the current graph as a PDF and save it to my desktop",
+    graph_fixture: "geopolitical_main",
+    forbid_tool_calls: true,
+    required_in_response: [
+      /(can'?t|cannot|unable|not able|don'?t (?:have|support)|no (?:tool|control|way)|isn'?t something i can)/i,
+    ],
+    tags: ["refusal", "no-tool", "capability-gap"],
+  },
 ];

--- a/src/lib/copilot/system-prompt.ts
+++ b/src/lib/copilot/system-prompt.ts
@@ -146,6 +146,8 @@ CRITICAL — invoking a tool requires the triple-angle-bracket syntax: <<<ACTION
 
 Rule about prose AROUND your action tags: describe the INTENT ("isolating Europe-related nodes", "running the interdiction solver"), not what the tool DID. The actual tool result appears in a SYS line below your response — let that line confirm what happened. If your prose claims one outcome and the tool produced a different one (different nodes matched, different module switched, different action entirely), the user sees a confusing mismatch. Be honest about what you're TRYING to do; trust the SYS line to report what was DONE.
 
+Honesty about capability gaps: if the user asks you to DO something (an action or command — change a setting, run a procedure, modify the view, control the platform) and NO tool in === COPILOT ACTIONS === can perform it, say so plainly in one line — e.g. "I can't do that yet — there's no control wired into me for <that capability>." Do NOT stay silent, do NOT answer as though you performed it, and do NOT bury the limitation inside unrelated prose. A clear "I can't do that yet" is the correct, useful response. This applies ONLY to actions you cannot take — ordinary questions, explanations, and analysis you should always answer normally from the live context.
+
 === FEATURE MANIFEST ===
 ${getFeatureManifestDigest(profileId)}`;
 }


### PR DESCRIPTION
## What

When the user asks the copilot to **do** something no tool supports, it used to go silent or answer in unrelated prose — which reads as *broken*. That's exactly how the axiom-selection gap surfaced during a live demo.

This adds a scoped system-prompt rule: if no tool in `=== COPILOT ACTIONS ===` can perform the requested **action**, the copilot must say so plainly in one line (e.g. *"I can't do that yet — there's no control wired into me for that"*). It must not stay silent, fake success, or flail with an unrelated tool. The rule is **scoped to actions only** — ordinary questions, explanations, and analysis are explicitly unaffected.

## Why it matters

This is **Part 1** of the gap-handling work:
- **Part 1 (this PR):** fail *honestly* — better UX, and no more mysterious silence during demos.
- **Part 2 (scoped separately):** mine `copilot_traces` for "clear action intent, zero tools fired" → an automated missing-capability detector. The honest refusal from Part 1 is also the clean signal Part 2 keys on.

Together they turn every real session into an automatic gap-finder for what to build next.

## Tests

- **+1 eval case** (`unsupported_action_honest_refusal`): an unsupported action (export PDF) must produce no tool call and an explicit admission of inability. Validated by the `copilot · eval` CI gate.
- Copilot unit suite: **167/167 pass**; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
