### PR TITLE
feat(graph): discovery-readiness assessment for inferred latents

### DIFF
--- a/src/components/CausalDAG2D.tsx
+++ b/src/components/CausalDAG2D.tsx
@@ -495,6 +495,12 @@ interface LatentNode2DData {
     statistic?: number;
     liveMembers: number;
   };
+  /** Discovery-readiness: what data is needed to discover this for real. */
+  readiness?: {
+    status: "ready" | "partial" | "blocked";
+    recommendation: string;
+    limitingFactor: "coverage" | "frequency" | "none";
+  };
 }
 function LatentNode2D({ data }: NodeProps<LatentNode2DData>) {
   const sup = data.support;
@@ -514,6 +520,7 @@ function LatentNode2D({ data }: NodeProps<LatentNode2DData>) {
     `Members: ${data.members}\n` +
     `Data check: ${supText ?? "n/a"}` +
     (sup ? ` (${sup.liveMembers} live member${sup.liveMembers === 1 ? "" : "s"})` : "") +
+    (data.readiness ? `\nDiscovery readiness: ${data.readiness.status.toUpperCase()} — ${data.readiness.recommendation}` : "") +
     `\nA hypothesis from authored confounded structure, checked against live data where available — not an empirical discovery.`;
   return (
     <div style={{ display: "flex", flexDirection: "column", alignItems: "center", cursor: "help" }} title={tooltip}>
@@ -1646,6 +1653,7 @@ function CausalDAG2DInner() {
           strength: lat.strength,
           driver: lat.hypothesizedDriver,
           support: lat.dataSupport,
+          readiness: lat.discoveryReadiness,
         },
         draggable: false,
         selectable: false,

--- a/src/lib/__tests__/latent-discovery-readiness.test.ts
+++ b/src/lib/__tests__/latent-discovery-readiness.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import {
+  assessDiscoveryReadiness,
+  deriveLatentNodes,
+  DISCOVERY_MIN_POINTS,
+  SUPPORT_MIN_ALIGNED,
+} from "@/lib/latent-nodes";
+import type {
+  CausalGraph,
+  CausalNode,
+  CausalEdge,
+  EdgeType,
+  LiveDataPoint,
+} from "@/lib/types";
+
+/** Daily live series (history + current point) of length `n`. */
+function series(n: number, start = "2026-01-01"): LiveDataPoint {
+  const base = new Date(`${start}T00:00:00Z`);
+  const at = (i: number) => {
+    const d = new Date(base);
+    d.setUTCDate(base.getUTCDate() + i);
+    return d.toISOString();
+  };
+  const values = Array.from({ length: n }, (_, i) => i + 1);
+  const history = values.slice(0, -1).map((v, i) => ({ value: v, observedAt: at(i) }));
+  return {
+    kind: "indicator",
+    value: values[n - 1],
+    capacity: 100,
+    unit: "x",
+    observedAt: at(n - 1),
+    source: "test",
+    history,
+  };
+}
+
+function node(id: string, liveData?: LiveDataPoint[]): CausalNode {
+  return { id, shortLabel: id, label: id, liveData } as unknown as CausalNode;
+}
+
+function confEdge(source: string, target: string): CausalEdge {
+  return {
+    id: `${source}__${target}`,
+    source,
+    target,
+    weight: 0.5,
+    lag: 1,
+    type: "confounded" as EdgeType,
+    confidence: 0.65,
+    isInconsistent: false,
+    physicalMechanism: "shared channel",
+  } as CausalEdge;
+}
+
+function graph(nodes: CausalNode[], edges: CausalEdge[] = []): CausalGraph {
+  return { nodes, edges, metadata: {} } as unknown as CausalGraph;
+}
+
+describe("assessDiscoveryReadiness", () => {
+  it("'blocked' on COVERAGE when a member carries no live feed", () => {
+    const g = graph([node("A", [series(40)]), node("B"), node("C")]);
+    const r = assessDiscoveryReadiness(["A", "B", "C"], g);
+    expect(r.status).toBe("blocked");
+    expect(r.limitingFactor).toBe("coverage");
+    expect(r.missingFeeds.sort()).toEqual(["B", "C"]);
+    expect(r.liveMembers).toBe(1);
+    expect(r.recommendation).toMatch(/Acquire a live feed/i);
+  });
+
+  it("'ready' when every member is live with ≥ DISCOVERY_MIN_POINTS aligned points", () => {
+    const n = DISCOVERY_MIN_POINTS + 5;
+    const g = graph([node("A", [series(n)]), node("B", [series(n)]), node("C", [series(n)])]);
+    const r = assessDiscoveryReadiness(["A", "B", "C"], g);
+    expect(r.status).toBe("ready");
+    expect(r.limitingFactor).toBe("none");
+    expect(r.maxAlignedPoints).toBeGreaterThanOrEqual(DISCOVERY_MIN_POINTS);
+    expect(r.missingFeeds).toEqual([]);
+  });
+
+  it("'partial' (underpowered) when all live but aligned points sit between the floors", () => {
+    const n = SUPPORT_MIN_ALIGNED + 4; // ≥8 but < 30
+    const g = graph([node("A", [series(n)]), node("B", [series(n)])]);
+    const r = assessDiscoveryReadiness(["A", "B"], g);
+    expect(r.status).toBe("partial");
+    expect(r.limitingFactor).toBe("frequency");
+    expect(r.maxAlignedPoints).toBe(n);
+    expect(r.recommendation).toMatch(/Underpowered/i);
+  });
+
+  it("'blocked' on FREQUENCY when aligned points are far too few", () => {
+    const g = graph([node("A", [series(4)]), node("B", [series(4)])]);
+    const r = assessDiscoveryReadiness(["A", "B"], g);
+    expect(r.status).toBe("blocked");
+    expect(r.limitingFactor).toBe("frequency");
+  });
+});
+
+describe("deriveLatentNodes — discoveryReadiness wiring", () => {
+  it("attaches a coverage-blocked readiness when members have no live data", () => {
+    const g = graph(
+      [node("A"), node("B"), node("C")],
+      [confEdge("A", "B"), confEdge("B", "C"), confEdge("A", "C")],
+    );
+    const [lat] = deriveLatentNodes(g);
+    expect(lat.discoveryReadiness?.status).toBe("blocked");
+    expect(lat.discoveryReadiness?.limitingFactor).toBe("coverage");
+    expect(lat.discoveryReadiness?.missingFeeds.sort()).toEqual(["A", "B", "C"]);
+  });
+});

--- a/src/lib/latent-nodes.ts
+++ b/src/lib/latent-nodes.ts
@@ -113,6 +113,121 @@ export function computeLatentSupport(
   };
 }
 
+/** Min date-aligned points for a credibly-powered CI test (rough floor). */
+export const DISCOVERY_MIN_POINTS = 30;
+
+const CADENCE_RANK: Record<string, number> = {
+  daily: 1, weekly: 2, monthly: 3, quarterly: 4, annual: 5, irregular: 6,
+};
+
+/** Rough sampling cadence from a series' median date-gap (days). */
+function inferCadence(series: Map<string, number>): string {
+  const dates = [...series.keys()].sort();
+  if (dates.length < 2) return "irregular";
+  const gaps: number[] = [];
+  for (let i = 1; i < dates.length; i++) {
+    const d0 = Date.parse(`${dates[i - 1]}T00:00:00Z`);
+    const d1 = Date.parse(`${dates[i]}T00:00:00Z`);
+    if (!Number.isNaN(d0) && !Number.isNaN(d1)) gaps.push((d1 - d0) / 86_400_000);
+  }
+  if (gaps.length === 0) return "irregular";
+  gaps.sort((a, b) => a - b);
+  const med = gaps[Math.floor(gaps.length / 2)];
+  if (med <= 3) return "daily";
+  if (med <= 10) return "weekly";
+  if (med <= 45) return "monthly";
+  if (med <= 135) return "quarterly";
+  if (med <= 450) return "annual";
+  return "irregular";
+}
+
+/**
+ * Discovery-readiness: could this latent be *discovered* from real data (vs the
+ * authored hypothesis), and if not, what data is missing? The honest
+ * prerequisite for FCI latent discovery — converts "insufficient" into a
+ * concrete acquisition spec. Pure; reads `liveData` only.
+ */
+export function assessDiscoveryReadiness(
+  memberIds: string[],
+  graph: CausalGraph,
+): NonNullable<LatentNode["discoveryReadiness"]> {
+  const labelOf = new Map(
+    graph.nodes.map((n) => [n.id, n.shortLabel || n.label || n.id]),
+  );
+  const seriesById = new Map<string, Map<string, number>>();
+  const missingFeeds: string[] = [];
+  for (const id of memberIds) {
+    const node = graph.nodes.find((n) => n.id === id);
+    const s = node ? liveSeries(node) : null;
+    if (s) seriesById.set(id, s);
+    else missingFeeds.push(id);
+  }
+  const liveMembers = seriesById.size;
+  const totalMembers = memberIds.length;
+
+  // Best pairwise date-aligned sample size — the n a CI test would actually get.
+  let maxAligned = 0;
+  const ids = [...seriesById.keys()];
+  for (let i = 0; i < ids.length; i++) {
+    for (let j = i + 1; j < ids.length; j++) {
+      const a = seriesById.get(ids[i])!;
+      const b = seriesById.get(ids[j])!;
+      let n = 0;
+      for (const d of a.keys()) if (b.has(d)) n++;
+      if (n > maxAligned) maxAligned = n;
+    }
+  }
+
+  // Slowest live member — names the alignment-limiting cadence in the rec.
+  let slowest: { label: string; cadence: string } | null = null;
+  for (const [id, s] of seriesById) {
+    const c = inferCadence(s);
+    if (!slowest || CADENCE_RANK[c] > CADENCE_RANK[slowest.cadence]) {
+      slowest = { label: labelOf.get(id) ?? id, cadence: c };
+    }
+  }
+  const freqNote =
+    slowest && CADENCE_RANK[slowest.cadence] >= CADENCE_RANK.quarterly
+      ? ` (limited by the ${slowest.cadence} cadence of ${slowest.label})`
+      : "";
+
+  if (missingFeeds.length > 0) {
+    const labels = missingFeeds.map((id) => labelOf.get(id) ?? id);
+    return {
+      status: "blocked",
+      liveMembers, totalMembers, maxAlignedPoints: maxAligned,
+      missingFeeds,
+      limitingFactor: "coverage",
+      recommendation: `Acquire a live feed for ${labels.join(", ")} (currently modeled). FCI can only test members it can observe.`,
+    };
+  }
+  if (maxAligned >= DISCOVERY_MIN_POINTS) {
+    return {
+      status: "ready",
+      liveMembers, totalMembers, maxAlignedPoints: maxAligned,
+      missingFeeds: [],
+      limitingFactor: "none",
+      recommendation: `Ready: ${maxAligned} date-aligned points across all ${totalMembers} members — FCI latent discovery is statistically viable.`,
+    };
+  }
+  if (maxAligned >= SUPPORT_MIN_ALIGNED) {
+    return {
+      status: "partial",
+      liveMembers, totalMembers, maxAlignedPoints: maxAligned,
+      missingFeeds: [],
+      limitingFactor: "frequency",
+      recommendation: `Underpowered: only ${maxAligned} aligned points${freqNote}. Upgrade to a higher-frequency feed (or accrue more history) to reach ≥${DISCOVERY_MIN_POINTS}.`,
+    };
+  }
+  return {
+    status: "blocked",
+    liveMembers, totalMembers, maxAlignedPoints: maxAligned,
+    missingFeeds: [],
+    limitingFactor: "frequency",
+    recommendation: `Too few aligned points (${maxAligned})${freqNote}. Need higher-frequency, longer-overlapping feeds (target ≥${DISCOVERY_MIN_POINTS}).`,
+  };
+}
+
 export function deriveLatentNodes(graph: CausalGraph): LatentNode[] {
   // Each confounded (non-severed) edge = "these two observed nodes share a
   // latent common cause."
@@ -201,6 +316,8 @@ export function deriveLatentNodes(graph: CausalGraph): LatentNode[] {
       hypothesizedDriver: driverEdge?.physicalMechanism,
       // Real-data consistency check (NOT discovery): do the live members co-move?
       dataSupport: computeLatentSupport(members, graph),
+      // What data is needed to *discover* this latent for real (FCI Phase 2).
+      discoveryReadiness: assessDiscoveryReadiness(members, graph),
     });
   }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -435,6 +435,28 @@ export interface LatentNode {
     method?: "pairwise-correlation";
     liveMembers: number;
   };
+  /**
+   * Discovery-readiness assessment: can this latent ever be *discovered* from
+   * real data (vs the current authored hypothesis), and if not, what data is
+   * missing? Turns "insufficient" into an actionable acquisition spec — the
+   * prerequisite for honest FCI latent discovery (Phase 2).
+   *   - "ready"   : every member observed + enough date-aligned points for a
+   *                 credible CI test (≥ DISCOVERY_MIN_POINTS)
+   *   - "partial" : every member observed but underpowered (too few aligned pts)
+   *   - "blocked" : a member is unobserved, or alignment is far too sparse
+   * `limitingFactor` names the binding gap; `recommendation` is the concrete
+   * "to discover this for real, acquire X" instruction.
+   */
+  discoveryReadiness?: {
+    status: "ready" | "partial" | "blocked";
+    liveMembers: number;
+    totalMembers: number;
+    maxAlignedPoints: number;
+    /** Member ids that carry no live feed (need instrumentation). */
+    missingFeeds: string[];
+    limitingFactor: "coverage" | "frequency" | "none";
+    recommendation: string;
+  };
   /** Render position (centroid of explained nodes); set by the render layer. */
   position3d?: { x: number; y: number; z: number };
 }


