### PR TITLE
feat(copilot): capability-gap detector over traces

### DIFF
--- a/src/app/api/copilot/traces/gaps/__tests__/route.test.ts
+++ b/src/app/api/copilot/traces/gaps/__tests__/route.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment node
+//
+// Tests for GET /api/copilot/traces/gaps. Mocks the supabase server
+// client at the module level. Validates anonymous → empty report,
+// authenticated → rows pass through analyzeCapabilityGaps(), limit
+// clamping, and the 503 / 500 error paths.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+import type { CapabilityGapReport } from "@/lib/copilot/capability-gaps";
+
+let mockUser: { id: string } | null = null;
+let mockRows: unknown[] = [];
+let mockError: { message: string } | null = null;
+let mockClientThrows = false;
+let lastLimitCalledWith: number | undefined;
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => {
+    if (mockClientThrows) throw new Error("supabase client init failed");
+    return {
+      auth: { getUser: async () => ({ data: { user: mockUser } }) },
+      from: () => {
+        const chain = {
+          select: () => chain,
+          order: () => chain,
+          limit: (n: number) => {
+            lastLimitCalledWith = n;
+            return Promise.resolve({ data: mockRows, error: mockError });
+          },
+        };
+        return chain;
+      },
+    };
+  },
+}));
+
+const { GET } = await import("@/app/api/copilot/traces/gaps/route");
+
+function req(url = "http://localhost/api/copilot/traces/gaps"): NextRequest {
+  return new NextRequest(url, { method: "GET" });
+}
+
+beforeEach(() => {
+  mockUser = null;
+  mockRows = [];
+  mockError = null;
+  mockClientThrows = false;
+  lastLimitCalledWith = undefined;
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("GET /api/copilot/traces/gaps", () => {
+  it("returns an empty report (200) for anonymous callers", async () => {
+    mockUser = null;
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { report: CapabilityGapReport };
+    expect(body.report.total_turns).toBe(0);
+    expect(body.report.explicit_refusals).toEqual([]);
+    expect(body.report.suspected_gaps).toEqual([]);
+  });
+
+  it("runs rows through analyzeCapabilityGaps() and returns the shape", async () => {
+    mockUser = { id: "u1" };
+    mockRows = [
+      {
+        created_at: "2026-06-04T10:00:00Z",
+        conversation_id: "c1",
+        user_message: "export the graph as a PDF",
+        display_text: "I can't do that yet — no control wired into me for that.",
+        tool_calls: [],
+      },
+      {
+        created_at: "2026-06-04T10:01:00Z",
+        conversation_id: "c1",
+        user_message: "hide the trade edges",
+        display_text: "Here's some prose instead.",
+        tool_calls: [],
+      },
+      {
+        created_at: "2026-06-04T10:02:00Z",
+        conversation_id: "c1",
+        user_message: "switch to pearl",
+        display_text: "done",
+        tool_calls: [{ name: "set_module" }],
+      },
+    ];
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { report: CapabilityGapReport };
+    expect(body.report.total_turns).toBe(3);
+    expect(body.report.turns_with_tools).toBe(1);
+    expect(body.report.explicit_refusal_count).toBe(1);
+    expect(body.report.suspected_gap_count).toBe(1);
+  });
+
+  it("clamps a too-large limit to MAX_LIMIT (5000)", async () => {
+    mockUser = { id: "u1" };
+    await GET(req("http://localhost/api/copilot/traces/gaps?limit=99999"));
+    expect(lastLimitCalledWith).toBe(5000);
+  });
+
+  it("falls back to the default limit (1000) when ?limit is absent", async () => {
+    mockUser = { id: "u1" };
+    await GET(req());
+    expect(lastLimitCalledWith).toBe(1000);
+  });
+
+  it("returns 503 when the supabase server client fails to init", async () => {
+    mockClientThrows = true;
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await GET(req());
+    expect(res.status).toBe(503);
+    consoleSpy.mockRestore();
+  });
+
+  it("returns 500 when the select itself errors", async () => {
+    mockUser = { id: "u1" };
+    mockError = { message: "boom" };
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await GET(req());
+    expect(res.status).toBe(500);
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/app/api/copilot/traces/gaps/route.ts
+++ b/src/app/api/copilot/traces/gaps/route.ts
@@ -1,0 +1,71 @@
+// ─── GET /api/copilot/traces/gaps ───────────────────────────────
+//
+// Returns the capability-gap backlog over the authenticated user's
+// recent copilot turns: actions they asked for that the copilot
+// couldn't perform. RLS on public.copilot_traces filters to
+// auth.uid() = user_id, same as the analytics endpoint.
+//
+// Anonymous callers see an empty report (not a 401), matching the
+// analytics route's pattern. Re-run as traces accumulate.
+
+import { NextRequest, NextResponse } from "next/server";
+import { createClient as createServerClient } from "@/lib/supabase/server";
+import {
+  analyzeCapabilityGaps,
+  type GapInputRow,
+  type CapabilityGapReport,
+} from "@/lib/copilot/capability-gaps";
+
+const DEFAULT_LIMIT = 1000;
+const MAX_LIMIT = 5000;
+
+export async function GET(request: NextRequest) {
+  const limitParam = request.nextUrl.searchParams.get("limit");
+  const requestedLimit = limitParam ? parseInt(limitParam, 10) : DEFAULT_LIMIT;
+  const limit = Math.min(
+    MAX_LIMIT,
+    Math.max(1, Number.isFinite(requestedLimit) ? requestedLimit : DEFAULT_LIMIT),
+  );
+
+  let supabase;
+  try {
+    supabase = await createServerClient();
+  } catch (err) {
+    console.error("[copilot-gaps] failed to create server client:", err);
+    return NextResponse.json(
+      { error: "Supabase server client unavailable" },
+      { status: 503 },
+    );
+  }
+
+  const { data: userData } = await supabase.auth.getUser();
+  if (!userData.user) {
+    return NextResponse.json({ report: emptyReport() });
+  }
+
+  const { data, error } = await supabase
+    .from("copilot_traces")
+    .select("created_at, conversation_id, user_message, display_text, tool_calls")
+    .order("created_at", { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    console.error("[copilot-gaps] select failed:", error);
+    return NextResponse.json({ error: "Failed to load gaps" }, { status: 500 });
+  }
+
+  const rows = (data ?? []) as GapInputRow[];
+  const report = analyzeCapabilityGaps(rows);
+  return NextResponse.json({ report });
+}
+
+function emptyReport(): CapabilityGapReport {
+  return {
+    total_turns: 0,
+    turns_with_tools: 0,
+    explicit_refusals: [],
+    suspected_gaps: [],
+    explicit_refusal_count: 0,
+    suspected_gap_count: 0,
+  };
+}

--- a/src/lib/__tests__/copilot-capability-gaps.test.ts
+++ b/src/lib/__tests__/copilot-capability-gaps.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { analyzeCapabilityGaps, type GapInputRow } from "@/lib/copilot/capability-gaps";
+
+function row(p: Partial<GapInputRow> & { user_message: string | null }): GapInputRow {
+  return {
+    created_at: "2026-06-04T00:00:00Z",
+    conversation_id: "c1",
+    display_text: "",
+    tool_calls: [],
+    ...p,
+  };
+}
+
+describe("analyzeCapabilityGaps", () => {
+  it("classifies an explicit refusal (Tier A) from the honesty marker", () => {
+    const r = analyzeCapabilityGaps([
+      row({
+        user_message: "export the graph as a PDF",
+        display_text: "I can't do that yet — there's no control wired into me for that.",
+      }),
+    ]);
+    expect(r.explicit_refusal_count).toBe(1);
+    expect(r.suspected_gap_count).toBe(0);
+    expect(r.explicit_refusals[0].examples[0]).toMatch(/export the graph/i);
+  });
+
+  it("classifies an action with no tool fired as a suspected gap (Tier B)", () => {
+    const r = analyzeCapabilityGaps([
+      row({ user_message: "change the background to dark mode", display_text: "Here's some prose." }),
+    ]);
+    expect(r.suspected_gap_count).toBe(1);
+    expect(r.explicit_refusal_count).toBe(0);
+  });
+
+  it("does NOT flag a turn where a tool fired", () => {
+    const r = analyzeCapabilityGaps([
+      row({
+        user_message: "switch to the pearl module",
+        display_text: "Switching now.",
+        tool_calls: [{ name: "set_module" }],
+      }),
+    ]);
+    expect(r.turns_with_tools).toBe(1);
+    expect(r.suspected_gap_count).toBe(0);
+    expect(r.explicit_refusal_count).toBe(0);
+  });
+
+  it("does NOT flag a plain question with no action verb", () => {
+    const r = analyzeCapabilityGaps([
+      row({ user_message: "what is omega-fragility?", display_text: "It's a 0-10 metric..." }),
+    ]);
+    expect(r.suspected_gap_count).toBe(0);
+    expect(r.explicit_refusal_count).toBe(0);
+  });
+
+  it("groups near-duplicate requests and ranks by count", () => {
+    const r = analyzeCapabilityGaps([
+      row({ user_message: "export the graph as a PDF please", display_text: "prose" }),
+      row({ user_message: "export the graph as a PDF now", display_text: "prose" }),
+      row({ user_message: "hide the trade edges", display_text: "prose" }),
+    ]);
+    expect(r.suspected_gaps[0].count).toBe(2); // the two PDF exports collapse
+    expect(r.suspected_gaps[0].examples.length).toBe(2);
+    expect(r.suspected_gaps).toHaveLength(2);
+  });
+
+  it("counts a refusal as Tier A even if the message also reads as an action", () => {
+    const r = analyzeCapabilityGaps([
+      row({
+        user_message: "set the theme to neon", // action verb present
+        display_text: "I can't do that yet.",
+      }),
+    ]);
+    expect(r.explicit_refusal_count).toBe(1);
+    expect(r.suspected_gap_count).toBe(0); // not double-counted
+  });
+
+  it("skips empty user messages and handles null display_text", () => {
+    const r = analyzeCapabilityGaps([
+      row({ user_message: "", display_text: null }),
+      row({ user_message: "   ", display_text: null }),
+    ]);
+    expect(r.total_turns).toBe(2);
+    expect(r.explicit_refusal_count).toBe(0);
+    expect(r.suspected_gap_count).toBe(0);
+  });
+});

--- a/src/lib/copilot/capability-gaps.ts
+++ b/src/lib/copilot/capability-gaps.ts
@@ -1,0 +1,133 @@
+// ─── Copilot capability-gap detector ───────────────────────────
+//
+// Mines copilot turns for things users asked the copilot to DO that
+// it couldn't — i.e. the auto-generated "what to build next" backlog.
+// Pure function (no I/O), same shape contract as analytics.ts: the
+// route fetches RLS-filtered rows and passes them here.
+//
+// Two signal tiers:
+//   A. EXPLICIT — the assistant emitted the honest-refusal marker
+//      ("I can't do that yet", "no control wired into me"). High
+//      precision: the copilot itself told us it lacks the capability.
+//      (Depends on the Part-1 honesty rule in the system prompt.)
+//   B. SUSPECTED — no tool fired AND the user message reads like an
+//      action request (imperative verb). Higher recall, noisier:
+//      catches gaps from turns recorded before the honesty rule, or
+//      where the model answered in prose instead of refusing cleanly.
+//
+// Re-run as traces accumulate — the more real usage, the sharper the
+// backlog.
+
+// ─── Input shape ────────────────────────────────────────────────
+
+/** Subset of copilot_traces columns the detector needs. */
+export interface GapInputRow {
+  created_at?: string | null;
+  conversation_id?: string | null;
+  user_message: string | null;
+  /** Tags-stripped assistant text shown to the user. */
+  display_text: string | null;
+  tool_calls: Array<{ name: string }>;
+}
+
+// ─── Output shape ───────────────────────────────────────────────
+
+export interface GapGroup {
+  /** Normalized key similar requests collapse onto. */
+  signature: string;
+  count: number;
+  /** Up to 3 representative raw user messages. */
+  examples: string[];
+}
+
+export interface CapabilityGapReport {
+  total_turns: number;
+  turns_with_tools: number;
+  /** Tier A — copilot explicitly said it couldn't. Sorted count desc. */
+  explicit_refusals: GapGroup[];
+  /** Tier B — action intent, zero tools fired. Sorted count desc. */
+  suspected_gaps: GapGroup[];
+  explicit_refusal_count: number;
+  suspected_gap_count: number;
+}
+
+// ─── Signals ────────────────────────────────────────────────────
+
+/** Markers the Part-1 honesty rule produces. Kept tight for precision. */
+const REFUSAL_MARKER =
+  /can'?t do (?:that|this) yet|no control wired into me|isn'?t something i can (?:do|control)|don'?t have a (?:tool|control|way) (?:to|for)/i;
+
+/** Imperative verbs that signal the user wanted an ACTION, not a question. */
+const ACTION_VERB =
+  /\b(show|display|set|switch|change|run|select|isolate|hide|filter|pin|unpin|add|remove|delete|enable|disable|turn (?:on|off)|go to|jump|step|export|save|apply|sever|cut|reset|compare|highlight|zoom|play|stop|start|ablate|restrict|focus|toggle|open|close|load|render|color|colour)\b/i;
+
+/** Collapse a message to a coarse signature so near-duplicates group. */
+function signatureOf(msg: string): string {
+  return msg
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .split(" ")
+    .slice(0, 6)
+    .join(" ");
+}
+
+function addToGroups(map: Map<string, GapGroup>, msg: string): void {
+  const sig = signatureOf(msg);
+  if (!sig) return;
+  const g = map.get(sig);
+  if (g) {
+    g.count++;
+    if (g.examples.length < 3 && !g.examples.includes(msg)) g.examples.push(msg);
+  } else {
+    map.set(sig, { signature: sig, count: 1, examples: [msg] });
+  }
+}
+
+function rank(map: Map<string, GapGroup>): GapGroup[] {
+  return [...map.values()].sort(
+    (a, b) => b.count - a.count || a.signature.localeCompare(b.signature),
+  );
+}
+
+// ─── Analyzer ───────────────────────────────────────────────────
+
+export function analyzeCapabilityGaps(rows: GapInputRow[]): CapabilityGapReport {
+  const explicit = new Map<string, GapGroup>();
+  const suspected = new Map<string, GapGroup>();
+  let turnsWithTools = 0;
+
+  for (const row of rows) {
+    const firedTool = (row.tool_calls?.length ?? 0) > 0;
+    if (firedTool) turnsWithTools++;
+
+    const user = (row.user_message ?? "").trim();
+    if (!user) continue;
+
+    const assistant = row.display_text ?? "";
+
+    // Tier A takes precedence — the copilot self-reported the gap.
+    if (REFUSAL_MARKER.test(assistant)) {
+      addToGroups(explicit, user);
+      continue;
+    }
+
+    // Tier B — wanted an action, nothing fired.
+    if (!firedTool && ACTION_VERB.test(user)) {
+      addToGroups(suspected, user);
+    }
+  }
+
+  const explicitGroups = rank(explicit);
+  const suspectedGroups = rank(suspected);
+
+  return {
+    total_turns: rows.length,
+    turns_with_tools: turnsWithTools,
+    explicit_refusals: explicitGroups,
+    suspected_gaps: suspectedGroups,
+    explicit_refusal_count: explicitGroups.reduce((s, g) => s + g.count, 0),
+    suspected_gap_count: suspectedGroups.reduce((s, g) => s + g.count, 0),
+  };
+}


### PR DESCRIPTION
## What

**Part 2** of the gap-handling work. Turns copilot usage into an automatic *"what to build next"* backlog — the actions users asked for that the copilot couldn't perform. (Part 1, PR #535, made the copilot fail *honestly*; this mines those failures.)

- **`capability-gaps.ts`** — pure `analyzeCapabilityGaps(rows)`, same contract as `analytics.ts`. Two signal tiers:
  - **A · EXPLICIT** — the assistant emitted the Part-1 honest-refusal marker ("I can't do that yet" / "no control wired into me"). High precision: the copilot told us it lacks the capability.
  - **B · SUSPECTED** — no tool fired *and* the user message reads like an action request (imperative verb). Higher recall, noisier — catches gaps from before Part 1 deployed, or where the model answered in prose instead of refusing cleanly.
  - Groups near-duplicate requests and ranks by frequency.
- **`GET /api/copilot/traces/gaps`** — RLS-scoped to the caller, mirrors the analytics route (anon → empty report, limit clamping, 503/500 paths). **Re-run as traces accumulate** — sharper with more real usage.

## Tests

- **+7 analyzer unit tests** (tier classification, tool-fired exclusion, question exclusion, grouping/ranking, Tier-A precedence, empty/null handling).
- **+6 route tests** (anon empty, aggregation pass-through, limit clamps, 503/500).
- Typecheck clean.

## Notes

- No UI yet — the endpoint is the re-runnable surface. A "GAPS" tab in the existing trace-analytics browser is an easy follow-up.
- Signal quality scales with real usage; works today on existing traces, richer the more the copilot is used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
