### PR TITLE
feat(graph): ground latent nodes in real data — identify + consistency check

### DIFF
--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -487,47 +487,112 @@ interface LatentNode2DData {
   label: string;
   members: string;
   strength: number;
+  /** Author-stated channel (verbatim physicalMechanism), not a named variable. */
+  driver?: string;
+  /** Real-data consistency check on the shared-driver hypothesis. */
+  support?: {
+    status: "supported" | "inconsistent" | "insufficient";
+    statistic?: number;
+    liveMembers: number;
+  };
 }
 function LatentNode2D({ data }: NodeProps<LatentNode2DData>) {
+  const sup = data.support;
+  const supColor =
+    sup?.status === "supported" ? "#00e676"
+      : sup?.status === "inconsistent" ? "#ff1744"
+        : "#9aa0a6";
+  const supText =
+    !sup ? null
+      : sup.status === "supported" ? `DATA ✓ r=${sup.statistic ?? "?"}`
+        : sup.status === "inconsistent" ? `DATA ✗ r=${sup.statistic ?? "?"}`
+          : "NO LIVE DATA";
+  const tooltip =
+    `INFERRED LATENT — not observed.\n` +
+    `${data.label}\n` +
+    (data.driver ? `Hypothesised channel: ${data.driver}\n` : "") +
+    `Members: ${data.members}\n` +
+    `Data check: ${supText ?? "n/a"}` +
+    (sup ? ` (${sup.liveMembers} live member${sup.liveMembers === 1 ? "" : "s"})` : "") +
+    `\nA hypothesis from authored confounded structure, checked against live data where available — not an empirical discovery.`;
   return (
-    <div
-      title={`INFERRED LATENT — not observed.\n${data.label}\nMembers: ${data.members}\nInference strength: ${data.strength}\nDerived from confounded structure (FCI-style latent common cause), not real data.`}
-      style={{
-        width: 40,
-        height: 40,
-        borderRadius: "50%",
-        border: "2px dashed #e040fb",
-        background: "rgba(224,64,251,0.07)",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        position: "relative",
-        cursor: "help",
-      }}
-    >
-      <Handle type="target" position={Position.Top} style={{ background: "transparent", border: "none", width: 0, height: 0 }} />
-      <Handle type="source" position={Position.Bottom} style={{ background: "transparent", border: "none", width: 0, height: 0 }} />
-      <span style={{ color: "#e040fb", fontSize: 16, fontWeight: 700, lineHeight: 1, opacity: 0.85 }}>?</span>
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", cursor: "help" }} title={tooltip}>
       <div
         style={{
-          position: "absolute",
-          top: -13,
-          left: "50%",
-          transform: "translateX(-50%)",
-          fontSize: 7,
-          letterSpacing: "0.08em",
-          fontFamily: "monospace",
-          color: "#e040fb",
-          background: "rgba(0,0,0,0.65)",
-          padding: "1px 4px",
-          borderRadius: 2,
-          whiteSpace: "nowrap",
-          border: "1px solid rgba(224,64,251,0.45)",
-          pointerEvents: "none",
+          width: 40,
+          height: 40,
+          borderRadius: "50%",
+          border: "2px dashed #e040fb",
+          background: "rgba(224,64,251,0.07)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          position: "relative",
         }}
       >
-        INFERRED
+        <Handle type="target" position={Position.Top} style={{ background: "transparent", border: "none", width: 0, height: 0 }} />
+        <Handle type="source" position={Position.Bottom} style={{ background: "transparent", border: "none", width: 0, height: 0 }} />
+        <span style={{ color: "#e040fb", fontSize: 16, fontWeight: 700, lineHeight: 1, opacity: 0.85 }}>?</span>
+        <div
+          style={{
+            position: "absolute",
+            top: -13,
+            left: "50%",
+            transform: "translateX(-50%)",
+            fontSize: 7,
+            letterSpacing: "0.08em",
+            fontFamily: "monospace",
+            color: "#e040fb",
+            background: "rgba(0,0,0,0.65)",
+            padding: "1px 4px",
+            borderRadius: 2,
+            whiteSpace: "nowrap",
+            border: "1px solid rgba(224,64,251,0.45)",
+            pointerEvents: "none",
+          }}
+        >
+          INFERRED
+        </div>
       </div>
+      {data.driver && (
+        <div
+          style={{
+            marginTop: 3,
+            maxWidth: 124,
+            fontSize: 7,
+            fontFamily: "monospace",
+            color: "#e7b8f5",
+            textAlign: "center",
+            lineHeight: 1.15,
+            overflow: "hidden",
+            display: "-webkit-box",
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: "vertical",
+            pointerEvents: "none",
+          }}
+        >
+          {data.driver}
+        </div>
+      )}
+      {supText && (
+        <div
+          style={{
+            marginTop: 2,
+            fontSize: 7,
+            fontFamily: "monospace",
+            fontWeight: 700,
+            color: supColor,
+            border: `1px solid ${supColor}55`,
+            background: `${supColor}14`,
+            borderRadius: 2,
+            padding: "0 3px",
+            whiteSpace: "nowrap",
+            pointerEvents: "none",
+          }}
+        >
+          {supText}
+        </div>
+      )}
     </div>
   );
 }
