### PR TITLE
feat(admin): COPILOT GAPS view — auto-mined backlog

### DIFF
--- a/src/app/admin/copilot-gaps/CopilotGapsAdminList.tsx
+++ b/src/app/admin/copilot-gaps/CopilotGapsAdminList.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import type { CapabilityGapReport, GapGroup } from "@/lib/copilot/capability-gaps";
+
+export default function CopilotGapsAdminList({
+  report,
+}: {
+  report: CapabilityGapReport;
+}) {
+  const noToolPct =
+    report.total_turns > 0
+      ? Math.round((1 - report.turns_with_tools / report.total_turns) * 100)
+      : 0;
+
+  return (
+    <div className="min-h-screen bg-background text-foreground p-6 font-mono">
+      <div className="max-w-4xl mx-auto">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <h1 className="text-[14px] font-[family-name:var(--font-michroma)] tracking-wider">
+              COPILOT GAPS
+            </h1>
+            <div className="text-[10px] text-text-muted mt-1">
+              Actions users asked the copilot to do that it couldn&apos;t — across
+              all users. Refresh after more usage to re-rank.
+            </div>
+          </div>
+          <Link
+            href="/admin"
+            className="text-[10px] tracking-wider text-text-muted hover:text-foreground transition-colors"
+          >
+            ← ADMIN
+          </Link>
+        </div>
+
+        {/* Summary */}
+        <div className="flex flex-wrap gap-6 mb-8 border-b border-border/60 pb-4">
+          <Stat label="turns analyzed" value={report.total_turns} />
+          <Stat label="fired no tool" value={`${noToolPct}%`} />
+          <Stat
+            label="explicit refusals"
+            value={report.explicit_refusal_count}
+            tone={report.explicit_refusal_count > 0 ? "warn" : "default"}
+          />
+          <Stat
+            label="suspected gaps"
+            value={report.suspected_gap_count}
+            tone={report.suspected_gap_count > 0 ? "warn" : "default"}
+          />
+        </div>
+
+        <GapSection
+          title="EXPLICITLY REFUSED"
+          subtitle={'the copilot said "I can’t do that yet" — high confidence'}
+          groups={report.explicit_refusals}
+          accent="text-accent-amber"
+        />
+        <GapSection
+          title="SUSPECTED GAPS"
+          subtitle="action asked, no tool fired — needs review"
+          groups={report.suspected_gaps}
+          accent="text-accent-cyan"
+        />
+
+        {report.total_turns === 0 && (
+          <div className="text-[11px] text-text-muted mt-8 leading-relaxed">
+            No copilot traces yet. As people use the copilot, the gaps they hit
+            will surface here automatically.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  tone = "default",
+}: {
+  label: string;
+  value: number | string;
+  tone?: "default" | "warn";
+}) {
+  return (
+    <div className="leading-tight">
+      <div
+        className={`text-[16px] font-[family-name:var(--font-michroma)] ${
+          tone === "warn" ? "text-accent-amber" : "text-foreground"
+        }`}
+      >
+        {value}
+      </div>
+      <div className="text-[8px] text-text-muted tracking-wider uppercase">
+        {label}
+      </div>
+    </div>
+  );
+}
+
+function GapSection({
+  title,
+  subtitle,
+  groups,
+  accent,
+}: {
+  title: string;
+  subtitle: string;
+  groups: GapGroup[];
+  accent: string;
+}) {
+  return (
+    <div className="mb-10">
+      <div className="mb-3">
+        <div
+          className={`text-[11px] font-[family-name:var(--font-michroma)] tracking-[0.2em] ${accent}`}
+        >
+          {title}
+        </div>
+        <div className="text-[9px] text-text-muted mt-1">{subtitle}</div>
+      </div>
+      {groups.length === 0 ? (
+        <div className="text-[10px] text-text-muted/70 italic">none</div>
+      ) : (
+        <div className="space-y-2">
+          {groups.map((g) => (
+            <GapRow key={g.signature} group={g} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function GapRow({ group }: { group: GapGroup }) {
+  const [open, setOpen] = useState(false);
+  const expandable = group.examples.length > 1;
+  return (
+    <div className="border border-border rounded bg-surface">
+      <button
+        type="button"
+        onClick={() => expandable && setOpen((o) => !o)}
+        className={`w-full flex items-center justify-between px-4 py-2.5 text-left transition-colors ${
+          expandable ? "hover:border-accent-cyan/40" : "cursor-default"
+        }`}
+      >
+        <span className="text-[11px] text-foreground truncate pr-3">
+          {group.examples[0] ?? group.signature}
+        </span>
+        <span className="text-[12px] font-[family-name:var(--font-michroma)] text-accent-amber shrink-0">
+          {group.count}&times;
+        </span>
+      </button>
+      {open && (
+        <div className="px-4 pb-3 pt-1 border-t border-border/50 space-y-1">
+          {group.examples.map((ex, i) => (
+            <div key={i} className="text-[10px] text-text-muted leading-relaxed">
+              &bull; {ex}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/copilot-gaps/page.tsx
+++ b/src/app/admin/copilot-gaps/page.tsx
@@ -1,0 +1,40 @@
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+import { analyzeCapabilityGaps, type GapInputRow } from "@/lib/copilot/capability-gaps";
+import CopilotGapsAdminList from "./CopilotGapsAdminList";
+
+export const dynamic = "force-dynamic";
+
+// Pull a generous window of recent turns. Service-role bypasses RLS so
+// this sees EVERY user's traces (the whole point — aggregate demand),
+// unlike the per-user /api/copilot/traces/gaps endpoint.
+const FETCH_LIMIT = 5000;
+
+export default async function CopilotGapsAdminPage() {
+  // Middleware gates /admin/* to the ADMIN_EMAILS allowlist, so the
+  // service-role client is safe here — the anon-session client would
+  // hit RLS on copilot_traces and read only the admin's own rows.
+  const supabase = createSupabaseClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+
+  const { data, error } = await supabase
+    .from("copilot_traces")
+    .select("created_at, conversation_id, user_message, display_text, tool_calls")
+    .order("created_at", { ascending: false })
+    .limit(FETCH_LIMIT);
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-background text-foreground p-8 font-mono">
+        <div className="text-accent-red">
+          Failed to load copilot traces: {error.message}
+        </div>
+      </div>
+    );
+  }
+
+  const rows = (data ?? []) as GapInputRow[];
+  const report = analyzeCapabilityGaps(rows);
+  return <CopilotGapsAdminList report={report} />;
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -2,6 +2,10 @@ import Link from "next/link";
 import { headers } from "next/headers";
 import { createClient as createSupabaseClient } from "@supabase/supabase-js";
 import TrustedInviteCard from "./TrustedInviteCard";
+import {
+  analyzeCapabilityGaps,
+  type GapInputRow,
+} from "@/lib/copilot/capability-gaps";
 
 export const dynamic = "force-dynamic";
 
@@ -25,7 +29,7 @@ export default async function AdminLandingPage() {
     Date.now() + 30 * 24 * 60 * 60 * 1000
   ).toISOString();
 
-  const [profilesAll, profilesDueSoon, leadsNew, feedbackNew] =
+  const [profilesAll, profilesDueSoon, leadsNew, feedbackNew, gapTraces] =
     await Promise.all([
       supabase.from("profiles").select("*", { count: "exact", head: true }),
       supabase
@@ -41,7 +45,18 @@ export default async function AdminLandingPage() {
         .from("feedback")
         .select("*", { count: "exact", head: true })
         .eq("status", "new"),
+      // Bounded sample of recent copilot turns for the COPILOT GAPS card
+      // headline stat. The full analysis lives on /admin/copilot-gaps.
+      supabase
+        .from("copilot_traces")
+        .select("user_message, display_text, tool_calls")
+        .order("created_at", { ascending: false })
+        .limit(1000),
     ]);
+
+  const gapReport = analyzeCapabilityGaps(
+    (gapTraces.data ?? []) as GapInputRow[],
+  );
 
   const cards: AdminCard[] = [
     {
@@ -81,6 +96,24 @@ export default async function AdminLandingPage() {
           label: "new",
           value: feedbackNew.count ?? 0,
           tone: (feedbackNew.count ?? 0) > 0 ? "warn" : "default",
+        },
+      ],
+    },
+    {
+      href: "/admin/copilot-gaps",
+      title: "COPILOT GAPS",
+      blurb:
+        "Actions users asked the copilot to do that it couldn't. Auto-mined backlog of what to build next.",
+      stats: [
+        {
+          label: "refused",
+          value: gapReport.explicit_refusal_count,
+          tone: gapReport.explicit_refusal_count > 0 ? "warn" : "default",
+        },
+        {
+          label: "suspected",
+          value: gapReport.suspected_gap_count,
+          tone: gapReport.suspected_gap_count > 0 ? "warn" : "default",
         },
       ],
     },


### PR DESCRIPTION
## What

Surfaces the #536 capability-gap detector in the **admin console**, across **all users** (service-role, bypassing the per-user RLS endpoint) — the aggregate "what to build next" backlog of actions people asked the copilot to do that it couldn't.

- **`/admin/copilot-gaps`** sub-page + `CopilotGapsAdminList` — two ranked, grouped sections (**Explicit refusals**, high confidence; **Suspected gaps**, action asked + no tool fired) with counts and expandable examples, plus summary stats (turns analyzed, % fired no tool, refusal/gap counts).
- **`/admin` hub** — a new COPILOT GAPS card with refused / suspected headline stats (bounded 1000-row sample).

Reuses `analyzeCapabilityGaps()` (already tested in #536) — no new analysis logic. Read-only, admin-gated by the existing ADMIN_EMAILS middleware, additive (no existing admin functionality touched).

## Why admin, not the per-user trace browser

The per-user browser is RLS-scoped to one user; the gap backlog is most useful **aggregated across everyone**, which the admin service-role context provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)