### PR TITLE
fix(pearl): two-mode copy for FORECAST empty state + unclip scenario box

### DIFF
--- a/src/components/MonteCarloForecast.tsx
+++ b/src/components/MonteCarloForecast.tsx
@@ -509,11 +509,25 @@ export default function MonteCarloForecast({
 
       {!effectiveTarget && !trialPrior && (
         <div className="p-2 rounded border border-border/60 bg-surface-elevated text-[8px] font-mono text-text-muted leading-relaxed">
-          Waiting for cuts. Three ways to get here:
-          {" "}<strong>scenario {"→"} interdiction</strong> at the top of PEARL,
-          {" "}<strong>ablation</strong> (your manual cuts), or a manual{" "}
-          <strong>do(X)</strong> target picked on the DAG. As soon as cuts
-          exist, this forecast auto-runs.
+          {embedded ? (
+            // Two-mode copy for the redesigned workspace — the classic text
+            // below describes a three-way layout that no longer exists there
+            // (founder caught the stale version live on prod).
+            <>
+              Waiting for cuts. Use <strong>Find cuts</strong> (the system
+              proposes them) or <strong>Manual</strong> (click nodes / edges
+              on the canvas) in DEFINE CUTS above. The forecast auto-runs as
+              soon as cuts exist.
+            </>
+          ) : (
+            <>
+              Waiting for cuts. Three ways to get here:
+              {" "}<strong>scenario {"→"} interdiction</strong> at the top of PEARL,
+              {" "}<strong>ablation</strong> (your manual cuts), or a manual{" "}
+              <strong>do(X)</strong> target picked on the DAG. As soon as cuts
+              exist, this forecast auto-runs.
+            </>
+          )}
         </div>
       )}
 

--- a/src/components/pearl/FindCutsPanel.tsx
+++ b/src/components/pearl/FindCutsPanel.tsx
@@ -136,7 +136,7 @@ export default function FindCutsPanel() {
           }
         }}
         placeholder={placeholder}
-        rows={2}
+        rows={3}
         className="w-full text-[9px] font-mono bg-surface border border-border rounded px-2 py-1.5 text-foreground leading-relaxed resize-none focus:outline-none focus:border-accent-amber/60"
       />
 


### PR DESCRIPTION
Founder caught the stale FORECAST waiting-for-cuts text live on prod right after the two-mode consolidation (#533): it still described the old three-way model (scenario→interdiction / ablation / do(X)) in exactly the jargon being removed. In embedded (NEW workspace) mode it now reads in plain two-mode language (Find cuts / Manual); the classic text is untouched for the CLASSIC stack. Also bumps the FindCutsPanel scenario textarea from 2 to 3 rows so the placeholder no longer clips behind a scrollbar (visible in the founder's screenshot).

tsc clean on touched files; full build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)