@@ -1579,6 +1644,8 @@ function CausalDAG2DInner() {
           label: lat.label,
           members: lat.explains.map((id) => labelOf.get(id) ?? id).join(", "),
           strength: lat.strength,
+          driver: lat.hypothesizedDriver,
+          support: lat.dataSupport,
         },
         draggable: false,
         selectable: false,

--- a/src/lib/__tests__/latent-nodes-support.test.ts
+++ b/src/lib/__tests__/latent-nodes-support.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveLatentNodes,
+  computeLatentSupport,
+  SUPPORT_MIN_ALIGNED,
+} from "@/lib/latent-nodes";
+import type {
+  CausalGraph,
+  CausalNode,
+  CausalEdge,
+  EdgeType,
+  LiveDataPoint,
+} from "@/lib/types";
+
+/** Build a daily live series (history + current point) starting at `start`. */
+function series(values: number[], start = "2026-01-01"): LiveDataPoint {
+  const base = new Date(`${start}T00:00:00Z`);
+  const at = (i: number) => {
+    const d = new Date(base);
+    d.setUTCDate(base.getUTCDate() + i);
+    return d.toISOString();
+  };
+  const history = values.slice(0, -1).map((v, i) => ({ value: v, observedAt: at(i) }));
+  return {
+    kind: "indicator",
+    value: values[values.length - 1],
+    capacity: 100,
+    unit: "x",
+    observedAt: at(values.length - 1),
+    source: "test",
+    history,
+  };
+}
+
+function node(id: string, liveData?: LiveDataPoint[]): CausalNode {
+  return { id, shortLabel: id, label: id, liveData } as unknown as CausalNode;
+}
+
+function confEdge(
+  source: string,
+  target: string,
+  physicalMechanism: string,
+  confidence: number,
+): CausalEdge {
+  return {
+    id: `${source}__${target}`,
+    source,
+    target,
+    weight: 0.5,
+    lag: 1,
+    type: "confounded" as EdgeType,
+    confidence,
+    isInconsistent: false,
+    physicalMechanism,
+  } as CausalEdge;
+}
+
+function graph(nodes: CausalNode[], edges: CausalEdge[]): CausalGraph {
+  return { nodes, edges, metadata: {} } as unknown as CausalGraph;
+}
+
+const N = SUPPORT_MIN_ALIGNED + 4; // comfortably above the alignment floor
+const rising = Array.from({ length: N }, (_, i) => i + 1);
+const falling = Array.from({ length: N }, (_, i) => N - i);
+
+describe("computeLatentSupport (real-data consistency check)", () => {
+  it("'supported' when live members co-move (positive correlation)", () => {
+    const g = graph(
+      [node("A", [series(rising)]), node("B", [series(rising)]), node("C")],
+      [],
+    );
+    const s = computeLatentSupport(["A", "B", "C"], g);
+    expect(s.status).toBe("supported");
+    expect(s.statistic).toBeGreaterThanOrEqual(0.4);
+    expect(s.liveMembers).toBe(2);
+    expect(s.method).toBe("pairwise-correlation");
+  });
+
+  it("'inconsistent' when live members do NOT co-move (anti-correlated)", () => {
+    const g = graph([node("A", [series(rising)]), node("B", [series(falling)])], []);
+    const s = computeLatentSupport(["A", "B"], g);
+    expect(s.status).toBe("inconsistent");
+    expect(s.statistic).toBeLessThan(0.4);
+    expect(s.liveMembers).toBe(2);
+  });
+
+  it("'insufficient' when fewer than 2 members carry live series", () => {
+    const g = graph([node("A", [series(rising)]), node("B"), node("C")], []);
+    const s = computeLatentSupport(["A", "B", "C"], g);
+    expect(s.status).toBe("insufficient");
+    expect(s.liveMembers).toBe(1);
+  });
+
+  it("'insufficient' when members have series but too few ALIGNED points", () => {
+    // Non-overlapping date ranges → zero aligned points → insufficient.
+    const g = graph(
+      [
+        node("A", [series(rising, "2026-01-01")]),
+        node("B", [series(rising, "2030-01-01")]),
+      ],
+      [],
+    );
+    const s = computeLatentSupport(["A", "B"], g);
+    expect(s.status).toBe("insufficient");
+  });
+
+  it("'insufficient' for short series below the alignment floor", () => {
+    const short = [1, 2, 3]; // 3 points < SUPPORT_MIN_ALIGNED
+    const g = graph([node("A", [series(short)]), node("B", [series(short)])], []);
+    expect(computeLatentSupport(["A", "B"], g).status).toBe("insufficient");
+  });
+});
+
+describe("deriveLatentNodes — hypothesizedDriver + dataSupport wiring", () => {
+  it("surfaces the strongest internal confounded edge's mechanism as the driver", () => {
+    const g = graph(
+      [node("A"), node("B"), node("C")],
+      [
+        confEdge("A", "B", "weak channel", 0.6),
+        confEdge("B", "C", "STRONGEST channel", 0.9),
+        confEdge("A", "C", "mid channel", 0.7),
+      ],
+    );
+    const [lat] = deriveLatentNodes(g);
+    expect(lat.hypothesizedDriver).toBe("STRONGEST channel");
+    // no live data on these nodes → support is insufficient, but present
+    expect(lat.dataSupport?.status).toBe("insufficient");
+  });
+
+  it("derived latent carries 'supported' when its members co-move on live data", () => {
+    const g = graph(
+      [
+        node("A", [series(rising)]),
+        node("B", [series(rising)]),
+        node("C", [series(rising)]),
+      ],
+      [
+        confEdge("A", "B", "shared driver", 0.7),
+        confEdge("B", "C", "shared driver", 0.7),
+        confEdge("A", "C", "shared driver", 0.7),
+      ],
+    );
+    const [lat] = deriveLatentNodes(g);
+    expect(lat.dataSupport?.status).toBe("supported");
+    expect(lat.dataSupport?.liveMembers).toBe(3);
+  });
+});

