### PR TITLE
fix(omega): honest provenance for AI-Safety ΩF weighting (Ghauri 2025)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# Local-only: private dissertation extract (Junaid's ETD master) — do NOT commit
+/dissertation/
+
 # dependencies
 /node_modules
 /.pnp

--- a/src/lib/__tests__/omega-weighting.test.ts
+++ b/src/lib/__tests__/omega-weighting.test.ts
@@ -110,6 +110,21 @@ describe("profile weight integrity", () => {
     // cascade + tail dominate
     expect(AI_SAFETY_PROFILE.weights.cascadeLoad + AI_SAFETY_PROFILE.weights.tailDepth).toBeCloseTo(0.6, 10);
   });
+
+  it("AI-Safety honors the dissertation-sourced rank-order C ≈ T > R > I ≈ J", () => {
+    // Per Ghauri (2025): cascade-bridge attention predicts endogenous failure
+    // far more strongly than generic connectivity (ρ(FR,BES) ≈ 0.76 vs
+    // ρ(FR,HES) ≈ 0.25, Ch 8 Table 8.1), and CVaR under distributional
+    // ambiguity is the governing tail metric (Ch 3). That evidence sources the
+    // ORDER, not the magnitudes — so this guard asserts the ranking (C, T are
+    // the two largest; R exceeds I and J), which is the part the dissertation
+    // actually justifies.
+    const w = AI_SAFETY_PROFILE.weights;
+    expect(Math.min(w.cascadeLoad, w.tailDepth)).toBeGreaterThan(w.restorationLatency);
+    expect(w.restorationLatency).toBeGreaterThanOrEqual(w.irreplaceability);
+    expect(w.restorationLatency).toBeGreaterThanOrEqual(w.jurisdictionalHazard);
+    expect(w.cascadeLoad + w.tailDepth).toBeGreaterThan(0.5);
+  });
 });
 
 describe("recomputeComposite", () => {

--- a/src/lib/domain-profiles.ts
+++ b/src/lib/domain-profiles.ts
@@ -73,7 +73,8 @@ export interface DomainProfile {
    * (`formatWeights`) read from here, so the displayed numbers can never
    * drift from the math again. Default domains carry
    * `DEFAULT_OMEGA_WEIGHTS`; domains with a deliberate skew (AI-Safety
-   * → cascade + tail, per Ghauri 2025) override it.
+   * → cascade + tail — direction sourced from Ghauri 2025, magnitudes by
+   * design) override it.
    */
   weights: OmegaPillarWeights;
   /**
@@ -439,11 +440,20 @@ const AI_SAFETY_PILLAR_DETAILS: Record<PillarKey, PillarDetail> = {
   },
 };
 
-// AI-Safety skews toward Cascade + Tail — endogenous failure (catastrophic
-// forgetting, χ⋆-bridge cascade, adversarial drift) is dominated by those
-// two pillars per Ghauri (2025). It has no nodes of its own (the
-// `ai-safety-ids` card overlays the `main` graph), so the borrowed authored
-// composites reflect the GEOPOLITICAL weighting; `compositeMode:
+// AI-Safety deliberately diverges from the platform default that Geopolitical
+// and T1D keep (their authored composites were tuned against the default, so
+// staying there preserves cross-domain comparability). The skew toward Cascade
+// (C) and Tail (T) is sourced IN DIRECTION from Ghauri (2025): cascade-bridge
+// attention predicts endogenous failure far more strongly than generic
+// connectivity (ρ(FR,BES) ≈ 0.76 vs ρ(FR,HES) ≈ 0.25, Ch 8 Table 8.1; the χ⋆
+// bridge set drives ~80% of attainable CVaR reduction, Ch 7), and CVaR under
+// Wasserstein-1 ambiguity is the framework's governing tail metric (Ch 3).
+// That evidence fixes the RANK-ORDER (C ≈ T > R > I ≈ J) — NOT the magnitudes:
+// the values below are a deliberate domain design choice, not an empirical
+// calibration (the dissertation calibrates per-pillar estimators — CVaR→T,
+// χ⋆→C, FR→R — not a five-pillar mixture). AI-Safety has no nodes of its own
+// (the `ai-safety-ids` card overlays the `main` graph), so the borrowed
+// authored composites reflect the GEOPOLITICAL weighting; `compositeMode:
 // "recomputed"` re-derives them under this skew at graph-build time.
 const AI_SAFETY_WEIGHTS: OmegaPillarWeights = {
   irreplaceability: 0.10,
@@ -454,7 +464,7 @@ const AI_SAFETY_WEIGHTS: OmegaPillarWeights = {
 };
 
 const AI_SAFETY_METHODOLOGY =
-  `The ENDOGENOUS FRAGILITY composite aggregates five orthogonal AI-system risk pillars, each scored 0–10: mechanism rarity, forgetting latency, threat-model exposure, cascade susceptibility, adversarial tail depth. AI-domain weights skew toward cascade and tail — the dominant endogenous failure modes per Ghauri (2025): ${formatWeights(AI_SAFETY_WEIGHTS)}. Scores above 7.0 flag mechanisms worth structural hardening (χ⋆-edge intervention, topology-aware replay); above 9.0 indicates architectural Achilles' heels where compromise cascades across reasoning, memory, and decision subsystems.`;
+  `The ENDOGENOUS FRAGILITY composite aggregates five orthogonal AI-system risk pillars, each scored 0–10: mechanism rarity, forgetting latency, threat-model exposure, cascade susceptibility, adversarial tail depth. The weighting skews toward cascade (C) and tail (T): ${formatWeights(AI_SAFETY_WEIGHTS)}. This rank-order follows Ghauri (2025) — cascade-bridge attention predicts endogenous failure far more strongly than generic connectivity (ρ ≈ 0.76 vs ≈ 0.25), and CVaR under distributional ambiguity is the governing tail metric — while the specific magnitudes are a domain design choice rather than an empirical calibration. Scores above 7.0 flag mechanisms worth structural hardening (χ⋆-edge intervention, topology-aware replay); above 9.0 indicates architectural Achilles' heels where compromise cascades across reasoning, memory, and decision subsystems.`;
 
 export const AI_SAFETY_PROFILE: DomainProfile = {
   id: "ai-safety",


### PR DESCRIPTION
## What & why

The AI-Safety `DomainProfile` shipped `weights = {I .10 / R .20 / J .10 / C .30 / T .30}` with methodology prose asserting the cascade/tail skew was *"the dominant endogenous failure modes **per Ghauri (2025)**"* — language that implies an **empirical calibration that does not exist**. This was flagged in an adviser-council deliberation: per-profile weights are the right architecture, but only with calibrated, dissertation-sourced numbers and comparability preserved as an explicit choice.

I read the dissertation directly (*Modeling Endogenous Catastrophes in Hierarchical Networks*, Ghauri 2025, JHU D.Eng. — Ch 3 framework, Ch 4 forgetting theory, Ch 7 benchmarking, Ch 8 results, References + all Appendices) to find the calibration. **It isn't there, and structurally can't be:** the dissertation calibrates per-pillar *estimators* (CVaR→T, χ⋆→C, FR→R) and a *lexicographic-CVaR ordering* — not a five-pillar linear mixture. The I/R/J/C/T composite is the Manifold composite-layer construct (Jeremy's "Omega Metrics v1"), layered on top of the dissertation's math. So "calibrated weights from the dissertation" is a category error.

## What the dissertation *does* source: the rank-order

The skew **direction** is genuinely Ghauri-sourced, even though the magnitudes are not:

- **ρ(FR, BES) ≈ 0.76 vs ρ(FR, HES) ≈ 0.25** (Ch 8, Table 8.1) — cascade-bridge attention predicts endogenous failure ~3× more strongly than generic connectivity ⇒ **C** dominant.
- **χ⋆ (top-5% bridges) drives ~80%** of attainable CVaR reduction (Ch 7) ⇒ cascade is the structural lever.
- **CVaR under Wasserstein-1 ambiguity** is the framework's governing tail metric (Ch 3) ⇒ **T** co-dominant.
- **I** (mechanism rarity) and **J** (threat-model exposure) have no endogenous-failure analog ⇒ smallest.

That sources the **order** `C ≈ T > R > I ≈ J` — which the shipped vector already satisfies.

## The change (Option B: keep the vector, fix the claim)

The actual defect was never the numbers (they're directionally right, and AI-Safety is an overlay/demo profile with no nodes of its own, so magnitude precision barely matters) — it was the false calibration claim in a product that sells auditable rigor. So:

- **Vector unchanged** (`{I .10 / R .20 / J .10 / C .30 / T .30}`).
- **`AI_SAFETY_METHODOLOGY`** now cites Ghauri (2025) for **direction/rank-order only**, cites the specific evidence (ρ ≈ 0.76 vs ≈ 0.25; CVaR as tail metric), and states the magnitudes are a **deliberate domain design choice, not an empirical calibration**.
- **`AI_SAFETY_WEIGHTS` comment** rewritten with the same honest provenance + the per-pillar estimator mapping, and an explicit note that Geopolitical/T1D keep the shared default for cross-domain comparability while AI-Safety deliberately diverges.
- **New test** asserts the dissertation-sourced **rank-order** (C, T largest; R > I, J) — the part that's actually justified — alongside the existing exact-magnitude pins.

## Why not the alternatives

- **A (encode a dissertation table):** impossible — no such table exists.
- **C (revert to default):** discards the dissertation's central AI finding (cascade/tail dominance) to avoid the mere *appearance* of a design choice — over-correction.
- **D (derive magnitudes from ρ ratios):** mapping correlation coefficients to composite weights is itself an arbitrary modeling leap — re-commits the same sin one level up.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` on touched files — clean
- `npx vitest run` — **144 files, 1764 tests, all green**

🤖 Generated with [Claude Code](https://claude.com/claude-code)