### PR TITLE
fix(security): SSRF guard + baseline security headers

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,49 @@ const withBundleAnalyzer = bundleAnalyzer({
   enabled: process.env.ANALYZE === "true",
 });
 
+// Security headers applied to every response. Split out so the policy
+// is reviewable in one place and the next.config object stays scannable.
+//
+//   X-Frame-Options       Manifold is never embedded in another origin's
+//                         frame. DENY removes the clickjacking surface
+//                         entirely. frame-ancestors in the CSP below is
+//                         the modern equivalent; we ship both for older
+//                         clients.
+//   X-Content-Type-Options
+//                         Prevents MIME sniffing on uploaded artefacts
+//                         (CSV / XLSX / PDF imports). Browsers must
+//                         honour the Content-Type the server sent.
+//   Referrer-Policy       Don't leak full URLs to third-party trackers
+//                         on outbound clicks (the docs drawer's external
+//                         links, copilot citation links, etc.).
+//   Permissions-Policy    Explicitly disable browser APIs we never use.
+//                         interest-cohort=() opts out of FLoC.
+//   Strict-Transport-Security
+//                         Force HTTPS for a year. The Vercel cert + redirect
+//                         already do this; HSTS makes downgrade attacks
+//                         visible to the browser, not just the server.
+//
+// Content-Security-Policy intentionally OMITTED for now: the app pulls
+// from Supabase, Vercel analytics, multiple LLM endpoints (Anthropic,
+// Gemini, OpenAI), Mapbox tiles, font CDNs, and inlines a small boot
+// script for text-size restoration. A wrong CSP breaks more than it
+// protects. We'll add it in a follow-up via Content-Security-Policy-
+// Report-Only first, collect violation reports for a couple of days,
+// then tighten and flip to enforcing mode.
+const SECURITY_HEADERS = [
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), interest-cohort=()",
+  },
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=31536000; includeSubDomains",
+  },
+];
+
 const nextConfig: NextConfig = {
   // Enable gzip/brotli compression for served assets
   compress: true,
@@ -24,6 +67,16 @@ const nextConfig: NextConfig = {
   // Inline critical CSS to cut render-blocking stylesheets
   experimental: {
     optimizeCss: true,
+  },
+
+  async headers() {
+    return [
+      {
+        // All routes including API.
+        source: "/:path*",
+        headers: SECURITY_HEADERS,
+      },
+    ];
   },
 };
 

--- a/src/app/api/news/fetch-url/route.ts
+++ b/src/app/api/news/fetch-url/route.ts
@@ -1,6 +1,7 @@
 import { Readability } from "@mozilla/readability";
 import { JSDOM } from "jsdom";
 import { NextRequest } from "next/server";
+import { ssrfGuard } from "@/lib/security/ssrf-guard";
 
 const USER_AGENT =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36";
@@ -25,6 +26,15 @@ export async function POST(req: NextRequest) {
 
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
       return jsonError("Only http(s) URLs are supported", 400);
+    }
+
+    // SSRF guard — blocks RFC 1918 / loopback / link-local literals,
+    // the cloud-metadata aliases, .local / .internal suffixes, and
+    // hostnames that resolve into any private range. See
+    // src/lib/security/ssrf-guard.ts for the policy detail.
+    const guard = await ssrfGuard(parsed);
+    if (guard.reason) {
+      return jsonError(guard.reason, 400);
     }
 
     const controller = new AbortController();

--- a/src/lib/security/ssrf-guard.ts
+++ b/src/lib/security/ssrf-guard.ts
@@ -1,0 +1,151 @@
+// ─── SSRF guard for server-side URL fetches ────────────────────────
+//
+// `/api/news/fetch-url` accepts a user-supplied URL and fetches it
+// from the server. Without this guard a caller can probe internal
+// services and cloud-metadata endpoints — the AWS / GCP metadata IPs
+// (169.254.169.254, metadata.google.internal) hand out temporary
+// instance credentials in plain JSON. Any internal Supabase / Vercel
+// orchestration endpoint reachable from the runtime is also fair game.
+//
+// Defence has two layers:
+//   1. Hostname-string heuristics — block obvious bad names without
+//      a DNS roundtrip (localhost, .local, .internal, the GCP / Azure
+//      metadata aliases, IPv4 / IPv6 literals in private ranges).
+//   2. DNS resolution — for everything else, look up the host and
+//      reject if any returned address lands in a private range. This
+//      catches public DNS names that resolve to private IPs
+//      (e.g. metadata.google.internal → 169.254.169.254, or any
+//      service-discovery name behind a corporate split-horizon DNS).
+//
+// Known TOCTOU window: between dns.lookup and fetch, an attacker
+// controlling the DNS server could return a public IP on the lookup
+// and a private one on the fetch. Closing that window properly
+// requires resolving + fetching by IP + setting the Host header,
+// which breaks SNI / virtual-hosting on the upstream. For Manifold's
+// threat model (the endpoint is for fetching news articles from the
+// public web) the heuristic + DNS check is the right altitude;
+// revisit if that endpoint ever processes higher-trust content.
+
+import { isIP } from "node:net";
+import dns from "node:dns/promises";
+
+const BLOCKED_HOSTNAMES = new Set<string>([
+  "localhost",
+  "metadata.google.internal", // GCP instance metadata
+  "metadata.azure.com", // Azure instance metadata
+  "instance-data", // AWS short alias (some VPCs)
+]);
+
+const BLOCKED_HOSTNAME_SUFFIXES = [
+  ".localhost",
+  ".local",
+  ".internal",
+  ".lan",
+  ".intranet",
+];
+
+/** RFC 1918, loopback, link-local, multicast, "this network", reserved. */
+function isPrivateIPv4(ip: string): boolean {
+  const parts = ip.split(".");
+  if (parts.length !== 4) return false;
+  const oct = parts.map((p) => Number(p));
+  if (oct.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return false;
+  const [a, b] = oct;
+  if (a === 0) return true; // 0.0.0.0/8 — "this network"
+  if (a === 10) return true; // 10.0.0.0/8 — RFC 1918
+  if (a === 127) return true; // 127.0.0.0/8 — loopback
+  if (a === 169 && b === 254) return true; // 169.254.0.0/16 — link-local (AWS / GCP metadata)
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12 — RFC 1918
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16 — RFC 1918
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 — CGNAT
+  if (a >= 224) return true; // 224.0.0.0/3 — multicast + reserved
+  return false;
+}
+
+/** IPv6 loopback, unique-local, link-local, multicast, IPv4-mapped private. */
+function isPrivateIPv6(ip: string): boolean {
+  const lower = ip.toLowerCase();
+  if (lower === "::1" || lower === "::") return true;
+  if (lower.startsWith("fc") || lower.startsWith("fd")) return true; // fc00::/7 unique local
+  if (
+    lower.startsWith("fe8") ||
+    lower.startsWith("fe9") ||
+    lower.startsWith("fea") ||
+    lower.startsWith("feb")
+  ) {
+    return true; // fe80::/10 link-local
+  }
+  if (lower.startsWith("ff")) return true; // ff00::/8 multicast
+  const mapped = lower.match(/^::ffff:([0-9.]+)$/);
+  if (mapped) return isPrivateIPv4(mapped[1]);
+  return false;
+}
+
+export interface SsrfGuardResult {
+  /** When non-null, the request must be rejected. Safe to surface to
+   *  the user — none of the messages leak which internal service was
+   *  probed. */
+  reason: string | null;
+}
+
+/**
+ * Validate a parsed URL against SSRF policy. Returns `{ reason: null }`
+ * to allow, or `{ reason: "..." }` to block. Async because non-literal
+ * hostnames trigger a DNS lookup.
+ */
+export async function ssrfGuard(parsed: URL): Promise<SsrfGuardResult> {
+  const hostname = parsed.hostname.toLowerCase();
+
+  if (BLOCKED_HOSTNAMES.has(hostname)) {
+    return { reason: "Hostname not allowed" };
+  }
+  for (const suffix of BLOCKED_HOSTNAME_SUFFIXES) {
+    if (hostname.endsWith(suffix)) {
+      return { reason: "Hostname not allowed" };
+    }
+  }
+
+  // Strip brackets that URL preserves on IPv6 hostnames.
+  const stripped = hostname.startsWith("[") && hostname.endsWith("]")
+    ? hostname.slice(1, -1)
+    : hostname;
+  const version = isIP(stripped);
+  if (version === 4) {
+    return isPrivateIPv4(stripped)
+      ? { reason: "Private IP addresses are not allowed" }
+      : { reason: null };
+  }
+  if (version === 6) {
+    return isPrivateIPv6(stripped)
+      ? { reason: "Private IP addresses are not allowed" }
+      : { reason: null };
+  }
+
+  // Hostname → DNS lookup. dns.lookup honours /etc/hosts and the
+  // platform resolver, so it catches OS-level overrides too.
+  try {
+    const addresses = await dns.lookup(hostname, { all: true });
+    for (const { address, family } of addresses) {
+      if (family === 4 && isPrivateIPv4(address)) {
+        return {
+          reason: "Hostname resolves to a private IP address",
+        };
+      }
+      if (family === 6 && isPrivateIPv6(address)) {
+        return {
+          reason: "Hostname resolves to a private IP address",
+        };
+      }
+    }
+    if (addresses.length === 0) {
+      return { reason: "Hostname did not resolve" };
+    }
+    return { reason: null };
+  } catch {
+    // DNS error — the fetch would have failed anyway. Block here so
+    // we never reach the network step on something unresolvable
+    // (some DNS-error edge cases on certain runtimes get retried as
+    // IPv6-only or vice versa, which we'd rather not race).
+    return { reason: "Hostname could not be resolved" };
+  }
+}


### PR DESCRIPTION
**Security audit Batch 1 — quick wins.** Two findings, both small, shipped together.

## S1 — SSRF guard on `/api/news/fetch-url`

The endpoint already restricted the scheme to `http(s)` but did not check the destination address. A caller could probe internal services and cloud-metadata endpoints — **`169.254.169.254` hands out temporary instance credentials in plain JSON**, GCP's `metadata.google.internal` does the same, and any Supabase / Vercel-orchestration host reachable from the runtime was fair game.

New `src/lib/security/ssrf-guard.ts::ssrfGuard()` runs two layers before the fetch:

1. **Hostname-string heuristics** — block obvious bad names without a DNS roundtrip (`localhost`, `.local`, `.internal`, `.lan`, `.intranet`, the cloud-metadata aliases, IPv4/IPv6 literals in private ranges).
2. **DNS resolution** — for everything else, look up the host and reject if any returned address lands in a private range. Catches public DNS names that resolve to private IPs (corporate split-horizon DNS, the metadata aliases, etc.).

**IPv4 ranges blocked:** `0/8`, `10/8`, `100.64/10` (CGNAT), `127/8`, `169.254/16`, `172.16-31/12`, `192.168/16`, `224/3` (multicast + reserved).
**IPv6:** `::1`, `::`, `fc00::/7`, `fe80::/10`, `ff00::/8`, plus IPv4-mapped `::ffff:a.b.c.d` translated through the v4 check.

**Known TOCTOU window** between `dns.lookup` and `fetch` — a DNS-controlling attacker could return a public IP on the lookup and a private one on the fetch. Closing that properly requires resolving + fetching by IP + setting the Host header, which breaks SNI on the upstream. The endpoint's threat model (fetching news articles from the public web) makes the heuristic + DNS check the right altitude; documented in the helper's preamble.

## S2 — baseline security headers

`next.config.ts` now ships headers on every response:

| Header | Value | Purpose |
|---|---|---|
| `X-Frame-Options` | `DENY` | No clickjacking — Manifold is never embedded |
| `X-Content-Type-Options` | `nosniff` | No MIME sniffing on CSV / XLSX / PDF imports |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Don't leak full URLs on outbound clicks |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=(), interest-cohort=()` | Disable unused APIs + FLoC opt-out |
| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` | Downgrade-attack defence |

**Content-Security-Policy intentionally NOT in this PR.** The app pulls from Supabase, Vercel analytics, multiple LLM endpoints (Anthropic, Gemini, OpenAI), Mapbox tiles, font CDNs, and inlines a small boot script for text-size restoration. A wrong CSP breaks more than it protects. Adding it correctly is a follow-up: ship `Content-Security-Policy-Report-Only` first, observe violation reports for a couple of days, tighten, then flip to enforcing mode.

## What's NOT in this PR

- **S3** (prompt-injection hardening in copilot system prompts) — Batch 2, separate PR with the LLM-key hygiene work.
- **S4** (LLM API key hygiene) — Batch 2.
- **S5** (grant-tier idempotency) — admin-only endpoint behind `requireAdmin`; the UPDATE is already idempotent at the row level for identical args. Not worth the surface area.

## Verification
- `tsc --noEmit`: clean for all changed files.
- `eslint`: clean.

https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx

---
_Generated by [Claude Code](https://claude.ai/code/session_018973VSz61ozQAbDsFnKmpx)_