--- a/src/lib/latent-nodes.ts
+++ b/src/lib/latent-nodes.ts
@@ -17,10 +17,101 @@
 //   - HYPOTHESIS FRAMING. The label never asserts what the latent *is* — it's a
 //     prompt for investigation, disclosed as inferred at the render layer.
 
-import type { CausalGraph, LatentNode } from "./types";
+import type { CausalGraph, CausalNode, LatentNode } from "./types";
 
 /** Minimum observed nodes a latent must explain to earn promotion from an edge. */
 export const MIN_LATENT_MEMBERS = 3;
+
+/** Min aligned observations between two members to compute a correlation. */
+export const SUPPORT_MIN_ALIGNED = 8;
+/** |mean pairwise r| at/above which the live data is judged to SUPPORT the
+ *  shared-driver hypothesis. (Adjustable.) */
+export const SUPPORT_R_THRESHOLD = 0.4;
+
+/**
+ * Date→value series for a node from its primary live signal (history +
+ * current point), keyed by ISO date (yyyy-mm-dd) for cross-member alignment.
+ * Returns null if the node carries no usable live history. Pure.
+ */
+function liveSeries(node: CausalNode): Map<string, number> | null {
+  const p = (node.liveData ?? []).find(
+    (d) => typeof d.value === "number" && (d.history?.length ?? 0) > 0,
+  );
+  if (!p) return null;
+  const series = new Map<string, number>();
+  for (const h of p.history ?? []) {
+    if (typeof h.value === "number" && h.observedAt) {
+      series.set(h.observedAt.slice(0, 10), h.value);
+    }
+  }
+  if (p.observedAt) series.set(p.observedAt.slice(0, 10), p.value);
+  return series.size > 0 ? series : null;
+}
+
+/** Pearson correlation over paired samples; null if degenerate. */
+function pearson(xs: number[], ys: number[]): number | null {
+  const n = xs.length;
+  if (n < 2) return null;
+  const mx = xs.reduce((a, b) => a + b, 0) / n;
+  const my = ys.reduce((a, b) => a + b, 0) / n;
+  let sxy = 0, sxx = 0, syy = 0;
+  for (let i = 0; i < n; i++) {
+    const dx = xs[i] - mx, dy = ys[i] - my;
+    sxy += dx * dy; sxx += dx * dx; syy += dy * dy;
+  }
+  if (sxx === 0 || syy === 0) return null;
+  return sxy / Math.sqrt(sxx * syy);
+}
+
+/**
+ * Consistency check, NOT a discovery claim: do the member nodes that carry
+ * live time-series actually co-move, as a shared hidden driver would predict?
+ * Mean pairwise Pearson correlation over date-aligned member series. Pure —
+ * reads node `liveData` only, never mutates.
+ */
+export function computeLatentSupport(
+  memberIds: string[],
+  graph: CausalGraph,
+): NonNullable<LatentNode["dataSupport"]> {
+  const seriesById = new Map<string, Map<string, number>>();
+  for (const id of memberIds) {
+    const node = graph.nodes.find((n) => n.id === id);
+    const s = node ? liveSeries(node) : null;
+    if (s) seriesById.set(id, s);
+  }
+  const liveMembers = seriesById.size;
+  if (liveMembers < 2) {
+    return { status: "insufficient", liveMembers, method: "pairwise-correlation" };
+  }
+  const ids = [...seriesById.keys()];
+  const rs: number[] = [];
+  for (let i = 0; i < ids.length; i++) {
+    for (let j = i + 1; j < ids.length; j++) {
+      const a = seriesById.get(ids[i])!;
+      const b = seriesById.get(ids[j])!;
+      const xs: number[] = [];
+      const ys: number[] = [];
+      for (const [date, v] of a) {
+        const bv = b.get(date);
+        if (bv !== undefined) { xs.push(v); ys.push(bv); }
+      }
+      if (xs.length >= SUPPORT_MIN_ALIGNED) {
+        const r = pearson(xs, ys);
+        if (r !== null) rs.push(r);
+      }
+    }
+  }
+  if (rs.length === 0) {
+    return { status: "insufficient", liveMembers, method: "pairwise-correlation" };
+  }
+  const meanR = Math.round((rs.reduce((a, b) => a + b, 0) / rs.length) * 100) / 100;
+  return {
+    status: meanR >= SUPPORT_R_THRESHOLD ? "supported" : "inconsistent",
+    statistic: meanR,
+    method: "pairwise-correlation",
+    liveMembers,
+  };
+}
 
 export function deriveLatentNodes(graph: CausalGraph): LatentNode[] {
   // Each confounded (non-severed) edge = "these two observed nodes share a
@@ -94,12 +185,22 @@ export function deriveLatentNodes(graph: CausalGraph): LatentNode[] {
       }
     }
 
