### PR TITLE
feat(graph): inferred latent nodes — reveal hidden cross-domain common causes (2D)

### DIFF
--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -24,6 +24,7 @@ import ReactFlow, {
 import "reactflow/dist/style.css";
 import { motion } from "framer-motion";
 import { useApexStore } from "@/stores/useApexStore";
+import { deriveLatentNodes } from "@/lib/latent-nodes";
 import { useFilteredGraph } from "@/hooks/useFilteredGraph";
 import { getCategoryColor, getDomainColor } from "@/lib/graph-color";
 import { getDomainCardColor } from "@/lib/domains";
@@ -476,7 +477,94 @@ function EdgeInspector({
   );
 }
 
-const nodeTypes = { causal: CausalNode2D };
+/**
+ * Inferred-latent ghost glyph (Dr. Pita synthetic-node #1). Deliberately
+ * looks UNLIKE a real node: dashed magenta ring, no fill, no ΩF score, a "?"
+ * and a persistent INFERRED badge. Hover discloses full provenance. Never
+ * carries omega data — it's a hypothesis, not an observation.
+ */
+interface LatentNode2DData {
+  label: string;
+  members: string;
+  strength: number;
+}
+function LatentNode2D({ data }: NodeProps<LatentNode2DData>) {
+  return (
+    <div
+      title={`INFERRED LATENT — not observed.\n${data.label}\nMembers: ${data.members}\nInference strength: ${data.strength}\nDerived from confounded structure (FCI-style latent common cause), not real data.`}
+      style={{
+        width: 40,
+        height: 40,
+        borderRadius: "50%",
+        border: "2px dashed #e040fb",
+        background: "rgba(224,64,251,0.07)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        position: "relative",
+        cursor: "help",
+      }}
+    >
+      <Handle type="target" position={Position.Top} style={{ background: "transparent", border: "none", width: 0, height: 0 }} />
+      <Handle type="source" position={Position.Bottom} style={{ background: "transparent", border: "none", width: 0, height: 0 }} />
+      <span style={{ color: "#e040fb", fontSize: 16, fontWeight: 700, lineHeight: 1, opacity: 0.85 }}>?</span>
+      <div
+        style={{
+          position: "absolute",
+          top: -13,
+          left: "50%",
+          transform: "translateX(-50%)",
+          fontSize: 7,
+          letterSpacing: "0.08em",
+          fontFamily: "monospace",
+          color: "#e040fb",
+          background: "rgba(0,0,0,0.65)",
+          padding: "1px 4px",
+          borderRadius: 2,
+          whiteSpace: "nowrap",
+          border: "1px solid rgba(224,64,251,0.45)",
+          pointerEvents: "none",
+        }}
+      >
+        INFERRED
+      </div>
+    </div>
+  );
+}
+
+/**
+ * A member node pulled into the current (filtered) view because an inferred
+ * latent binds it — i.e. cross-domain structure the domain filter was hiding.
+ * Rendered as a small dashed-magenta chip, clearly marked as brought in by the
+ * latent (not a normal node in this view), read-only. Disappears on toggle-off.
+ */
+function LatentMember2D({ data }: NodeProps<{ label: string }>) {
+  return (
+    <div
+      title={`Pulled into view by an inferred latent — this node lives in another domain but shares the hidden common cause.`}
+      style={{
+        padding: "2px 6px",
+        borderRadius: 4,
+        border: "1px dashed rgba(224,64,251,0.7)",
+        background: "rgba(224,64,251,0.06)",
+        color: "#e7b8f5",
+        fontSize: 8,
+        fontFamily: "monospace",
+        whiteSpace: "nowrap",
+        position: "relative",
+        cursor: "help",
+        opacity: 0.92,
+      }}
+    >
+      <Handle type="target" position={Position.Top} style={{ background: "transparent", border: "none", width: 0, height: 0 }} />
+      <Handle type="source" position={Position.Bottom} style={{ background: "transparent", border: "none", width: 0, height: 0 }} />
+      {data.label}
+      <span style={{ marginLeft: 4, fontSize: 6, color: "#e040fb", letterSpacing: "0.05em" }}>via latent</span>
+    </div>
+  );
+}
+
+const nodeTypes = { causal: CausalNode2D, latent: LatentNode2D, latentMember: LatentMember2D };
 
 /**
  * Custom edge component that subscribes to hover/selection state itself
@@ -766,6 +854,11 @@ function CausalDAG2DInner() {
   const activeTimeline = useApexStore((s) => s.activeTimeline);
   const isolateSelection = useApexStore((s) => s.isolateSelection);
   const visibleEdgeTypes = useApexStore((s) => s.visibleEdgeTypes);
+  const showLatentNodes = useApexStore((s) => s.showLatentNodes);
+  // Latents derive from the FULL (unfiltered) store graph, not the filtered
+  // view — confounded clusters are inherently cross-domain, so a single-domain
+  // filter would hide the very structure the feature exists to reveal.
+  const fullGraphForLatent = useApexStore((s) => s.graphData);
   const multiSelectedNodes = useApexStore((s) => s.selectedNodes);
 
   const [selectedEdge, setSelectedEdge] = useState<CausalEdge | null>(null);
@@ -1427,6 +1520,101 @@ function CausalDAG2DInner() {
   // recompute themselves from these. Memoised so context-only consumers
   // (CausalNode2D, EmphasizedEdge) don't re-run their useMemo on parent
   // re-render when the values are equal.
+  // Inferred-latent overlay (Dr. Pita synthetic-node #1). Injected into the
+  // React Flow arrays ONLY when the analyst opts in — the store graph
+  // (graphData) is never mutated, so latent nodes can't enter cascade / ΩF /
+  // system metrics. Glyph sits at the centroid of the members it explains,
+  // with faint dashed tethers to each member.
+  const latentOverlay = useMemo<{ nodes: Node[]; edges: Edge[] }>(() => {
+    if (!showLatentNodes) return { nodes: [], edges: [] };
+    // Derive from the FULL store graph so cross-domain confounded clusters
+    // aren't hidden by the active domain filter (the structure the feature exists
+    // to reveal). Members not in the current view are pulled in as marked chips.
+    const latents = deriveLatentNodes(fullGraphForLatent);
+    if (latents.length === 0) return { nodes: [], edges: [] };
+    const labelOf = new Map(
+      fullGraphForLatent.nodes.map((n) => [n.id, n.shortLabel || n.label || n.id] as const),
+    );
+
+    // Fallback anchor when none of a latent's members are in the current view:
+    // above the centroid of whatever IS on screen.
+    let vcx = 0, vcy = 0, vk = 0;
+    nodePositions.forEach((p) => { vcx += p.x; vcy += p.y; vk++; });
+    const viewCx = vk ? vcx / vk : 0;
+    const viewCy = vk ? vcy / vk : 0;
+
+    const lNodes: Node[] = [];
+    const lEdges: Edge[] = [];
+    const PULL_RADIUS = 110;
+    const tether = (latId: string, targetId: string) =>
+      lEdges.push({
+        id: `${latId}__tether__${targetId}`,
+        source: latId,
+        target: targetId,
+        type: "default",
+        style: { stroke: "#e040fb", strokeDasharray: "3 3", strokeWidth: 1, opacity: 0.45 },
+      });
+
+    latents.forEach((lat, latIdx) => {
+      const visible = lat.explains.filter((m) => nodePositions.has(m));
+      const missing = lat.explains.filter((m) => !nodePositions.has(m));
+
+      // Glyph anchor: centroid of visible members, else offset above the view
+      // centroid (per-latent offset so multiple latents don't stack).
+      let ax: number, ay: number;
+      if (visible.length) {
+        let cx = 0, cy = 0;
+        for (const m of visible) { const p = nodePositions.get(m)!; cx += p.x; cy += p.y; }
+        ax = cx / visible.length; ay = cy / visible.length;
+      } else {
+        ax = viewCx + latIdx * 240;
+        ay = viewCy - 260;
+      }
+
+      lNodes.push({
+        id: lat.id,
+        type: "latent",
+        position: { x: ax, y: ay },
+        data: {
+          label: lat.label,
+          members: lat.explains.map((id) => labelOf.get(id) ?? id).join(", "),
+          strength: lat.strength,
+        },
+        draggable: false,
+        selectable: false,
+      });
+
+      // Visible members: tether to their existing node.
+      for (const m of visible) tether(lat.id, m);
+
+      // Missing (cross-domain) members: pull in as marked chips around the glyph.
+      missing.forEach((m, i) => {
+        const ang = (2 * Math.PI * i) / Math.max(1, missing.length);
+        const mid = `${lat.id}__member__${m}`;
+        lNodes.push({
+          id: mid,
+          type: "latentMember",
+          position: { x: ax + Math.cos(ang) * PULL_RADIUS, y: ay + Math.sin(ang) * PULL_RADIUS },
+          data: { label: labelOf.get(m) ?? m },
+          draggable: false,
+          selectable: false,
+        });
+        tether(lat.id, mid);
+      });
+    });
+
+    return { nodes: lNodes, edges: lEdges };
+  }, [showLatentNodes, fullGraphForLatent, nodePositions]);
+
+  const renderNodes = useMemo(
+    () => (latentOverlay.nodes.length ? visibleNodes.concat(latentOverlay.nodes) : visibleNodes),
+    [visibleNodes, latentOverlay.nodes],
+  );
+  const renderEdges = useMemo(
+    () => (latentOverlay.edges.length ? (visibleEdges as Edge[]).concat(latentOverlay.edges) : (visibleEdges as Edge[])),
+    [visibleEdges, latentOverlay.edges],
+  );
+
   const dag2dContextValue = useMemo<Dag2DContextValue>(
     () => ({
       adjacency,
@@ -1443,8 +1631,8 @@ function CausalDAG2DInner() {
       <DAGOverlay />
       <div ref={flowWrapperRef} className="absolute inset-0">
         <ReactFlow
-          nodes={visibleNodes}
-          edges={visibleEdges}
+          nodes={renderNodes}
+          edges={renderEdges}
           nodeTypes={nodeTypes}
           edgeTypes={edgeTypes}
           onInit={onInit}

--- a/src/components/dag3d/DAGOverlay.tsx
+++ b/src/components/dag3d/DAGOverlay.tsx
@@ -336,6 +336,8 @@ export default function DAGOverlay() {
   const setViewMode = useApexStore((s) => s.setViewMode);
   const visibleEdgeTypes = useApexStore((s) => s.visibleEdgeTypes);
   const toggleEdgeTypeVisibility = useApexStore((s) => s.toggleEdgeTypeVisibility);
+  const showLatentNodes = useApexStore((s) => s.showLatentNodes);
+  const setShowLatentNodes = useApexStore((s) => s.setShowLatentNodes);
   const nodeSizeMetric = useApexStore((s) => s.nodeSizeMetric);
   const setNodeSizeMetric = useApexStore((s) => s.setNodeSizeMetric);
   const truthFilter = useApexStore((s) => s.truthFilter);
@@ -545,6 +547,29 @@ export default function DAGOverlay() {
               );
             })}
           </div>
+        )}
+
+        {/* Inferred-latent overlay toggle (Dr. Pita synthetic-node #1).
+            Opt-in, default OFF. 2D only for now (3D render is a fast-follow).
+            Surfaces hidden common causes the model posits from confounded
+            structure — read-only, never enters cascade/ΩF/metrics. */}
+        {viewMode === "2d" && (
+          <button
+            onClick={() => setShowLatentNodes(!showLatentNodes)}
+            className="px-1.5 py-1 text-[8px] font-[family-name:var(--font-michroma)] tracking-wider rounded border border-border transition-colors"
+            style={{
+              backgroundColor: showLatentNodes ? "#e040fb15" : "transparent",
+              color: showLatentNodes ? "#e040fb" : "var(--text-muted)",
+              opacity: showLatentNodes ? 1 : 0.6,
+            }}
+            title={
+              showLatentNodes
+                ? "Hide inferred latent nodes"
+                : "Show inferred latent nodes — hidden common causes the model posits from confounded structure (read-only, not real data)"
+            }
+          >
+            ◌ LATENT
+          </button>
         )}
         {/* Encoding legend — visible in 3D and 2D where the visual
             primitive is a sized, coloured node with edges. MAP and TOPO

--- a/src/lib/__tests__/latent-nodes.test.ts
+++ b/src/lib/__tests__/latent-nodes.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import { deriveLatentNodes, MIN_LATENT_MEMBERS } from "@/lib/latent-nodes";
+import type { CausalGraph, CausalNode, CausalEdge, EdgeType } from "@/lib/types";
+
+function node(id: string): CausalNode {
+  return { id, shortLabel: id, label: id } as unknown as CausalNode;
+}
+
+function edge(
+  source: string,
+  target: string,
+  opts: Partial<CausalEdge> = {},
+): CausalEdge {
+  return {
+    id: `${source}__${target}`,
+    source,
+    target,
+    weight: 0.5,
+    lag: 1,
+    type: "confounded" as EdgeType,
+    confidence: 0.6,
+    isInconsistent: false,
+    physicalMechanism: "",
+    ...opts,
+  } as CausalEdge;
+}
+
+function graph(nodes: CausalNode[], edges: CausalEdge[]): CausalGraph {
+  return { nodes, edges, metadata: {} } as unknown as CausalGraph;
+}
+
+describe("deriveLatentNodes", () => {
+  it("returns nothing when there are no confounded edges", () => {
+    const g = graph(
+      [node("A"), node("B")],
+      [edge("A", "B", { type: "directed" as EdgeType })],
+    );
+    expect(deriveLatentNodes(g)).toEqual([]);
+  });
+
+  it("promotes a 3-node confounded cluster to one latent node (node-over-edge rule)", () => {
+    const g = graph(
+      [node("A"), node("B"), node("C")],
+      [
+        edge("A", "B", { confidence: 0.6 }),
+        edge("B", "C", { confidence: 0.8 }),
+        edge("A", "C", { confidence: 0.7 }),
+      ],
+    );
+    const latents = deriveLatentNodes(g);
+    expect(latents).toHaveLength(1);
+    expect(latents[0].explains.sort()).toEqual(["A", "B", "C"]);
+    expect(latents[0].method).toBe("confounded-cluster");
+    // strength = mean confidence of internal confounded edges = (0.6+0.8+0.7)/3
+    expect(latents[0].strength).toBe(0.7);
+    expect(latents[0].label).toContain("Inferred common cause");
+  });
+
+  it("does NOT promote a pairwise (2-node) confounded relationship — stays an edge", () => {
+    const g = graph([node("A"), node("B")], [edge("A", "B")]);
+    expect(deriveLatentNodes(g)).toEqual([]);
+    expect(MIN_LATENT_MEMBERS).toBe(3);
+  });
+
+  it("separates disjoint clusters into distinct latent nodes", () => {
+    const g = graph(
+      ["A", "B", "C", "D", "E", "F"].map(node),
+      [
+        edge("A", "B"), edge("B", "C"), edge("A", "C"),
+        edge("D", "E"), edge("E", "F"), edge("D", "F"),
+      ],
+    );
+    const latents = deriveLatentNodes(g);
+    expect(latents).toHaveLength(2);
+    const sets = latents.map((l) => l.explains.sort().join(","));
+    expect(sets).toContain("A,B,C");
+    expect(sets).toContain("D,E,F");
+  });
+
+  it("ignores severed confounded edges", () => {
+    // A-B-C triangle but A-C severed → A,B,C still connected via A-B-C path? No:
+    // A-B and B-C remain → component {A,B,C} of size 3 still promotes.
+    const g = graph(
+      ["A", "B", "C"].map(node),
+      [edge("A", "B"), edge("B", "C"), edge("A", "C", { isSevered: true })],
+    );
+    expect(deriveLatentNodes(g)).toHaveLength(1);
+
+    // Now sever B-C too → only A-B remains → pair → no latent.
+    const g2 = graph(
+      ["A", "B", "C"].map(node),
+      [edge("A", "B"), edge("B", "C", { isSevered: true }), edge("A", "C", { isSevered: true })],
+    );
+    expect(deriveLatentNodes(g2)).toEqual([]);
+  });
+});
+
+describe("safety guarantee — latent nodes never enter the real graph", () => {
+  const g = graph(
+    ["A", "B", "C"].map(node),
+    [edge("A", "B"), edge("B", "C"), edge("A", "C")],
+  );
+
+  it("does not mutate the input graph", () => {
+    const nodesBefore = g.nodes.length;
+    const edgesBefore = g.edges.length;
+    deriveLatentNodes(g);
+    expect(g.nodes.length).toBe(nodesBefore);
+    expect(g.edges.length).toBe(edgesBefore);
+  });
+
+  it("latent ids are namespaced and never collide with real node ids", () => {
+    const latents = deriveLatentNodes(g);
+    const realIds = new Set(g.nodes.map((n) => n.id));
+    for (const l of latents) {
+      expect(l.id.startsWith("latent__")).toBe(true);
+      expect(realIds.has(l.id)).toBe(false);
+    }
+  });
+});

--- a/src/lib/latent-nodes.ts
+++ b/src/lib/latent-nodes.ts
@@ -1,0 +1,107 @@
+// Inferred latent-node derivation — Dr. Pita's "synthetic node" #1.
+//
+// A `confounded` edge asserts that its two endpoints share an *unobserved*
+// common cause (latent confounder; the FCI bidirected ↔ made concrete). When
+// several confounded edges share endpoints, the honest reading is that one
+// hidden factor drives the whole cluster. This module surfaces that factor as
+// an INFERRED LATENT node so the analyst can see "you're missing a measurement
+// here" rather than having to read it off a tangle of dashed edges.
+//
+// Design guarantees (see LatentNode in types.ts):
+//   - PURE + ON-DEMAND. Latent nodes are computed from the graph, never stored
+//     on it, so they cannot enter cascade sim, ΩF, or the ΩSF/ΩSX/contagion
+//     system metrics. Read-only annotation only.
+//   - NODE-OVER-EDGE RULE. A cluster is promoted to a latent node only when it
+//     is the common cause of MIN_LATENT_MEMBERS (3) or more observed nodes; a
+//     pairwise hidden cause stays the dashed edge it already is.
+//   - HYPOTHESIS FRAMING. The label never asserts what the latent *is* — it's a
+//     prompt for investigation, disclosed as inferred at the render layer.
+
+import type { CausalGraph, LatentNode } from "./types";
+
+/** Minimum observed nodes a latent must explain to earn promotion from an edge. */
+export const MIN_LATENT_MEMBERS = 3;
+
+export function deriveLatentNodes(graph: CausalGraph): LatentNode[] {
+  // Each confounded (non-severed) edge = "these two observed nodes share a
+  // latent common cause."
+  const confounded = graph.edges.filter(
+    (e) => e.type === "confounded" && !e.isSevered,
+  );
+  if (confounded.length === 0) return [];
+
+  // Undirected adjacency over the confounded endpoints.
+  const adj = new Map<string, Set<string>>();
+  const link = (a: string, b: string) => {
+    (adj.get(a) ?? adj.set(a, new Set()).get(a)!).add(b);
+  };
+  for (const e of confounded) {
+    link(e.source, e.target);
+    link(e.target, e.source);
+  }
+
+  // Connected components (BFS) — each is one candidate hidden factor.
+  const seen = new Set<string>();
+  const components: string[][] = [];
+  for (const start of adj.keys()) {
+    if (seen.has(start)) continue;
+    const comp: string[] = [];
+    const queue = [start];
+    seen.add(start);
+    while (queue.length) {
+      const v = queue.shift()!;
+      comp.push(v);
+      for (const w of adj.get(v) ?? []) {
+        if (!seen.has(w)) {
+          seen.add(w);
+          queue.push(w);
+        }
+      }
+    }
+    components.push(comp);
+  }
+
+  const shortLabelOf = new Map(
+    graph.nodes.map((n) => [n.id, n.shortLabel || n.label || n.id]),
+  );
+
+  const latents: LatentNode[] = [];
+  for (const comp of components) {
+    if (comp.length < MIN_LATENT_MEMBERS) continue; // node-over-edge rule
+
+    const members = [...comp].sort();
+    const memberSet = new Set(members);
+    const internal = confounded.filter(
+      (e) => memberSet.has(e.source) && memberSet.has(e.target),
+    );
+    const strength =
+      internal.length > 0
+        ? Math.round(
+            (internal.reduce((s, e) => s + e.confidence, 0) / internal.length) *
+              100,
+          ) / 100
+        : 0;
+
+    // Hub = the most-confounded member; used only to make the hypothesis
+    // label legible ("...behind <hub> + N more"), not as an assertion.
+    let hub = members[0];
+    let hubDeg = -1;
+    for (const m of members) {
+      const deg = adj.get(m)?.size ?? 0;
+      if (deg > hubDeg) {
+        hubDeg = deg;
+        hub = m;
+      }
+    }
+
+    latents.push({
+      id: `latent__${members[0]}`,
+      explains: members,
+      method: "confounded-cluster",
+      strength,
+      label: `Inferred common cause of ${shortLabelOf.get(hub) ?? hub} + ${members.length - 1} more`,
+    });
+  }
+
+  return latents;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -381,6 +381,40 @@ export interface CausalGraph {
   metadata: GraphMetadata;
 }
 
+/**
+ * An INFERRED LATENT node — a hidden common cause the model posits to
+ * explain dependencies among observed nodes that no observed node accounts
+ * for (Dr. Pita's "synthetic node" #1: missing from the MAP, not the
+ * territory). Derived on demand from the `confounded`/FCI latent-common-
+ * cause signal (see `deriveLatentNodes`); it is DELIBERATELY:
+ *
+ *   - NOT a `CausalNode` — it has no measured ΩF, category, or metadata,
+ *     because we don't observe it. Forcing it into the node shape would
+ *     invite the UI to render fake fragility scores for a thing we can't see.
+ *   - NOT stored on `CausalGraph.nodes` — it is computed when the analyst
+ *     opts in, so it can never leak into cascade simulation, ΩF, or the
+ *     system metrics (ΩSF/ΩSX/contagion). Read-only annotation only.
+ *
+ * It earns promotion from the dashed `confounded` edge ONLY when it is the
+ * common cause of 3+ observed nodes (a pairwise hidden cause stays an edge).
+ * Always framed as a hypothesis, never asserted as real (honours the
+ * "nothing synthetic under a real-data label" directive via a persistent
+ * INFERRED badge + provenance tooltip at the render layer).
+ */
+export interface LatentNode {
+  id: string;
+  /** Observed node ids this inferred latent is the common cause of (≥3). */
+  explains: string[];
+  /** How it was inferred. */
+  method: "confounded-cluster" | "fci";
+  /** Inference strength 0-1 (e.g. mean confidence of the source signals). */
+  strength: number;
+  /** Hypothesis-framed label — never an assertion of what the latent IS. */
+  label: string;
+  /** Render position (centroid of explained nodes); set by the render layer. */
+  position3d?: { x: number; y: number; z: number };
+}
+
 // ─── Copilot ─────────────────────────────────────────────────────
 export type CopilotRole = "system" | "user" | "assistant";
 

--- a/src/stores/useApexStore.ts
+++ b/src/stores/useApexStore.ts
@@ -413,6 +413,12 @@ export interface ApexState {
   setAblationMode: (on: boolean) => void;
   toggleAblatedNode: (nodeId: string) => void;
   toggleAblatedEdge: (edgeId: string) => void;
+
+  // Inferred latent nodes (Dr. Pita synthetic-node #1) — opt-in, default OFF.
+  // Read-only overlay derived on demand via deriveLatentNodes; never stored
+  // on the graph, never enters cascade / ΩF / system metrics.
+  showLatentNodes: boolean;
+  setShowLatentNodes: (on: boolean) => void;
   resetAblation: () => void;
   startAblationReplay: () => void;
 
@@ -1233,6 +1239,10 @@ export const useApexStore = create<ApexState>((set, get) => ({
     ...(on ? { scissorsMode: false } : {}),
     ...(!on ? { ablatedNodeIds: [], ablatedEdgeIds: [] } : {}),
   })),
+
+  // Inferred latent-node overlay toggle (opt-in, default OFF).
+  showLatentNodes: false,
+  setShowLatentNodes: (on) => set({ showLatentNodes: on }),
   toggleAblatedNode: (nodeId) =>
     set((s) => {
       const removing = s.ablatedNodeIds.includes(nodeId);


### PR DESCRIPTION
## Inferred latent nodes — reveal hidden cross-domain common causes (2D)

Dr. Pita's "synthetic node" #1: materialize the **latent common cause** that confounded-edge / FCI structure implies but no observed node accounts for. The graph stops being only what you authored and starts *positing* the hidden driver.

### What it does
- **`LatentNode` type** — thin, **not** a `CausalNode`, **never** on `CausalGraph` (no fake ΩF/metadata; derived on demand so it can't enter cascade / ΩF / system metrics).
- **`deriveLatentNodes`** — connected-component clustering over `confounded` edges; promotes a cluster to one latent only at **≥3 members** (pairwise stays a dashed edge).
- **`◌ LATENT` toggle** (opt-in, default OFF) in the DAGOverlay strip.
- **2D render** — magenta dashed ghost glyph (no fill, no score, `?` + persistent **INFERRED** badge + provenance tooltip). The toggle is a **"reveal hidden cross-domain drivers" lens**: it derives from the **full** graph and pulls each latent's missing cross-domain members into view as marked "via latent" chips with dashed tethers — so structure the domain filter hides becomes visible from any view. Toggle-off restores.

### Safety
Read-only overlay only — latents + pulled-in members never touch `graph.nodes`, cascade, or ΩF/ΩSF/ΩSX. A guard test pins this.

### Verification
- `tsc` clean; 7 unit/guard tests.
- **GUI-verified** from the Energy Systems view (which doesn't contain the cluster): toggling on rendered 2 inferred glyphs + 7 pulled-in member chips (Hormuz + 3 fertilizer markets, + a frontier-science cluster) + 7 magenta dashed tethers; toggle-off cleared everything.

3D port is a fast-follow (toggle is 2D-only for now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