### PR DESCRIPTION
## Discovery-readiness assessment for inferred latents

**Phase 1 of "make latent discovery real."** Council call (after #540): don't run FCI on insufficient data — it would overclaim (the #539 trap). Instead, surface exactly what data each latent needs to become *discoverable*, turning "insufficient" into a concrete acquisition spec.

### What it does
`assessDiscoveryReadiness(members, graph)` reports, per latent cluster:
- **coverage** — which members carry no live feed (need instrumentation)
- **max date-aligned sample size** vs a CI-test power floor (`DISCOVERY_MIN_POINTS = 30`)
- **limitingFactor** (`coverage` / `frequency` / `none`) + inferred cadence of the slowest live member
- a concrete **recommendation**: *"Acquire a live feed for X"* / *"Underpowered: upgrade to a higher-frequency feed to reach ≥N"* / *"Ready: N aligned points — FCI viable"*

Surfaced in the `LatentNode2D` hover tooltip. This is the honest prerequisite for FCI latent discovery (Phase 2, gated on coverage) — it tells you *when* discovery will actually work and *what to buy* to get there (ties into the partnerships/data lane).

### Real-graph output
The Hormuz + fertilizer cluster reports → *"Acquire a live feed for AIM, BFM, IFM, SOH-T (currently modeled). FCI can only test members it can observe."* In production (feeds live) it names only the still-modeled members.

### Safety / verification
- Pure / read-only; reuses #540's series helpers; never mutates the store graph.
- `tsc` clean; **19 latent tests** (5 new: coverage-blocked / ready / partial / frequency-blocked / wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