+    // Hypothesised channel — the author-stated mechanism of the strongest
+    // internal confounded edge, surfaced verbatim (not an empirically named
+    // variable; it's the channel the graph author asserted).
+    const driverEdge = internal
+      .filter((e) => (e.physicalMechanism ?? "").trim().length > 0)
+      .sort((a, b) => b.confidence - a.confidence)[0];
+
     latents.push({
       id: `latent__${members[0]}`,
       explains: members,
       method: "confounded-cluster",
       strength,
       label: `Inferred common cause of ${shortLabelOf.get(hub) ?? hub} + ${members.length - 1} more`,
+      hypothesizedDriver: driverEdge?.physicalMechanism,
+      // Real-data consistency check (NOT discovery): do the live members co-move?
+      dataSupport: computeLatentSupport(members, graph),
     });
   }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -411,6 +411,30 @@ export interface LatentNode {
   strength: number;
   /** Hypothesis-framed label — never an assertion of what the latent IS. */
   label: string;
+  /**
+   * The hypothesised channel/driver, surfaced verbatim from the
+   * `physicalMechanism` of the cluster's confounded edges (an author-stated
+   * mechanism, e.g. "Gulf route disruption raises freight cost"). Turns the
+   * glyph from "?" into a named hypothesis. NOT an empirically identified
+   * variable — it's the channel the graph author asserted.
+   */
+  hypothesizedDriver?: string;
+  /**
+   * Real-data consistency check on the hypothesis (NOT a discovery claim):
+   * do the member nodes that carry live time-series actually co-move, as a
+   * shared hidden driver would predict? Computed from `liveData.history`.
+   *   - "supported"    : enough aligned data AND members co-move (|r| ≥ thresh)
+   *   - "inconsistent" : enough aligned data BUT members don't co-move
+   *   - "insufficient" : not enough live/aligned data to judge
+   * `statistic` is the mean pairwise correlation; `liveMembers` is how many
+   * members had usable series. Absent ⇒ support not computed.
+   */
+  dataSupport?: {
+    status: "supported" | "inconsistent" | "insufficient";
+    statistic?: number;
+    method?: "pairwise-correlation";
+    liveMembers: number;
+  };
   /** Render position (centroid of explained nodes); set by the render layer. */
   position3d?: { x: number; y: number; z: number };
 }


### PR DESCRIPTION
## Ground inferred latent nodes in real data (identify + consistency check)

Follow-up to #538. Addresses the integrity question: *"is this actually showing valid, actionable information, or just re-drawing an authored assumption?"* Council decision was **validate-against-real-data now, full FCI discovery deferred** (data coverage would force a #539-style overclaim).

### What changed
- **Identify** — `hypothesizedDriver`: the glyph now surfaces the author-stated `physicalMechanism` of the cluster's strongest confounded edge (e.g. *"Gulf route disruption raises freight cost"*) instead of a bare `?`. A *named hypothesis*, explicitly not an empirically identified variable.
- **Validate** — `dataSupport`: `computeLatentSupport` does a real-data **consistency check** (not discovery). Where ≥2 members carry live `liveData.history`, it date-aligns their series and computes mean pairwise Pearson r → labels **supported** (|r| ≥ 0.4, enough aligned points), **inconsistent** (data, but no co-movement), or **insufficient** (not enough live/aligned data). Badge + strength reflect the statistic.
- **Render** — `LatentNode2D` shows the driver caption + a colored support badge (`DATA ✓ r=… / DATA ✗ / NO LIVE DATA`); tooltip states it's a hypothesis checked against live data, **not** an empirical discovery.

### Honest by construction
With sparse, mixed-frequency feeds most clusters read **"insufficient data"** (EIA-monthly Hormuz vs World-Bank-annual fertilizer) — the correct, non-overclaiming outcome, and it doubles as a data-acquisition prompt (*what to instrument*). Full FCI latent discovery (`fci.ts` → bidirected edges) is deferred to a coverage-gated Phase 2.

### Safety / verification
- Still a **read-only overlay** — latents + pulled-in members never enter `graph.nodes` / cascade / ΩF metrics.
- `tsc` clean; **14 latent tests** (7 new: supported / inconsistent / insufficient / short-series / driver-wiring).
- **Not GUI-re-verified this round** — local has no live feeds, so the badge would only exercise the "insufficient" path; the supported/inconsistent logic is covered by unit tests. The base glyph render was GUI-verified in #538.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
